### PR TITLE
Refactor PR: Visual Basic Test Helpers

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -11,7 +11,7 @@ Imports Roslyn.Test.Utilities
 Imports Xunit
 
 Public MustInherit Class BasicTestBase
-    Inherits BasicTestBaseBase
+    Inherits CommonTestBase
 
     Protected Overloads Function GetCompilationForEmit(
         source As IEnumerable(Of String),
@@ -19,7 +19,7 @@ Public MustInherit Class BasicTestBase
         options As VisualBasicCompilationOptions,
         parseOptions As VisualBasicParseOptions
     ) As VisualBasicCompilation
-        Return DirectCast(MyBase.GetCompilationForEmit(source, additionalRefs, options, parseOptions), VisualBasicCompilation)
+        Return DirectCast(MyClass.GetCompilationForEmit(source, additionalRefs, options, parseOptions), VisualBasicCompilation)
     End Function
 
     Public Function XCDataToString(Optional data As XCData = Nothing) As String
@@ -408,11 +408,6 @@ Public MustInherit Class BasicTestBase
                                 validator:=Sub(assembly) MetadataValidation.MarshalAsMetadataValidator(assembly, getExpectedBlob, isField),
                                 expectedSignatures:=expectedSignatures)
     End Function
-
-End Class
-
-Public MustInherit Class BasicTestBaseBase
-    Inherits CommonTestBase
 
     Protected Overrides ReadOnly Property CompilationOptionsReleaseDll As CompilationOptions
         Get

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -39,7 +39,7 @@ Public MustInherit Class BasicTestBase
         expectedOutput As XCData,
         Optional expectedReturnCode As Integer? = Nothing,
         Optional args As String() = Nothing,
-        Optional additionalRefs As MetadataReference() = Nothing,
+        Optional references As MetadataReference() = Nothing,
         Optional dependencies As IEnumerable(Of ModuleData) = Nothing,
         Optional sourceSymbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional validator As Action(Of PEAssembly) = Nothing,
@@ -56,7 +56,7 @@ Public MustInherit Class BasicTestBase
             XCDataToString(expectedOutput),
             expectedReturnCode,
             args,
-            additionalRefs,
+            references,
             dependencies,
             sourceSymbolValidator,
             validator,
@@ -130,7 +130,7 @@ Public MustInherit Class BasicTestBase
         Optional expectedOutput As String = Nothing,
         Optional expectedReturnCode As Integer? = Nothing,
         Optional args As String() = Nothing,
-        Optional additionalRefs As MetadataReference() = Nothing,
+        Optional references As MetadataReference() = Nothing,
         Optional dependencies As IEnumerable(Of ModuleData) = Nothing,
         Optional sourceSymbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional validator As Action(Of PEAssembly) = Nothing,
@@ -144,7 +144,7 @@ Public MustInherit Class BasicTestBase
     ) As CompilationVerifier
 
         Dim defaultRefs = If(useLatestFramework, LatestVbReferences, DefaultVbReferences)
-        Dim allReferences = If(additionalRefs IsNot Nothing, defaultRefs.Concat(additionalRefs), defaultRefs)
+        Dim allReferences = If(references IsNot Nothing, defaultRefs.Concat(references), defaultRefs)
 
         Return Me.CompileAndVerify(source,
                                    allReferences,
@@ -307,7 +307,7 @@ Public MustInherit Class BasicTestBase
     Friend Shadows Function CompileAndVerifyOnWin8Only(
         source As XElement,
         Optional expectedOutput As String = Nothing,
-        Optional additionalRefs() As MetadataReference = Nothing,
+        Optional references() As MetadataReference = Nothing,
         Optional dependencies As IEnumerable(Of ModuleData) = Nothing,
         Optional sourceSymbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional validator As Action(Of PEAssembly) = Nothing,
@@ -321,7 +321,7 @@ Public MustInherit Class BasicTestBase
         Return CompileAndVerify(
             source,
             expectedOutput:=If(OSVersion.IsWin8, expectedOutput, Nothing),
-            additionalRefs:=additionalRefs,
+            references:=references,
             dependencies:=dependencies,
             sourceSymbolValidator:=sourceSymbolValidator,
             validator:=validator,
@@ -336,28 +336,28 @@ Public MustInherit Class BasicTestBase
     ''' <summary>
     ''' Compile sources and adds a custom reference using a custom IL
     ''' </summary>
-    ''' <param name="sources">The sources compile according to the following schema
+    ''' <param name="source">The sources compile according to the following schema
     ''' &lt;compilation name="assemblyname[optional]"&gt;
     ''' &lt;file name="file1.vb[optional]"&gt;
     ''' source
     ''' &lt;/file&gt;
     ''' &lt;/compilation&gt;
     ''' </param>
-    Friend Function CompileWithCustomILSource(sources As XElement, ilSource As XCData) As CompilationVerifier
-        Return CompileWithCustomILSource(sources, ilSource.Value)
+    Friend Function CompileWithCustomILSource(source As XElement, ilSource As XCData) As CompilationVerifier
+        Return CompileWithCustomILSource(source, ilSource.Value)
     End Function
 
     ''' <summary>
     ''' Compile sources and adds a custom reference using a custom IL
     ''' </summary>
-    ''' <param name="sources">The sources compile according to the following schema
+    ''' <param name="source">The sources compile according to the following schema
     ''' &lt;compilation name="assemblyname[optional]"&gt;
     ''' &lt;file name="file1.vb[optional]"&gt;
     ''' source
     ''' &lt;/file&gt;
     ''' &lt;/compilation&gt;
     ''' </param>
-    Friend Function CompileWithCustomILSource(sources As XElement,
+    Friend Function CompileWithCustomILSource(source As XElement,
                                               ilSource As String,
                                               Optional options As VisualBasicCompilationOptions = Nothing,
                                               Optional compilationVerifier As Action(Of VisualBasicCompilation) = Nothing,
@@ -367,7 +367,7 @@ Public MustInherit Class BasicTestBase
         End If
 
         If ilSource = Nothing Then
-            Return CompileAndVerify(sources)
+            Return CompileAndVerify(source)
         End If
 
         Dim reference As MetadataReference = Nothing
@@ -375,7 +375,7 @@ Public MustInherit Class BasicTestBase
             reference = MetadataReference.CreateFromImage(ReadFromFile(tempAssembly.Path))
         End Using
 
-        Dim compilation = CreateCompilationWithReferences(sources, {MscorlibRef, MsvbRef, reference}, options)
+        Dim compilation = CreateCompilationWithReferences(source, {MscorlibRef, MsvbRef, reference}, options)
 
         If compilationVerifier IsNot Nothing Then
             compilationVerifier(compilation)
@@ -417,14 +417,14 @@ Public MustInherit Class BasicTestBase
 
     Protected Overrides Function GetCompilationForEmit(
         source As IEnumerable(Of String),
-        additionalRefs As IEnumerable(Of MetadataReference),
+        references As IEnumerable(Of MetadataReference),
         options As CompilationOptions,
         parseOptions As ParseOptions
     ) As Compilation
         Return VisualBasicCompilation.Create(
             GetUniqueName(),
             syntaxTrees:=source.Select(Function(t) VisualBasicSyntaxTree.ParseText(t, options:=DirectCast(parseOptions, VisualBasicParseOptions))),
-            references:=If(additionalRefs IsNot Nothing, DefaultVbReferences.Concat(additionalRefs), DefaultVbReferences),
+            references:=If(references IsNot Nothing, DefaultVbReferences.Concat(references), DefaultVbReferences),
             options:=DirectCast(options, VisualBasicCompilationOptions))
     End Function
 
@@ -802,14 +802,14 @@ Public MustInherit Class BasicTestBase
     End Function
 
     Friend Shared Function GetOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(
-        testSrc As String,
+        source As String,
         Optional compilationOptions As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional which As Integer = 0,
         Optional useLatestFrameworkReferences As Boolean = False) As (tree As String, syntax As SyntaxNode, operation As IOperation, compilation As Compilation)
 
         Dim fileName = "a.vb"
-        Dim syntaxTree = Parse(testSrc, fileName, parseOptions)
+        Dim syntaxTree = Parse(source, fileName, parseOptions)
         Dim defaultRefs = If(useLatestFrameworkReferences, LatestVbReferences, DefaultVbReferences)
         Dim compilation = CreateCompilationWithMscorlib45AndVBRuntime({syntaxTree}, references:=defaultRefs.Append({ValueTupleRef, SystemRuntimeFacadeRef}), options:=If(compilationOptions, TestOptions.ReleaseDll))
         Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, which)
@@ -825,7 +825,7 @@ Public MustInherit Class BasicTestBase
     End Sub
 
     Friend Shared Sub VerifyOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(
-        testSrc As String,
+        source As String,
         expectedOperationTree As String,
         Optional compilationOptions As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
@@ -833,7 +833,7 @@ Public MustInherit Class BasicTestBase
         Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing,
         Optional useLatestFrameworkReferences As Boolean = False)
 
-        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(testSrc, compilationOptions, parseOptions, which, useLatestFrameworkReferences)
+        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(source, compilationOptions, parseOptions, which, useLatestFrameworkReferences)
         OperationTreeVerifier.Verify(expectedOperationTree, operationTree.tree)
         If additionalOperationTreeVerifier IsNot Nothing Then
             additionalOperationTreeVerifier(operationTree.operation, operationTree.compilation, operationTree.syntax)
@@ -841,13 +841,13 @@ Public MustInherit Class BasicTestBase
     End Sub
 
     Friend Shared Sub VerifyNoOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(
-        testSrc As String,
+        source As String,
         Optional compilationOptions As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional which As Integer = 0,
         Optional useLatestFrameworkReferences As Boolean = False)
 
-        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(testSrc, compilationOptions, parseOptions, which, useLatestFrameworkReferences)
+        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(source, compilationOptions, parseOptions, which, useLatestFrameworkReferences)
         Assert.Null(operationTree.tree)
     End Sub
 
@@ -857,22 +857,22 @@ Public MustInherit Class BasicTestBase
     End Sub
 
     Friend Shared Sub VerifyOperationTreeAndDiagnosticsForTest(Of TSyntaxNode As SyntaxNode)(
-        testSrc As String,
+        source As String,
         expectedOperationTree As String,
         expectedDiagnostics As String,
         Optional compilationOptions As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional which As Integer = 0,
-        Optional additionalReferences As IEnumerable(Of MetadataReference) = Nothing,
+        Optional references As IEnumerable(Of MetadataReference) = Nothing,
         Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing,
         Optional useLatestFramework As Boolean = False)
 
         Dim fileName = "a.vb"
-        Dim syntaxTree = Parse(testSrc, fileName, parseOptions)
+        Dim syntaxTree = Parse(source, fileName, parseOptions)
         Dim defaultRefs = If(useLatestFramework, LatestVbReferences, DefaultVbReferences)
-        Dim references = defaultRefs.Concat({ValueTupleRef, SystemRuntimeFacadeRef})
-        references = If(additionalReferences IsNot Nothing, references.Concat(additionalReferences), references)
-        Dim compilation = CreateCompilationWithMscorlib45AndVBRuntime({syntaxTree}, references:=references, options:=If(compilationOptions, TestOptions.ReleaseDll))
+        Dim allReferences = defaultRefs.Concat({ValueTupleRef, SystemRuntimeFacadeRef})
+        allReferences = If(references IsNot Nothing, allReferences.Concat(references), allReferences)
+        Dim compilation = CreateCompilationWithMscorlib45AndVBRuntime({syntaxTree}, references:=allReferences, options:=If(compilationOptions, TestOptions.ReleaseDll))
         VerifyOperationTreeAndDiagnosticsForTest(Of TSyntaxNode)(compilation, fileName, expectedOperationTree, expectedDiagnostics, which, additionalOperationTreeVerifier)
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Tuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Tuples.vb
@@ -785,7 +785,7 @@ End Interface
                 End Sub
 
             CompileAndVerify(src,
-                             additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef},
+                             references:={ValueTupleRef, SystemRuntimeFacadeRef},
                              validator:=validator,
                              symbolValidator:=symbolValidator)
         End Sub
@@ -891,7 +891,7 @@ End Interface
                 End Sub
 
             CompileAndVerify(src,
-                additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef},
+                references:={ValueTupleRef, SystemRuntimeFacadeRef},
                 validator:=validator,
                 symbolValidator:=symbolValidator)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -765,7 +765,7 @@ End Class
 </compilation>
 
             Dim ilReference = CompileIL(ilSource.Value)
-            CompileAndVerify(source, expectedOutput:="0", additionalRefs:={ilReference})
+            CompileAndVerify(source, expectedOutput:="0", references:={ilReference})
             ' The native compiler would produce a working exe, but that exe would fail at runtime
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenDelegateCreation.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenDelegateCreation.vb
@@ -1817,7 +1817,7 @@ End Module
     </file>
 </compilation>
             CompileAndVerify(source,
-                additionalRefs:={TestReferences.SymbolsTests.DelegateImplementation.DelegateByRefParamArray},
+                references:={TestReferences.SymbolsTests.DelegateImplementation.DelegateByRefParamArray},
                 expectedOutput:=<![CDATA[
 Called SubWithParamArray: 1 2
 SubWithParamArray returned: 1 2
@@ -1877,7 +1877,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                additionalRefs:={TestReferences.SymbolsTests.DelegateImplementation.DelegateByRefParamArray},
+                references:={TestReferences.SymbolsTests.DelegateImplementation.DelegateByRefParamArray},
                 expectedOutput:=<![CDATA[
 Called SubWithByRefParamArrayOfReferenceTypes_Identify_1.
 SubWithByRefParamArrayOfReferenceTypes_Identify_1 returned: 1 2
@@ -1914,7 +1914,7 @@ End Module
     </file>
     </compilation>
                 CompileAndVerify(source,
-                    additionalRefs:={TestReferences.SymbolsTests.DelegateImplementation.DelegateByRefParamArray},
+                    references:={TestReferences.SymbolsTests.DelegateImplementation.DelegateByRefParamArray},
                     expectedOutput:=<![CDATA[
 Called SubWithParamArray: 1 2
 Called SubWithByRefParamArrayOfReferenceTypes_Identify_2.
@@ -2137,7 +2137,7 @@ End Module
     </compilation>
 
             CompileAndVerify(source,
-                additionalRefs:={TestReferences.SymbolsTests.DelegateImplementation.DelegateByRefParamArray},
+                references:={TestReferences.SymbolsTests.DelegateImplementation.DelegateByRefParamArray},
                 expectedOutput:=<![CDATA[
 ByRefParamArraySubOfBase returned: 23 2 3
     ]]>)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenForeach.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenForeach.vb
@@ -913,7 +913,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, options:=TestOptions.ReleaseExe.WithModuleName("MODULE"), additionalRefs:={LinqAssemblyRef}, expectedOutput:=<![CDATA[
+</compilation>, options:=TestOptions.ReleaseExe.WithModuleName("MODULE"), references:={LinqAssemblyRef}, expectedOutput:=<![CDATA[
 1
 2
 3
@@ -2520,7 +2520,7 @@ Module Program
 End Module
 </file>
 </compilation>,
-            additionalRefs:={LinqAssemblyRef},
+            references:={LinqAssemblyRef},
             expectedOutput:="123")
 
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenLateBound.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenLateBound.vb
@@ -4022,7 +4022,7 @@ End Module
 
    ]]>
     </file>
-</compilation>, expectedOutput:="HELLO", additionalRefs:=XmlReferences)
+</compilation>, expectedOutput:="HELLO", references:=XmlReferences)
 
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -645,7 +645,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 0.0000000000000000000000000031
 0.0000000000000000000000000030
 
@@ -703,7 +703,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 00000000000000000000000000000000
 00000000000000000000000000010000
 00000000000000000000000000020000
@@ -5941,7 +5941,7 @@ Module Program1
 
 End Module
     </file>
-</compilation>, additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef})
+</compilation>, references:={TestReferences.SymbolsTests.PropertiesWithByRef})
 
             verifier.VerifyIL("Module1.M",
             <![CDATA[
@@ -13160,7 +13160,7 @@ End Module
 </compilation>
 
             Dim testReference = AssemblyMetadata.CreateFromImage(TestResources.Repros.BadDefaultParameterValue).GetReference()
-            Dim compilation = CompileAndVerify(source, additionalRefs:=New MetadataReference() {testReference})
+            Dim compilation = CompileAndVerify(source, references:=New MetadataReference() {testReference})
             compilation.VerifyIL("C.Main",
             <![CDATA[
 {

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -169,7 +169,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.ValueTuple`2[System.Int32,System.String]
             ]]>)
 
@@ -209,7 +209,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.ValueTuple`2[System.Int32,System.String]
             ]]>)
 
@@ -385,7 +385,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (, )
             ]]>)
 
@@ -448,7 +448,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.ValueTuple`2[System.Object[],System.Object[]]
 System.ValueTuple`2[System.Object,System.Object][]
             ]]>)
@@ -475,7 +475,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 VB$AnonymousDelegate_0`1[System.ValueTuple`2[System.Object,System.Object][]]
 VB$AnonymousDelegate_0`1[System.ValueTuple`2[System.Object,System.Object]][]
             ]]>)
@@ -506,7 +506,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Object[]
 System.Object[,]
 
@@ -538,7 +538,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 VB$AnonymousDelegate_0`2[System.Int32,VB$AnonymousDelegate_1`1[System.Int32]]
 VB$AnonymousDelegate_0`2[System.Int64,System.ValueTuple`2[System.Object[],System.Object[]][]]
             ]]>)
@@ -577,7 +577,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.String
 System.String
 System.String
@@ -645,7 +645,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Action
 VB$AnonymousDelegate_0
             ]]>)
@@ -829,7 +829,7 @@ End Module
     </file>
 </compilation>, expectedOutput:=<![CDATA[
 3
-            ]]>, additionalRefs:=s_valueTupleRefs)
+            ]]>, references:=s_valueTupleRefs)
 
             verifier.VerifyIL("C.M1", <![CDATA[
 {
@@ -878,7 +878,7 @@ End Module
     </file>
 </compilation>, expectedOutput:=<![CDATA[
 hello
-            ]]>, additionalRefs:=s_valueTupleRefs)
+            ]]>, references:=s_valueTupleRefs)
 
             verifier.VerifyIL("C.Main", <![CDATA[
 {
@@ -991,7 +991,7 @@ End Module
 </compilation>, expectedOutput:=<![CDATA[
 42
 123
-            ]]>, additionalRefs:=s_valueTupleRefs)
+            ]]>, references:=s_valueTupleRefs)
 
             verifier.VerifyIL("Module1.Main", <![CDATA[
 {
@@ -1073,7 +1073,7 @@ End Module
 42
 42
 False
-            ]]>, additionalRefs:=s_valueTupleRefs)
+            ]]>, references:=s_valueTupleRefs)
 
             verifier.VerifyIL("C.Main", <![CDATA[
 {
@@ -1244,7 +1244,7 @@ End Module
     </file>
 </compilation>, expectedOutput:=<![CDATA[
 (1, 2)
-            ]]>, additionalRefs:=s_valueTupleRefs)
+            ]]>, references:=s_valueTupleRefs)
 
             verifier.VerifyIL("C.Main", <![CDATA[
 {
@@ -1278,7 +1278,7 @@ End Module
     </file>
 </compilation>, expectedOutput:=<![CDATA[
 hello
-            ]]>, additionalRefs:=s_valueTupleRefs)
+            ]]>, references:=s_valueTupleRefs)
 
             verifier.VerifyIL("C.Main", <![CDATA[
 {
@@ -1381,7 +1381,7 @@ Module Module1
 End Module
     </file>
 </compilation>,
-additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, useLatestFramework:=True, options:=TestOptions.DebugDll)
+references:={ValueTupleRef, SystemRuntimeFacadeRef}, useLatestFramework:=True, options:=TestOptions.DebugDll)
 
         End Sub
 
@@ -1453,7 +1453,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (, )
             ]]>)
 
@@ -1530,7 +1530,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (42, hi)
             ]]>)
         End Sub
@@ -1551,7 +1551,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (42, )
             ]]>)
         End Sub
@@ -1572,7 +1572,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (, 1)
             ]]>)
 
@@ -1633,7 +1633,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (, 1)
             ]]>)
 
@@ -1672,7 +1672,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (, 100)
             ]]>)
 
@@ -1715,7 +1715,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (, 100)
             ]]>)
 
@@ -1783,7 +1783,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (, 100)
             ]]>)
 
@@ -1854,7 +1854,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (100, 100)
             ]]>)
 
@@ -1912,7 +1912,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (100, 100)
             ]]>)
 
@@ -1972,7 +1972,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, options:=TestOptions.ReleaseExe.WithOverflowChecks(False), expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, options:=TestOptions.ReleaseExe.WithOverflowChecks(False), expectedOutput:=<![CDATA[
 (100, 100)
             ]]>)
 
@@ -2020,7 +2020,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (1, (2, 3))
             ]]>)
 
@@ -2091,7 +2091,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 integer
 integer
 long            ]]>)
@@ -2157,7 +2157,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (100, 100)
             ]]>)
 
@@ -2208,7 +2208,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (100, 100)
             ]]>)
 
@@ -2258,7 +2258,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (100, 100)
             ]]>)
 
@@ -2318,7 +2318,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (100, 100)
             ]]>)
 
@@ -2393,7 +2393,7 @@ Class C1
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (2, 2)
 (2, 2)
             ]]>)
@@ -2480,7 +2480,7 @@ Class C1
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (2, 2)
 (2, 2)
             ]]>)
@@ -2567,7 +2567,7 @@ Class C1
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (2, 2)
 (2, 2)
             ]]>)
@@ -2686,7 +2686,7 @@ Class C1
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (1, 2)
 (3, (4, 5))
 (6, (7, (8, (9, (10, (11, (12, (13, (14, (15, (16, 17)))))))))))
@@ -2749,7 +2749,7 @@ Class C1
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (1, 2)
 (3, (4, 5))
 (6, (7, (8, (9, (10, (11, (12, (13, (14, (15, (16, 17)))))))))))
@@ -3679,7 +3679,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Int32
 System.String
 (1, q)
@@ -3710,7 +3710,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Object
 (System.Object, q)
 
@@ -3817,7 +3817,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.String
 (, q)
 System.String
@@ -3882,7 +3882,7 @@ Imports System
         End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Object
 (a, a)
 q
@@ -3921,7 +3921,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Object
 (System.Object, q)
 System.ValueTuple`2[System.Object,System.String]
@@ -3994,7 +3994,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Object
 System.Object
             ]]>)
@@ -4024,7 +4024,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Collections.Generic.IEnumerable`1[System.Int32]
 System.Int32
             ]]>)
@@ -4054,7 +4054,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Collections.Generic.IEnumerable`1[System.Int32]
 System.Int32
             ]]>)
@@ -4085,7 +4085,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.Int64
 System.Int64
             ]]>)
@@ -4162,7 +4162,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 first
 3
 second
@@ -4198,7 +4198,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 1
 1
 2
@@ -4229,7 +4229,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (((0, 0), (0, 0)), ((0, 0), (0, 0)))
 System.Int32
 System.ValueTuple`2[System.Int32,System.Int32]
@@ -4262,7 +4262,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (((0, ), (0, )), ((0, ), (0, )))
 System.Object
 System.ValueTuple`2[System.Int32,System.Object]
@@ -4285,7 +4285,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(1, (2, (3, 4)))]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(1, (2, (3, 4)))]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("Module1.Main", <![CDATA[
@@ -4331,7 +4331,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[2
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[2
 42]]>)
 
             verifier.VerifyDiagnostics()
@@ -4378,7 +4378,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[2
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[2
 42]]>)
 
             verifier.VerifyDiagnostics()
@@ -4425,7 +4425,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[2
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[2
 42]]>)
 
             verifier.VerifyDiagnostics()
@@ -4472,7 +4472,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[2
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[2
 42]]>)
 
             verifier.VerifyDiagnostics()
@@ -4526,7 +4526,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(1, hello, 2)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(1, hello, 2)]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("Module1.Main", <![CDATA[
@@ -4697,7 +4697,7 @@ Module Module1
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[1
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[1
 hello]]>)
 
             verifier.VerifyDiagnostics()
@@ -4729,7 +4729,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[4]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[4]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("C.Main", <![CDATA[
@@ -4783,7 +4783,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[42]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[42]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("C._Closure$__2-0(Of $CLS0)._Lambda$__0()", <![CDATA[
@@ -4817,7 +4817,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(42, 42)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(42, 42)]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("C._Closure$__2-0(Of $CLS0)._Lambda$__0()", <![CDATA[
@@ -4869,7 +4869,7 @@ Namespace System
 End Namespace
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[42]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[42]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("Module1.Main", <![CDATA[
@@ -4912,7 +4912,7 @@ Namespace System
 End Namespace
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[42]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[42]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("Module1.Main", <![CDATA[
@@ -4958,7 +4958,7 @@ Namespace System
 End Namespace
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[42]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[42]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("Module1.Main", <![CDATA[
@@ -4988,7 +4988,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef, MscorlibRef_v46}, expectedOutput:=<![CDATA[42]]>)
+</compilation>, references:={ValueTupleRef, SystemRuntimeFacadeRef, MscorlibRef_v46}, expectedOutput:=<![CDATA[42]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("C.VB$StateMachine_2_Test(Of SM$T).MoveNext()", <![CDATA[
@@ -5107,7 +5107,7 @@ Class C
     End Function
 End Class
     </file>
-</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef, MscorlibRef_v46}, expectedOutput:=<![CDATA[(42, 42)]]>)
+</compilation>, references:={ValueTupleRef, SystemRuntimeFacadeRef, MscorlibRef_v46}, expectedOutput:=<![CDATA[(42, 42)]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("C.VB$StateMachine_2_Test(Of SM$T).MoveNext()", <![CDATA[
@@ -5245,7 +5245,7 @@ Namespace System
     End Structure
 End Namespace
     </file>
-</compilation>, additionalRefs:={MscorlibRef_v46}, expectedOutput:=<![CDATA[42]]>)
+</compilation>, references:={MscorlibRef_v46}, expectedOutput:=<![CDATA[42]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("C.VB$StateMachine_2_Test(Of SM$T).MoveNext()", <![CDATA[
@@ -5273,7 +5273,7 @@ Class C
     End Function
 End Class
     </file>
-</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef, MscorlibRef_v46}, expectedOutput:=<![CDATA[42]]>)
+</compilation>, references:={ValueTupleRef, SystemRuntimeFacadeRef, MscorlibRef_v46}, expectedOutput:=<![CDATA[42]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -5451,7 +5451,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[0
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[0
 null]]>)
 
             verifier.VerifyDiagnostics()
@@ -5582,7 +5582,7 @@ Class C
 End Class
     </file>
 </compilation>,
-                additionalRefs:=s_valueTupleRefs,
+                references:=s_valueTupleRefs,
                 expectedOutput:=<![CDATA[1 2 3 4 5 6 7 Alice 2 3 4 5]]>,
                 sourceSymbolValidator:=
                     Sub(m As ModuleSymbol)
@@ -5618,7 +5618,7 @@ Class C
 End Class
     </file>
 </compilation>,
-                additionalRefs:=s_valueTupleRefs,
+                references:=s_valueTupleRefs,
                 expectedOutput:=<![CDATA[1 2 3 4 5 6 7 Alice 2 3 4 5]]>,
                 sourceSymbolValidator:=Sub(m As ModuleSymbol)
                                            Dim compilation = m.DeclaringCompilation
@@ -5817,7 +5817,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[0 False]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[0 False]]>)
 
         End Sub
 
@@ -5836,7 +5836,7 @@ Class C
 End Class
     </file>
 </compilation>,
-                additionalRefs:=s_valueTupleRefs,
+                references:=s_valueTupleRefs,
                 expectedOutput:=<![CDATA[1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3]]>,
                 sourceSymbolValidator:=
                     Sub(m As ModuleSymbol)
@@ -5870,7 +5870,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[42 Alice]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[42 Alice]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -5889,7 +5889,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[42 Alice]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[42 Alice]]>)
 
         End Sub
 
@@ -5908,7 +5908,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[42 Alice]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[42 Alice]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -5932,7 +5932,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:="42 Alice")
+</compilation>, references:=s_valueTupleRefs, expectedOutput:="42 Alice")
 
         End Sub
 
@@ -5972,7 +5972,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[0 ]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[0 ]]>)
 
             verifier.VerifyDiagnostics()
         End Sub
@@ -5993,7 +5993,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[42 Alice]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[42 Alice]]>)
 
             verifier.VerifyDiagnostics()
         End Sub
@@ -6012,7 +6012,7 @@ Class C
 End Class
     </file>
 </compilation>,
-                additionalRefs:=s_valueTupleRefs,
+                references:=s_valueTupleRefs,
                 expectedOutput:=<![CDATA[1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3]]>,
                 sourceSymbolValidator:=
                     Sub(m As ModuleSymbol)
@@ -6057,7 +6057,7 @@ Class C
 End Class
     </file>
 </compilation>,
-                additionalRefs:=s_valueTupleRefs,
+                references:=s_valueTupleRefs,
                 parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15),
                 sourceSymbolValidator:=
                     Sub(m As ModuleSymbol)
@@ -6101,7 +6101,7 @@ Class C
 End Class
     </file>
 </compilation>,
-                additionalRefs:=s_valueTupleRefs,
+                references:=s_valueTupleRefs,
                 parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3),
                 sourceSymbolValidator:=
                     Sub(m As ModuleSymbol)
@@ -6137,7 +6137,7 @@ Class C
 End Class
     </file>
 </compilation>,
-                additionalRefs:=s_valueTupleRefs,
+                references:=s_valueTupleRefs,
                 parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3),
                 sourceSymbolValidator:=
                     Sub(m As ModuleSymbol)
@@ -6359,7 +6359,7 @@ Class C
 End Class
     </file>
 </compilation>,
-                additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef, LinqAssemblyRef},
+                references:={ValueTupleRef, SystemRuntimeFacadeRef, LinqAssemblyRef},
                 parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3),
                 sourceSymbolValidator:=
                     Sub(m As ModuleSymbol)
@@ -6393,7 +6393,7 @@ Class C
 End Class
     </file>
 </compilation>,
-                additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef, LinqAssemblyRef},
+                references:={ValueTupleRef, SystemRuntimeFacadeRef, LinqAssemblyRef},
                 parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3),
                 expectedOutput:="1")
 
@@ -6432,7 +6432,7 @@ BC37289: Tuple element name 'M' is inferred. Please use language version 15.3 or
                                           </errors>)
 
             Dim verifier15_3 = CompileAndVerify(source,
-                additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef, SystemCoreRef},
+                references:={ValueTupleRef, SystemRuntimeFacadeRef, SystemCoreRef},
                 parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3),
                 expectedOutput:="lambda")
             verifier15_3.VerifyDiagnostics()
@@ -6475,7 +6475,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[1 4 7 Alice 7 Bob 3]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[1 4 7 Alice 7 Bob 3]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -6533,7 +6533,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[1 2]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[1 2]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -6558,7 +6558,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[1 2
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[1 2
 3 4]]>)
 
             verifier.VerifyDiagnostics()
@@ -6584,7 +6584,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[0 0
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[0 0
 1 2]]>)
 
             verifier.VerifyDiagnostics()
@@ -6609,7 +6609,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[1 Alice]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[1 Alice]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -6631,7 +6631,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[True 1 Alice]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[True 1 Alice]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -6822,7 +6822,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[12
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[12
 123
 1234
 12345
@@ -7575,7 +7575,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(1, hello)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(1, hello)]]>)
 
             verifier.VerifyDiagnostics()
             verifier.VerifyIL("C.Main", <![CDATA[
@@ -7807,7 +7807,7 @@ Class C
 End Class
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.ValueTuple`2[System.Int32,VB$AnonymousDelegate_0`1[System.Object]]
 System.ValueTuple`2[System.Object,VB$AnonymousDelegate_1`2[System.Object,System.Object]]
 System.ValueTuple`2[System.Int32,VB$AnonymousDelegate_1`2[System.Object,System.Object]]
@@ -8522,7 +8522,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[second
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[second
 first
 third
 7]]>)
@@ -8566,7 +8566,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=
 "first
 first")
 
@@ -8595,7 +8595,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[System.Nullable`1[System.ValueTuple`2[System.Int32,System.Double]]
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[System.Nullable`1[System.ValueTuple`2[System.Int32,System.Double]]
 (1, 2)]]>)
 
             verifier.VerifyDiagnostics()
@@ -8627,7 +8627,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[second
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[second
 first
 first]]>)
 
@@ -8656,7 +8656,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[System.Nullable`1[System.ValueTuple`2[System.Int32,System.String]]
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[System.Nullable`1[System.ValueTuple`2[System.Int32,System.String]]
 (1, )]]>)
 
             verifier.VerifyDiagnostics()
@@ -8685,7 +8685,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[System.Nullable`1[System.ValueTuple`2[System.Int32,System.String]]
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[System.Nullable`1[System.ValueTuple`2[System.Int32,System.String]]
 (1, )]]>)
 
             verifier.VerifyDiagnostics()
@@ -8719,7 +8719,7 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[first
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[first
 fourth]]>)
 
             verifier.VerifyDiagnostics()
@@ -8801,7 +8801,7 @@ Module C
 End Module
 
     </file>
- </compilation>, additionalRefs:=s_valueTupleRefs)
+ </compilation>, references:=s_valueTupleRefs)
 
             Dim comp = verifier.Compilation
             Dim tree = comp.SyntaxTrees(0)
@@ -8926,7 +8926,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[102012]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[102012]]>)
 
         End Sub
 
@@ -9013,7 +9013,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (, , )
             ]]>)
 
@@ -9064,7 +9064,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (1, 2, 3, 4, 5, 6, 7, 8, 9)
             ]]>)
 
@@ -10029,7 +10029,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:="1 hello 3")
+</compilation>, references:=s_valueTupleRefs, expectedOutput:="1 hello 3")
 
         End Sub
 
@@ -10110,7 +10110,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, w)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, w)]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10133,7 +10133,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, )]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, )]]>)
 
             verifier.VerifyDiagnostics(
                     Diagnostic(ERRID.WRN_DefAsgUseNullRefStr, "ss").WithArguments("ss").WithLocation(8, 34)
@@ -10159,7 +10159,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(w, w)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(w, w)]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10183,7 +10183,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, (w, e))]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, (w, e))]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10223,7 +10223,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, q, q, q, q)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, q, q, q, q)]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10263,7 +10263,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, q, q, q, q)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, q, q, q, q)]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10303,7 +10303,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, q, q, q, q)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, q, q, q, q)]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10343,7 +10343,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q)]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10376,7 +10376,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q)]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10450,7 +10450,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 (, , , , , , , , , )
 
 q
@@ -10502,7 +10502,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, q, , , )]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, q, , , )]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10533,7 +10533,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[w]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[w]]>)
 
             verifier.VerifyDiagnostics()
 
@@ -10614,7 +10614,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, , q)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, , q)]]>)
 
             verifier.VerifyDiagnostics(
                     Diagnostic(ERRID.WRN_DefAsgUseNullRefStr, "ss").WithArguments("ss").WithLocation(44, 38),
@@ -10697,7 +10697,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, , q)]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(q, q, q, q, q, q, , q)]]>)
 
             verifier.VerifyDiagnostics(
                     Diagnostic(ERRID.WRN_DefAsgUseNullRefStr, "ss").WithArguments("ss").WithLocation(43, 38),
@@ -10743,7 +10743,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[()]]>)
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[()]]>)
 
             verifier.VerifyDiagnostics(
                     Diagnostic(ERRID.WRN_DefAsgUseNullRefStr, "ss.Rest").WithArguments("Rest").WithLocation(28, 38)
@@ -10778,7 +10778,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[q
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[q
 aa]]>)
 
             verifier.VerifyDiagnostics(
@@ -10818,7 +10818,7 @@ Module Module1
 End Module
 
             </file>
-    </compilation>, useLatestFramework:=True, additionalRefs:=s_valueTupleRefs, expectedOutput:="5")
+    </compilation>, useLatestFramework:=True, references:=s_valueTupleRefs, expectedOutput:="5")
 
             ' NOTE: !!! There should be NO IL local for  " v1 as (Long, Integer)" , it should be captured instead
             ' NOTE: !!! There should be an IL local for  " v2 as (Byte, Integer)" , it should not be captured 
@@ -10938,7 +10938,7 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs,
+</compilation>, references:=s_valueTupleRefs,
                 options:=TestOptions.DebugExe, expectedOutput:="9",
                 sourceSymbolValidator:=
                     Sub(m As ModuleSymbol)
@@ -19829,7 +19829,7 @@ End Module
 
 
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs.Concat({comp.EmitToImageReference()}).ToArray(), expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs.Concat({comp.EmitToImageReference()}).ToArray(), expectedOutput:=<![CDATA[
 (0, 0)
 key:  0
 val:  0
@@ -20790,7 +20790,7 @@ End Class
             Dim verifier = CompileAndVerify(
                 source,
                 options:=TestOptions.ReleaseExe.WithOverflowChecks(False),
-                additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(-1, 255)]]>)
+                references:=s_valueTupleRefs, expectedOutput:=<![CDATA[(-1, 255)]]>)
             verifier.VerifyIL("C.F", <![CDATA[
 {
   // Code size       22 (0x16)
@@ -20811,7 +20811,7 @@ End Class
             verifier = CompileAndVerify(
                 source,
                 options:=TestOptions.ReleaseExe.WithOverflowChecks(True),
-                additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[overflow]]>)
+                references:=s_valueTupleRefs, expectedOutput:=<![CDATA[overflow]]>)
             verifier.VerifyIL("C.F", <![CDATA[
 {
   // Code size       22 (0x16)
@@ -20975,7 +20975,7 @@ End Module
 Public Class A(Of T)
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 24
 ]]>)
         End Sub
@@ -21003,7 +21003,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 4
 ]]>)
         End Sub
@@ -21041,7 +21041,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 12
 ]]>)
         End Sub
@@ -21079,7 +21079,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 12
 ]]>)
         End Sub
@@ -21119,7 +21119,7 @@ End Module
 Interface I(Of in T)
 End Interface
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 12
 ]]>)
         End Sub
@@ -21159,7 +21159,7 @@ End Module
 Interface I(Of out T)
 End Interface
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 12
 ]]>)
         End Sub
@@ -21195,7 +21195,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 12
 ]]>)
         End Sub
@@ -21226,7 +21226,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 2
 ]]>)
         End Sub
@@ -21297,7 +21297,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 12
 ]]>)
         End Sub
@@ -21325,7 +21325,7 @@ Module Module1
     End Sub
 End Module
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+</compilation>, references:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 3
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWinMdDelegates.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWinMdDelegates.vb
@@ -284,7 +284,7 @@ End Class
 
             Dim verifier = CompileAndVerify(
                 allDelegates,
-                additionalRefs:={
+                references:={
                     winRtDelegateLibrary,
                     nonWinRtDelegateLibrary},
                 symbolValidator:=validator)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
@@ -247,7 +247,7 @@ End Class
 
             Dim comp = CompileAndVerifyOnWin8Only(source,
                                                   expectedOutput:=output,
-                                                  additionalRefs:=LegacyRefs)
+                                                  references:=LegacyRefs)
             comp.VerifyIL("A.Main", <![CDATA[
 {
   // Code size      114 (0x72)
@@ -510,7 +510,7 @@ End Class
 
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIIterableMembers", <![CDATA[
@@ -1584,7 +1584,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             verifier.VerifyIL("AllMembers.TestIMapIntIntMembers", <![CDATA[
 {
@@ -2492,7 +2492,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIVectorIntIVectorViewIntIMapIntIntIMapViewIntIntMembers", <![CDATA[
@@ -3699,7 +3699,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestISimpleInterfaceImplMembers", <![CDATA[
@@ -4036,7 +4036,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestCollectionInitializers", <![CDATA[
@@ -4206,7 +4206,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestExpressionTreeCompiler", <![CDATA[
@@ -4376,7 +4376,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 options:=TestOptions.ReleaseExe.WithModuleName("MODULE"),
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
@@ -4607,7 +4607,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestNamedArguments", <![CDATA[
@@ -4728,7 +4728,7 @@ End Class
     </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestNullableArgs", <![CDATA[
@@ -4963,7 +4963,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableVectorMembers", <![CDATA[
@@ -5183,7 +5183,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableIterableMembers", <![CDATA[
@@ -5337,7 +5337,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableVectorIVectorIntMembers", <![CDATA[
@@ -5688,7 +5688,7 @@ End Class
                 </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableIterableIIterableMembers", <![CDATA[
@@ -5819,7 +5819,7 @@ End Class
 
             Dim verifier = CompileAndVerify(
                 source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.INotifyCollectionAndBindableVectorMembers", <![CDATA[
@@ -6078,7 +6078,7 @@ End Class
 
             Dim verifier = CompileAndVerify(
                 source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.INotifyCollectionChangedMembers", <![CDATA[
@@ -6180,7 +6180,7 @@ End Class
 
             Dim verifier = CompileAndVerify(
                 source,
-                additionalRefs:=LegacyRefs,
+                references:=LegacyRefs,
                 verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.IPropertyChangedMembers", <![CDATA[
@@ -6238,7 +6238,7 @@ End Class
                 </compilation>
 
             Dim comp = CompileAndVerify(src,
-                                        additionalRefs:=LegacyRefs,
+                                        references:=LegacyRefs,
                                         verify:=Verification.Fails,
                                         options:=TestOptions.ReleaseExe)
 
@@ -6286,7 +6286,7 @@ End Namespace
 
             Dim verifier As CompilationVerifier = CompileAndVerify(source,
                 options:=TestOptions.ReleaseWinMD,
-                additionalRefs:=WinRtRefs)
+                references:=WinRtRefs)
 
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("Test.C.GetEnumerator()", <![CDATA[
@@ -6324,7 +6324,7 @@ End Namespace
                 </compilation>
 
             verifier = CompileAndVerify(source,
-                additionalRefs:=allRefs.ToArray())
+                references:=allRefs.ToArray())
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("Test2.D.Main", <![CDATA[
 {

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -1553,7 +1553,7 @@ Imports System
             </compilation>
 
             Dim verifier = CompileAndVerify(source,
-                                            additionalRefs:={TestReferences.SymbolsTests.DifferByCase.CsharpDifferCaseOverloads},
+                                            references:={TestReferences.SymbolsTests.DifferByCase.CsharpDifferCaseOverloads},
                                  expectedOutput:=<![CDATA[
 Keep calm and carry on.
 The authorities have been called.]]>)
@@ -3379,7 +3379,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib(source1, OutputKind.NetModule)
             Dim metadataRef = comp.EmitToImageReference()
-            CompileAndVerify(source2, additionalRefs:={metadataRef}, options:=TestOptions.ReleaseModule, verify:=Verification.Fails)
+            CompileAndVerify(source2, references:={metadataRef}, options:=TestOptions.ReleaseModule, verify:=Verification.Fails)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
@@ -4249,7 +4249,7 @@ BC35000: Requested operation is not available because the runtime library functi
 ]]></file>
                            </compilation>
             Dim reference1 = CompileIL(sources1, prependDefaultHeader:=False, embedInteropTypes:=True)
-            CompileAndVerify(sources2, additionalRefs:={reference1}, symbolValidator:=
+            CompileAndVerify(sources2, references:={reference1}, symbolValidator:=
                                                 Sub([module] As ModuleSymbol)
                                                     DirectCast([module], PEModuleSymbol).Module.PretendThereArentNoPiaLocalTypes()
                                                     Dim ia = [module].GlobalNamespace.GetMember(Of NamedTypeSymbol)("IA")
@@ -4320,7 +4320,7 @@ BC35000: Requested operation is not available because the runtime library functi
 ]]></file>
                            </compilation>
             Dim reference1 = CompileIL(sources1, prependDefaultHeader:=False, embedInteropTypes:=True)
-            CompileAndVerify(sources2, additionalRefs:={reference1}, symbolValidator:=
+            CompileAndVerify(sources2, references:={reference1}, symbolValidator:=
                                                 Sub([module] As ModuleSymbol)
                                                     DirectCast([module], PEModuleSymbol).Module.PretendThereArentNoPiaLocalTypes()
                                                     Dim ia = [module].GlobalNamespace.GetMember(Of NamedTypeSymbol)("IA")

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/OptionalArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/OptionalArgumentsTests.vb
@@ -192,7 +192,7 @@ End Module
 ]]></file>
 </compilation>
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 i = 1
 Member: OptionalArg
@@ -228,7 +228,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 Member: OptionalArg
 Parameter: Type=System.Int32, Name=i, Optional=True, DefaultValue=System.Reflection.Missing
@@ -265,7 +265,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 i = hello world
 Member: OptionalArg
@@ -303,7 +303,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 i = 1/26/2012 12:00:00 AM
 Member: OptionalArg
@@ -342,7 +342,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 i = 999.99
 Member: OptionalArg
@@ -387,7 +387,7 @@ End Class
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:="Nothing;Nothing;C1;")
         End Sub
 
@@ -421,7 +421,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 Member: OptionalArg
 Parameter: Type=System.DateTime, Name=i, Optional=False, DefaultValue=1/26/2012 12:00:00 AM
@@ -458,7 +458,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 Member: OptionalArg
 Parameter: Type=System.DateTime, Name=i, Optional=True, DefaultValue=1/26/2012 12:00:00 AM
@@ -507,7 +507,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
    1/26/2012 12:00:00 AM
 ]]>)
@@ -538,7 +538,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
    999.99
 ]]>)
@@ -566,7 +566,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 1/1/0001 12:00:00 AM
 ]]>)
@@ -651,7 +651,7 @@ End Module
 </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 True
 True
@@ -1195,7 +1195,7 @@ End Module
 </compilation>
             Dim comp = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source, additionalRefs:={_classLibrary})
             CompileAndVerify(source,
-                 additionalRefs:={_classLibrary},
+                 references:={_classLibrary},
                  expectedOutput:=<![CDATA[
    0
 False
@@ -1222,7 +1222,7 @@ End Module
 ]]></file>
 </compilation>
             CompileAndVerify(source,
-                             additionalRefs:={_classLibrary},
+                             references:={_classLibrary},
                              expectedOutput:=<![CDATA[
 Member: get_PropertyIntegerOptionalDouble
 Parameter: Type=System.Int32, Name=i, Optional=False, DefaultValue=
@@ -1308,7 +1308,7 @@ End Module
             Dim comp = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source, additionalRefs:={_classLibrary})
             comp.VerifyDiagnostics()
             CompileAndVerify(source,
-                 additionalRefs:={_classLibrary},
+                 references:={_classLibrary},
                  expectedOutput:=<![CDATA[
 ]]>)
         End Sub
@@ -1332,7 +1332,7 @@ End Module
             Dim comp = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntimeAndReferences(source, additionalRefs:={_classLibrary})
             comp.VerifyDiagnostics()
             CompileAndVerify(source,
-                 additionalRefs:={_classLibrary},
+                 references:={_classLibrary},
                  expectedOutput:=<![CDATA[
 Member: TestWithMultipleOptionalEnumValues
 Parameter: Type=Library+Animal, Name=e1, Optional=True, DefaultValue=Dog

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -35,7 +35,7 @@ End Module]]></file>
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  options:=TestOptions.ReleaseExe.WithOverflowChecks(True),
                  expectedOutput:=<![CDATA[
 Lambda(
@@ -730,13 +730,13 @@ Lambda(
 ]]>
 
             CompileAndVerify(source,
-                          additionalRefs:={SystemCoreRef},
+                          references:={SystemCoreRef},
                           options:=TestOptions.ReleaseExe.WithOverflowChecks(True),
                           expectedOutput:=expected
             )
 
             CompileAndVerify(source,
-                        additionalRefs:={SystemCoreRef},
+                        references:={SystemCoreRef},
                         options:=TestOptions.ReleaseExe.WithOverflowChecks(False),
                         expectedOutput:=expected
             )
@@ -1199,7 +1199,7 @@ Lambda(
                          </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              options:=TestOptions.ReleaseExe.WithOverflowChecks(checked),
                              expectedOutput:=result.Trim
             ).VerifyDiagnostics()
@@ -1221,7 +1221,7 @@ Lambda(
                          </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              options:=TestOptions.ReleaseExe.WithOverflowChecks(checked),
                              expectedOutput:=result.Trim
             ).VerifyDiagnostics()
@@ -1446,7 +1446,7 @@ Lambda(
                          </compilation>
 
             CompileAndVerify(source,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              options:=TestOptions.ReleaseExe.WithOverflowChecks(checked),
                              expectedOutput:=result.Trim
             ).VerifyDiagnostics(Diagnostic(ERRID.WRN_ObsoleteIdentityDirectCastForValueType, "x"),
@@ -1829,7 +1829,7 @@ End Structure
                 </compilation>,
                 options:=If(optimize, TestOptions.ReleaseExe, TestOptions.DebugExe).WithOverflowChecks(checked),
                 expectedOutput:=If(result IsNot Nothing, result.Trim, Nothing),
-                additionalRefs:=If(addXmlReferences, XmlReferences, {}),
+                references:=If(addXmlReferences, XmlReferences, {}),
                 useLatestFramework:=latestReferences)
         End Function
 
@@ -1917,7 +1917,7 @@ End Module
             Dim src = source...<file>.Value
 
             CompileAndVerify(source,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              options:=TestOptions.ReleaseExe.WithOverflowChecks(checked),
                              expectedOutput:=result.Trim
             ).VerifyDiagnostics(If(diagnostics, {}))
@@ -2010,7 +2010,7 @@ End Module
 ]]></file>
                          </compilation>
 
-            CompileAndVerify(source, additionalRefs:={SystemCoreRef}).VerifyDiagnostics()
+            CompileAndVerify(source, references:={SystemCoreRef}).VerifyDiagnostics()
         End Sub
 
         <Fact, WorkItem(577271, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/577271")>
@@ -6600,7 +6600,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:=<![CDATA[
 Lambda(
   Parameter(
@@ -6658,7 +6658,7 @@ End Class
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:=<![CDATA[
 Lambda(
   Parameter(
@@ -6762,7 +6762,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:=<![CDATA[
 Infer A=System.Decimal
 Infer B=System.String
@@ -6805,7 +6805,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:=<![CDATA[Where Select]]>).VerifyDiagnostics()
         End Sub
 
@@ -6855,7 +6855,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:="GroupBy 1;Select;GroupBy 2;Select;").VerifyDiagnostics()
         End Sub
 
@@ -6898,7 +6898,7 @@ End Module]]></file>
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:="GroupJoin;").VerifyDiagnostics()
         End Sub
 
@@ -6981,7 +6981,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:=<![CDATA[A1 B2 C1 D2 E1 F2]]>)
         End Sub
 
@@ -7022,7 +7022,7 @@ End Module]]></file>
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:=<![CDATA[f1 f1 g1]]>)
         End Sub
 
@@ -7049,7 +7049,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:="() => (value(Form1+_Closure$__0-0).$VB$Local_s1_a ?? Convert(value(Form1+_Closure$__0-0).$VB$Local_s1_b))").VerifyDiagnostics()
         End Sub
 
@@ -7167,7 +7167,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:="10").VerifyDiagnostics()
         End Sub
 
@@ -7246,7 +7246,7 @@ end class
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:="m => m").VerifyDiagnostics()
         End Sub
 
@@ -7286,7 +7286,7 @@ End Class
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  expectedOutput:="").VerifyDiagnostics()
         End Sub
 
@@ -8275,7 +8275,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 () => (value(M+_Closure$__2-0`1[M+X]).$VB$Local_x == null)
@@ -8334,7 +8334,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 () => (value(M+_Closure$__2-0`1[M+X]).$VB$Local_x == null)
@@ -8375,7 +8375,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 () => Concat(value(M+_Closure$__0-0).$VB$Local_str, null)
@@ -8428,7 +8428,7 @@ End Namespace
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 In catch
@@ -8492,7 +8492,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 x => x.set_City(ItIs(s => IsNullOrEmpty(s)))
@@ -8568,7 +8568,7 @@ End Module
                          </compilation>
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 x => x.set_City(1, ItIs(s => IsNullOrEmpty(s)))
@@ -8684,7 +8684,7 @@ End Class
 
 
             CompileAndVerify(source,
-                 additionalRefs:={SystemCoreRef},
+                 references:={SystemCoreRef},
                  options:=TestOptions.ReleaseExe,
                  expectedOutput:=<![CDATA[
 42

--- a/src/Compilers/VisualBasic/Test/Emit/Perf.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Perf.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
                                  <file name="VBPerfTest.vb">
                                      <%= TestResources.PerfTests.VBPerfTest %>
                                  </file>
-                             </compilation>, additionalRefs:={SystemCoreRef}).VerifyDiagnostics()
+                             </compilation>, references:={SystemCoreRef}).VerifyDiagnostics()
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/XmlLiteralTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/XmlLiteralTests.vb
@@ -24,7 +24,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <!-- comment -->
 ]]>)
             compilation.VerifyIL("M..cctor", <![CDATA[
@@ -63,7 +63,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <!-- A -->
 <?p?>
 <x>
@@ -166,7 +166,7 @@ Partial Class C
 End Class
 ]]>
     </file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x a="0" />
 x, a
 <x a="1" xmlns="http://roslyn/default1" />
@@ -221,7 +221,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 1
 4
 
@@ -387,7 +387,7 @@ Partial Class C
     Private Shared F4 As XElement = <p1:x a="a2" p2:b="b2"/>
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <p:x xmlns="http://roslyn/p" a="a1" p:b="b1" xmlns:p="http://roslyn/p" />
 a1
 [none]
@@ -436,7 +436,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 0
 
 http://roslyn/default
@@ -480,7 +480,7 @@ Partial Class C
     Private Shared F2 As XElement = <x xmlns="http://roslyn/2" xmlns:q="http://roslyn/q"/>
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns="http://roslyn/1" xmlns:p="http://roslyn/p" />
 http://roslyn/1
 [none]
@@ -525,7 +525,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 1
 1
 <c>1</c>
@@ -609,7 +609,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <c>1</c>
 <c>4</c>
 <p3:c xmlns:p3="http://roslyn/p">3</p3:c>
@@ -799,7 +799,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <y />
 <y />
 1
@@ -860,7 +860,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <y />
 <y />
 1
@@ -956,7 +956,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <pb:b xmlns:pb="http://roslyn" />
 <pa:c xmlns:pa="http://roslyn" />
 <pa:d xmlns:pa="http://roslyn" />
@@ -1029,7 +1029,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x a="1">
   <y />
   <y />
@@ -1057,7 +1057,7 @@ Module M
 End Module
 ]]>
     </file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x a="12" b="3" />
 ]]>)
         End Sub
@@ -1075,7 +1075,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 b
 c
 ]]>)
@@ -1101,7 +1101,7 @@ Module M
 End Module
 ]]>
     </file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x a="2" />
 ]]>)
         End Sub
@@ -1121,7 +1121,7 @@ Module M
 End Module
 ]]>
     </file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:="b")
+</compilation>, references:=XmlReferences, expectedOutput:="b")
         End Sub
 
         ' Project-level imports should be used if file-level
@@ -1154,7 +1154,7 @@ Class C
     End Sub
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, options:=options, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, options:=options, expectedOutput:=<![CDATA[
 default1
 p1
 q2
@@ -1252,7 +1252,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, options:=options, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, options:=options, expectedOutput:=<![CDATA[
 <x xmlns:p="http://roslyn/p" xmlns="http://roslyn">
   <p:y />
 </x>
@@ -1287,7 +1287,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <p:x xmlns="http://roslyn/default" xmlns:p="http://roslyn/p">
   <y />
   <z xmlns="" />
@@ -1359,7 +1359,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns="http://roslyn/default" xmlns:p="http://roslyn/p" xmlns:q="http://roslyn/q">
   <p:y1 />
   <p:y2 />
@@ -1435,7 +1435,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <a xmlns:p1="http://roslyn/1" xmlns:p2="http://roslyn/2">
   <b>
     <c>
@@ -1526,7 +1526,7 @@ Partial Class C
     End Function
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x>
   <y />
   <y xmlns="http://roslyn/2" />
@@ -1576,7 +1576,7 @@ Module N
     Public F As Object = <p:z q:a="b" s:c="d"/>
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns:r="http://roslyn/r" xmlns:q="http://roslyn/q1" xmlns:p="http://roslyn/p" xmlns:s="http://roslyn/r">
   <y>
     <p:z q:a="b" s:c="d" />
@@ -1607,7 +1607,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns:p="http://roslyn/">
   <p:y />
 </x>
@@ -1644,7 +1644,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns:q="http://roslyn/q" xmlns:p="http://roslyn/p">
   <p:y q:a="b" />
   <p:z />
@@ -1679,7 +1679,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <p:x xmlns:p="http://roslyn/p" xmlns:q="http://roslyn/q">
   <q:y />
 </p:x>
@@ -1705,7 +1705,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x x="..." />
 ]]>)
             compilation.VerifyIL("M..cctor", <![CDATA[
@@ -1751,7 +1751,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x x="..." />
 <y p1:y="..." xmlns:p1="http://roslyn" xmlns="http://roslyn" />
 <z z="...">z</z>
@@ -1827,7 +1827,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 [1] <x a1="b1" />
 [1] <x a2="b2" />
 [1] <x a3="3" />
@@ -1915,7 +1915,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <w w="f" />
 <x>f</x>
 <y>
@@ -1957,7 +1957,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x1>s</x1>
 <x2>s</x2>
 <y1>n</y1>
@@ -2034,7 +2034,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x0>
   <c1 />
   <c2 />
@@ -2311,7 +2311,7 @@ Module M
     End Function
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences)
+</compilation>, references:=XmlReferences)
             compilation.VerifyIL("M.F", <![CDATA[
 {
   // Code size      114 (0x72)
@@ -2413,7 +2413,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x />
 <x a="b">c</x>
 <x1 a1="b1" a2="b2">c1c2</x1>
@@ -2629,7 +2629,7 @@ Class C
     End Sub
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <f />
 <g />
 ]]>)
@@ -2677,7 +2677,7 @@ Class C
     End Sub
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 &'><"XYZ
 &'><"XYZ
 ]]>)
@@ -2748,7 +2748,7 @@ Module M
     End Sub
 End Module
 </file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:="System.Xml.Linq.XCData: <![CDATA[value]]>")
+</compilation>, references:=XmlReferences, expectedOutput:="System.Xml.Linq.XCData: <![CDATA[value]]>")
             compilation.VerifyIL("M.Main", <![CDATA[
 {
   // Code size       29 (0x1d)
@@ -2785,7 +2785,7 @@ Module M
     End Sub
 End Module
 </file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:="<b>" & vbLf & "  <c/>" & vbLf & "</>")
+</compilation>, references:=XmlReferences, expectedOutput:="<b>" & vbLf & "  <c/>" & vbLf & "</>")
         End Sub
 
         <Fact()>
@@ -2809,7 +2809,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 http://www.w3.org/XML/1998/namespace
 http://www.w3.org/2000/xmlns/
 
@@ -2883,7 +2883,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 [x,    ]: <x xmlns="   " />
 [y, http://roslyn]: <y xmlns="http://roslyn" />
 ]]>)
@@ -2905,7 +2905,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 [x, http://roslyn/2]: <x xmlns="http://roslyn/2" />
 ]]>)
         End Sub
@@ -2965,7 +2965,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences)
+</compilation>, references:=XmlReferences)
             compilation.VerifyIL("M.M(Of T)", <![CDATA[
 {
   // Code size      166 (0xa6)
@@ -3177,7 +3177,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x>
   <y>content2</y>
   <z>3</z>
@@ -3446,7 +3446,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <y>
   <z> nested </z>
 </y>
@@ -3595,7 +3595,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 {N0}x1: <x1 a="b" xmlns="N0" />
   a
   xmlns
@@ -3640,7 +3640,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 [Nothing]
 ]]>)
             compilation.Compilation.AssertTheseDiagnostics(<errors><![CDATA[
@@ -3700,7 +3700,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x0 a="b" xmlns:p="http://roslyn/" />
 <x1 p:a="b" xmlns:p="http://roslyn/" />
 <x2 xmlns:p="http://roslyn/">
@@ -3770,7 +3770,7 @@ Partial Class C
     End Sub
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns:p="http://roslyn/" />
 <x xmlns:p="http://roslyn/" />
 ]]>)
@@ -3852,7 +3852,7 @@ Partial Class C
     End Function
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns:p="http://roslyn/p">
   <p:y />
 </x>
@@ -3891,7 +3891,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x a="1" />
 <x a="1" xmlns="" />
 <x xmlns="">
@@ -3927,7 +3927,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x a="1" p:b="2" xmlns:p="ns" xmlns="default" />
 <x a="1" p:b="2" xmlns:p="ns" xmlns="" />
 <p:x a="1" b="2" xmlns:p="ns" />
@@ -4062,7 +4062,7 @@ Class C(Of T)
     End Function
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences)
+</compilation>, references:=XmlReferences)
             Assert.True(CallsRemoveNamespaceAttributes(verifier.VisualizeIL("C(Of T).F1()")))
             Assert.False(CallsRemoveNamespaceAttributes(verifier.VisualizeIL("C(Of T).F2()")))
             Assert.False(CallsRemoveNamespaceAttributes(verifier.VisualizeIL("C(Of T).F3()")))
@@ -4110,7 +4110,7 @@ Module M
     End Function
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences)
+</compilation>, references:=XmlReferences)
             Assert.False(CallsRemoveNamespaceAttributes(verifier.VisualizeIL("M.F1()")))
 
             ' xmlns attribute.
@@ -4127,7 +4127,7 @@ Module M
     End Function
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences)
+</compilation>, references:=XmlReferences)
             Assert.False(CallsRemoveNamespaceAttributes(verifier.VisualizeIL("M.F1()")))
 
             ' Imports <...> in file.
@@ -4145,7 +4145,7 @@ Module M
     End Function
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences)
+</compilation>, references:=XmlReferences)
             Assert.True(CallsRemoveNamespaceAttributes(verifier.VisualizeIL("M.F1()")))
 
             ' Imports <...> at project scope.
@@ -4163,7 +4163,7 @@ Module M
     End Function
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, options:=options)
+</compilation>, references:=XmlReferences, options:=options)
             Assert.True(CallsRemoveNamespaceAttributes(verifier.VisualizeIL("M.F1()")))
         End Sub
 
@@ -4196,7 +4196,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 [0] <x />
 [0] <x></x>
 [0] <x></x>
@@ -4307,7 +4307,7 @@ Class scen1(Of T As XElement)
     End Sub
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, options:=TestOptions.ReleaseDll).
+</compilation>, references:=XmlReferences, options:=TestOptions.ReleaseDll).
             VerifyIL("scen1(Of T).goo(T)",
             <![CDATA[
 {
@@ -4363,7 +4363,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, options:=options, expectedOutput:=expectedOutput)
+</compilation>, references:=XmlReferences, options:=options, expectedOutput:=expectedOutput)
         End Sub
 
         <WorkItem(623035, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/623035")>
@@ -4423,7 +4423,7 @@ Module Program
 End Module
 ]]>
     </file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[True]]>)
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[True]]>)
         End Sub
 
         <WorkItem(814075, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/814075")>
@@ -4447,7 +4447,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 x => get_Value(x.Elements(Get("y", "")))
 content
 ]]>)
@@ -4585,7 +4585,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns:p="http://roslyn/">
   <y>
     <p:z />
@@ -4707,7 +4707,7 @@ Class C
     End Sub
 End Class
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns:r="http://roslyn/r" xmlns:q="http://roslyn/q" xmlns:p="http://roslyn/p">
   <y>
     <a>
@@ -4896,7 +4896,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <x xmlns:q="http://roslyn/q" xmlns:p="http://roslyn/p">
   <y>
     <p:z />
@@ -4933,7 +4933,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, references:=XmlReferences, expectedOutput:=<![CDATA[
 <q:y xmlns:q="http://roslyn/q" />
 <p:x xmlns:p="http://roslyn/p" xmlns:r="http://roslyn/r">
   <r:z />

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Expressions_Tests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/Binder_Expressions_Tests.vb
@@ -69,7 +69,7 @@ expectedOutput:="123")
     <file name="a.vb">
         <%= My.Resources.Resource.T_68086 %>
     </file>
-</compilation>, additionalRefs:={MsvbRef})
+</compilation>, references:={MsvbRef})
         End Sub
 
         <WorkItem(707924, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/707924")>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/ForEachTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/ForEachTests.vb
@@ -3238,7 +3238,7 @@ BC30105: Number of indices is less than the number of dimensions of the indexed 
 1
 2
 3
-]]>, additionalRefs:={SystemCoreRef})
+]]>, references:={SystemCoreRef})
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/AnonymousTypesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/AnonymousTypesTests.vb
@@ -659,7 +659,7 @@ BC36556: Anonymous type member name can be inferred only from a simple or qualif
                           ~~~~~~~~~~~~~~~~~~~~~~~
 ]]>.Value
 
-            VerifyOperationTreeAndDiagnosticsForTest(Of AnonymousObjectCreationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics, additionalReferences:=XmlReferences)
+            VerifyOperationTreeAndDiagnosticsForTest(Of AnonymousObjectCreationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics, references:=XmlReferences)
         End Sub
 
         <CompilerTrait(CompilerFeature.IOperation)>
@@ -680,7 +680,7 @@ IAnonymousObjectCreationOperation (OperationKind.AnonymousObjectCreation, Type: 
 
             Dim expectedDiagnostics = String.Empty
 
-            VerifyOperationTreeAndDiagnosticsForTest(Of AnonymousObjectCreationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics, additionalReferences:=XmlReferences)
+            VerifyOperationTreeAndDiagnosticsForTest(Of AnonymousObjectCreationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics, references:=XmlReferences)
         End Sub
 
         <CompilerTrait(CompilerFeature.IOperation)>
@@ -705,7 +705,7 @@ BC36613: Anonymous type member name cannot be inferred from an XML identifier th
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ]]>.Value
 
-            VerifyOperationTreeAndDiagnosticsForTest(Of AnonymousObjectCreationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics, additionalReferences:=XmlReferences)
+            VerifyOperationTreeAndDiagnosticsForTest(Of AnonymousObjectCreationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics, references:=XmlReferences)
         End Sub
 
         <CompilerTrait(CompilerFeature.IOperation)>
@@ -760,7 +760,7 @@ BC36613: Anonymous type member name cannot be inferred from an XML identifier th
                             ~~~~~~~~
 ]]>.Value
 
-            VerifyOperationTreeAndDiagnosticsForTest(Of MethodBlockSyntax)(source, expectedOperationTree, expectedDiagnostics, additionalReferences:=XmlReferences)
+            VerifyOperationTreeAndDiagnosticsForTest(Of MethodBlockSyntax)(source, expectedOperationTree, expectedDiagnostics, references:=XmlReferences)
         End Sub
 
         <CompilerTrait(CompilerFeature.IOperation)>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/MethodCalls.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/MethodCalls.vb
@@ -2983,7 +2983,7 @@ End Module
             Dim assemblyPath = TestReferences.SymbolsTests.DelegateImplementation.DelegateByRefParamArray
 
             CompileAndVerify(source,
-                        additionalRefs:={assemblyPath},
+                        references:={assemblyPath},
                          expectedOutput:=<![CDATA[
 Called SubWithByRefParamArrayOfReferenceTypes_Identify_1.
 True
@@ -3086,7 +3086,7 @@ End Class
     </file>
 </compilation>
             CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 get_P1(123)
 123
@@ -3154,7 +3154,7 @@ End Module
     </file>
 </compilation>
             Dim compilationVerifier = CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 get_P1(1)
 PassByRef: 2, 1.
@@ -3225,7 +3225,7 @@ End Module
     </file>
 </compilation>
             Dim compilationVerifier = CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 get_P1(1)
 PassByRef: 2, 1.
@@ -3295,7 +3295,7 @@ End Module
     </file>
 </compilation>
             Dim compilationVerifier = CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 get_P1(1)
 PassByRef: 2, 1.
@@ -3369,7 +3369,7 @@ End Module
     </file>
 </compilation>
             Dim compilationVerifier = CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 get_P1(1)
 PassByRef: 2, 1.
@@ -3442,7 +3442,7 @@ End Module
     </file>
 </compilation>
             Dim compilationVerifier = CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 get_P1(1)
 PassByRef: 2, 1.
@@ -3558,7 +3558,7 @@ End Class
     </file>
 </compilation>
             Dim compilationVerifier = CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 get_P1(123)
 PassByRef: 124, 123.
@@ -3738,7 +3738,7 @@ End Class
     </file>
 </compilation>
             Dim compilationVerifier = CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 101
 101
@@ -4074,7 +4074,7 @@ End Module
     </file>
 </compilation>
             CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 get_P1(123)
 123
@@ -4208,7 +4208,7 @@ End Module
     </file>
 </compilation>
             CompileAndVerify(source,
-                        additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef},
+                        references:={TestReferences.SymbolsTests.PropertiesWithByRef},
                          expectedOutput:=<![CDATA[
 100
 0

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/MyBaseMyClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/MyBaseMyClassTests.vb
@@ -3990,7 +3990,7 @@ End Module
 
             Dim verifier = CompileAndVerify(compilationDef,
                              options:=TestOptions.DebugDll,
-                             additionalRefs:={SystemCoreRef})
+                             references:={SystemCoreRef})
 
 
             Dim _assembly = Assembly.Load(verifier.EmittedAssemblyData.ToArray())

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
@@ -330,11 +330,11 @@ End Class
 
             Dim libComp = CreateCompilationWithMscorlibAndVBRuntime(lib_vb, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15))
 
-            Dim verifier1 = CompileAndVerify(source, expectedOutput:="1 2.", additionalRefs:={libComp.ToMetadataReference()},
+            Dim verifier1 = CompileAndVerify(source, expectedOutput:="1 2.", references:={libComp.ToMetadataReference()},
                                             parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
             verifier1.VerifyDiagnostics()
 
-            Dim verifier2 = CompileAndVerify(source, expectedOutput:="1 2.", additionalRefs:={libComp.EmitToImageReference()},
+            Dim verifier2 = CompileAndVerify(source, expectedOutput:="1 2.", references:={libComp.EmitToImageReference()},
                                             parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
             verifier2.VerifyDiagnostics()
         End Sub

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/OptionalArgumentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/OptionalArgumentTests.vb
@@ -704,7 +704,7 @@ End Module
 
             Dim metadataRef = MetadataReference.CreateFromImage(libComp.EmitToArray())
 
-            CompileAndVerify(source, additionalRefs:={metadataRef}, expectedOutput:=<![CDATA[
+            CompileAndVerify(source, references:={metadataRef}, expectedOutput:=<![CDATA[
 1
 System.Reflection.Missing
 3
@@ -765,7 +765,7 @@ End Module
 
             Dim libRef = MetadataReference.CreateFromImage(libComp.EmitToArray())
 
-            CompileAndVerify(source, additionalRefs:=New MetadataReference() {libRef}, expectedOutput:=<![CDATA[
+            CompileAndVerify(source, references:=New MetadataReference() {libRef}, expectedOutput:=<![CDATA[
 1
 2
 ]]>).VerifyDiagnostics()
@@ -854,7 +854,7 @@ System.Runtime.InteropServices.DispatchWrapper
 ]]>
 
             Dim metadataRef = MetadataReference.CreateFromImage(libComp.EmitToArray())
-            Dim verifier = CompileAndVerify(source, additionalRefs:={metadataRef}, expectedOutput:=expected).VerifyDiagnostics()
+            Dim verifier = CompileAndVerify(source, references:={metadataRef}, expectedOutput:=expected).VerifyDiagnostics()
             Dim compilation = verifier.Compilation
 
             Dim tree = compilation.SyntaxTrees.Single()
@@ -946,7 +946,7 @@ End Module
 
             libRef = MetadataReference.CreateFromImage(libComp.EmitToArray())
 
-            CompileAndVerify(source, additionalRefs:=New MetadataReference() {libRef}, expectedOutput:=<![CDATA[
+            CompileAndVerify(source, references:=New MetadataReference() {libRef}, expectedOutput:=<![CDATA[
 System.Reflection.Missing
 nothing
 0
@@ -1010,7 +1010,7 @@ End Module
 </compilation>
             Dim libRef As MetadataReference = libComp.ToMetadataReference()
 
-            CompileAndVerify(source, additionalRefs:=New MetadataReference() {libRef}, expectedOutput:=<![CDATA[
+            CompileAndVerify(source, references:=New MetadataReference() {libRef}, expectedOutput:=<![CDATA[
 True
 5
 a
@@ -1019,7 +1019,7 @@ a
 
             libRef = MetadataReference.CreateFromImage(libComp.EmitToArray())
 
-            CompileAndVerify(source, additionalRefs:=New MetadataReference() {libRef}, expectedOutput:=<![CDATA[
+            CompileAndVerify(source, references:=New MetadataReference() {libRef}, expectedOutput:=<![CDATA[
 False
 0
 0
@@ -1027,7 +1027,7 @@ False
 ]]>).VerifyDiagnostics()
 
             CompileAndVerify(source,
-                             additionalRefs:=New MetadataReference() {libRef},
+                             references:=New MetadataReference() {libRef},
                              options:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication, optionCompareText:=True),
                              expectedOutput:=<![CDATA[
 True

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions.vb
@@ -5273,7 +5273,7 @@ End Module
     </file>
 </compilation>
 
-            CompileAndVerify(compilationDef, additionalRefs:={LinqAssemblyRef},
+            CompileAndVerify(compilationDef, references:={LinqAssemblyRef},
                                 expectedOutput:=
             <![CDATA[
 { s = 1, t = 2 }
@@ -5562,7 +5562,7 @@ End Module
     </file>
 </compilation>
 
-            CompileAndVerify(compilationDef, additionalRefs:={LinqAssemblyRef},
+            CompileAndVerify(compilationDef, references:={LinqAssemblyRef},
                                 expectedOutput:=
             <![CDATA[
 { s1 = 1, s2 = 2 }
@@ -6515,7 +6515,7 @@ End Module
     </file>
 </compilation>
 
-            CompileAndVerify(compilationDef, additionalRefs:={LinqAssemblyRef},
+            CompileAndVerify(compilationDef, references:={LinqAssemblyRef},
                                 expectedOutput:=
             <![CDATA[
 { s1 = 1, s2 = 2 }
@@ -7310,7 +7310,7 @@ End Module
     </file>
 </compilation>
 
-            CompileAndVerify(compilationDef, additionalRefs:={LinqAssemblyRef},
+            CompileAndVerify(compilationDef, references:={LinqAssemblyRef},
                                 expectedOutput:=
             <![CDATA[
 { s1 = 3, s2 = 3 }
@@ -8617,7 +8617,7 @@ End Module
     </file>
 </compilation>
 
-            CompileAndVerify(compilationDef, additionalRefs:={LinqAssemblyRef},
+            CompileAndVerify(compilationDef, references:={LinqAssemblyRef},
                                 expectedOutput:=
             <![CDATA[
 { s1 = 1, Group = System.Int32[] }
@@ -9672,7 +9672,7 @@ End Module
     </file>
 </compilation>
 
-            CompileAndVerify(compilationDef, additionalRefs:={LinqAssemblyRef},
+            CompileAndVerify(compilationDef, references:={LinqAssemblyRef},
                                 expectedOutput:=
             <![CDATA[
 { s1 = 1, Group = System.Int32[] }
@@ -11220,7 +11220,7 @@ End Module
     </file>
 </compilation>
 
-            CompileAndVerify(compilationDef, additionalRefs:={LinqAssemblyRef},
+            CompileAndVerify(compilationDef, references:={LinqAssemblyRef},
                                 expectedOutput:=
             <![CDATA[
 2
@@ -13547,7 +13547,7 @@ Class CI003
 End Class
     </file>
     </compilation>,
-            expectedOutput:="CI003.Count", additionalRefs:={TestReferences.NetFx.v4_0_30319.System_Core})
+            expectedOutput:="CI003.Count", references:={TestReferences.NetFx.v4_0_30319.System_Core})
 
             verifier.VerifyDiagnostics()
         End Sub
@@ -13914,7 +13914,7 @@ End Module
     </file>
 </compilation>
 
-            Dim verifier = CompileAndVerify(compilationDef, additionalRefs:={SystemCoreRef},
+            Dim verifier = CompileAndVerify(compilationDef, references:={SystemCoreRef},
                              expectedOutput:=
             <![CDATA[
 0

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousDelegates/AnonymousDelegates_CreationAndEmit.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousDelegates/AnonymousDelegates_CreationAndEmit.vb
@@ -149,7 +149,7 @@ End Module
     </file>
 </compilation>
 
-            CompileAndVerify(compilationDef, options:=TestOptions.ReleaseExe, additionalRefs:={SystemCoreRef},
+            CompileAndVerify(compilationDef, options:=TestOptions.ReleaseExe, references:={SystemCoreRef},
                              expectedOutput:=
             <![CDATA[
 1

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesEmittedSymbolsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesEmittedSymbolsTests.vb
@@ -64,7 +64,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`3")
                                                   Assert.NotNull(type)
@@ -90,7 +90,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim types = m.ContainingAssembly.GlobalNamespace.GetTypeMembers()
                                                   Dim list = types.Where(Function(t) t.Name.StartsWith("VB$AnonymousType_", StringComparison.Ordinal)).ToList()
@@ -132,7 +132,7 @@ End Structure
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim types = m.ContainingAssembly.GlobalNamespace.GetTypeMembers()
                                                   Dim list = types.Where(Function(t) t.Name.StartsWith("VB$AnonymousType", StringComparison.Ordinal)).ToList()
@@ -177,7 +177,7 @@ End Class
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim types = m.ContainingAssembly.GlobalNamespace.GetTypeMembers()
                                                   Dim list = types.Where(Function(t) t.Name.StartsWith("VB$AnonymousType", StringComparison.Ordinal)).ToList()
@@ -225,7 +225,7 @@ End Class
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef, TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll})
+                             references:={SystemCoreRef, TestReferences.SymbolsTests.CustomModifiers.Modifiers.dll})
         End Sub
 
         <Fact>
@@ -292,7 +292,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`1")
                                                   Assert.NotNull(type)
@@ -336,7 +336,7 @@ End Module
             ' Cycle to hopefully get different order of files
             For i = 0 To 50
                 CompileAndVerify(compilationDef,
-                                 additionalRefs:={SystemCoreRef},
+                                 references:={SystemCoreRef},
                                  symbolValidator:=Sub(m As ModuleSymbol)
                                                       Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`1")
                                                       Assert.NotNull(type)
@@ -365,7 +365,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`3")
                                                   Assert.NotNull(type)
@@ -402,7 +402,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`3")
                                                   Assert.NotNull(type)
@@ -433,7 +433,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`3")
                                                   Assert.NotNull(type)
@@ -460,7 +460,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`3")
                                                   Assert.NotNull(type)
@@ -499,7 +499,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`3")
                                                   Assert.NotNull(type)
@@ -530,7 +530,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`3")
                                                   Assert.NotNull(type)
@@ -574,7 +574,7 @@ End Module
             Dim position = compilationDef.<file>.Value.IndexOf("'POSITION", StringComparison.Ordinal)
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              sourceSymbolValidator:=Sub(m As ModuleSymbol)
                                                         Dim compilation = m.DeclaringCompilation
                                                         Dim tree = compilation.SyntaxTrees(0)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
@@ -1498,7 +1498,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(1, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1529,7 +1529,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(1, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1562,7 +1562,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(1, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1594,7 +1594,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(1, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1624,7 +1624,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(0, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",
@@ -1653,7 +1653,7 @@ End Module
     </compilation>
 
             CompileAndVerify(compilationDef,
-                             additionalRefs:={SystemCoreRef},
+                             references:={SystemCoreRef},
                              symbolValidator:=Sub(m As ModuleSymbol)
                                                   Assert.Equal(0, m.ContainingAssembly.
                                                                   GetAttributes("System.Runtime.CompilerServices",

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/InaccessibleOverriding.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/InaccessibleOverriding.vb
@@ -73,7 +73,7 @@ Public Module Module1
 End Module
 ]]>
                     </file>
-                </compilation>, additionalRefs:={proj1ref, proj2ref}, expectedOutput:="Class3.f")
+                </compilation>, references:={proj1ref, proj2ref}, expectedOutput:="Class3.f")
 
             proj3.VerifyDiagnostics()   ' no errors.
         End Sub
@@ -144,7 +144,7 @@ Public Module Module1
 End Module
 ]]>
                     </file>
-                </compilation>, additionalRefs:={proj1ref, proj2ref}, expectedOutput:="Class3.P")
+                </compilation>, references:={proj1ref, proj2ref}, expectedOutput:="Class3.P")
 
             proj3.VerifyDiagnostics()   ' no errors.
         End Sub
@@ -421,7 +421,7 @@ Public Module Module1
 End Module
 ]]>
                             </file>
-                        </compilation>, additionalRefs:={proj1Ref, proj2Ref}, expectedOutput:="Class3.f")
+                        </compilation>, references:={proj1Ref, proj2Ref}, expectedOutput:="Class3.f")
 
                     proj3.VerifyDiagnostics()   ' no errors.
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/InAttributeModifierTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/InAttributeModifierTests.vb
@@ -31,7 +31,7 @@ End Class
     </file>
                 </compilation>
 
-            CompileAndVerify(source, additionalRefs:={reference}, expectedOutput:="5")
+            CompileAndVerify(source, references:={reference}, expectedOutput:="5")
         End Sub
 
         <Fact>
@@ -58,7 +58,7 @@ End Class
     </file>
                 </compilation>
 
-            CompileAndVerify(source, additionalRefs:={reference}, expectedOutput:="5")
+            CompileAndVerify(source, references:={reference}, expectedOutput:="5")
         End Sub
 
         <Fact>
@@ -88,7 +88,7 @@ End Class
     </file>
                 </compilation>
 
-            CompileAndVerify(source, additionalRefs:={reference}, expectedOutput:="5")
+            CompileAndVerify(source, references:={reference}, expectedOutput:="5")
         End Sub
 
         <Fact>
@@ -113,7 +113,7 @@ End Class
     </file>
                 </compilation>
 
-            CompileAndVerify(source, additionalRefs:={reference}, expectedOutput:="4")
+            CompileAndVerify(source, references:={reference}, expectedOutput:="4")
         End Sub
 
         <Fact>
@@ -907,7 +907,7 @@ End Class
     </file>
                 </compilation>
 
-            CompileAndVerify(source, additionalRefs:={reference}, expectedOutput:="20")
+            CompileAndVerify(source, references:={reference}, expectedOutput:="20")
         End Sub
 
         <Fact>
@@ -941,7 +941,7 @@ End Class
     </file>
                 </compilation>
 
-            CompileAndVerify(source, additionalRefs:={reference}, expectedOutput:="20")
+            CompileAndVerify(source, references:={reference}, expectedOutput:="20")
         End Sub
 
         <Fact>
@@ -978,7 +978,7 @@ End Class
     </file>
                 </compilation>
 
-            CompileAndVerify(source, additionalRefs:={reference}, expectedOutput:="20")
+            CompileAndVerify(source, references:={reference}, expectedOutput:="20")
         End Sub
 
         <Fact>
@@ -1017,7 +1017,7 @@ End Class
     </file>
                 </compilation>
 
-            CompileAndVerify(source, additionalRefs:={reference}, expectedOutput:="20")
+            CompileAndVerify(source, references:={reference}, expectedOutput:="20")
         End Sub
     End Class
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetingTests.vb
@@ -933,7 +933,7 @@ End Namespace
             Dim referenceLibrary_Compilation = DirectCast(CompileAndVerify(CL1_source, options:=TestOptions.ReleaseDll).Compilation, VisualBasicCompilation)
 
             Dim referenceLibrary_Metadata = referenceLibrary_Compilation.ToMetadataReference
-            Dim main_NoRetarget = CompileAndVerify(source, additionalRefs:={referenceLibrary_Metadata},
+            Dim main_NoRetarget = CompileAndVerify(source, references:={referenceLibrary_Metadata},
                                                    expectedOutput:=<![CDATA[Success
 ]]>)
             main_NoRetarget.VerifyDiagnostics()
@@ -941,7 +941,7 @@ End Namespace
 
             'Retargetted - should result in No additional Errors also and same runtime behavior
             Dim RetargetReference = RetargetCompilationToV2MsCorlib(referenceLibrary_Compilation)
-            Dim Main_Retarget = CompileAndVerify(source, additionalRefs:={RetargetReference}, options:=TestOptions.ReleaseExe,
+            Dim Main_Retarget = CompileAndVerify(source, references:={RetargetReference}, options:=TestOptions.ReleaseExe,
                                                  expectedOutput:=<![CDATA[Success
 ]]>)
             Main_Retarget.VerifyDiagnostics()
@@ -1297,7 +1297,7 @@ End Namespace
             Dim referenceLibrary_Compilation = DirectCast(CompileAndVerify(CL1_source, options:=TestOptions.ReleaseDll).Compilation, VisualBasicCompilation)
 
             Dim referenceLibrary_Metadata = referenceLibrary_Compilation.ToMetadataReference
-            Dim main_NoRetarget = CompileAndVerify(source, additionalRefs:={referenceLibrary_Metadata},
+            Dim main_NoRetarget = CompileAndVerify(source, references:={referenceLibrary_Metadata},
                                                    expectedOutput:=<![CDATA[Success
 ]]>)
             main_NoRetarget.VerifyDiagnostics()
@@ -1305,7 +1305,7 @@ End Namespace
 
             '//Retargetted - should result in No Errors also and same runtime behavior
             Dim RetargetReference = RetargetCompilationToV2MsCorlib(referenceLibrary_Compilation)
-            Dim Main_Retarget = CompileAndVerify(source, additionalRefs:={RetargetReference}, options:=TestOptions.ReleaseExe,
+            Dim Main_Retarget = CompileAndVerify(source, references:={RetargetReference}, options:=TestOptions.ReleaseExe,
                                                  expectedOutput:=<![CDATA[Success
 ]]>)
             Main_Retarget.VerifyDiagnostics()
@@ -1676,7 +1676,7 @@ Imports System
             Dim referenceLibrary_Compilation = DirectCast(CompileAndVerify(CL1_source, options:=TestOptions.ReleaseDll).Compilation, VisualBasicCompilation)
 
             Dim referenceLibrary_Metadata = referenceLibrary_Compilation.ToMetadataReference
-            Dim main_NoRetarget = CompileAndVerify(source, additionalRefs:={referenceLibrary_Metadata},
+            Dim main_NoRetarget = CompileAndVerify(source, references:={referenceLibrary_Metadata},
                                                    expectedOutput:=<![CDATA[11
 12
 13
@@ -1691,7 +1691,7 @@ Imports System
 
             '//Retargetted - should result in No Errors also and same runtime behavior
             Dim RetargetReference = RetargetCompilationToV2MsCorlib(referenceLibrary_Compilation)
-            Dim Main_Retarget = CompileAndVerify(source, additionalRefs:={RetargetReference}, options:=TestOptions.ReleaseExe,
+            Dim Main_Retarget = CompileAndVerify(source, references:={RetargetReference}, options:=TestOptions.ReleaseExe,
                                                  expectedOutput:=<![CDATA[11
 12
 13
@@ -1878,7 +1878,7 @@ End Class
             Dim referenceLibrary_Compilation = DirectCast(CompileAndVerify(CL1_source, options:=TestOptions.ReleaseDll).Compilation, VisualBasicCompilation)
 
             Dim referenceLibrary_Metadata = referenceLibrary_Compilation.ToMetadataReference
-            Dim main_NoRetarget = CompileAndVerify(source, additionalRefs:={referenceLibrary_Metadata},
+            Dim main_NoRetarget = CompileAndVerify(source, references:={referenceLibrary_Metadata},
                                                    expectedOutput:=<![CDATA[Sharedmethod
 method(Other)
 MethodOverload(Other)
@@ -1892,7 +1892,7 @@ MethodOverload(Base)
 
             '//Retargetted - should result in No Errors also same runtime behavior
             Dim RetargetReference = RetargetCompilationToV2MsCorlib(referenceLibrary_Compilation)
-            Dim Main_Retarget = CompileAndVerify(source, additionalRefs:={RetargetReference}, options:=TestOptions.ReleaseExe,
+            Dim Main_Retarget = CompileAndVerify(source, references:={RetargetReference}, options:=TestOptions.ReleaseExe,
                                                  expectedOutput:=<![CDATA[Sharedmethod
 method(Other)
 MethodOverload(Other)
@@ -2156,7 +2156,7 @@ End Class
             Dim referenceLibrary_Compilation = DirectCast(CompileAndVerify(CL1_source, options:=TestOptions.ReleaseDll).Compilation, VisualBasicCompilation)
 
             Dim referenceLibrary_Metadata = referenceLibrary_Compilation.ToMetadataReference
-            Dim main_NoRetarget = CompileAndVerify(source, additionalRefs:={referenceLibrary_Metadata},
+            Dim main_NoRetarget = CompileAndVerify(source, references:={referenceLibrary_Metadata},
                                                    expectedOutput:=<![CDATA[Success
 Success
 Success
@@ -2170,7 +2170,7 @@ Success]]>)
 
             '//Retargetted - should result in No Errors also and same runtime behavior
             Dim RetargetReference = RetargetCompilationToV2MsCorlib(referenceLibrary_Compilation)
-            Dim Main_Retarget = CompileAndVerify(source, additionalRefs:={RetargetReference}, options:=TestOptions.ReleaseExe,
+            Dim Main_Retarget = CompileAndVerify(source, references:={RetargetReference}, options:=TestOptions.ReleaseExe,
                                                  expectedOutput:=<![CDATA[Success
 Success
 Success
@@ -2354,7 +2354,7 @@ End Class
             Dim referenceLibrary_Compilation = DirectCast(CompileAndVerify(CL1_source, options:=TestOptions.ReleaseDll).Compilation, VisualBasicCompilation)
 
             Dim referenceLibrary_Metadata = referenceLibrary_Compilation.ToMetadataReference
-            Dim main_NoRetarget = CompileAndVerify(source, additionalRefs:={referenceLibrary_Metadata},
+            Dim main_NoRetarget = CompileAndVerify(source, references:={referenceLibrary_Metadata},
                                                    expectedOutput:=<![CDATA[1
 test
 ]]>)
@@ -2363,7 +2363,7 @@ test
 
             '//Retargetted - should result in No Errors also
             Dim RetargetReference = RetargetCompilationToV2MsCorlib(referenceLibrary_Compilation)
-            Dim Main_Retarget = CompileAndVerify(source, additionalRefs:={RetargetReference}, options:=TestOptions.ReleaseExe,
+            Dim Main_Retarget = CompileAndVerify(source, references:={RetargetReference}, options:=TestOptions.ReleaseExe,
                                                  expectedOutput:=<![CDATA[1
 test
 ]]>)
@@ -2679,12 +2679,12 @@ End Class
 </compilation>
             ''//All on same FX - should result in No Errors
             Dim referenceLibrary_Compilation = DirectCast(CompileAndVerify(sourceLibV1, options:=TestOptions.ReleaseDll).Compilation, VisualBasicCompilation)
-            Dim main_NoRetarget = CompileAndVerify(sourceMain, additionalRefs:={referenceLibrary_Compilation.ToMetadataReference})
+            Dim main_NoRetarget = CompileAndVerify(sourceMain, references:={referenceLibrary_Compilation.ToMetadataReference})
             main_NoRetarget.VerifyDiagnostics()
 
             ''//Retargetted - should result in No Errors also
             Dim RetargetReference = RetargetCompilationToV2MsCorlib(referenceLibrary_Compilation)
-            Dim Main_Retarget = CompileAndVerify(sourceMain, additionalRefs:={RetargetReference}, options:=TestOptions.ReleaseExe)
+            Dim Main_Retarget = CompileAndVerify(sourceMain, references:={RetargetReference}, options:=TestOptions.ReleaseExe)
             main_NoRetarget.VerifyDiagnostics()
         End Sub
 
@@ -3071,7 +3071,7 @@ End Namespace
             Dim referenceLibrary_Compilation = DirectCast(CompileAndVerify(CL1_source, options:=TestOptions.ReleaseDll).Compilation, VisualBasicCompilation)
 
             Dim referenceLibrary_Metadata = referenceLibrary_Compilation.ToMetadataReference
-            Dim main_NoRetarget = CompileAndVerify(source, additionalRefs:={referenceLibrary_Metadata},
+            Dim main_NoRetarget = CompileAndVerify(source, references:={referenceLibrary_Metadata},
                                                    expectedOutput:=<![CDATA[Success
 ]]>)
             main_NoRetarget.VerifyDiagnostics()
@@ -3079,7 +3079,7 @@ End Namespace
 
             '//Retargetted - should result in No Errors also and same runtime behavior
             Dim RetargetReference = RetargetCompilationToV2MsCorlib(referenceLibrary_Compilation)
-            Dim Main_Retarget = CompileAndVerify(source, additionalRefs:={RetargetReference}, options:=TestOptions.ReleaseExe,
+            Dim Main_Retarget = CompileAndVerify(source, references:={RetargetReference}, options:=TestOptions.ReleaseExe,
                                                  expectedOutput:=<![CDATA[Success
 ]]>)
             Main_Retarget.VerifyDiagnostics()

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MeMyBaseMyClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MeMyBaseMyClassTests.vb
@@ -618,7 +618,7 @@ Module Module1
     End Class
 End Module
     </file>
-</compilation>, additionalRefs:={SystemCoreRef}).VerifyIL("Module1.Class2.TEST", <![CDATA[
+</compilation>, references:={SystemCoreRef}).VerifyIL("Module1.Class2.TEST", <![CDATA[
 {
   // Code size       26 (0x1a)
   .maxstack  3
@@ -1125,7 +1125,7 @@ Module Module1
     End Class
 End Module
     </file>
-</compilation>, additionalRefs:={SystemCoreRef}).VerifyIL("Module1.Class2.TEST", <![CDATA[
+</compilation>, references:={SystemCoreRef}).VerifyIL("Module1.Class2.TEST", <![CDATA[
 {
   // Code size       50 (0x32)
   .maxstack  3
@@ -1436,7 +1436,7 @@ Module MyExtensionModule
     End Function
 End Module
     </file>
-</compilation>, additionalRefs:={SystemCoreRef}).VerifyIL("C1.Goo", <![CDATA[
+</compilation>, references:={SystemCoreRef}).VerifyIL("C1.Goo", <![CDATA[
 {
   // Code size       12 (0xc)
   .maxstack  1

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/PropertyTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/PropertyTests.vb
@@ -5433,7 +5433,7 @@ Class Program
 End Class
 ]]></file></compilation>
 
-            Dim compilation = CompileAndVerify(source, additionalRefs:={s_propertiesDll}, expectedOutput:="0")
+            Dim compilation = CompileAndVerify(source, references:={s_propertiesDll}, expectedOutput:="0")
             Dim ilSource = <![CDATA[{
   // Code size       27 (0x1b)
   .maxstack  2
@@ -5529,7 +5529,7 @@ BC30456: 'StaticInt32Get' is not a member of 'Mismatched'.
             End Sub
         End Class
         ]]></file></compilation>
-            Dim result = CompileAndVerify(source, additionalRefs:={s_propertiesDll}, expectedOutput:="0")
+            Dim result = CompileAndVerify(source, references:={s_propertiesDll}, expectedOutput:="0")
             Dim ilSource = <![CDATA[{
 // Code size       27 (0x1b)
 .maxstack  2
@@ -7002,7 +7002,7 @@ End Module
 ]]>
                     </file>
                 </compilation>
-            Dim compilation2 = CompileAndVerify(source2, additionalRefs:={reference1}, expectedOutput:=<![CDATA[
+            Dim compilation2 = CompileAndVerify(source2, references:={reference1}, expectedOutput:=<![CDATA[
 get_P: 1
 set_Q: 2
 ]]>)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -23832,7 +23832,7 @@ End Namespace
 
             CompileAndVerify(
                 source:= code,
-                additionalRefs:= { ilReference },
+                references:= { ilReference },
                 expectedOutput:= "TEST VALUE")
         End Sub
         
@@ -24089,7 +24089,7 @@ End Namespace
 
             CompileAndVerify(
                 source:=codeA,
-                additionalRefs:={referenceB, referenceC},
+                references:={referenceB, referenceC},
                 expectedOutput:="obj is nothing")
 
             Dim codeC2 = "
@@ -24130,7 +24130,7 @@ End Namespace"
 
             CompileAndVerify(
                 source:=codeA,
-                additionalRefs:={referenceB, referenceC2, referenceD},
+                references:={referenceB, referenceC2, referenceD},
                 expectedOutput:="obj is nothing")
         End Sub
 


### PR DESCRIPTION
This is a refactor PR:

- Removes the BasicTestBaseBase helper 
- Unifies parameter names with C# counter parts
    - source: name ofr the test sources 
    - references: name for the parameters to add to the compilation