### PR TITLE
Factoring parts common with BindSimpleBinaryOperator

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -504,7 +504,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             LookupResultKind resultKind;
             ImmutableArray<MethodSymbol> originalUserDefinedOperators;
-            var best = this.BinaryOperatorOverloadResolution(kind, left, right, node, diagnostics, out resultKind, out originalUserDefinedOperators);
+            BinaryOperatorAnalysisResult best = this.BinaryOperatorOverloadResolution(kind, left, right, node, diagnostics, out resultKind, out originalUserDefinedOperators);
 
             // However, as an implementation detail, we never "fail to find an applicable 
             // operator" during overload resolution if we have x == null, etc. We always
@@ -560,6 +560,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (hasErrors)
             {
+                // PROTOTYPE(tuple-equality) There is likely a bug where logic above could have produced diagnostics
+                // PROTOTYPE(tuple-equality) Instead of a separate phase, could tuple equality binding be folded into BinaryOperatorOverloadResolution?
                 if (GetTupleCardinality(left).HasValue &&
                     GetTupleCardinality(right).HasValue &&
                     (kind == BinaryOperatorKind.Equal || kind == BinaryOperatorKind.NotEqual))

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bool isNullableEquality = (object)signature.Method == null &&
                     (signature.Kind.Operator() == BinaryOperatorKind.Equal || signature.Kind.Operator() == BinaryOperatorKind.NotEqual) &&
                     (leftNull && (object)rightType != null && rightType.IsNullableType() ||
-                    rightNull && (object)leftType != null && leftType.IsNullableType());
+                        rightNull && (object)leftType != null && leftType.IsNullableType());
 
                 if (isNullableEquality)
                 {
@@ -560,6 +560,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (hasErrors)
             {
+                if (GetTupleCardinality(left).HasValue &&
+                    GetTupleCardinality(right).HasValue &&
+                    (kind == BinaryOperatorKind.Equal || kind == BinaryOperatorKind.NotEqual))
+                {
+                    CheckFeatureAvailability(node, MessageID.IDS_FeatureTupleEquality, diagnostics);
+                    return BindTupleBinaryOperator(node, kind, left, right, diagnostics);
+                }
+
                 ReportBinaryOperatorError(node, diagnostics, node.OperatorToken, left, right, resultKind);
                 resultOperatorKind &= ~BinaryOperatorKind.TypeMask;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -504,75 +504,31 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             LookupResultKind resultKind;
             ImmutableArray<MethodSymbol> originalUserDefinedOperators;
-            BinaryOperatorAnalysisResult best = this.BinaryOperatorOverloadResolution(kind, left, right, node, diagnostics, out resultKind, out originalUserDefinedOperators);
+            BinaryOperatorSignature signature;
+            DiagnosticBag regularOperatorDiagnostics = DiagnosticBag.GetInstance();
 
-            // However, as an implementation detail, we never "fail to find an applicable 
-            // operator" during overload resolution if we have x == null, etc. We always
-            // find at least the reference conversion object == object; the overload resolution
-            // code does not reject that.  Therefore what we should do is only bind 
-            // "x == null" as a nullable-to-null comparison if overload resolution chooses
-            // the reference conversion.
+            bool foundOperator = BindSimpleBinaryOperatorParts(node, regularOperatorDiagnostics, left, right, kind,
+                out resultKind, out originalUserDefinedOperators, out signature);
 
-            BoundExpression resultLeft = left;
-            BoundExpression resultRight = right;
-            MethodSymbol resultMethod = null;
-            ConstantValue resultConstant = null;
-            BinaryOperatorKind resultOperatorKind;
-            TypeSymbol resultType;
-            bool hasErrors;
-
-            if (!best.HasValue)
+            BinaryOperatorKind resultOperatorKind = signature.Kind;
+            bool hasErrors = false;
+            if (!foundOperator)
             {
-                resultOperatorKind = kind;
-                resultType = CreateErrorType();
-                hasErrors = true;
-            }
-            else
-            {
-                var signature = best.Signature;
-
-                bool isObjectEquality = signature.Kind == BinaryOperatorKind.ObjectEqual || signature.Kind == BinaryOperatorKind.ObjectNotEqual;
-
-                bool isNullableEquality = (object)signature.Method == null &&
-                    (signature.Kind.Operator() == BinaryOperatorKind.Equal || signature.Kind.Operator() == BinaryOperatorKind.NotEqual) &&
-                    (leftNull && (object)rightType != null && rightType.IsNullableType() ||
-                        rightNull && (object)leftType != null && leftType.IsNullableType());
-
-                if (isNullableEquality)
-                {
-                    resultOperatorKind = kind | BinaryOperatorKind.NullableNull;
-                    resultType = GetSpecialType(SpecialType.System_Boolean, diagnostics, node);
-                    hasErrors = false;
-                }
-                else
-                {
-                    resultOperatorKind = signature.Kind;
-                    resultType = signature.ReturnType;
-                    resultMethod = signature.Method;
-                    resultLeft = CreateConversion(left, best.LeftConversion, signature.LeftType, diagnostics);
-                    resultRight = CreateConversion(right, best.RightConversion, signature.RightType, diagnostics);
-                    resultConstant = FoldBinaryOperator(node, resultOperatorKind, resultLeft, resultRight, resultType.SpecialType, diagnostics, ref compoundStringLength);
-                    HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                    hasErrors = isObjectEquality && !BuiltInOperators.IsValidObjectEquality(Conversions, leftType, leftNull, rightType, rightNull, ref useSiteDiagnostics);
-                    diagnostics.Add(node, useSiteDiagnostics);
-                }
-            }
-
-            if (hasErrors)
-            {
-                // PROTOTYPE(tuple-equality) There is likely a bug where logic above could have produced diagnostics
-                // PROTOTYPE(tuple-equality) Instead of a separate phase, could tuple equality binding be folded into BinaryOperatorOverloadResolution?
-                if (GetTupleCardinality(left).HasValue &&
-                    GetTupleCardinality(right).HasValue &&
+                if (GetTupleCardinality(left) > 1 &&
+                    GetTupleCardinality(right) > 1 &&
                     (kind == BinaryOperatorKind.Equal || kind == BinaryOperatorKind.NotEqual))
                 {
+                    regularOperatorDiagnostics.Free();
+
                     CheckFeatureAvailability(node, MessageID.IDS_FeatureTupleEquality, diagnostics);
                     return BindTupleBinaryOperator(node, kind, left, right, diagnostics);
                 }
 
                 ReportBinaryOperatorError(node, diagnostics, node.OperatorToken, left, right, resultKind);
                 resultOperatorKind &= ~BinaryOperatorKind.TypeMask;
+                hasErrors = true;
             }
+            diagnostics.AddRange(regularOperatorDiagnostics.ToReadOnlyAndFree());
 
             switch (node.Kind())
             {
@@ -593,6 +549,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
+            TypeSymbol resultType = signature.ReturnType;
+            BoundExpression resultLeft = left;
+            BoundExpression resultRight = right;
+            ConstantValue resultConstant = null;
+
+            if ((object)signature.LeftType != null)
+            {
+                Debug.Assert((object)signature.RightType != null);
+
+                resultLeft = GenerateConversionForAssignment(signature.LeftType, left, diagnostics);
+                resultRight = GenerateConversionForAssignment(signature.RightType, right, diagnostics);
+                resultConstant = FoldBinaryOperator(node, resultOperatorKind, resultLeft, resultRight, resultType.SpecialType, diagnostics, ref compoundStringLength);
+            }
+
             hasErrors = hasErrors || resultConstant != null && resultConstant.IsBad;
 
             return new BoundBinaryOperator(
@@ -601,11 +571,66 @@ namespace Microsoft.CodeAnalysis.CSharp
                 resultLeft,
                 resultRight,
                 resultConstant,
-                resultMethod,
+                signature.Method,
                 resultKind,
                 originalUserDefinedOperators,
                 resultType,
                 hasErrors);
+        }
+
+        private bool BindSimpleBinaryOperatorParts(BinaryExpressionSyntax node, DiagnosticBag diagnostics, BoundExpression left, BoundExpression right, BinaryOperatorKind kind,
+            out LookupResultKind resultKind, out ImmutableArray<MethodSymbol> originalUserDefinedOperators,
+            out BinaryOperatorSignature resultSignature)
+        {
+            bool foundOperator;
+            BinaryOperatorAnalysisResult best = this.BinaryOperatorOverloadResolution(kind, left, right, node, diagnostics, out resultKind, out originalUserDefinedOperators);
+
+            // However, as an implementation detail, we never "fail to find an applicable 
+            // operator" during overload resolution if we have x == null, etc. We always
+            // find at least the reference conversion object == object; the overload resolution
+            // code does not reject that.  Therefore what we should do is only bind 
+            // "x == null" as a nullable-to-null comparison if overload resolution chooses
+            // the reference conversion.
+
+            if (!best.HasValue)
+            {
+                resultSignature = new BinaryOperatorSignature(kind, leftType: null, rightType: null, CreateErrorType());
+                foundOperator = false;
+            }
+            else
+            {
+                var signature = best.Signature;
+
+                bool isObjectEquality = signature.Kind == BinaryOperatorKind.ObjectEqual || signature.Kind == BinaryOperatorKind.ObjectNotEqual;
+
+                bool leftNull = left.IsLiteralNull();
+                bool rightNull = right.IsLiteralNull();
+
+                TypeSymbol leftType = left.Type;
+                TypeSymbol rightType = right.Type;
+
+                bool isNullableEquality = (object)signature.Method == null &&
+                    (signature.Kind.Operator() == BinaryOperatorKind.Equal || signature.Kind.Operator() == BinaryOperatorKind.NotEqual) &&
+                    (leftNull && (object)rightType != null && rightType.IsNullableType() ||
+                        rightNull && (object)leftType != null && leftType.IsNullableType());
+
+                if (isNullableEquality)
+                {
+                    // PROTOTYPE(tuple-equality) I find it strange that we leave leftType and rightType null here
+                    resultSignature = new BinaryOperatorSignature(kind | BinaryOperatorKind.NullableNull, leftType: null, rightType: null, 
+                        GetSpecialType(SpecialType.System_Boolean, diagnostics, node));
+
+                    foundOperator = true;
+                }
+                else
+                {
+                    resultSignature = signature;
+                    HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                    foundOperator = !isObjectEquality || BuiltInOperators.IsValidObjectEquality(Conversions, leftType, leftNull, rightType, rightNull, ref useSiteDiagnostics);
+                    diagnostics.Add(node, useSiteDiagnostics);
+                }
+            }
+            return foundOperator;
         }
 
         private static void ReportUnaryOperatorError(CSharpSyntaxNode node, DiagnosticBag diagnostics, string operatorName, BoundExpression operand, LookupResultKind resultKind)
@@ -1046,6 +1071,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        /// <summary>
+        /// Note this method only deals with regular binary operator overload resolution. The tuple case (for tuple equality) must be handled by the caller.
+        /// </summary>
         private BinaryOperatorAnalysisResult BinaryOperatorOverloadResolution(BinaryOperatorKind kind, BoundExpression left, BoundExpression right, CSharpSyntaxNode node, DiagnosticBag diagnostics, out LookupResultKind resultKind, out ImmutableArray<MethodSymbol> originalUserDefinedOperators)
         {
             if (!IsDefaultLiteralAllowedInBinaryOperator(kind, left, right))

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -32,15 +32,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         private TupleBinaryOperatorInfo BindTupleBinaryOperatorInfo(BinaryExpressionSyntax node, BinaryOperatorKind kind,
             BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
         {
-            int? leftCardinality = GetTupleCardinality(left);
-            int? rightCardinality = GetTupleCardinality(right);
+            int leftCardinality = GetTupleCardinality(left).GetValueOrDefault();
+            int rightCardinality = GetTupleCardinality(right).GetValueOrDefault();
 
-            if (leftCardinality.HasValue && rightCardinality.HasValue)
+            if (leftCardinality > 1 && rightCardinality > 1)
             {
                 TypeSymbol leftType = left.Type;
                 TypeSymbol rightType = right.Type;
 
-                if (leftCardinality.Value != rightCardinality.Value)
+                if (leftCardinality != rightCardinality)
                 {
                     Error(diagnostics, ErrorCode.ERR_TupleSizesMismatchForBinOps, node, leftCardinality, rightCardinality);
 
@@ -81,6 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol returnType;
             bool hasErrors;
 
+            // PROTOTYPE(tuple-equality) Logic here is similar to that in BindSimpleBinaryOperator. Is there a way to factore more?
             if (!best.HasValue)
             {
                 resultOperatorKind = kind;
@@ -91,6 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
+                // PROTOTYPE(tuple-equality) Remember to implement and test equality on `default`
                 bool leftNull = left.IsLiteralNull();
                 bool rightNull = right.IsLiteralNull();
 
@@ -159,7 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             LookupResultKind resultKind;
             ImmutableArray<MethodSymbol> originalUserDefinedOperators;
-            var best = this.UnaryOperatorOverloadResolution(boolOpKind, comparisonResult, node, diagnostics, out resultKind, out originalUserDefinedOperators);
+            UnaryOperatorAnalysisResult best = this.UnaryOperatorOverloadResolution(boolOpKind, comparisonResult, node, diagnostics, out resultKind, out originalUserDefinedOperators);
             if (best.HasValue)
             {
                 boolConversion = best.Conversion;
@@ -275,6 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return tuple;
             }
 
+            // PROTOTYPE(tuple-equality) check constraints
             NamedTypeSymbol nullableT = GetSpecialType(SpecialType.System_Nullable_T, diagnostics, syntax);
             return nullableT.Construct(tuple);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -1,0 +1,386 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class Binder
+    {
+        /// <summary>
+        /// If the left and right are tuples of matching cardinality, we'll try to bind the operator element-wise.
+        /// When that succeeds, the element-wise conversions are collected and their result type is applied as tuple conversions.
+        /// The element-wise binary operators are collected and stored as a tree for lowering.
+        /// </summary>
+        private BoundTupleBinaryOperator BindTupleBinaryOperator(BinaryExpressionSyntax node, BinaryOperatorKind kind,
+            BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
+        {
+            TupleBinaryOperatorInfo operators = BindTupleBinaryOperatorInfo(node, kind, left, right, diagnostics);
+
+            TypeSymbol leftConvertedType = operators.GetConvertedType(isRight: false);
+            TypeSymbol rightConvertedType = operators.GetConvertedType(isRight: true);
+
+            BoundExpression convertedLeft = GenerateConversionForAssignment(leftConvertedType, left, diagnostics);
+            BoundExpression convertedRight = GenerateConversionForAssignment(rightConvertedType, right, diagnostics);
+
+            TypeSymbol resultType = GetSpecialType(SpecialType.System_Boolean, diagnostics, node);
+            return new BoundTupleBinaryOperator(node, convertedLeft, convertedRight, kind, operators, resultType);
+        }
+
+        private TupleBinaryOperatorInfo BindTupleBinaryOperatorInfo(BinaryExpressionSyntax node, BinaryOperatorKind kind,
+            BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
+        {
+            TypeSymbol leftType = left.Type;
+            TypeSymbol rightType = right.Type;
+            int? leftCardinality = GetTupleCardinality(left);
+            int? rightCardinality = GetTupleCardinality(right);
+
+            if (leftCardinality.HasValue && rightCardinality.HasValue)
+            {
+                if (leftCardinality.Value != rightCardinality.Value)
+                {
+                    Error(diagnostics, ErrorCode.ERR_TupleSizesMismatchForBinOps, node, leftCardinality, rightCardinality);
+
+                    return new TupleBinaryOperatorInfo.Single(leftType ?? CreateErrorType(), rightType ?? CreateErrorType(),
+                        BinaryOperatorKind.Error, methodSymbolOpt: null, boolConversion: Conversion.NoConversion, boolOperator: default);
+                }
+
+                // typeless tuple literals are not nullable
+                bool leftNullable = leftType?.IsNullableType() == true;
+                bool rightNullable = rightType?.IsNullableType() == true;
+
+                return BindTupleBinaryOperatorNestedInfo(node, kind,
+                    GetTupleArgumentsOrPlaceholders(left), GetTupleArgumentsOrPlaceholders(right),
+                    leftNullable || rightNullable, diagnostics);
+            }
+
+            return BindTupleBinaryOperatorSingleInfo(node, kind, left, right, diagnostics);
+        }
+
+        private TupleBinaryOperatorInfo BindTupleBinaryOperatorSingleInfo(BinaryExpressionSyntax node, BinaryOperatorKind kind,
+            BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
+        {
+            TypeSymbol leftType = left.Type;
+            TypeSymbol rightType = right.Type;
+
+            if ((object)leftType != null && leftType.IsDynamic() || (object)rightType != null && rightType.IsDynamic())
+            {
+                return BindTupleDynamicBinaryOperatorSingleInfo(node, kind, left, right, diagnostics);
+            }
+
+            LookupResultKind resultKind;
+            BinaryOperatorAnalysisResult best = this.BinaryOperatorOverloadResolution(kind, left, right, node, diagnostics, out resultKind, out var _);
+
+            MethodSymbol resultMethod = null;
+            BinaryOperatorKind resultOperatorKind;
+            TypeSymbol convertedLeftType = null;
+            TypeSymbol convertedRightType = null;
+            TypeSymbol returnType;
+            bool hasErrors;
+
+            if (!best.HasValue)
+            {
+                resultOperatorKind = kind;
+                returnType = CreateErrorType();
+                hasErrors = true;
+            }
+            else
+            {
+                bool leftNull = left.IsLiteralNull();
+                bool rightNull = right.IsLiteralNull();
+
+                var signature = best.Signature;
+
+                bool isObjectEquality = signature.Kind == BinaryOperatorKind.ObjectEqual || signature.Kind == BinaryOperatorKind.ObjectNotEqual;
+
+                resultOperatorKind = signature.Kind;
+                resultMethod = signature.Method;
+                convertedLeftType = signature.LeftType;
+                convertedRightType = signature.RightType;
+                returnType = signature.ReturnType; // PROTOTYPE(tuple-equality) Do we need a special case for nullable equality? (see BindSimpleBinaryOperator)
+
+                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                hasErrors = isObjectEquality && !BuiltInOperators.IsValidObjectEquality(Conversions, leftType, leftNull, rightType, rightNull, ref useSiteDiagnostics);
+                diagnostics.Add(node, useSiteDiagnostics);
+            }
+
+            if (convertedLeftType is null || convertedRightType is null)
+            {
+                convertedLeftType = convertedLeftType ?? leftType ?? CreateErrorType();
+                convertedRightType = convertedRightType ?? rightType ?? CreateErrorType();
+                hasErrors = true;
+            }
+
+            if (hasErrors)
+            {
+                ReportBinaryOperatorError(node, diagnostics, node.OperatorToken, left, right, resultKind);
+                //resultOperatorKind &= ~BinaryOperatorKind.TypeMask; // PROTOTYPE(tuple-equality) Not sure what this is for
+            }
+
+            ConvertToBool(returnType, node, kind, diagnostics, out Conversion boolConversion, out UnaryOperatorSignature boolOperator);
+            return new TupleBinaryOperatorInfo.Single(convertedLeftType, convertedRightType, resultOperatorKind, resultMethod, boolConversion, boolOperator);
+        }
+
+        private void ConvertToBool(TypeSymbol type, BinaryExpressionSyntax node, BinaryOperatorKind binaryOperator, DiagnosticBag diagnostics,
+            out Conversion boolConversion, out UnaryOperatorSignature boolOperator)
+        {
+            BoundExpression comparisonResult = new BoundTupleOperandPlaceholder(node, type);
+            var boolean = GetSpecialType(SpecialType.System_Boolean, diagnostics, node);
+
+            // Is the operand implicitly convertible to bool?
+
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+            var conversion = this.Conversions.ClassifyConversionFromExpression(comparisonResult, boolean, ref useSiteDiagnostics);
+            diagnostics.Add(node, useSiteDiagnostics);
+
+            if (conversion.IsImplicit)
+            {
+                boolConversion = conversion;
+                boolOperator = default;
+                return;
+            }
+
+            // It was not. Does it implement operator true (or false)?
+
+            UnaryOperatorKind boolOpKind;
+            switch (binaryOperator)
+            {
+                case BinaryOperatorKind.Equal:
+                    boolOpKind = UnaryOperatorKind.False;
+                    break;
+                case BinaryOperatorKind.NotEqual:
+                    boolOpKind = UnaryOperatorKind.True;
+                    break;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(binaryOperator);
+            }
+
+            LookupResultKind resultKind;
+            ImmutableArray<MethodSymbol> originalUserDefinedOperators;
+            var best = this.UnaryOperatorOverloadResolution(boolOpKind, comparisonResult, node, diagnostics, out resultKind, out originalUserDefinedOperators);
+            if (best.HasValue)
+            {
+                boolConversion = best.Conversion;
+                boolOperator = best.Signature;
+                return;
+            }
+
+            // It did not. Give a "not convertible to bool" error.
+
+            GenerateImplicitConversionError(diagnostics, node, conversion, comparisonResult, boolean);
+            boolConversion = Conversion.NoConversion;
+            boolOperator = default;
+            return;
+        }
+
+        private TupleBinaryOperatorInfo BindTupleDynamicBinaryOperatorSingleInfo(BinaryExpressionSyntax node, BinaryOperatorKind kind,
+            BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
+        {
+            // This method binds binary == and != operators where one or both of the operands are dynamic.
+            Debug.Assert((object)left.Type != null && left.Type.IsDynamic() || (object)right.Type != null && right.Type.IsDynamic());
+
+            bool hasError = false;
+            bool leftValidOperand = IsLegalDynamicOperand(left);
+            bool rightValidOperand = IsLegalDynamicOperand(right);
+
+            if (!leftValidOperand || !rightValidOperand)
+            {
+                // Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'
+                Error(diagnostics, ErrorCode.ERR_BadBinaryOps, node, node.OperatorToken.Text, left.Display, right.Display);
+                hasError = true;
+            }
+
+            BinaryOperatorKind elementOperatorKind = hasError ? kind : kind.WithType(BinaryOperatorKind.Dynamic);
+            TypeSymbol dynamicType = Compilation.DynamicType;
+
+            // We'll end up dynamically invoking operators true and false, so no result conversion. We'll deal with that during lowering.
+            return new TupleBinaryOperatorInfo.Single(dynamicType, dynamicType, elementOperatorKind,
+                methodSymbolOpt: null, boolConversion: Conversion.Identity, boolOperator: default);
+        }
+
+        private TupleBinaryOperatorInfo BindTupleBinaryOperatorNestedInfo(BinaryExpressionSyntax node, BinaryOperatorKind kind,
+            ImmutableArray<BoundExpression> left, ImmutableArray<BoundExpression> right,
+            bool nullable, DiagnosticBag diagnostics)
+        {
+            int length = left.Length;
+            Debug.Assert(length == right.Length);
+
+            var operatorsBuilder = ArrayBuilder<TupleBinaryOperatorInfo>.GetInstance(length);
+
+            for (int i = 0; i < length; i++)
+            {
+                operatorsBuilder.Add(BindTupleBinaryOperatorInfo(node, kind, left[i], right[i], diagnostics));
+            }
+
+            var compilation = this.Compilation;
+            TypeSymbol leftTupleType = MakeConvertedType(operatorsBuilder, node.Left, left, nullable, compilation, diagnostics, isRight: false);
+            TypeSymbol rightTupleType = MakeConvertedType(operatorsBuilder, node.Right, right, nullable, compilation, diagnostics, isRight: true);
+
+            return new TupleBinaryOperatorInfo.Nested(operatorsBuilder.ToImmutableAndFree(), leftTupleType, rightTupleType);
+        }
+
+        private static int? GetTupleCardinality(BoundExpression expr)
+        {
+            if (expr.Kind == BoundKind.TupleLiteral)
+            {
+                var tuple = (BoundTupleLiteral)expr;
+                return tuple.Arguments.Length;
+            }
+
+            TypeSymbol type = expr.Type;
+            if (type is null)
+            {
+                return null;
+            }
+
+            type = type.StrippedType();
+
+            if (type.IsTupleType)
+            {
+                return type.TupleElementTypes.Length;
+            }
+
+            return null;
+        }
+
+        private static ImmutableArray<BoundExpression> GetTupleArgumentsOrPlaceholders(BoundExpression expr)
+        {
+            if (expr.Kind == BoundKind.TupleLiteral)
+            {
+                return ((BoundTupleLiteral)expr).Arguments;
+            }
+
+            // placeholder bound nodes with the proper types are sufficient to bind the element-wise binary operators
+            return expr.Type.StrippedType().TupleElementTypes
+                .SelectAsArray(t => (BoundExpression)new BoundTupleOperandPlaceholder(expr.Syntax, t));
+        }
+
+        /// <summary>
+        /// Make a tuple type (with appropriate nesting) from the types (on the left or on the right) collected
+        /// from binding element-wise binary operators.
+        /// </summary>
+        private TypeSymbol MakeConvertedType(ArrayBuilder<TupleBinaryOperatorInfo> operators, CSharpSyntaxNode syntax,
+            ImmutableArray<BoundExpression> elements, bool nullable, CSharpCompilation compilation, DiagnosticBag diagnostics, bool isRight)
+        {
+            ImmutableArray<TypeSymbol> convertedTypes = operators.SelectAsArray(o => o.GetConvertedType(isRight));
+            ImmutableArray<Location> elementLocations = elements.SelectAsArray(e => e.Syntax.Location);
+
+            var tuple = TupleTypeSymbol.Create(locationOpt: null, elementTypes: convertedTypes,
+                elementLocations, elementNames: default, compilation,
+                shouldCheckConstraints: true, errorPositions: default, syntax, diagnostics);
+
+            if (!nullable)
+            {
+                return tuple;
+            }
+
+            NamedTypeSymbol nullableT = GetSpecialType(SpecialType.System_Nullable_T, diagnostics, syntax);
+            return nullableT.Construct(tuple);
+        }
+    }
+
+    /// <summary>
+    /// A tree of binary operators
+    /// </summary>
+    internal abstract class TupleBinaryOperatorInfo
+    {
+        internal abstract TypeSymbol GetConvertedType(bool isRight);
+        internal abstract bool IsSingle();
+#if DEBUG
+        internal abstract TreeDumperNode DumpCore();
+        internal string Dump() => TreeDumper.DumpCompact(DumpCore());
+#endif
+
+        internal class Single : TupleBinaryOperatorInfo
+        {
+            internal TypeSymbol LeftConvertedType { get; }
+            internal TypeSymbol RightConvertedType { get; }
+            internal BinaryOperatorKind Kind { get; }
+            internal MethodSymbol MethodSymbolOpt { get; } // User-defined comparison operator, if applicable
+
+            // To convert the result of comparison to bool
+            internal Conversion BoolConversion { get; }
+            internal UnaryOperatorSignature BoolOperator { get; } // Information for op_true or op_false
+
+            internal Single(TypeSymbol leftConvertedType, TypeSymbol rightConvertedType, BinaryOperatorKind kind,
+                MethodSymbol methodSymbolOpt, Conversion boolConversion, UnaryOperatorSignature boolOperator)
+            {
+                // If a user-defined comparison operator is present, then the operator kind must be user-defined
+                Debug.Assert(Kind.IsUserDefined() || (object)MethodSymbolOpt == null);
+
+                // If the return type of methodSymbolOpt is not bool, then there must be a boolConversion or boolOperator
+                Debug.Assert(BoolConversion != default || !Kind.IsDynamic() || (Kind.IsUserDefined() && MethodSymbolOpt.ReturnType.SpecialType == SpecialType.System_Boolean));
+                Debug.Assert((object)BoolOperator != null || !Kind.IsDynamic() || (Kind.IsUserDefined() && MethodSymbolOpt.ReturnType.SpecialType == SpecialType.System_Boolean));
+
+                LeftConvertedType = leftConvertedType;
+                RightConvertedType = rightConvertedType;
+                Kind = kind;
+                MethodSymbolOpt = methodSymbolOpt;
+                BoolConversion = boolConversion;
+                BoolOperator = boolOperator;
+            }
+
+            internal override TypeSymbol GetConvertedType(bool isRight)
+                => isRight ? RightConvertedType : LeftConvertedType;
+
+            internal override bool IsSingle()
+                => true;
+
+            public override string ToString()
+                => $"binaryOperatorKind: {Kind}";
+
+#if DEBUG
+            internal override TreeDumperNode DumpCore()
+            {
+                var sub = new List<TreeDumperNode>();
+                if ((object)MethodSymbolOpt != null)
+                {
+                    sub.Add(new TreeDumperNode("methodSymbolOpt", MethodSymbolOpt.ToDisplayString(), null));
+                }
+                sub.Add(new TreeDumperNode("leftConversion", LeftConvertedType.ToDisplayString(), null));
+                sub.Add(new TreeDumperNode("rightConversion", RightConvertedType.ToDisplayString(), null));
+
+                return new TreeDumperNode("nested", Kind, sub);
+            }
+#endif
+        }
+
+        internal class Nested : TupleBinaryOperatorInfo
+        {
+            internal ImmutableArray<TupleBinaryOperatorInfo> NestedOperators { get; }
+            internal TypeSymbol LeftConvertedType { get; }
+            internal TypeSymbol RightConvertedType { get; }
+
+            internal Nested(ImmutableArray<TupleBinaryOperatorInfo> nestedOperators,
+                TypeSymbol leftConvertedType, TypeSymbol rightConvertedType)
+            {
+                Debug.Assert(!nestedOperators.IsDefaultOrEmpty);
+                NestedOperators = nestedOperators;
+                LeftConvertedType = leftConvertedType;
+                RightConvertedType = rightConvertedType;
+            }
+
+            internal override TypeSymbol GetConvertedType(bool isRight)
+                => isRight ? RightConvertedType : LeftConvertedType;
+
+            internal override bool IsSingle()
+                => false;
+
+#if DEBUG
+            internal override TreeDumperNode DumpCore()
+            {
+                var sub = new List<TreeDumperNode>();
+                sub.Add(new TreeDumperNode($"nestedOperators[{NestedOperators.Length}]", null,
+                    NestedOperators.SelectAsArray(c => c.DumpCore())));
+
+                return new TreeDumperNode("nested", null, sub);
+            }
+#endif
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundTupleBinaryOperator BindTupleBinaryOperator(BinaryExpressionSyntax node, BinaryOperatorKind kind,
             BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
         {
-            TupleBinaryOperatorInfo operators = BindTupleBinaryOperatorInfo(node, kind, left, right, diagnostics);
+            TupleBinaryOperatorInfo operators = BindTupleBinaryOperatorNestedInfo(node, kind, left, right, diagnostics);
 
             BoundExpression convertedLeft = GenerateConversionForAssignment(operators.LeftConvertedType, left, diagnostics);
             BoundExpression convertedRight = GenerateConversionForAssignment(operators.RightConvertedType, right, diagnostics);
@@ -32,37 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private TupleBinaryOperatorInfo BindTupleBinaryOperatorInfo(BinaryExpressionSyntax node, BinaryOperatorKind kind,
             BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
         {
-            int leftCardinality = GetTupleCardinality(left).GetValueOrDefault();
-            int rightCardinality = GetTupleCardinality(right).GetValueOrDefault();
-
-            if (leftCardinality > 1 && rightCardinality > 1)
-            {
-                TypeSymbol leftType = left.Type;
-                TypeSymbol rightType = right.Type;
-
-                if (leftCardinality != rightCardinality)
-                {
-                    Error(diagnostics, ErrorCode.ERR_TupleSizesMismatchForBinOps, node, leftCardinality, rightCardinality);
-
-                    return new TupleBinaryOperatorInfo.Single(leftType ?? CreateErrorType(), rightType ?? CreateErrorType(),
-                        BinaryOperatorKind.Error, methodSymbolOpt: null, boolConversion: Conversion.NoConversion, boolOperator: default);
-                }
-
-                // typeless tuple literals are not nullable
-                bool leftNullable = leftType?.IsNullableType() == true;
-                bool rightNullable = rightType?.IsNullableType() == true;
-
-                return BindTupleBinaryOperatorNestedInfo(node, kind,
-                    GetTupleArgumentsOrPlaceholders(left), GetTupleArgumentsOrPlaceholders(right),
-                    leftNullable || rightNullable, diagnostics);
-            }
-
-            return BindTupleBinaryOperatorSingleInfo(node, kind, left, right, diagnostics);
-        }
-
-        private TupleBinaryOperatorInfo BindTupleBinaryOperatorSingleInfo(BinaryExpressionSyntax node, BinaryOperatorKind kind,
-            BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
-        {
             TypeSymbol leftType = left.Type;
             TypeSymbol rightType = right.Type;
 
@@ -72,52 +41,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             LookupResultKind resultKind;
-            BinaryOperatorAnalysisResult best = this.BinaryOperatorOverloadResolution(kind, left, right, node, diagnostics, out resultKind, out var _);
+            BinaryOperatorSignature signature;
+            DiagnosticBag regularOperatorDiagnostics = DiagnosticBag.GetInstance();
 
-            MethodSymbol resultMethod = null;
-            BinaryOperatorKind resultOperatorKind;
-            TypeSymbol convertedLeftType;
-            TypeSymbol convertedRightType;
-            TypeSymbol returnType;
-            bool hasErrors;
+            bool foundOperator = BindSimpleBinaryOperatorParts(node, regularOperatorDiagnostics, left, right, kind,
+                out resultKind, originalUserDefinedOperators: out _, out signature);
 
-            // PROTOTYPE(tuple-equality) Logic here is similar to that in BindSimpleBinaryOperator. Is there a way to factore more?
-            if (!best.HasValue)
+            if (!foundOperator)
             {
-                resultOperatorKind = kind;
-                convertedLeftType = leftType ?? CreateErrorType();
-                convertedRightType = rightType ?? CreateErrorType();
-                returnType = CreateErrorType();
-                hasErrors = true;
-            }
-            else
-            {
-                // PROTOTYPE(tuple-equality) Remember to implement and test equality on `default`
-                bool leftNull = left.IsLiteralNull();
-                bool rightNull = right.IsLiteralNull();
+                int leftCardinality = GetTupleCardinality(left);
+                int rightCardinality = GetTupleCardinality(right);
 
-                var signature = best.Signature;
+                if (leftCardinality > 1 && rightCardinality > 1)
+                {
+                    regularOperatorDiagnostics.Free();
+                    return BindTupleBinaryOperatorNestedInfo(node, kind, left, right, diagnostics);
+                }
 
-                bool isObjectEquality = signature.Kind == BinaryOperatorKind.ObjectEqual || signature.Kind == BinaryOperatorKind.ObjectNotEqual;
-
-                resultOperatorKind = signature.Kind;
-                resultMethod = signature.Method;
-                convertedLeftType = signature.LeftType;
-                convertedRightType = signature.RightType;
-                returnType = signature.ReturnType; // PROTOTYPE(tuple-equality) Do we need a special case for nullable equality? (see BindSimpleBinaryOperator)
-
-                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                hasErrors = isObjectEquality && !BuiltInOperators.IsValidObjectEquality(Conversions, leftType, leftNull, rightType, rightNull, ref useSiteDiagnostics);
-                diagnostics.Add(node, useSiteDiagnostics);
-            }
-
-            if (hasErrors)
-            {
                 ReportBinaryOperatorError(node, diagnostics, node.OperatorToken, left, right, resultKind);
             }
+            diagnostics.AddRange(regularOperatorDiagnostics.ToReadOnlyAndFree());
 
-            PrepareBoolConversionAndTruthOperator(returnType, node, kind, diagnostics, out Conversion boolConversion, out UnaryOperatorSignature boolOperator);
-            return new TupleBinaryOperatorInfo.Single(convertedLeftType, convertedRightType, resultOperatorKind, resultMethod, boolConversion, boolOperator);
+            TypeSymbol convertedLeftType = signature.LeftType;
+            TypeSymbol convertedRightType = signature.RightType;
+            if (convertedLeftType is null)
+            {
+                Debug.Assert(convertedRightType is null);
+
+                convertedLeftType = leftType ?? CreateErrorType();
+                convertedRightType = rightType ?? CreateErrorType();
+            }
+
+            PrepareBoolConversionAndTruthOperator(signature.ReturnType, node, kind, diagnostics, out Conversion boolConversion, out UnaryOperatorSignature boolOperator);
+            return new TupleBinaryOperatorInfo.Single(convertedLeftType, convertedRightType, signature.Kind, signature.Method, boolConversion, boolOperator);
         }
 
         /// <summary>
@@ -200,29 +156,49 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private TupleBinaryOperatorInfo BindTupleBinaryOperatorNestedInfo(BinaryExpressionSyntax node, BinaryOperatorKind kind,
-            ImmutableArray<BoundExpression> left, ImmutableArray<BoundExpression> right,
-            bool isNullable, DiagnosticBag diagnostics)
+            BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
         {
-            int length = left.Length;
-            Debug.Assert(length == right.Length);
+            TypeSymbol leftType = left.Type;
+            TypeSymbol rightType = right.Type;
+
+            int leftCardinality = GetTupleCardinality(left);
+            int rightCardinality = GetTupleCardinality(right);
+
+            if (leftCardinality != rightCardinality)
+            {
+                Error(diagnostics, ErrorCode.ERR_TupleSizesMismatchForBinOps, node, leftCardinality, rightCardinality);
+
+                return new TupleBinaryOperatorInfo.Single(leftType ?? CreateErrorType(), rightType ?? CreateErrorType(),
+                    BinaryOperatorKind.Error, methodSymbolOpt: null, boolConversion: Conversion.NoConversion, boolOperator: default);
+            }
+
+            // typeless tuple literals are not nullable
+            bool leftNullable = leftType?.IsNullableType() == true;
+            bool rightNullable = rightType?.IsNullableType() == true;
+
+            var leftParts = GetTupleArgumentsOrPlaceholders(left);
+            var rightParts = GetTupleArgumentsOrPlaceholders(right);
+
+            int length = leftParts.Length;
+            Debug.Assert(length == rightParts.Length);
 
             var operatorsBuilder = ArrayBuilder<TupleBinaryOperatorInfo>.GetInstance(length);
 
             for (int i = 0; i < length; i++)
             {
-                operatorsBuilder.Add(BindTupleBinaryOperatorInfo(node, kind, left[i], right[i], diagnostics));
+                operatorsBuilder.Add(BindTupleBinaryOperatorInfo(node, kind, leftParts[i], rightParts[i], diagnostics));
             }
 
             var compilation = this.Compilation;
             var operators = operatorsBuilder.ToImmutableAndFree();
-
-            TypeSymbol leftTupleType = MakeConvertedType(operators.SelectAsArray(o => o.LeftConvertedType), node.Left, left, isNullable, compilation, diagnostics, isRight: false);
-            TypeSymbol rightTupleType = MakeConvertedType(operators.SelectAsArray(o => o.RightConvertedType), node.Right, right, isNullable, compilation, diagnostics, isRight: true);
+            bool isNullable = leftNullable || rightNullable;
+            TypeSymbol leftTupleType = MakeConvertedType(operators.SelectAsArray(o => o.LeftConvertedType), node.Left, leftParts, isNullable, compilation, diagnostics, isRight: false);
+            TypeSymbol rightTupleType = MakeConvertedType(operators.SelectAsArray(o => o.RightConvertedType), node.Right, rightParts, isNullable, compilation, diagnostics, isRight: true);
 
             return new TupleBinaryOperatorInfo.Multiple(operators, leftTupleType, rightTupleType);
         }
 
-        private static int? GetTupleCardinality(BoundExpression expr)
+        private static int GetTupleCardinality(BoundExpression expr)
         {
             if (expr.Kind == BoundKind.TupleLiteral)
             {
@@ -233,7 +209,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol type = expr.Type;
             if (type is null)
             {
-                return null;
+                return -1;
             }
 
             type = type.StrippedType();
@@ -243,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return type.TupleElementTypes.Length;
             }
 
-            return null;
+            return -1;
         }
 
         private static ImmutableArray<BoundExpression> GetTupleArgumentsOrPlaceholders(BoundExpression expr)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -90,6 +90,15 @@
     <Field Name="ValEscape" Type="uint" Null="NotApplicable"/>
   </Node>
 
+  <!--
+  In a tuple binary operator, this node is used to represent tuple elements in a tuple binary
+  operator, and to represent an element-wise comparison result to convert back to bool.
+  It is does not survive the initial binding.
+  -->
+  <Node Name="BoundTupleOperandPlaceholder" Base="BoundValuePlaceholderBase">
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+  </Node>
+
   <!-- only used by codegen -->
   <Node Name="BoundDup" Base="BoundExpression">
     <!-- when duplicating a local or parameter, must remember original ref kind -->
@@ -300,6 +309,16 @@
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>
     <Field Name="MethodOpt" Type="MethodSymbol" Null="allow"/>
     <Field Name="ResultKind" PropertyOverrides="true" Type="LookupResultKind"/>
+  </Node>
+
+  <Node Name="BoundTupleBinaryOperator" Base="BoundExpression">
+    <!-- Non-null type is required for this node kind -->
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+
+    <Field Name="Left" Type="BoundExpression"/>
+    <Field Name="Right" Type="BoundExpression"/>
+    <Field Name="OperatorKind" Type="BinaryOperatorKind"/>
+    <Field Name="Operators" Type="TupleBinaryOperatorInfo"/>
   </Node>
 
   <Node Name="BoundUserDefinedConditionalLogicalOperator" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -93,7 +93,7 @@
   <!--
   In a tuple binary operator, this node is used to represent tuple elements in a tuple binary
   operator, and to represent an element-wise comparison result to convert back to bool.
-  It is does not survive the initial binding.
+  It does not survive the initial binding.
   -->
   <Node Name="BoundTupleOperandPlaceholder" Base="BoundValuePlaceholderBase">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// A tree of binary operators for tuple comparisons.
     ///
     /// For `(a, (b, c)) == (d, (e, f))` we'll hold a Multiple with two elements.
-    /// The first element is a Single (describing the binary operator and conversions are involved in `a == d`).
+    /// The first element is a Single (describing the binary operator and conversions that are involved in `a == d`).
     /// The second element is a Multiple containing two Singles (one for the `b == e` comparison and the other for `c == f`).
     /// </summary>
     internal abstract class TupleBinaryOperatorInfo
@@ -50,8 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoolConversion = boolConversion;
                 BoolOperator = boolOperator;
 
-                // If a user-defined comparison operator is present, then the operator kind must be user-defined
-                Debug.Assert(Kind.IsUserDefined() || (object)MethodSymbolOpt == null);
+                Debug.Assert(Kind.IsUserDefined() == ((object)MethodSymbolOpt != null));
             }
 
             internal override bool IsSingle()
@@ -86,6 +85,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal Multiple(ImmutableArray<TupleBinaryOperatorInfo> operators, TypeSymbol leftConvertedType, TypeSymbol rightConvertedType) 
                 : base(leftConvertedType, rightConvertedType)
             {
+                Debug.Assert(leftConvertedType.StrippedType().IsTupleType);
+                Debug.Assert(rightConvertedType.StrippedType().IsTupleType);
                 Debug.Assert(!operators.IsDefaultOrEmpty);
                 Operators = operators;
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// A tree of binary operators for tuple comparisons.
+    ///
+    /// For `(a, (b, c)) == (d, (e, f))` we'll hold a Multiple with two elements.
+    /// The first element is a Single (describing the binary operator and conversions are involved in `a == d`).
+    /// The second element is a Multiple containing two Singles (one for the `b == e` comparison and the other for `c == f`).
+    /// </summary>
+    internal abstract class TupleBinaryOperatorInfo
+    {
+        internal abstract bool IsSingle();
+        internal readonly TypeSymbol LeftConvertedType;
+        internal readonly TypeSymbol RightConvertedType;
+#if DEBUG
+        internal abstract TreeDumperNode DumpCore();
+        internal string Dump() => TreeDumper.DumpCompact(DumpCore());
+#endif
+
+        private TupleBinaryOperatorInfo(TypeSymbol leftConvertedType, TypeSymbol rightConvertedType)
+        {
+            LeftConvertedType = leftConvertedType;
+            RightConvertedType = rightConvertedType;
+        }
+
+        /// <summary>
+        /// Holds the information for an element-wise comparison (like `a == b`)
+        /// </summary>
+        internal class Single : TupleBinaryOperatorInfo
+        {
+            internal readonly BinaryOperatorKind Kind;
+            internal readonly MethodSymbol MethodSymbolOpt; // User-defined comparison operator, if applicable
+
+            // To convert the result of comparison to bool
+            internal readonly Conversion BoolConversion;
+            internal readonly UnaryOperatorSignature BoolOperator; // Information for op_true or op_false
+
+            internal Single(TypeSymbol leftConvertedType, TypeSymbol rightConvertedType, BinaryOperatorKind kind,
+                MethodSymbol methodSymbolOpt, Conversion boolConversion, UnaryOperatorSignature boolOperator) : base(leftConvertedType, rightConvertedType)
+            {
+                Kind = kind;
+                MethodSymbolOpt = methodSymbolOpt;
+                BoolConversion = boolConversion;
+                BoolOperator = boolOperator;
+
+                // If a user-defined comparison operator is present, then the operator kind must be user-defined
+                Debug.Assert(Kind.IsUserDefined() || (object)MethodSymbolOpt == null);
+            }
+
+            internal override bool IsSingle()
+                => true;
+
+            public override string ToString()
+                => $"binaryOperatorKind: {Kind}";
+
+#if DEBUG
+            internal override TreeDumperNode DumpCore()
+            {
+                var sub = new List<TreeDumperNode>();
+                if ((object)MethodSymbolOpt != null)
+                {
+                    sub.Add(new TreeDumperNode("methodSymbolOpt", MethodSymbolOpt.ToDisplayString(), null));
+                }
+                sub.Add(new TreeDumperNode("leftConversion", LeftConvertedType.ToDisplayString(), null));
+                sub.Add(new TreeDumperNode("rightConversion", RightConvertedType.ToDisplayString(), null));
+
+                return new TreeDumperNode("nested", Kind, sub);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Holds the information for a tuple comparison, either at the top-level (like `(a, b) == ...`) or nested (like `(..., (a, b)) == (..., ...)`).
+        /// </summary>
+        internal class Multiple : TupleBinaryOperatorInfo
+        {
+            internal readonly ImmutableArray<TupleBinaryOperatorInfo> Operators;
+
+            internal Multiple(ImmutableArray<TupleBinaryOperatorInfo> operators, TypeSymbol leftConvertedType, TypeSymbol rightConvertedType) 
+                : base(leftConvertedType, rightConvertedType)
+            {
+                Debug.Assert(!operators.IsDefaultOrEmpty);
+                Operators = operators;
+            }
+
+            internal override bool IsSingle()
+                => false;
+
+#if DEBUG
+            internal override TreeDumperNode DumpCore()
+            {
+                var sub = new List<TreeDumperNode>();
+                sub.Add(new TreeDumperNode($"nestedOperators[{Operators.Length}]", null,
+                    Operators.SelectAsArray(c => c.DumpCore())));
+
+                return new TreeDumperNode("nested", null, sub);
+            }
+#endif
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -9440,6 +9440,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right..
+        /// </summary>
+        internal static string ERR_TupleSizesMismatchForBinOps {
+            get {
+                return ResourceManager.GetString("ERR_TupleSizesMismatchForBinOps", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Tuple must contain at least two elements..
         /// </summary>
         internal static string ERR_TupleTooFewElements {
@@ -10778,6 +10787,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_FeatureThrowExpression {
             get {
                 return ResourceManager.GetString("IDS_FeatureThrowExpression", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to tuple equality.
+        /// </summary>
+        internal static string IDS_FeatureTupleEquality {
+            get {
+                return ResourceManager.GetString("IDS_FeatureTupleEquality", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -216,6 +216,9 @@
   <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
     <value>private protected</value>
   </data>
+  <data name="IDS_FeatureTupleEquality" xml:space="preserve">
+    <value>tuple equality</value>
+  </data>
   <data name="IDS_FeatureNullable" xml:space="preserve">
     <value>nullable types</value>
   </data>
@@ -5255,5 +5258,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_InDynamicMethodArg" xml:space="preserve">
     <value>Arguments with 'in' modifier cannot be used in dynamically dispatched expessions.</value>
+  </data>
+  <data name="ERR_TupleSizesMismatchForBinOps" xml:space="preserve">
+    <value>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1554,9 +1554,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DefaultInPattern = 8363,
         ERR_InDynamicMethodArg = 8364,
 
+        #region diagnostics introduced for C# 7.3
         ERR_FeatureNotAvailableInVersion7_3 = 8370,
         WRN_AttributesOnBackingFieldsNotAvailable = 8371,
         ERR_DoNotUseFixedBufferAttrOnProperty = 8372,
+
+        ERR_TupleSizesMismatchForBinOps = 8373,
+        #endregion diagnostics introduced for C# 7.3
 
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -148,6 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         IDS_FeatureRefConditional = MessageBase + 12731,
         IDS_FeatureAttributesOnBackingFields = MessageBase + 12732,
+        IDS_FeatureTupleEquality = MessageBase + 12733,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -189,6 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // C# 7.3 features.
                 case MessageID.IDS_FeatureAttributesOnBackingFields: // semantic check
+                case MessageID.IDS_FeatureTupleEquality: // semantic check
                     return LanguageVersion.CSharp7_3;
 
                 // C# 7.2 features.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1025,6 +1025,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitTupleBinaryOperator(BoundTupleBinaryOperator node)
+        {
+            Visit(node.Left);
+            Visit(node.Right);
+            return null;
+        }
+
         public override BoundNode VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node)
         {
             VisitArguments(node.Arguments, node.ArgumentRefKindsOpt, null);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ParameterEqualsValue,
         GlobalStatementInitializer,
         DeconstructValuePlaceholder,
+        TupleOperandPlaceholder,
         Dup,
         BadExpression,
         BadStatement,
@@ -41,6 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         MakeRefOperator,
         RefValueOperator,
         BinaryOperator,
+        TupleBinaryOperator,
         UserDefinedConditionalLogicalOperator,
         CompoundAssignmentOperator,
         AssignmentOperator,
@@ -443,6 +445,42 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (valEscape != this.ValEscape || type != this.Type)
             {
                 var result = new BoundDeconstructValuePlaceholder(this.Syntax, valEscape, type, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundTupleOperandPlaceholder : BoundValuePlaceholderBase
+    {
+        public BoundTupleOperandPlaceholder(SyntaxNode syntax, TypeSymbol type, bool hasErrors)
+            : base(BoundKind.TupleOperandPlaceholder, syntax, type, hasErrors)
+        {
+
+            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+        }
+
+        public BoundTupleOperandPlaceholder(SyntaxNode syntax, TypeSymbol type)
+            : base(BoundKind.TupleOperandPlaceholder, syntax, type)
+        {
+
+            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+        }
+
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitTupleOperandPlaceholder(this);
+        }
+
+        public BoundTupleOperandPlaceholder Update(TypeSymbol type)
+        {
+            if (type != this.Type)
+            {
+                var result = new BoundTupleOperandPlaceholder(this.Syntax, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -1012,6 +1050,49 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (operatorKind != this.OperatorKind || left != this.Left || right != this.Right || constantValueOpt != this.ConstantValueOpt || methodOpt != this.MethodOpt || resultKind != this.ResultKind || type != this.Type)
             {
                 var result = new BoundBinaryOperator(this.Syntax, operatorKind, left, right, constantValueOpt, methodOpt, resultKind, type, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundTupleBinaryOperator : BoundExpression
+    {
+        public BoundTupleBinaryOperator(SyntaxNode syntax, BoundExpression left, BoundExpression right, BinaryOperatorKind operatorKind, TupleBinaryOperatorInfo operators, TypeSymbol type, bool hasErrors = false)
+            : base(BoundKind.TupleBinaryOperator, syntax, type, hasErrors || left.HasErrors() || right.HasErrors())
+        {
+
+            Debug.Assert(left != null, "Field 'left' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(right != null, "Field 'right' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(operators != null, "Field 'operators' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Left = left;
+            this.Right = right;
+            this.OperatorKind = operatorKind;
+            this.Operators = operators;
+        }
+
+
+        public BoundExpression Left { get; }
+
+        public BoundExpression Right { get; }
+
+        public BinaryOperatorKind OperatorKind { get; }
+
+        public TupleBinaryOperatorInfo Operators { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitTupleBinaryOperator(this);
+        }
+
+        public BoundTupleBinaryOperator Update(BoundExpression left, BoundExpression right, BinaryOperatorKind operatorKind, TupleBinaryOperatorInfo operators, TypeSymbol type)
+        {
+            if (left != this.Left || right != this.Right || operatorKind != this.OperatorKind || operators != this.Operators || type != this.Type)
+            {
+                var result = new BoundTupleBinaryOperator(this.Syntax, left, right, operatorKind, operators, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -6168,6 +6249,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitGlobalStatementInitializer(node as BoundGlobalStatementInitializer, arg);
                 case BoundKind.DeconstructValuePlaceholder: 
                     return VisitDeconstructValuePlaceholder(node as BoundDeconstructValuePlaceholder, arg);
+                case BoundKind.TupleOperandPlaceholder: 
+                    return VisitTupleOperandPlaceholder(node as BoundTupleOperandPlaceholder, arg);
                 case BoundKind.Dup: 
                     return VisitDup(node as BoundDup, arg);
                 case BoundKind.BadExpression: 
@@ -6198,6 +6281,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitRefValueOperator(node as BoundRefValueOperator, arg);
                 case BoundKind.BinaryOperator: 
                     return VisitBinaryOperator(node as BoundBinaryOperator, arg);
+                case BoundKind.TupleBinaryOperator: 
+                    return VisitTupleBinaryOperator(node as BoundTupleBinaryOperator, arg);
                 case BoundKind.UserDefinedConditionalLogicalOperator: 
                     return VisitUserDefinedConditionalLogicalOperator(node as BoundUserDefinedConditionalLogicalOperator, arg);
                 case BoundKind.CompoundAssignmentOperator: 
@@ -6488,6 +6573,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return this.DefaultVisit(node, arg);
         }
+        public virtual R VisitTupleOperandPlaceholder(BoundTupleOperandPlaceholder node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
         public virtual R VisitDup(BoundDup node, A arg)
         {
             return this.DefaultVisit(node, arg);
@@ -6545,6 +6634,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return this.DefaultVisit(node, arg);
         }
         public virtual R VisitBinaryOperator(BoundBinaryOperator node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitTupleBinaryOperator(BoundTupleBinaryOperator node, A arg)
         {
             return this.DefaultVisit(node, arg);
         }
@@ -7092,6 +7185,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return this.DefaultVisit(node);
         }
+        public virtual BoundNode VisitTupleOperandPlaceholder(BoundTupleOperandPlaceholder node)
+        {
+            return this.DefaultVisit(node);
+        }
         public virtual BoundNode VisitDup(BoundDup node)
         {
             return this.DefaultVisit(node);
@@ -7149,6 +7246,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return this.DefaultVisit(node);
         }
         public virtual BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitTupleBinaryOperator(BoundTupleBinaryOperator node)
         {
             return this.DefaultVisit(node);
         }
@@ -7701,6 +7802,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return null;
         }
+        public override BoundNode VisitTupleOperandPlaceholder(BoundTupleOperandPlaceholder node)
+        {
+            return null;
+        }
         public override BoundNode VisitDup(BoundDup node)
         {
             return null;
@@ -7770,6 +7875,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
         public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+        {
+            this.Visit(node.Left);
+            this.Visit(node.Right);
+            return null;
+        }
+        public override BoundNode VisitTupleBinaryOperator(BoundTupleBinaryOperator node)
         {
             this.Visit(node.Left);
             this.Visit(node.Right);
@@ -8479,6 +8590,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.ValEscape, type);
         }
+        public override BoundNode VisitTupleOperandPlaceholder(BoundTupleOperandPlaceholder node)
+        {
+            TypeSymbol type = this.VisitType(node.Type);
+            return node.Update(type);
+        }
         public override BoundNode VisitDup(BoundDup node)
         {
             TypeSymbol type = this.VisitType(node.Type);
@@ -8566,6 +8682,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.OperatorKind, left, right, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, type);
+        }
+        public override BoundNode VisitTupleBinaryOperator(BoundTupleBinaryOperator node)
+        {
+            BoundExpression left = (BoundExpression)this.Visit(node.Left);
+            BoundExpression right = (BoundExpression)this.Visit(node.Right);
+            TypeSymbol type = this.VisitType(node.Type);
+            return node.Update(left, right, node.OperatorKind, node.Operators, type);
         }
         public override BoundNode VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
         {
@@ -9394,6 +9517,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             );
         }
+        public override TreeDumperNode VisitTupleOperandPlaceholder(BoundTupleOperandPlaceholder node, object arg)
+        {
+            return new TreeDumperNode("tupleOperandPlaceholder", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("type", node.Type, null)
+            }
+            );
+        }
         public override TreeDumperNode VisitDup(BoundDup node, object arg)
         {
             return new TreeDumperNode("dup", null, new TreeDumperNode[]
@@ -9546,6 +9677,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new TreeDumperNode("constantValueOpt", node.ConstantValueOpt, null),
                 new TreeDumperNode("methodOpt", node.MethodOpt, null),
                 new TreeDumperNode("resultKind", node.ResultKind, null),
+                new TreeDumperNode("type", node.Type, null)
+            }
+            );
+        }
+        public override TreeDumperNode VisitTupleBinaryOperator(BoundTupleBinaryOperator node, object arg)
+        {
+            return new TreeDumperNode("tupleBinaryOperator", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("left", null, new TreeDumperNode[] { Visit(node.Left, null) }),
+                new TreeDumperNode("right", null, new TreeDumperNode[] { Visit(node.Right, null) }),
+                new TreeDumperNode("operatorKind", node.OperatorKind, null),
+                new TreeDumperNode("operators", node.Operators, null),
                 new TreeDumperNode("type", node.Type, null)
             }
             );

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return outLocals.ToImmutableAndFree();
         }
 
-        BoundExpression EvaluateSideEffectingArgumentToTemp(BoundExpression arg, ArrayBuilder<BoundExpression> effects,
+        private BoundExpression EvaluateSideEffectingArgumentToTemp(BoundExpression arg, ArrayBuilder<BoundExpression> effects,
             ref ArrayBuilder<LocalSymbol> temps)
         {
             if (CanChangeValueBetweenReads(arg, localsMayBeAssignedOrCaptured: true))
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return assignmentTargets;
         }
 
-        internal class DeconstructionSideEffects
+        private class DeconstructionSideEffects
         {
             internal ArrayBuilder<BoundExpression> init;
             internal ArrayBuilder<BoundExpression> deconstructions;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return outerSequence;
         }
 
-        private BoundExpression WithoutImplicitNullableConversions(BoundExpression expr)
+        private static BoundExpression WithoutImplicitNullableConversions(BoundExpression expr)
         {
             while (true)
             {
@@ -161,9 +161,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundExpression MakeTemp(BoundExpression expression, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> effects)
+        private BoundExpression MakeTemp(BoundExpression loweredExpression, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> effects)
         {
-            BoundLocal temp = _factory.StoreToTemp(VisitExpression(expression), out BoundAssignmentOperator assignmentToTemp);
+            BoundLocal temp = _factory.StoreToTemp(loweredExpression, out BoundAssignmentOperator assignmentToTemp);
             effects.Add(assignmentToTemp);
             temps.Add(temp.LocalSymbol);
             return temp;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
@@ -1,0 +1,406 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed partial class LocalRewriter
+    {
+        /// <summary>
+        /// Rewrite `GetTuple() == (1, 2)` to `tuple.Item1 == 1 &amp;&amp; tuple.Item2 == 2`.
+        /// Also supports the != operator, nullable and nested tuples.
+        /// Note that all the side-effects for visible expressions are evaluated first (into temporaries as needed).
+        /// Element-wise conversions occur late, together with the element-wise comparisons. They may not be evaluated.
+        /// </summary>
+        /// There are 2 cases:
+        /// - tuple literal cannot be null and it produces as many temps as elements
+        /// - tuple types or nullable tuple types produce a single temp (and no further temps are initialized)
+        public override BoundNode VisitTupleBinaryOperator(BoundTupleBinaryOperator node)
+        {
+            var boolType = node.Type; // we can re-use the bool type
+            var initialEffectsAndTemps = TupleOperatorSideEffectsAndTemps.GetInstance();
+
+            var returnValue = RewriteTupleOperator(node.Operators, node.Left, node.Right, boolType, initialEffectsAndTemps, node.OperatorKind, inLeftInit: true, inRightInit: true);
+
+            var (effects, temps) = initialEffectsAndTemps.ToImmutableAndFree();
+            var result = _factory.Sequence(temps, effects, returnValue);
+            return result;
+        }
+
+        private BoundExpression RewriteTupleOperator(TupleBinaryOperatorInfo @operator,
+            BoundExpression left, BoundExpression right, TypeSymbol boolType,
+            TupleOperatorSideEffectsAndTemps initialEffectsAndTemps, BinaryOperatorKind operatorKind, bool inLeftInit, bool inRightInit)
+        {
+            switch (@operator)
+            {
+                case TupleBinaryOperatorInfo.Nested nested:
+                    return RewriteTupleNestedOperators(nested, left, right, boolType, initialEffectsAndTemps, operatorKind, inLeftInit, inRightInit);
+
+                case TupleBinaryOperatorInfo.Single single:
+                    return RewriteTupleSingleOperator(single, left, right, boolType, operatorKind);
+
+                default:
+                    throw ExceptionUtilities.Unreachable;
+            }
+        }
+
+        private BoundExpression RewriteTupleNestedOperators(TupleBinaryOperatorInfo.Nested operators, BoundExpression left, BoundExpression right,
+            TypeSymbol boolType, TupleOperatorSideEffectsAndTemps initialEffectsAndTemps, BinaryOperatorKind operatorKind, bool inLeftInit, bool inRightInit)
+        {
+            // If either left or right is nullable, produce:
+            //
+            //      // outer sequence
+            //      var leftHasValue = left.HasValue; (or true if !leftNullable)
+            //      var rightHasValue = right.HasValue; (or true if !rightNullable)
+            //      leftHasValue == rightHasValue
+            //          ? leftHasValue ? ... inner sequence ... : true/false
+            //          : false/true
+            //
+            // where inner sequence is:
+            //      var leftValue = left.GetValueOrDefault(); (or left if !leftNullable)
+            //      var rightValue = right.GetValueOrDefault(); (or right if !rightNullable)
+            //      ... logical expression using leftValue and rightValue ...
+            //
+            // and true/false and false/true depend on operatorKind (== vs. !=)
+            //
+            // and temps are created an initialized with early side-effects for:
+            //  - elements from left and right, in case of a tuple literal
+            //  - left and right, in case of a tuple or nullable tuple type
+            //
+            // But if neither is nullable, then just produce the inner sequence.
+            //
+            // Note: all the temps are created in a single bucket (rather than different scopes of applicability) for simplicity
+
+            var outerEffects = ArrayBuilder<BoundExpression>.GetInstance();
+            var innerEffects = ArrayBuilder<BoundExpression>.GetInstance();
+
+            BoundExpression leftHasValue;
+            BoundExpression leftValue;
+
+            var coreLeft = WithoutImplicitNullableConversions(left);
+            var isLeftNullable = coreLeft.Type.IsNullableType();
+            if (isLeftNullable)
+            {
+                BoundExpression savedLeft = EvaluateSideEffectingArgumentToTemp(VisitExpression(left), outerEffects, ref initialEffectsAndTemps.temps);
+                leftHasValue = MakeHasValueTemp(savedLeft, initialEffectsAndTemps.temps, outerEffects);
+                leftValue = MakeValueOrDefaultTemp(savedLeft, initialEffectsAndTemps.temps, innerEffects);
+                inLeftInit = false;
+            }
+            else
+            {
+                leftHasValue = MakeBooleanConstant(left.Syntax, true);
+                leftValue = SaveTupleIfNotLiteral(coreLeft, ref inLeftInit, initialEffectsAndTemps, isRight: false);
+            }
+
+            BoundExpression rightHasValue;
+            BoundExpression rightValue;
+
+            var coreRight = WithoutImplicitNullableConversions(right);
+            var isRightNullable = coreRight.Type.IsNullableType();
+            if (isRightNullable)
+            {
+                BoundExpression savedRight = EvaluateSideEffectingArgumentToTemp(VisitExpression(right), outerEffects, ref initialEffectsAndTemps.temps);
+                rightHasValue = MakeNullableHasValue(savedRight.Syntax, savedRight); // no need for local for right.HasValue since used once
+                rightValue = MakeValueOrDefaultTemp(savedRight, initialEffectsAndTemps.temps, innerEffects);
+                inRightInit = false;
+            }
+            else
+            {
+                rightHasValue = MakeBooleanConstant(right.Syntax, true);
+                rightValue = SaveTupleIfNotLiteral(coreRight, ref inRightInit, initialEffectsAndTemps, isRight: true);
+            }
+
+            BoundExpression logicalExpression = RewriteNonNullableNestedTupleOperators(operators, leftValue, rightValue, boolType, initialEffectsAndTemps.temps, innerEffects, initialEffectsAndTemps, operatorKind, inLeftInit, inRightInit);
+
+            BoundExpression innerSequence = _factory.Sequence(ImmutableArray<LocalSymbol>.Empty, innerEffects.ToImmutableAndFree(), logicalExpression);
+
+            if (!isLeftNullable && !isRightNullable)
+            {
+                return innerSequence;
+            }
+
+            // outer sequence:
+            //      leftHasValue == rightHasValue
+            //          ? leftHasValue ? ... inner sequence ... : true/false
+            //          : false/true
+            bool boolValue = operatorKind == BinaryOperatorKind.Equal; // true/false
+            BoundExpression outerSequence =
+                _factory.Sequence(ImmutableArray<LocalSymbol>.Empty, outerEffects.ToImmutableAndFree(),
+                    _factory.Conditional(
+                        _factory.Binary(BinaryOperatorKind.Equal, boolType, leftHasValue, rightHasValue),
+                        _factory.Conditional(leftHasValue, innerSequence, MakeBooleanConstant(right.Syntax, boolValue), boolType),
+                        MakeBooleanConstant(right.Syntax, !boolValue),
+                        boolType));
+
+            return outerSequence;
+        }
+
+        private BoundExpression WithoutImplicitNullableConversions(BoundExpression expr)
+        {
+            while (true)
+            {
+                if (expr.Kind != BoundKind.Conversion)
+                {
+                    return expr;
+                }
+
+                var conversion = (BoundConversion)expr;
+                if (!conversion.Conversion.IsImplicit || !conversion.Conversion.IsNullable)
+                {
+                    return expr;
+                }
+
+                expr = conversion.Operand;
+            }
+        }
+
+        private BoundExpression MakeTemp(BoundExpression expression, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> effects)
+        {
+            BoundLocal temp = _factory.StoreToTemp(VisitExpression(expression), out BoundAssignmentOperator assignmentToTemp);
+            effects.Add(assignmentToTemp);
+            temps.Add(temp.LocalSymbol);
+            return temp;
+        }
+
+        /// <summary>
+        /// Returns a temp which is initialized with lowered-expression.HasValue
+        /// </summary>
+        private BoundExpression MakeHasValueTemp(BoundExpression expression, ArrayBuilder<LocalSymbol> temps,
+            ArrayBuilder<BoundExpression> effects)
+        {
+            BoundExpression hasValueCall = MakeNullableHasValue(expression.Syntax, expression);
+            return MakeTemp(hasValueCall, temps, effects);
+        }
+
+        /// <summary>
+        /// Returns a temp which is initialized with lowered-expression.GetValueOrDefault()
+        /// </summary>
+        private BoundExpression MakeValueOrDefaultTemp(BoundExpression expression,
+            ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> effects)
+        {
+            BoundExpression valueOrDefaultCall = MakeOptimizedGetValueOrDefault(expression.Syntax, expression);
+            return MakeTemp(valueOrDefaultCall, temps, effects);
+        }
+
+        /// <summary>
+        /// Produces a chain of equality (or inequality) checks combined logically with AND (or OR)
+        /// </summary>
+        private BoundExpression RewriteNonNullableNestedTupleOperators(TupleBinaryOperatorInfo.Nested operators,
+            BoundExpression left, BoundExpression right, TypeSymbol type,
+            ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> effects, TupleOperatorSideEffectsAndTemps effectAndTemps, BinaryOperatorKind operatorKind, bool inLeftInit, bool inRightInit)
+        {
+            Debug.Assert(left.Type?.IsNullableType() == false);
+            Debug.Assert(right.Type?.IsNullableType() == false);
+
+            ImmutableArray<TupleBinaryOperatorInfo> nestedOperators = operators.NestedOperators;
+
+            BoundExpression currentResult = null;
+            for (int i = 0; i < nestedOperators.Length; i++)
+            {
+                BoundExpression leftElement = GetTuplePart(left, i, nestedOperators, temps, effects, effectAndTemps, isRight: false);
+                BoundExpression rightElement = GetTuplePart(right, i, nestedOperators, temps, effects, effectAndTemps, isRight: true);
+                var nextLogicalOperand = RewriteTupleOperator(nestedOperators[i], leftElement, rightElement, type, effectAndTemps, operatorKind, inLeftInit, inRightInit);
+                if (currentResult is null)
+                {
+                    currentResult = nextLogicalOperand;
+                }
+                else
+                {
+                    var logicalOperator = operatorKind == BinaryOperatorKind.Equal ? BinaryOperatorKind.LogicalBoolAnd : BinaryOperatorKind.LogicalBoolOr;
+                    currentResult = _factory.Binary(logicalOperator, type, currentResult, nextLogicalOperand);
+                }
+            }
+
+            return currentResult;
+        }
+
+        private BoundExpression SaveTupleIfNotLiteral(BoundExpression tuple, ref bool inInit, TupleOperatorSideEffectsAndTemps effectsAndTemps, bool isRight)
+        {
+            if (!TupleNeedsSaving(tuple) || !inInit)
+            {
+                return tuple;
+            }
+
+            var tupleTemp = EvaluateSideEffectingArgumentToTemp(VisitExpression(tuple), isRight ? effectsAndTemps.rightInit : effectsAndTemps.leftInit, ref effectsAndTemps.temps);
+            inInit = false;
+            return tupleTemp;
+        }
+
+        private bool TupleNeedsSaving(BoundExpression tuple)
+        {
+            if (IsTupleExpression(tuple.Kind))
+            {
+                return false;
+            }
+
+            if (tuple.Kind == BoundKind.Conversion)
+            {
+                var tupleConversion = (BoundConversion)tuple;
+                if (tupleConversion.Conversion.Kind == ConversionKind.ImplicitNullable)
+                {
+                    return TupleNeedsSaving(tupleConversion.Operand);
+                }
+
+                if ((tupleConversion.Conversion.Kind == ConversionKind.ImplicitTupleLiteral || tupleConversion.Conversion.Kind == ConversionKind.Identity)
+                    && IsTupleExpression(tupleConversion.Operand.Kind))
+                {
+                    return false;
+                }
+            }
+
+            Debug.Assert(tuple.Type is var tupleType && tupleType.IsTupleType);
+            return true;
+        }
+
+        // The tuple itself was already saved to temp if necessary
+        // If getting the element of a tuple literal corresponding to a single operator, we save it into initialization side-effects
+        // If getting the element of a tuple literal corresponding to a nested operator, we just return it
+        // If getting the element of a tuple type, we save it into the local side-effects
+        private BoundExpression GetTuplePart(BoundExpression tuple, int i, ImmutableArray<TupleBinaryOperatorInfo> operators,
+            ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> effects, TupleOperatorSideEffectsAndTemps initialEffectsAndTemps, bool isRight)
+        {
+            // Example:
+            // (1, 2) == (1, 2);
+            if (IsTupleExpression(tuple.Kind))
+            {
+                return MakeTemp(((BoundTupleExpression)tuple).Arguments[i], operators[i], initialEffectsAndTemps, isRight);
+            }
+
+            // Example:
+            // (1L, 2L == (1, 2);
+            // (1, "hello") == (1, null);
+            if (tuple.Kind == BoundKind.Conversion)
+            {
+                var tupleConversion = (BoundConversion)tuple;
+                if (tupleConversion.Conversion.Kind == ConversionKind.ImplicitNullable)
+                {
+                    return GetTuplePart(tupleConversion.Operand, i, operators, temps, effects, initialEffectsAndTemps, isRight);
+                }
+
+                if ((tupleConversion.Conversion.Kind == ConversionKind.ImplicitTupleLiteral || tupleConversion.Conversion.Kind == ConversionKind.Identity)
+                    && IsTupleExpression(tupleConversion.Operand.Kind))
+                {
+                    var coreArgument = WithoutImplicitNullableConversions(((BoundTupleExpression)tupleConversion.Operand).Arguments[i]);
+                    return MakeTemp(coreArgument, operators[i], initialEffectsAndTemps, isRight);
+                }
+            }
+
+            Debug.Assert(tuple.Type.IsTupleType);
+
+            // Example:
+            // t == GetTuple();
+            // t == ((byte, byte)) (1, 2);
+            // t == ((short, short))((int, int))(1L, 2L);
+            return MakeTupleFieldAccessAndReportUseSiteDiagnostics(tuple, tuple.Syntax, tuple.Type.TupleElements[i]);
+        }
+
+        private BoundExpression MakeTemp(BoundExpression expr, TupleBinaryOperatorInfo op, TupleOperatorSideEffectsAndTemps initialEffectsAndTemps, bool isRight)
+        {
+            if (op.IsSingle())
+            {
+                return EvaluateSideEffectingArgumentToTemp(VisitExpression(expr), isRight ? initialEffectsAndTemps.rightInit : initialEffectsAndTemps.leftInit, ref initialEffectsAndTemps.temps);
+            }
+            else
+            {
+                return expr;
+            }
+        }
+
+        /// <summary>
+        /// Produce an element-wise comparison and logic to ensure the result is a bool type.
+        /// 
+        /// If an element-wise comparison doesn't return bool, then:
+        /// - if it is dynamic, we'll do `!(comparisonResult.false)` or `comparisonResult.true`
+        /// - if it implicitly converts to bool, we'll just do the conversion
+        /// - otherwise, we'll do `!(comparisonResult.false)` or `comparisonResult.true` (as we'd do for `if` or `while`)
+        /// </summary>
+        private BoundExpression RewriteTupleSingleOperator(TupleBinaryOperatorInfo.Single single,
+            BoundExpression left, BoundExpression right, TypeSymbol boolType, BinaryOperatorKind operatorKind)
+        {
+            if (single.Kind.IsDynamic())
+            {
+                // Produce
+                // !((left == right).op_false)
+                // (left != right).op_true
+
+                var dynamicResult = _dynamicFactory.MakeDynamicBinaryOperator(single.Kind, left, right, isCompoundAssignment: false, _compilation.DynamicType).ToExpression();
+                if (operatorKind == BinaryOperatorKind.Equal)
+                {
+                    return _factory.Not(MakeUnaryOperator(UnaryOperatorKind.DynamicFalse, left.Syntax, method: null, dynamicResult, boolType));
+                }
+                else
+                {
+                    return MakeUnaryOperator(UnaryOperatorKind.DynamicTrue, left.Syntax, method: null, dynamicResult, boolType);
+                }
+            }
+            else
+            {
+                BoundExpression binary = _factory.Binary(single.Kind, single.MethodSymbolOpt?.ReturnType ?? boolType, left, right, single.MethodSymbolOpt);
+
+                UnaryOperatorSignature boolOperator = single.BoolOperator;
+                Conversion boolConversion = single.BoolConversion;
+
+                BoundExpression result;
+                if (boolOperator.Kind != UnaryOperatorKind.Error)
+                {
+                    // Produce
+                    // !((left == right).op_false)
+                    // (left != right).op_true
+
+                    BoundExpression convertedBinary = _factory.Convert(boolOperator.OperandType, binary, boolConversion);
+                    Debug.Assert(boolOperator.ReturnType.SpecialType == SpecialType.System_Boolean);
+
+                    result = new BoundUnaryOperator(binary.Syntax, boolOperator.Kind, binary, ConstantValue.NotAvailable,
+                        boolOperator.Method, LookupResultKind.Viable, boolType).MakeCompilerGenerated();
+
+                    if (operatorKind == BinaryOperatorKind.Equal)
+                    {
+                        result = _factory.Not(result);
+                    }
+                }
+                else if (boolConversion != Conversion.Identity)
+                {
+                    // Produce
+                    // (bool)(left == right)
+                    // (bool)(left != right)
+                    result = _factory.Convert(boolType, binary, boolConversion);
+                }
+                else
+                {
+                    result = binary;
+                }
+
+                return VisitExpression(result);
+            }
+        }
+
+        private class TupleOperatorSideEffectsAndTemps
+        {
+            internal ArrayBuilder<BoundExpression> leftInit;
+            internal ArrayBuilder<BoundExpression> rightInit;
+            internal ArrayBuilder<LocalSymbol> temps;
+
+            internal static TupleOperatorSideEffectsAndTemps GetInstance()
+            {
+                var result = new TupleOperatorSideEffectsAndTemps();
+                result.leftInit = ArrayBuilder<BoundExpression>.GetInstance();
+                result.rightInit = ArrayBuilder<BoundExpression>.GetInstance();
+                result.temps = ArrayBuilder<LocalSymbol>.GetInstance();
+
+                return result;
+            }
+
+            internal (ImmutableArray<BoundExpression>, ImmutableArray<LocalSymbol>) ToImmutableAndFree()
+            {
+                leftInit.AddRange(rightInit);
+                rightInit.Free();
+
+                return (leftInit.ToImmutableAndFree(), temps.ToImmutableAndFree());
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
@@ -76,20 +76,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (kind.IsDynamic())
             {
-                Debug.Assert(kind == UnaryOperatorKind.DynamicTrue && type.SpecialType == SpecialType.System_Boolean || type.IsDynamic());
+                Debug.Assert((kind == UnaryOperatorKind.DynamicTrue || kind == UnaryOperatorKind.DynamicFalse) && type.SpecialType == SpecialType.System_Boolean
+                    || type.IsDynamic());
                 Debug.Assert((object)method == null);
 
                 // Logical operators on boxed Boolean constants:
                 var constant = UnboxConstant(loweredOperand);
                 if (constant == ConstantValue.True || constant == ConstantValue.False)
                 {
-                    if (kind == UnaryOperatorKind.DynamicTrue)
+                    switch (kind)
                     {
-                        return _factory.Literal(constant.BooleanValue);
-                    }
-                    else if (kind == UnaryOperatorKind.DynamicLogicalNegation)
-                    {
-                        return MakeConversionNode(_factory.Literal(!constant.BooleanValue), type, @checked: false);
+                        case UnaryOperatorKind.DynamicTrue:
+                        case UnaryOperatorKind.DynamicFalse:
+                            return _factory.Literal(constant.BooleanValue);
+                        case UnaryOperatorKind.DynamicLogicalNegation:
+                            return MakeConversionNode(_factory.Literal(!constant.BooleanValue), type, @checked: false);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -491,9 +491,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return SynthesizedParameterSymbol.Create(container, type, ordinal, RefKind.None, name);
         }
 
-        public BoundBinaryOperator Binary(BinaryOperatorKind kind, TypeSymbol type, BoundExpression left, BoundExpression right)
+        public BoundBinaryOperator Binary(BinaryOperatorKind kind, TypeSymbol type, BoundExpression left, BoundExpression right, MethodSymbol methodSymbolOpt = null)
         {
-            return new BoundBinaryOperator(this.Syntax, kind, left, right, ConstantValue.NotAvailable, null, LookupResultKind.Viable, type) { WasCompilerGenerated = true };
+            return new BoundBinaryOperator(this.Syntax, kind, left, right, ConstantValue.NotAvailable, methodSymbolOpt, LookupResultKind.Viable, type) { WasCompilerGenerated = true };
         }
 
         public BoundAsOperator As(BoundExpression operand, TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -491,9 +491,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return SynthesizedParameterSymbol.Create(container, type, ordinal, RefKind.None, name);
         }
 
-        public BoundBinaryOperator Binary(BinaryOperatorKind kind, TypeSymbol type, BoundExpression left, BoundExpression right, MethodSymbol methodSymbolOpt = null)
+        public BoundBinaryOperator Binary(BinaryOperatorKind kind, TypeSymbol type, BoundExpression left, BoundExpression right)
         {
-            return new BoundBinaryOperator(this.Syntax, kind, left, right, ConstantValue.NotAvailable, methodSymbolOpt, LookupResultKind.Viable, type) { WasCompilerGenerated = true };
+            return new BoundBinaryOperator(this.Syntax, kind, left, right, ConstantValue.NotAvailable, null, LookupResultKind.Viable, type) { WasCompilerGenerated = true };
         }
 
         public BoundAsOperator As(BoundExpression operand, TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -94,13 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(!shouldCheckConstraints || (object)syntax != null);
             Debug.Assert(elementNames.IsDefault || elementTypes.Length == elementNames.Length);
-
-            int numElements = elementTypes.Length;
-
-            if (numElements <= 1)
-            {
-                throw ExceptionUtilities.Unreachable;
-            }
+            Debug.Assert(elementTypes.Length > 1 || elementNames.IsDefault);
 
             NamedTypeSymbol underlyingType = GetTupleUnderlyingType(elementTypes, syntax, compilation, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -94,7 +94,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(!shouldCheckConstraints || (object)syntax != null);
             Debug.Assert(elementNames.IsDefault || elementTypes.Length == elementNames.Length);
-            Debug.Assert(elementTypes.Length > 1 || elementNames.IsDefault);
+
+            int numElements = elementTypes.Length;
+
+            if (numElements <= 1)
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
 
             NamedTypeSymbol underlyingType = GetTupleUnderlyingType(elementTypes, syntax, compilation, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8615,6 +8615,16 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8615,6 +8615,16 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8615,6 +8615,16 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8615,6 +8615,16 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8615,6 +8615,16 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8615,6 +8615,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8615,6 +8615,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8615,6 +8615,16 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8615,6 +8615,16 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8615,6 +8615,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8615,6 +8615,16 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8615,6 +8615,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8615,6 +8615,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">'{0}' cannot implement interface member '{1}' in type '{2}' because it has an __arglist parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureTupleEquality">
+        <source>tuple equality</source>
+        <target state="new">tuple equality</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_TupleSizesMismatchForBinOps">
+        <source>Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</source>
+        <target state="new">Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality {0} on the left and {1} on the right.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -1,0 +1,2783 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
+{
+    [CompilerTrait(CompilerFeature.TupleEquality)]
+    public class CodeGenTupleEqualityTests : CSharpTestBase
+    {
+        private static readonly MetadataReference[] s_valueTupleRefs = new[] { SystemRuntimeFacadeRef, ValueTupleRef };
+
+        [Fact]
+        void TestCSharp7_2()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var t = (1, 2);
+        System.Console.Write(t == (1, 2));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (7,30): error CS8320: Feature 'tuple equality' is not available in C# 7.2. Please use language version 7.3 or greater.
+                //         System.Console.Write(t == (1, 2));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_2, "t == (1, 2)").WithArguments("tuple equality", "7.3").WithLocation(7, 30)
+                );
+        }
+
+        [Theory]
+        [InlineData("(1, 2)", "(1L, 2L)", true)]
+        [InlineData("(1, 2)", "(1, 0)", false)]
+        [InlineData("(1, 2)", "(0, 2)", false)]
+        [InlineData("(1, 2)", "((long, long))(1, 2)", true)]
+        [InlineData("((1, 2L), (3, 4))", "((1L, 2), (3L, 4))", true)]
+        [InlineData("((1, 2L), (3, 4))", "((0L, 2), (3L, 4))", false)]
+        [InlineData("((1, 2L), (3, 4))", "((1L, 0), (3L, 4))", false)]
+        [InlineData("((1, 2L), (3, 4))", "((1L, 0), (0L, 4))", false)]
+        [InlineData("((1, 2L), (3, 4))", "((1L, 0), (3L, 0))", false)]
+        void TestSimple(string change1, string change2, bool expectedMatch)
+        {
+            var sourceTemplate = @"
+class C
+{
+    static void Main()
+    {
+        var t1 = CHANGE1;
+        var t2 = CHANGE2;
+        System.Console.Write($""{(t1 == t2) == EXPECTED} {(t1 != t2) != EXPECTED}"");
+    }
+}";
+            string source = sourceTemplate
+                .Replace("CHANGE1", change1)
+                .Replace("CHANGE2", change2)
+                .Replace("EXPECTED", expectedMatch ? "true" : "false");
+            string name = GetUniqueName();
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe, assemblyName: name);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "True True");
+        }
+
+        [Fact]
+        void TestTuplesWithDifferentCardinalities()
+        {
+            var source = @"
+class C
+{
+    static bool M()
+    {
+        var t1 = (1, 1);
+        var t2 = (2, 2, 2);
+        return t1 == t2;
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (8,16): error CS8355: Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality 2 on the left and 3 on the right.
+                //         return t1 == t2;
+                Diagnostic(ErrorCode.ERR_TupleSizesMismatchForBinOps, "t1 == t2").WithArguments("2", "3").WithLocation(8, 16)
+                );
+        }
+
+        [Fact]
+        void TestNestedTuplesWithDifferentCardinalities()
+        {
+            var source = @"
+class C
+{
+    static bool M()
+    {
+        var t1 = (1, (1, 1));
+        var t2 = (2, (2, 2, 2));
+        return t1 == t2;
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (8,16): error CS8355: Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality 2 on the left and 3 on the right.
+                //         return t1 == t2;
+                Diagnostic(ErrorCode.ERR_TupleSizesMismatchForBinOps, "t1 == t2").WithArguments("2", "3").WithLocation(8, 16)
+                );
+        }
+
+        [Fact]
+        void TestNestedNullableTuplesWithDifferentCardinalities()
+        {
+            var source = @"
+class C
+{
+    static bool M()
+    {
+        (int, int)? nt = (1, 1);
+        var t1 = (1, nt);
+        var t2 = (2, (2, 2, 2));
+        return t1 == t2;
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (9,16): error CS8373: Tuple types used as operands of a binary operator must have matching cardinalities. But this operator has tuple types of cardinality 2 on the left and 3 on the right.
+                //         return t1 == t2;
+                Diagnostic(ErrorCode.ERR_TupleSizesMismatchForBinOps, "t1 == t2").WithArguments("2", "3").WithLocation(9, 16)
+                );
+        }
+
+        [Fact]
+        void TestILForSimpleEqual()
+        {
+            var source = @"
+class C
+{
+    static bool M()
+    {
+        var t1 = (1, 1);
+        var t2 = (2, 2);
+        return t1 == t2;
+    }
+}";
+            var comp = CompileAndVerify(source, additionalRefs: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.M", @"{
+  // Code size       50 (0x32)
+  .maxstack  3
+  .locals init (System.ValueTuple<int, int> V_0, //t1
+                System.ValueTuple<int, int> V_1,
+                System.ValueTuple<int, int> V_2)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""System.ValueTuple<int, int>..ctor(int, int)""
+  IL_0009:  ldc.i4.2
+  IL_000a:  ldc.i4.2
+  IL_000b:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
+  IL_0010:  ldloc.0
+  IL_0011:  stloc.1
+  IL_0012:  stloc.2
+  IL_0013:  ldloc.1
+  IL_0014:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_0019:  ldloc.2
+  IL_001a:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_001f:  bne.un.s   IL_0030
+  IL_0021:  ldloc.1
+  IL_0022:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_0027:  ldloc.2
+  IL_0028:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_002d:  ceq
+  IL_002f:  ret
+  IL_0030:  ldc.i4.0
+  IL_0031:  ret
+}");
+        }
+
+        [Fact]
+        void TestILForSimpleNotEqual()
+        {
+            var source = @"
+class C
+{
+    static bool M((int, int) t1, (int, int) t2)
+    {
+        return t1 != t2;
+    }
+}";
+            var comp = CompileAndVerify(source, additionalRefs: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.M", @"{
+  // Code size       38 (0x26)
+  .maxstack  2
+  .locals init (System.ValueTuple<int, int> V_0,
+                System.ValueTuple<int, int> V_1)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldarg.1
+  IL_0003:  stloc.1
+  IL_0004:  ldloc.0
+  IL_0005:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_000a:  ldloc.1
+  IL_000b:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_0010:  bne.un.s   IL_0024
+  IL_0012:  ldloc.0
+  IL_0013:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_0018:  ldloc.1
+  IL_0019:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_001e:  ceq
+  IL_0020:  ldc.i4.0
+  IL_0021:  ceq
+  IL_0023:  ret
+  IL_0024:  ldc.i4.1
+  IL_0025:  ret
+}");
+        }
+
+        [Fact]
+        void TestILForSimpleEqualOnTupleLiterals()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        M(1, 1);
+        M(1, 2);
+        M(2, 1);
+    }
+    static void M(int x, byte y)
+    {
+        System.Console.Write($""{(x, x) == (y, y)} "");
+    }
+}";
+            var comp = CompileAndVerify(source, additionalRefs: s_valueTupleRefs, expectedOutput: "True False False");
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.M", @"{
+  // Code size       38 (0x26)
+  .maxstack  3
+  .locals init (int V_0,
+                int V_1,
+                int V_2)
+  IL_0000:  ldstr      ""{0} ""
+  IL_0005:  ldarg.0
+  IL_0006:  ldarg.0
+  IL_0007:  stloc.1
+  IL_0008:  ldarg.1
+  IL_0009:  stloc.0
+  IL_000a:  ldarg.1
+  IL_000b:  stloc.2
+  IL_000c:  ldloc.0
+  IL_000d:  bne.un.s   IL_0015
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ceq
+  IL_0013:  br.s       IL_0016
+  IL_0015:  ldc.i4.0
+  IL_0016:  box        ""bool""
+  IL_001b:  call       ""string string.Format(string, object)""
+  IL_0020:  call       ""void System.Console.Write(string)""
+  IL_0025:  ret
+}");
+
+            var tree = comp.Compilation.SyntaxTrees.First();
+            var model = comp.Compilation.GetSemanticModel(tree);
+
+            var tupleY = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().Last();
+            Assert.Equal("(y, y)", tupleY.ToString());
+
+            var tupleYSymbol = model.GetTypeInfo(tupleY);
+            Assert.Equal("(System.Byte, System.Byte)", tupleYSymbol.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)", tupleYSymbol.ConvertedType.ToTestDisplayString());
+
+            var y = tupleY.Arguments[0].Expression;
+            var ySymbol = model.GetTypeInfo(y);
+            Assert.Equal("System.Byte", ySymbol.Type.ToTestDisplayString());
+            Assert.Equal("System.Int32", ySymbol.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        void TestILForNullableElementsEqualsToNull()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write(M(null, null));
+        System.Console.Write(M(1, true));
+    }
+    static bool M(int? i1, bool? b1)
+    {
+        var t1 = (i1, b1);
+        return t1 == (null, null);
+    }
+}";
+            var comp = CompileAndVerify(source, additionalRefs: s_valueTupleRefs, expectedOutput: "TrueFalse");
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.M", @"{
+  // Code size       40 (0x28)
+  .maxstack  2
+  .locals init (System.ValueTuple<int?, bool?> V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  newobj     ""System.ValueTuple<int?, bool?>..ctor(int?, bool?)""
+  IL_0007:  stloc.0
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  ldflda     ""int? System.ValueTuple<int?, bool?>.Item1""
+  IL_000f:  call       ""bool int?.HasValue.get""
+  IL_0014:  brtrue.s   IL_0026
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  ldflda     ""bool? System.ValueTuple<int?, bool?>.Item2""
+  IL_001d:  call       ""bool bool?.HasValue.get""
+  IL_0022:  ldc.i4.0
+  IL_0023:  ceq
+  IL_0025:  ret
+  IL_0026:  ldc.i4.0
+  IL_0027:  ret
+}");
+        }
+
+        [Fact]
+        void TestILForNullableElementsNotEqualsToNull()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write(M(null, null));
+        System.Console.Write(M(1, true));
+    }
+    static bool M(int? i1, bool? b1)
+    {
+        var t1 = (i1, b1);
+        return t1 != (null, null);
+    }
+}";
+            var comp = CompileAndVerify(source, additionalRefs: s_valueTupleRefs, expectedOutput: "FalseTrue");
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.M", @"{
+  // Code size       37 (0x25)
+  .maxstack  2
+  .locals init (System.ValueTuple<int?, bool?> V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  newobj     ""System.ValueTuple<int?, bool?>..ctor(int?, bool?)""
+  IL_0007:  stloc.0
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  ldflda     ""int? System.ValueTuple<int?, bool?>.Item1""
+  IL_000f:  call       ""bool int?.HasValue.get""
+  IL_0014:  brtrue.s   IL_0023
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  ldflda     ""bool? System.ValueTuple<int?, bool?>.Item2""
+  IL_001d:  call       ""bool bool?.HasValue.get""
+  IL_0022:  ret
+  IL_0023:  ldc.i4.1
+  IL_0024:  ret
+}");
+        }
+
+        [Fact]
+        void TestILForNullableElementsComparedToNonNullValues()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write(M((null, null)));
+        System.Console.Write(M((2, true)));
+    }
+    static bool M((int?, bool?) t1)
+    {
+        return t1 == (2, true);
+    }
+}";
+            var comp = CompileAndVerify(source, additionalRefs: s_valueTupleRefs, expectedOutput: "FalseTrue");
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.M", @"{
+  // Code size       66 (0x42)
+  .maxstack  2
+  .locals init (System.ValueTuple<int?, bool?> V_0,
+                int? V_1,
+                int V_2,
+                bool? V_3,
+                bool V_4)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldfld      ""int? System.ValueTuple<int?, bool?>.Item1""
+  IL_0008:  stloc.1
+  IL_0009:  ldc.i4.2
+  IL_000a:  stloc.2
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  call       ""int int?.GetValueOrDefault()""
+  IL_0012:  ldloc.2
+  IL_0013:  beq.s      IL_0018
+  IL_0015:  ldc.i4.0
+  IL_0016:  br.s       IL_001f
+  IL_0018:  ldloca.s   V_1
+  IL_001a:  call       ""bool int?.HasValue.get""
+  IL_001f:  brfalse.s  IL_0040
+  IL_0021:  ldloc.0
+  IL_0022:  ldfld      ""bool? System.ValueTuple<int?, bool?>.Item2""
+  IL_0027:  stloc.3
+  IL_0028:  ldc.i4.1
+  IL_0029:  stloc.s    V_4
+  IL_002b:  ldloca.s   V_3
+  IL_002d:  call       ""bool bool?.GetValueOrDefault()""
+  IL_0032:  ldloc.s    V_4
+  IL_0034:  beq.s      IL_0038
+  IL_0036:  ldc.i4.0
+  IL_0037:  ret
+  IL_0038:  ldloca.s   V_3
+  IL_003a:  call       ""bool bool?.HasValue.get""
+  IL_003f:  ret
+  IL_0040:  ldc.i4.0
+  IL_0041:  ret
+}");
+        }
+
+        [Fact]
+        void TestSimpleEqualOnTypelessTupleLiteral()
+        {
+            var source = @"
+class C
+{
+    static bool M((string, long) t)
+    {
+        return t == (null, 1) && t == (""hello"", 1);
+    }
+}";
+            var comp = CompileAndVerify(source, additionalRefs: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            var tree = comp.Compilation.SyntaxTrees.First();
+            var model = comp.Compilation.GetSemanticModel(tree);
+
+            var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            var symbol1 = model.GetTypeInfo(tuple1);
+            Assert.Null(symbol1.Type);
+            Assert.Equal("(System.String, System.Int64)", symbol1.ConvertedType.ToTestDisplayString());
+
+            var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            var symbol2 = model.GetTypeInfo(tuple2);
+            Assert.Equal("(System.String, System.Int32)", symbol2.Type.ToTestDisplayString());
+            Assert.Equal("(System.String, System.Int64)", symbol2.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        void TestOtherOperatorsOnTuples()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        var t1 = (1, 2);
+        _ = t1 + t1; // error 1
+        _ = t1 > t1; // error 2
+        _ = t1 >= t1; // error 3
+        _ = !t1; // error 4
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (7,13): error CS0019: Operator '+' cannot be applied to operands of type '(int, int)' and '(int, int)'
+                //         _ = t1 + t1; // error 1
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "t1 + t1").WithArguments("+", "(int, int)", "(int, int)").WithLocation(7, 13),
+                // (8,13): error CS0019: Operator '>' cannot be applied to operands of type '(int, int)' and '(int, int)'
+                //         _ = t1 > t1; // error 2
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "t1 > t1").WithArguments(">", "(int, int)", "(int, int)").WithLocation(8, 13),
+                // (9,13): error CS0019: Operator '>=' cannot be applied to operands of type '(int, int)' and '(int, int)'
+                //         _ = t1 >= t1; // error 3
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "t1 >= t1").WithArguments(">=", "(int, int)", "(int, int)").WithLocation(9, 13),
+                // (10,13): error CS0023: Operator '!' cannot be applied to operand of type '(int, int)'
+                //         _ = !t1; // error 4
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!t1").WithArguments("!", "(int, int)").WithLocation(10, 13)
+                );
+        }
+
+        [Fact]
+        void TestTypelessTuples()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        string s = null;
+        System.Console.Write((s, null) == (null, s));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "True");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            Assert.Equal("(s, null)", tuple1.ToString());
+            var tupleType1 = model.GetTypeInfo(tuple1);
+            Assert.Null(tupleType1.Type);
+            Assert.Equal("(System.String, System.String)", tupleType1.ConvertedType.ToTestDisplayString());
+
+            var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(null, s)", tuple2.ToString());
+            var tupleType2 = model.GetTypeInfo(tuple2);
+            Assert.Null(tupleType2.Type);
+            Assert.Equal("(System.String, System.String)", tupleType2.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        void TestSimpleTypelessTupleAndTupleType()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var t1 = (1, 2L);
+        System.Console.Write(t1 == (1L, 2));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "True");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(1L, 2)", tuple.ToString());
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Equal("(System.Int64, System.Int32)", tupleType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int64, System.Int64)", tupleType.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        void TestNestedTypelessTupleAndTupleType()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var t1 = (1, (2L, ""hello""));
+        var t2 = (2, ""hello"");
+        System.Console.Write(t1 == (1L, t2));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "True");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(3);
+            Assert.Equal("(1L, t2)", tuple.ToString());
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Equal("(System.Int64, (System.Int32, System.String) t2)", tupleType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int64, (System.Int64, System.String))", tupleType.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        void TestTypelessTupleAndTupleType2()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (string, string) t = (null, null);
+        System.Console.Write(t == (null, null));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "True");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(null, null)", tuple.ToString());
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Null(tupleType.Type);
+            Assert.Equal("(System.String, System.String)", tupleType.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        void TestTypedTupleAndDefault()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (string, string) t = (null, null);
+        System.Console.Write(t == default);
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (7,30): error CS8310: Operator '==' cannot be applied to operand 'default'
+                //         System.Console.Write(t == default);
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "t == default").WithArguments("==", "default").WithLocation(7, 30)
+                );
+        }
+
+        [Fact]
+        void TestMixedTupleLiteralsAndTypes()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (string, string) t = (null, null);
+        System.Console.Write((t, (null, null)) == ((null, null), t));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "True");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(3);
+            Assert.Equal("((null, null), t)", tuple.ToString());
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Null(tupleType.Type);
+            Assert.Equal("((System.String, System.String), (System.String, System.String))",
+                tupleType.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        void TestFailedInference()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write((null, null) == (null, () => { }));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,30): error CS0019: Operator '==' cannot be applied to operands of type '<null>' and 'lambda expression'
+                //         System.Console.Write((null, null) == (null, () => { }));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(null, null) == (null, () => { })").WithArguments("==", "<null>", "lambda expression").WithLocation(6, 30)
+                );
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            Assert.Equal("(null, null)", tuple1.ToString());
+            var tupleType1 = model.GetTypeInfo(tuple1);
+            Assert.Null(tupleType1.Type);
+            Assert.Equal("(System.Object, ?)", tupleType1.ConvertedType.ToTestDisplayString());
+
+            var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(null, () => { })", tuple2.ToString());
+            var tupleType2 = model.GetTypeInfo(tuple2);
+            Assert.Null(tupleType2.Type);
+            Assert.Equal("(System.Object, ?)", tupleType2.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        void TestFailedConversion()
+        {
+            var source = @"
+class C
+{
+    static void M(string s)
+    {
+        System.Console.Write((s, s) == (1, () => { }));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,30): error CS0019: Operator '==' cannot be applied to operands of type 'string' and 'int'
+                //         System.Console.Write((s, s) == (1, () => { }));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(s, s) == (1, () => { })").WithArguments("==", "string", "int").WithLocation(6, 30),
+                // (6,30): error CS0019: Operator '==' cannot be applied to operands of type 'string' and 'lambda expression'
+                //         System.Console.Write((s, s) == (1, () => { }));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(s, s) == (1, () => { })").WithArguments("==", "string", "lambda expression").WithLocation(6, 30)
+                );
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            Assert.Equal("(s, s)", tuple1.ToString());
+            var tupleType1 = model.GetTypeInfo(tuple1);
+            Assert.Equal("(System.String, System.String)", tupleType1.Type.ToTestDisplayString());
+            Assert.Equal("(System.Object, System.String)", tupleType1.ConvertedType.ToTestDisplayString());
+
+            var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(1, () => { })", tuple2.ToString());
+            var tupleType2 = model.GetTypeInfo(tuple2);
+            Assert.Null(tupleType2.Type);
+            Assert.Equal("(System.Object, ?)", tupleType2.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        void TestDynamic()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d1 = 1;
+        dynamic d2 = 2;
+        System.Console.Write($""{(d1, 2) == (1, d2)} "");
+        System.Console.Write($""{(d1, 2) != (1, d2)} "");
+
+        System.Console.Write($""{(d1, 20) == (10, d2)} "");
+        System.Console.Write($""{(d1, 20) != (10, d2)} "");
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "True False False True");
+        }
+
+        [Fact]
+        void TestDynamic_WithTypelessExpression()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d1 = 1;
+        dynamic d2 = 2;
+        System.Console.Write((d1, 2) == (() => 1, d2));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (8,30): error CS0019: Operator '==' cannot be applied to operands of type 'dynamic' and 'lambda expression'
+                //         System.Console.Write((d1, 2) == (() => 1, d2));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(d1, 2) == (() => 1, d2)").WithArguments("==", "dynamic", "lambda expression").WithLocation(8, 30),
+                // (8,42): error CS1660: Cannot convert lambda expression to type 'dynamic' because it is not a delegate type
+                //         System.Console.Write((d1, 2) == (() => 1, d2));
+                Diagnostic(ErrorCode.ERR_AnonMethToNonDel, "() => 1").WithArguments("lambda expression", "dynamic").WithLocation(8, 42)
+                );
+        }
+
+        [Fact]
+        void TestDynamic_WithBadType()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d1 = 1;
+        dynamic d2 = 2;
+        try
+        {
+            bool b = ((d1, 2) == (""hello"", d2));
+        }
+        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+        {
+            System.Console.Write(e.Message);
+        }
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "Operator '==' cannot be applied to operands of type 'int' and 'string'");
+        }
+
+        [Fact]
+        void TestDynamic_WithNull()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d1 = null;
+        dynamic d2 = null;
+        System.Console.Write((d1, null) == (null, d2));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "True");
+            // TODO verify converted type on null
+        }
+
+        [Fact]
+        void TestBadConstraintOnTuple()
+        {
+            var source = @"
+ref struct S
+{
+    void M(S s1, S s2)
+    {
+        System.Console.Write(("""", s1) == (null, s2));
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,35): error CS0306: The type 'S' may not be used as a type argument
+                //         System.Console.Write(("", s1) == (null, s2));
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "s1").WithArguments("S").WithLocation(6, 35),
+                // (6,30): error CS0019: Operator '==' cannot be applied to operands of type 'S' and 'S'
+                //         System.Console.Write(("", s1) == (null, s2));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, @"("""", s1) == (null, s2)").WithArguments("==", "S", "S").WithLocation(6, 30),
+                // (6,35): error CS0306: The type 'S' may not be used as a type argument
+                //         System.Console.Write(("", s1) == (null, s2));
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "s1").WithArguments("S").WithLocation(6, 35),
+                // (6,49): error CS0306: The type 'S' may not be used as a type argument
+                //         System.Console.Write(("", s1) == (null, s2));
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "s2").WithArguments("S").WithLocation(6, 49)
+                );
+        }
+
+        [Fact]
+        void TestErrorInTuple()
+        {
+            var source = @"
+public class C
+{
+    public void M()
+    {
+        if (error1 == (error2, 3)) { }
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,13): error CS0103: The name 'error1' does not exist in the current context
+                //         if (error1 == (error2, 3)) { }
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error1").WithArguments("error1").WithLocation(6, 13),
+                // (6,24): error CS0103: The name 'error2' does not exist in the current context
+                //         if (error1 == (error2, 3)) { }
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error2").WithArguments("error2").WithLocation(6, 24)
+                );
+        }
+
+        [Fact]
+        void TempTest()
+        {
+            var source = @"
+public class C
+{
+    public void M()
+    {
+        var t = (null, null);
+        if (null == (() => {}) ) {}
+        if ("""" == 1) {}
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,13): error CS0815: Cannot assign (<null>, <null>) to an implicitly-typed variable
+                //         var t = (null, null);
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, "t = (null, null)").WithArguments("(<null>, <null>)").WithLocation(6, 13),
+                // (7,13): error CS0019: Operator '==' cannot be applied to operands of type '<null>' and 'lambda expression'
+                //         if (null == (() => {}) ) {}
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "null == (() => {})").WithArguments("==", "<null>", "lambda expression").WithLocation(7, 13),
+                // (8,13): error CS0019: Operator '==' cannot be applied to operands of type 'string' and 'int'
+                //         if ("" == 1) {}
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, @""""" == 1").WithArguments("==", "string", "int").WithLocation(8, 13)
+                );
+        }
+
+        [Fact]
+        public void TestNoCompatBreak()
+        {
+            var source = @"
+namespace System
+{
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+
+        public static bool operator ==(ValueTuple<T1, T2> t1, ValueTuple<T1, T2> t2)
+        {
+            System.Console.Write(""Correct operator was called"");
+            return true;
+        }
+        public static bool operator !=(ValueTuple<T1, T2> t1, ValueTuple<T1, T2> t2)
+            => throw null;
+
+        public override bool Equals(object o)
+            => throw null;
+
+        public override int GetHashCode()
+            => throw null;
+    }
+}
+public class C
+{
+    public static void Main()
+    {
+        var t1 = (1, 1);
+        var t2 = (2, 2);
+        if (t1 == t2)
+        {
+            return;
+        }
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "Correct operator was called");
+        }
+
+        [Fact]
+        public void TestNaN()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        var t1 = (System.Double.NaN, 1);
+        var t2 = (System.Double.NaN, 1);
+        System.Console.Write($""{t1 == t2} {t1.Equals(t2)} {t1 != t2} {t1 == (System.Double.NaN, 1)}"");
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "False True True False");
+        }
+
+        [Fact]
+        public void TestTopLevelDynamic()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        dynamic d1 = (1, 1);
+
+        try
+        {
+            _ = d1 == (1, 1);
+        }
+        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+        {
+            System.Console.WriteLine(e.Message);
+        }
+
+        try
+        {
+            _ = d1 != (1, 2);
+        }
+        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+        {
+            System.Console.WriteLine(e.Message);
+        }
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugExe,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            comp.VerifyDiagnostics();
+
+            CompileAndVerify(comp, expectedOutput:
+@"Operator '==' cannot be applied to operands of type 'System.ValueTuple<int,int>' and 'System.ValueTuple<int,int>'
+Operator '!=' cannot be applied to operands of type 'System.ValueTuple<int,int>' and 'System.ValueTuple<int,int>'");
+        }
+
+        [Fact]
+        public void TestComparisonWithDeconstruction()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        var b1 = (1, 2) == ((_, _) = new C());
+        var b2 = (1, 42) != ((_, _) = new C());
+        var b3 = (1, 42) == ((_, _) = new C()); // false
+        var b4 = ((_, _) = new C()) == (1, 2);
+        var b5 = ((_, _) = new C()) != (1, 42);
+        var b6 = ((_, _) = new C()) == (1, 42); // false
+        System.Console.Write($""{b1} {b2} {b3} {b4} {b5} {b6}"");
+    }
+    public void Deconstruct(out int x, out int y)
+    {
+        x = 1;
+        y = 2;
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+
+            CompileAndVerify(comp, expectedOutput: @"True True False True True False");
+        }
+
+        [Fact]
+        public void TestEvaluationOrderOnTupleLiteral()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        System.Console.WriteLine($""{(new A(1), new A(2)) == (new X(3), new Y(4))}"");
+    }
+}
+namespace System
+{
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            System.Console.WriteLine(""ValueTuple"");
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+}
+public class Base
+{
+    public int I;
+    public Base(int i) { I = i; }
+}
+public class A : Base
+{
+    public A(int i) : base(i)
+    {
+        System.Console.WriteLine($""A:{i}"");
+    }
+    public static bool operator ==(A a, Y y)
+    {
+        System.Console.WriteLine(""A == Y"");
+        return true;
+    }
+    public static bool operator !=(A a, Y y)
+        => throw null;
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+public class X : Base
+{
+    public X(int i) : base(i)
+    {
+        System.Console.WriteLine($""X:{i}"");
+    }
+}
+public class Y : Base
+{
+    public Y(int i) : base(i)
+    {
+        System.Console.WriteLine($""Y:{i}"");
+    }
+    public static implicit operator Y(X x)
+    {
+        System.Console.Write(""X -> "");
+        return new Y(x.I);
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"A:1
+A:2
+X:3
+X -> Y:3
+Y:4
+A == Y
+A == Y
+True");
+        }
+
+        [Fact]
+        public void TestEvaluationOrderOnTupleType()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        System.Console.WriteLine($""{(new A(1), GetTuple(), new A(4)) == (new X(5), (new X(6), new Y(7)), new Y(8))}"");
+    }
+    public static (A, A) GetTuple()
+    {
+        System.Console.WriteLine($""GetTuple"");
+        return (new A(30), new A(40));
+    }
+}
+namespace System
+{
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            System.Console.WriteLine(""ValueTuple2"");
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+    public struct ValueTuple<T1, T2, T3>
+    {
+        public ValueTuple(T1 item1, T2 item2, T3 item3)
+        {
+            // ValueTuple'3 required (constructed in bound tree), but not emitted
+            throw null;
+        }
+    }
+}
+public class Base
+{
+    public int I;
+    public Base(int i) { I = i; }
+}
+public class A : Base
+{
+    public A(int i) : base(i)
+    {
+        System.Console.WriteLine($""A:{i}"");
+    }
+    public static bool operator ==(A a, Y y)
+    {
+        System.Console.WriteLine(""A == Y"");
+        return true;
+    }
+    public static bool operator !=(A a, Y y)
+        => throw null;
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+public class X : Base
+{
+    public X(int i) : base(i)
+    {
+        System.Console.WriteLine($""X:{i}"");
+    }
+}
+public class Y : Base
+{
+    public Y(int i) : base(i)
+    {
+        System.Console.WriteLine($""Y:{i}"");
+    }
+    public static implicit operator Y(X x)
+    {
+        System.Console.Write(""X -> "");
+        return new Y(x.I);
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"A:1
+GetTuple
+A:30
+A:40
+ValueTuple2
+A:4
+X:5
+X -> Y:5
+X:6
+X -> Y:6
+Y:7
+Y:8
+A == Y
+A == Y
+A == Y
+A == Y
+True");
+        }
+
+        [Fact]
+        public void TestEvaluationOrderOnTupleType2()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        System.Console.WriteLine($""{(new A(1), (new A(2), new A(3)), new A(4)) == (new X(5), GetTuple(), new Y(8))}"");
+    }
+    public static (X, Y) GetTuple()
+    {
+        System.Console.WriteLine($""GetTuple"");
+        return (new X(6), new Y(7));
+    }
+}
+namespace System
+{
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            System.Console.WriteLine(""ValueTuple2"");
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+    public struct ValueTuple<T1, T2, T3>
+    {
+        public ValueTuple(T1 item1, T2 item2, T3 item3)
+        {
+            // ValueTuple'3 required (constructed in bound tree), but not emitted
+            throw null;
+        }
+    }
+}
+public class Base
+{
+    public int I;
+    public Base(int i) { I = i; }
+}
+public class A : Base
+{
+    public A(int i) : base(i)
+    {
+        System.Console.WriteLine($""A:{i}"");
+    }
+    public static bool operator ==(A a, Y y)
+    {
+        System.Console.WriteLine(""A == Y"");
+        return true;
+    }
+    public static bool operator !=(A a, Y y)
+        => throw null;
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+public class X : Base
+{
+    public X(int i) : base(i)
+    {
+        System.Console.WriteLine($""X:{i}"");
+    }
+}
+public class Y : Base
+{
+    public Y(int i) : base(i)
+    {
+        System.Console.WriteLine($""Y:{i}"");
+    }
+    public static implicit operator Y(X x)
+    {
+        System.Console.Write($""X:{x.I} -> "");
+        return new Y(x.I);
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: @"
+A:1
+A:2
+A:3
+A:4
+X:5
+X:5 -> Y:5
+GetTuple
+X:6
+Y:7
+ValueTuple2
+X:6 -> Y:6
+ValueTuple2
+Y:8
+A == Y
+A == Y
+A == Y
+A == Y
+True");
+        }
+
+        [Fact]
+        public void TestObsoleteEqualityOperator()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        System.Console.WriteLine($""{(new A(), new A()) == (new X(), new Y())}"");
+        System.Console.WriteLine($""{(new A(), new A()) != (new X(), new Y())}"");
+    }
+}
+public class A
+{
+    [System.Obsolete(""obsolete"", true)]
+    public static bool operator ==(A a, Y y)
+        => throw null;
+    [System.Obsolete(""obsolete too"", true)]
+    public static bool operator !=(A a, Y y)
+        => throw null;
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+public class X
+{
+}
+public class Y
+{
+    public static implicit operator Y(X x)
+        => throw null;
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,37): error CS0619: 'A.operator ==(A, Y)' is obsolete: 'obsolete'
+                //         System.Console.WriteLine($"{(new A(), new A()) == (new X(), new Y())}");
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "(new A(), new A()) == (new X(), new Y())").WithArguments("A.operator ==(A, Y)", "obsolete").WithLocation(6, 37),
+                // (6,37): error CS0619: 'A.operator ==(A, Y)' is obsolete: 'obsolete'
+                //         System.Console.WriteLine($"{(new A(), new A()) == (new X(), new Y())}");
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "(new A(), new A()) == (new X(), new Y())").WithArguments("A.operator ==(A, Y)", "obsolete").WithLocation(6, 37),
+                // (7,37): error CS0619: 'A.operator !=(A, Y)' is obsolete: 'obsolete too'
+                //         System.Console.WriteLine($"{(new A(), new A()) != (new X(), new Y())}");
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "(new A(), new A()) != (new X(), new Y())").WithArguments("A.operator !=(A, Y)", "obsolete too").WithLocation(7, 37),
+                // (7,37): error CS0619: 'A.operator !=(A, Y)' is obsolete: 'obsolete too'
+                //         System.Console.WriteLine($"{(new A(), new A()) != (new X(), new Y())}");
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "(new A(), new A()) != (new X(), new Y())").WithArguments("A.operator !=(A, Y)", "obsolete too").WithLocation(7, 37)
+                );
+        }
+
+        [Fact]
+        public void TestDefiniteAssignment()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        int error1;
+        System.Console.Write((1, 2) == (error1, 2));
+
+        int error2;
+        System.Console.Write((1, (error2, 3)) == (1, (2, 3)));
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (7,41): error CS0165: Use of unassigned local variable 'error1'
+                //         System.Console.Write((1, 2) == (error1, 2));
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "error1").WithArguments("error1").WithLocation(7, 41),
+                // (10,35): error CS0165: Use of unassigned local variable 'error2'
+                //         System.Console.Write((1, (error2, 3)) == (1, (2, 3)));
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "error2").WithArguments("error2").WithLocation(10, 35)
+                );
+        }
+
+        [Fact]
+        public void TestEqualityOfTypeConvertingToTuple()
+        {
+            var source = @"
+class C
+{
+    private int i;
+    void M()
+    {
+        System.Console.Write(this == (1, 1));
+        System.Console.Write((1, 1) == this);
+    }
+    public static implicit operator (int, int)(C c)
+    {
+        return (c.i, c.i);
+    }
+    C(int i) { this.i = i; }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (7,30): error CS0019: Operator '==' cannot be applied to operands of type 'C' and '(int, int)'
+                //         System.Console.Write(this == (1, 1));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "this == (1, 1)").WithArguments("==", "C", "(int, int)").WithLocation(7, 30),
+                // (8,30): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and 'C'
+                //         System.Console.Write((1, 1) == this);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(1, 1) == this").WithArguments("==", "(int, int)", "C").WithLocation(8, 30)
+                );
+        }
+
+        [Fact]
+        public void TestEqualityOfTypeConvertingFromTuple()
+        {
+            var source = @"
+class C
+{
+    private int i;
+    public static void Main()
+    {
+        var c = new C(2);
+        System.Console.Write(c == (1, 1));
+        System.Console.Write((1, 1) == c);
+    }
+    public static implicit operator C((int, int) x)
+    {
+        return new C(x.Item1 + x.Item2);
+    }
+    public static bool operator ==(C c1, C c2)
+        => c1.i == c2.i;
+    public static bool operator !=(C c1, C c2)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+    public override bool Equals(object other)
+        => throw null;
+    C(int i) { this.i = i; }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "TrueTrue");
+        }
+
+        [Fact]
+        public void TestEqualityOfTypeComparableWithTuple()
+        {
+            var source = @"
+class C
+{
+    private static void Main()
+    {
+        System.Console.Write(new C() == (1, 1));
+        System.Console.Write(new C() != (1, 1));
+    }
+    public static bool operator ==(C c, (int, int) t)
+    {
+        return t.Item1 + t.Item2 == 2;
+    }
+    public static bool operator !=(C c, (int, int) t)
+    {
+        return t.Item1 + t.Item2 != 2;
+    }
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "TrueFalse");
+        }
+
+        [Fact]
+        public void TestOfTwoUnrelatedTypes()
+        {
+            var source = @"
+class A { }
+class C
+{
+    static void M()
+    {
+        System.Console.Write(new C() == new A());
+        System.Console.Write((1, new C()) == (1, new A()));
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (7,30): error CS0019: Operator '==' cannot be applied to operands of type 'C' and 'A'
+                //         System.Console.Write(new C() == new A());
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "new C() == new A()").WithArguments("==", "C", "A").WithLocation(7, 30),
+                // (8,30): error CS0019: Operator '==' cannot be applied to operands of type 'C' and 'A'
+                //         System.Console.Write((1, new C()) == (1, new A()));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(1, new C()) == (1, new A())").WithArguments("==", "C", "A").WithLocation(8, 30)
+                );
+        }
+
+        [Fact]
+        public void TestOfTwoUnrelatedTypes2()
+        {
+            var source = @"
+class A { }
+class C
+{
+    static void M(string s, System.Exception e)
+    {
+        System.Console.Write(s == 3);
+        System.Console.Write((1, s) == (1, e));
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (7,30): error CS0019: Operator '==' cannot be applied to operands of type 'string' and 'int'
+                //         System.Console.Write(s == 3);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "s == 3").WithArguments("==", "string", "int").WithLocation(7, 30),
+                // (8,30): error CS0019: Operator '==' cannot be applied to operands of type 'string' and 'Exception'
+                //         System.Console.Write((1, s) == (1, e));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(1, s) == (1, e)").WithArguments("==", "string", "System.Exception").WithLocation(8, 30)
+                );
+        }
+
+        [Fact]
+        public void TestBadRefCompare()
+        {
+            var source = @"
+class C
+{
+    static void M()
+    {
+        string s = ""11"";
+        object o = s + s;
+        (object, object) t = default;
+
+        bool b = o == s;
+        bool b2 = t == (s, s); // no warning
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (10,18): warning CS0252: Possible unintended reference comparison; to get a value comparison, cast the left hand side to type 'string'
+                //         bool b = o == s;
+                Diagnostic(ErrorCode.WRN_BadRefCompareLeft, "o == s").WithArguments("string").WithLocation(10, 18)
+                );
+        }
+
+        [Fact]
+        public void TestEqualOnNullableVsNullableTuples()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        Compare(null, null);
+        Compare(null, (1, 2));
+        Compare((2, 3), null);
+        Compare((4, 4), (4, 4));
+        Compare((5, 5), (10, 10));
+    }
+    private static void Compare((int, int)? nt1, (int, int)? nt2)
+    {
+        System.Console.Write($""{nt1 == nt2} "");
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "True False False True False");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
+            var nt1 = comparison.Left;
+            var nt1Type = model.GetTypeInfo(nt1);
+            Assert.Equal("nt1", nt1.ToString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.ConvertedType.ToTestDisplayString());
+
+            var nt2 = comparison.Right;
+            var nt2Type = model.GetTypeInfo(nt2);
+            Assert.Equal("nt2", nt2.ToString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt2Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt2Type.ConvertedType.ToTestDisplayString());
+
+            verifier.VerifyIL("C.Compare", @"{
+  // Code size      104 (0x68)
+  .maxstack  3
+  .locals init ((int, int)? V_0,
+                bool V_1,
+                System.ValueTuple<int, int> V_2,
+                (int, int)? V_3,
+                System.ValueTuple<int, int> V_4)
+  IL_0000:  nop
+  IL_0001:  ldstr      ""{0} ""
+  IL_0006:  ldarg.0
+  IL_0007:  stloc.0
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       ""bool (int, int)?.HasValue.get""
+  IL_000f:  stloc.1
+  IL_0010:  ldarg.1
+  IL_0011:  stloc.3
+  IL_0012:  ldloc.1
+  IL_0013:  ldloca.s   V_3
+  IL_0015:  call       ""bool (int, int)?.HasValue.get""
+  IL_001a:  beq.s      IL_001f
+  IL_001c:  ldc.i4.0
+  IL_001d:  br.s       IL_0057
+  IL_001f:  ldloc.1
+  IL_0020:  brtrue.s   IL_0025
+  IL_0022:  ldc.i4.1
+  IL_0023:  br.s       IL_0057
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_002c:  stloc.2
+  IL_002d:  ldloca.s   V_3
+  IL_002f:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_0034:  stloc.s    V_4
+  IL_0036:  ldloc.2
+  IL_0037:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_003c:  ldloc.s    V_4
+  IL_003e:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_0043:  bne.un.s   IL_0056
+  IL_0045:  ldloc.2
+  IL_0046:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_004b:  ldloc.s    V_4
+  IL_004d:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_0052:  ceq
+  IL_0054:  br.s       IL_0057
+  IL_0056:  ldc.i4.0
+  IL_0057:  box        ""bool""
+  IL_005c:  call       ""string string.Format(string, object)""
+  IL_0061:  call       ""void System.Console.Write(string)""
+  IL_0066:  nop
+  IL_0067:  ret
+}");
+        }
+
+        [Fact]
+        public void TestNotEqualOnNullableVsNullableTuples()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        Compare(null, null);
+        Compare(null, (1, 2));
+        Compare((2, 3), null);
+        Compare((4, 4), (4, 4));
+        Compare((5, 5), (10, 10));
+    }
+    private static void Compare((int, int)? nt1, (int, int)? nt2)
+    {
+        System.Console.Write($""{nt1 != nt2} "");
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "False True True False True");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
+            var nt1 = comparison.Left;
+            var nt1Type = model.GetTypeInfo(nt1);
+            Assert.Equal("nt1", nt1.ToString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.ConvertedType.ToTestDisplayString());
+
+            var nt2 = comparison.Right;
+            var nt2Type = model.GetTypeInfo(nt2);
+            Assert.Equal("nt2", nt2.ToString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt2Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt2Type.ConvertedType.ToTestDisplayString());
+
+            verifier.VerifyIL("C.Compare", @"{
+  // Code size      107 (0x6b)
+  .maxstack  3
+  .locals init ((int, int)? V_0,
+                bool V_1,
+                System.ValueTuple<int, int> V_2,
+                (int, int)? V_3,
+                System.ValueTuple<int, int> V_4)
+  IL_0000:  nop
+  IL_0001:  ldstr      ""{0} ""
+  IL_0006:  ldarg.0
+  IL_0007:  stloc.0
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       ""bool (int, int)?.HasValue.get""
+  IL_000f:  stloc.1
+  IL_0010:  ldarg.1
+  IL_0011:  stloc.3
+  IL_0012:  ldloc.1
+  IL_0013:  ldloca.s   V_3
+  IL_0015:  call       ""bool (int, int)?.HasValue.get""
+  IL_001a:  beq.s      IL_001f
+  IL_001c:  ldc.i4.1
+  IL_001d:  br.s       IL_005a
+  IL_001f:  ldloc.1
+  IL_0020:  brtrue.s   IL_0025
+  IL_0022:  ldc.i4.0
+  IL_0023:  br.s       IL_005a
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_002c:  stloc.2
+  IL_002d:  ldloca.s   V_3
+  IL_002f:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_0034:  stloc.s    V_4
+  IL_0036:  ldloc.2
+  IL_0037:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_003c:  ldloc.s    V_4
+  IL_003e:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_0043:  bne.un.s   IL_0059
+  IL_0045:  ldloc.2
+  IL_0046:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_004b:  ldloc.s    V_4
+  IL_004d:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_0052:  ceq
+  IL_0054:  ldc.i4.0
+  IL_0055:  ceq
+  IL_0057:  br.s       IL_005a
+  IL_0059:  ldc.i4.1
+  IL_005a:  box        ""bool""
+  IL_005f:  call       ""string string.Format(string, object)""
+  IL_0064:  call       ""void System.Console.Write(string)""
+  IL_0069:  nop
+  IL_006a:  ret
+}");
+        }
+
+        [Fact]
+        public void TestNotEqualOnNullableVsNullableNestedTuples()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        Compare((1, null), (1, null), true);
+        Compare(null, (1, (2, 3)), false);
+        Compare((1, (2, 3)), (1, null), false);
+        Compare((1, (4, 4)), (1, (4, 4)), true);
+        Compare((1, (5, 5)), (1, (10, 10)), false);
+        System.Console.Write(""Success"");
+    }
+    private static void Compare((int, (int, int)?)? nt1, (int, (int, int)?)? nt2, bool expectMatch)
+    {
+        if (expectMatch != (nt1 == nt2) || expectMatch == (nt1 != nt2))
+        {
+            throw null;
+        }
+     }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "Success");
+        }
+
+        [Fact]
+        public void TestEqualOnNullableVsNullableTuples_WithImplicitConversion()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        Compare(null, null);
+        Compare(null, (1, 2));
+        Compare((2, 3), null);
+        Compare((4, 4), (4, 4));
+        Compare((5, 5), (10, 10));
+    }
+    private static void Compare((int, int)? nt1, (byte, long)? nt2)
+    {
+        System.Console.Write($""{nt1 == nt2} "");
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "True False False True False");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
+            var nt1 = comparison.Left;
+            var nt1Type = model.GetTypeInfo(nt1);
+            Assert.Equal("nt1", nt1.ToString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int64)?", nt1Type.ConvertedType.ToTestDisplayString());
+
+            var nt2 = comparison.Right;
+            var nt2Type = model.GetTypeInfo(nt2);
+            Assert.Equal("nt2", nt2.ToString());
+            Assert.Equal("(System.Byte, System.Int64)?", nt2Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int64)?", nt2Type.ConvertedType.ToTestDisplayString());
+
+            verifier.VerifyIL("C.Compare", @"{
+  // Code size      217 (0xd9)
+  .maxstack  3
+  .locals init ((int, long)? V_0,
+                bool V_1,
+                System.ValueTuple<int, long> V_2,
+                (int, long)? V_3,
+                System.ValueTuple<int, long> V_4,
+                (int, int)? V_5,
+                (int, long)? V_6,
+                System.ValueTuple<int, int> V_7,
+                (byte, long)? V_8,
+                System.ValueTuple<byte, long> V_9)
+  IL_0000:  nop
+  IL_0001:  ldstr      ""{0} ""
+  IL_0006:  ldarg.0
+  IL_0007:  stloc.s    V_5
+  IL_0009:  ldloca.s   V_5
+  IL_000b:  call       ""bool (int, int)?.HasValue.get""
+  IL_0010:  brtrue.s   IL_001e
+  IL_0012:  ldloca.s   V_6
+  IL_0014:  initobj    ""(int, long)?""
+  IL_001a:  ldloc.s    V_6
+  IL_001c:  br.s       IL_0040
+  IL_001e:  ldloca.s   V_5
+  IL_0020:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_0025:  stloc.s    V_7
+  IL_0027:  ldloc.s    V_7
+  IL_0029:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_002e:  ldloc.s    V_7
+  IL_0030:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_0035:  conv.i8
+  IL_0036:  newobj     ""System.ValueTuple<int, long>..ctor(int, long)""
+  IL_003b:  newobj     ""(int, long)?..ctor((int, long))""
+  IL_0040:  stloc.0
+  IL_0041:  ldloca.s   V_0
+  IL_0043:  call       ""bool (int, long)?.HasValue.get""
+  IL_0048:  stloc.1
+  IL_0049:  ldarg.1
+  IL_004a:  stloc.s    V_8
+  IL_004c:  ldloca.s   V_8
+  IL_004e:  call       ""bool (byte, long)?.HasValue.get""
+  IL_0053:  brtrue.s   IL_0061
+  IL_0055:  ldloca.s   V_6
+  IL_0057:  initobj    ""(int, long)?""
+  IL_005d:  ldloc.s    V_6
+  IL_005f:  br.s       IL_0082
+  IL_0061:  ldloca.s   V_8
+  IL_0063:  call       ""(byte, long) (byte, long)?.GetValueOrDefault()""
+  IL_0068:  stloc.s    V_9
+  IL_006a:  ldloc.s    V_9
+  IL_006c:  ldfld      ""byte System.ValueTuple<byte, long>.Item1""
+  IL_0071:  ldloc.s    V_9
+  IL_0073:  ldfld      ""long System.ValueTuple<byte, long>.Item2""
+  IL_0078:  newobj     ""System.ValueTuple<int, long>..ctor(int, long)""
+  IL_007d:  newobj     ""(int, long)?..ctor((int, long))""
+  IL_0082:  stloc.3
+  IL_0083:  ldloc.1
+  IL_0084:  ldloca.s   V_3
+  IL_0086:  call       ""bool (int, long)?.HasValue.get""
+  IL_008b:  beq.s      IL_0090
+  IL_008d:  ldc.i4.0
+  IL_008e:  br.s       IL_00c8
+  IL_0090:  ldloc.1
+  IL_0091:  brtrue.s   IL_0096
+  IL_0093:  ldc.i4.1
+  IL_0094:  br.s       IL_00c8
+  IL_0096:  ldloca.s   V_0
+  IL_0098:  call       ""(int, long) (int, long)?.GetValueOrDefault()""
+  IL_009d:  stloc.2
+  IL_009e:  ldloca.s   V_3
+  IL_00a0:  call       ""(int, long) (int, long)?.GetValueOrDefault()""
+  IL_00a5:  stloc.s    V_4
+  IL_00a7:  ldloc.2
+  IL_00a8:  ldfld      ""int System.ValueTuple<int, long>.Item1""
+  IL_00ad:  ldloc.s    V_4
+  IL_00af:  ldfld      ""int System.ValueTuple<int, long>.Item1""
+  IL_00b4:  bne.un.s   IL_00c7
+  IL_00b6:  ldloc.2
+  IL_00b7:  ldfld      ""long System.ValueTuple<int, long>.Item2""
+  IL_00bc:  ldloc.s    V_4
+  IL_00be:  ldfld      ""long System.ValueTuple<int, long>.Item2""
+  IL_00c3:  ceq
+  IL_00c5:  br.s       IL_00c8
+  IL_00c7:  ldc.i4.0
+  IL_00c8:  box        ""bool""
+  IL_00cd:  call       ""string string.Format(string, object)""
+  IL_00d2:  call       ""void System.Console.Write(string)""
+  IL_00d7:  nop
+  IL_00d8:  ret
+}");
+        }
+
+        [Fact]
+        public void TestOnNullableVsNullableTuples_WithImplicitCustomConversion()
+        {
+            var source = @"
+class C
+{
+    int _value;
+    public C(int v) { _value = v; }
+
+    public static void Main()
+    {
+        Compare(null, null);
+        Compare(null, (1, new C(20)));
+        Compare((new C(30), 3), null);
+        Compare((new C(4), 4), (4, new C(4)));
+        Compare((new C(5), 5), (10, new C(10)));
+    }
+    private static void Compare((C, int)? nt1, (int, C)? nt2)
+    {
+        System.Console.Write($""{nt1 == nt2} "");
+    }
+    public static implicit operator int(C c)
+    {
+        System.Console.Write($""Convert{c._value} "");
+        return c._value;
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "True Convert20 False Convert30 False Convert4 Convert4 True Convert5 Convert10 False");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
+            var nt1 = comparison.Left;
+            var nt1Type = model.GetTypeInfo(nt1);
+            Assert.Equal("nt1", nt1.ToString());
+            Assert.Equal("(C, System.Int32)?", nt1Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.ConvertedType.ToTestDisplayString());
+
+            var nt2 = comparison.Right;
+            var nt2Type = model.GetTypeInfo(nt2);
+            Assert.Equal("nt2", nt2.ToString());
+            Assert.Equal("(System.Int32, C)?", nt2Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt2Type.ConvertedType.ToTestDisplayString());
+            verifier.VerifyIL("C.Compare", @"{
+  // Code size      226 (0xe2)
+  .maxstack  3
+  .locals init ((int, int)? V_0,
+                bool V_1,
+                System.ValueTuple<int, int> V_2,
+                (int, int)? V_3,
+                System.ValueTuple<int, int> V_4,
+                (C, int)? V_5,
+                (int, int)? V_6,
+                System.ValueTuple<C, int> V_7,
+                (int, C)? V_8,
+                System.ValueTuple<int, C> V_9)
+  IL_0000:  nop
+  IL_0001:  ldstr      ""{0} ""
+  IL_0006:  ldarg.0
+  IL_0007:  stloc.s    V_5
+  IL_0009:  ldloca.s   V_5
+  IL_000b:  call       ""bool (C, int)?.HasValue.get""
+  IL_0010:  brtrue.s   IL_001e
+  IL_0012:  ldloca.s   V_6
+  IL_0014:  initobj    ""(int, int)?""
+  IL_001a:  ldloc.s    V_6
+  IL_001c:  br.s       IL_0044
+  IL_001e:  ldloca.s   V_5
+  IL_0020:  call       ""(C, int) (C, int)?.GetValueOrDefault()""
+  IL_0025:  stloc.s    V_7
+  IL_0027:  ldloc.s    V_7
+  IL_0029:  ldfld      ""C System.ValueTuple<C, int>.Item1""
+  IL_002e:  call       ""int C.op_Implicit(C)""
+  IL_0033:  ldloc.s    V_7
+  IL_0035:  ldfld      ""int System.ValueTuple<C, int>.Item2""
+  IL_003a:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
+  IL_003f:  newobj     ""(int, int)?..ctor((int, int))""
+  IL_0044:  stloc.0
+  IL_0045:  ldloca.s   V_0
+  IL_0047:  call       ""bool (int, int)?.HasValue.get""
+  IL_004c:  stloc.1
+  IL_004d:  ldarg.1
+  IL_004e:  stloc.s    V_8
+  IL_0050:  ldloca.s   V_8
+  IL_0052:  call       ""bool (int, C)?.HasValue.get""
+  IL_0057:  brtrue.s   IL_0065
+  IL_0059:  ldloca.s   V_6
+  IL_005b:  initobj    ""(int, int)?""
+  IL_0061:  ldloc.s    V_6
+  IL_0063:  br.s       IL_008b
+  IL_0065:  ldloca.s   V_8
+  IL_0067:  call       ""(int, C) (int, C)?.GetValueOrDefault()""
+  IL_006c:  stloc.s    V_9
+  IL_006e:  ldloc.s    V_9
+  IL_0070:  ldfld      ""int System.ValueTuple<int, C>.Item1""
+  IL_0075:  ldloc.s    V_9
+  IL_0077:  ldfld      ""C System.ValueTuple<int, C>.Item2""
+  IL_007c:  call       ""int C.op_Implicit(C)""
+  IL_0081:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
+  IL_0086:  newobj     ""(int, int)?..ctor((int, int))""
+  IL_008b:  stloc.3
+  IL_008c:  ldloc.1
+  IL_008d:  ldloca.s   V_3
+  IL_008f:  call       ""bool (int, int)?.HasValue.get""
+  IL_0094:  beq.s      IL_0099
+  IL_0096:  ldc.i4.0
+  IL_0097:  br.s       IL_00d1
+  IL_0099:  ldloc.1
+  IL_009a:  brtrue.s   IL_009f
+  IL_009c:  ldc.i4.1
+  IL_009d:  br.s       IL_00d1
+  IL_009f:  ldloca.s   V_0
+  IL_00a1:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_00a6:  stloc.2
+  IL_00a7:  ldloca.s   V_3
+  IL_00a9:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_00ae:  stloc.s    V_4
+  IL_00b0:  ldloc.2
+  IL_00b1:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_00b6:  ldloc.s    V_4
+  IL_00b8:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_00bd:  bne.un.s   IL_00d0
+  IL_00bf:  ldloc.2
+  IL_00c0:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_00c5:  ldloc.s    V_4
+  IL_00c7:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_00cc:  ceq
+  IL_00ce:  br.s       IL_00d1
+  IL_00d0:  ldc.i4.0
+  IL_00d1:  box        ""bool""
+  IL_00d6:  call       ""string string.Format(string, object)""
+  IL_00db:  call       ""void System.Console.Write(string)""
+  IL_00e0:  nop
+  IL_00e1:  ret
+}");
+        }
+
+        [Fact]
+        public void TestOnNullableVsNullableTuples_WithImplicitCustomConversion_NoTuples()
+        {
+            var source = @"
+struct C
+{
+    int _value;
+    public C(int v) { _value = v; }
+
+    public static void Main()
+    {
+        Compare(null, new C(20));
+    }
+    private static void Compare(int? nt1, C? nt2)
+    {
+        System.Console.Write($""{nt1 == nt2} "");
+    }
+    public static implicit operator int(C c)
+    {
+        System.Console.Write($""Convert{c._value} "");
+        return c._value;
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "Convert20 False");
+
+            verifier.VerifyIL("C.Compare", @"{
+  // Code size      100 (0x64)
+  .maxstack  3
+  .locals init (int? V_0,
+                int? V_1,
+                C? V_2,
+                int? V_3)
+  IL_0000:  nop
+  IL_0001:  ldstr      ""{0} ""
+  IL_0006:  ldarg.0
+  IL_0007:  stloc.0
+  IL_0008:  ldarg.1
+  IL_0009:  stloc.2
+  IL_000a:  ldloca.s   V_2
+  IL_000c:  call       ""bool C?.HasValue.get""
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloca.s   V_3
+  IL_0015:  initobj    ""int?""
+  IL_001b:  ldloc.3
+  IL_001c:  br.s       IL_002f
+  IL_001e:  ldloca.s   V_2
+  IL_0020:  call       ""C C?.GetValueOrDefault()""
+  IL_0025:  call       ""int C.op_Implicit(C)""
+  IL_002a:  newobj     ""int?..ctor(int)""
+  IL_002f:  stloc.1
+  IL_0030:  ldloca.s   V_0
+  IL_0032:  call       ""int int?.GetValueOrDefault()""
+  IL_0037:  ldloca.s   V_1
+  IL_0039:  call       ""int int?.GetValueOrDefault()""
+  IL_003e:  beq.s      IL_0043
+  IL_0040:  ldc.i4.0
+  IL_0041:  br.s       IL_0053
+  IL_0043:  ldloca.s   V_0
+  IL_0045:  call       ""bool int?.HasValue.get""
+  IL_004a:  ldloca.s   V_1
+  IL_004c:  call       ""bool int?.HasValue.get""
+  IL_0051:  ceq
+  IL_0053:  box        ""bool""
+  IL_0058:  call       ""string string.Format(string, object)""
+  IL_005d:  call       ""void System.Console.Write(string)""
+  IL_0062:  nop
+  IL_0063:  ret
+}");
+        }
+
+        [Fact]
+        public void TestOnNullableVsNonNullableTuples()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        M(null);
+        M((1, 2));
+        M((10, 20));
+    }
+    private static void M((byte, int)? nt)
+    {
+        System.Console.Write((1, 2) == nt);
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+
+            var verifier = CompileAndVerify(comp, expectedOutput: "FalseTrueFalse");
+            verifier.VerifyIL("C.M", @"{
+  // Code size      107 (0x6b)
+  .maxstack  2
+  .locals init ((int, int)? V_0,
+                System.ValueTuple<int, int> V_1,
+                (byte, int)? V_2,
+                (int, int)? V_3,
+                System.ValueTuple<byte, int> V_4)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.2
+  IL_0003:  ldloca.s   V_2
+  IL_0005:  call       ""bool (byte, int)?.HasValue.get""
+  IL_000a:  brtrue.s   IL_0017
+  IL_000c:  ldloca.s   V_3
+  IL_000e:  initobj    ""(int, int)?""
+  IL_0014:  ldloc.3
+  IL_0015:  br.s       IL_0038
+  IL_0017:  ldloca.s   V_2
+  IL_0019:  call       ""(byte, int) (byte, int)?.GetValueOrDefault()""
+  IL_001e:  stloc.s    V_4
+  IL_0020:  ldloc.s    V_4
+  IL_0022:  ldfld      ""byte System.ValueTuple<byte, int>.Item1""
+  IL_0027:  ldloc.s    V_4
+  IL_0029:  ldfld      ""int System.ValueTuple<byte, int>.Item2""
+  IL_002e:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
+  IL_0033:  newobj     ""(int, int)?..ctor((int, int))""
+  IL_0038:  stloc.0
+  IL_0039:  ldloca.s   V_0
+  IL_003b:  call       ""bool (int, int)?.HasValue.get""
+  IL_0040:  brtrue.s   IL_0045
+  IL_0042:  ldc.i4.0
+  IL_0043:  br.s       IL_0064
+  IL_0045:  br.s       IL_0047
+  IL_0047:  ldloca.s   V_0
+  IL_0049:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_004e:  stloc.1
+  IL_004f:  ldc.i4.1
+  IL_0050:  ldloc.1
+  IL_0051:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_0056:  bne.un.s   IL_0063
+  IL_0058:  ldc.i4.2
+  IL_0059:  ldloc.1
+  IL_005a:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_005f:  ceq
+  IL_0061:  br.s       IL_0064
+  IL_0063:  ldc.i4.0
+  IL_0064:  call       ""void System.Console.Write(bool)""
+  IL_0069:  nop
+  IL_006a:  ret
+}");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
+            var tuple = comparison.Left;
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Equal("(1, 2)", tuple.ToString());
+            Assert.Equal("(System.Int32, System.Int32)", tupleType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", tupleType.ConvertedType.ToTestDisplayString());
+
+            var nt = comparison.Right;
+            var ntType = model.GetTypeInfo(nt);
+            Assert.Equal("nt", nt.ToString());
+            Assert.Equal("(System.Byte, System.Int32)?", ntType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", ntType.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestOnNullableVsNonNullableTuples_WithCustomConversion()
+        {
+            var source = @"
+class C
+{
+    int _value;
+    public C(int v) { _value = v; }
+    public static void Main()
+    {
+        M(null);
+        M((new C(1), 2));
+        M((new C(10), 20));
+    }
+    private static void M((C, int)? nt)
+    {
+        System.Console.Write($""{(1, 2) == nt} "");
+        System.Console.Write($""{nt == (1, 2)} "");
+    }
+    public static implicit operator int(C c)
+    {
+        System.Console.Write($""Convert{c._value} "");
+        return c._value;
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+
+            var verifier = CompileAndVerify(comp, expectedOutput: "False False Convert1 True Convert1 True Convert10 False Convert10 False");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().First();
+            Assert.Equal("(1, 2) == nt", comparison.ToString());
+            var tuple = comparison.Left;
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Equal("(1, 2)", tuple.ToString());
+            Assert.Equal("(System.Int32, System.Int32)", tupleType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", tupleType.ConvertedType.ToTestDisplayString());
+
+            var nt = comparison.Right;
+            var ntType = model.GetTypeInfo(nt);
+            Assert.Equal("nt", nt.ToString());
+            Assert.Equal("(C, System.Int32)?", ntType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", ntType.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestOnNullableVsNonNullableTuples3()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        M(null);
+        M((1, 2));
+        M((10, 20));
+    }
+    private static void M((int, int)? nt)
+    {
+        System.Console.Write(nt == (1, 2));
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+
+            var verifier = CompileAndVerify(comp, expectedOutput: "FalseTrueFalse");
+            verifier.VerifyIL("C.M", @"{
+  // Code size       59 (0x3b)
+  .maxstack  2
+  .locals init ((int, int)? V_0,
+                bool V_1,
+                System.ValueTuple<int, int> V_2)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  call       ""bool (int, int)?.HasValue.get""
+  IL_000a:  stloc.1
+  IL_000b:  ldloc.1
+  IL_000c:  brtrue.s   IL_0011
+  IL_000e:  ldc.i4.0
+  IL_000f:  br.s       IL_0034
+  IL_0011:  ldloc.1
+  IL_0012:  brtrue.s   IL_0017
+  IL_0014:  ldc.i4.1
+  IL_0015:  br.s       IL_0034
+  IL_0017:  ldloca.s   V_0
+  IL_0019:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_001e:  stloc.2
+  IL_001f:  ldloc.2
+  IL_0020:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_0025:  ldc.i4.1
+  IL_0026:  bne.un.s   IL_0033
+  IL_0028:  ldloc.2
+  IL_0029:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_002e:  ldc.i4.2
+  IL_002f:  ceq
+  IL_0031:  br.s       IL_0034
+  IL_0033:  ldc.i4.0
+  IL_0034:  call       ""void System.Console.Write(bool)""
+  IL_0039:  nop
+  IL_003a:  ret
+}");
+        }
+
+        [Fact]
+        public void TestOnNullableVsLiteralTuples()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        CheckNull(null);
+        CheckNull((1, 2));
+    }
+    private static void CheckNull((int, int)? nt)
+    {
+        System.Console.Write($""{nt == null} "");
+        System.Console.Write($""{nt != null} "");
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "True False False True");
+        }
+
+        [Fact]
+        public void TestOn1Tuple()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        var x1 = MakeLongTuple(1).Rest;
+        var x1again = MakeLongTuple(1).Rest;
+        var x2 = MakeLongTuple(2).Rest;
+
+        var xNull = MakeLongTuple(null).Rest;
+
+        Assert(x1 == x1again);
+        Assert(!(x1 != x1again));
+
+        Assert(x1 != x2);
+        Assert(!(x1 == x2));
+
+        Assert(x1 != xNull);
+        Assert(!(x1 == xNull));
+
+        System.Console.Write(""Success"");
+    }
+    private static (int, int, int, int, int, int, int, int?) MakeLongTuple(int? x)
+    {
+        return (1, 2, 3, 4, 5, 6, 7, x);
+    }
+    private static void Assert(bool value)
+    {
+        if (!value)
+        {
+            throw null;
+        }
+    }
+}
+";
+
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "Success");
+        }
+
+        [Fact]
+        public void TestOnTupleOfDecimals()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        System.Console.Write(Compare((1, 2), (1, 2)));
+        System.Console.Write(Compare((1, 2), (10, 20)));
+    }
+    public static bool Compare((decimal, decimal) t1, (decimal, decimal) t2)
+    {
+        return t1 == t2;
+    }
+}
+";
+
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "TrueFalse");
+            verifier.VerifyIL("C.Compare", @"{
+  // Code size       49 (0x31)
+  .maxstack  2
+  .locals init (System.ValueTuple<decimal, decimal> V_0,
+                System.ValueTuple<decimal, decimal> V_1,
+                bool V_2)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  ldarg.1
+  IL_0004:  stloc.1
+  IL_0005:  ldloc.0
+  IL_0006:  ldfld      ""decimal System.ValueTuple<decimal, decimal>.Item1""
+  IL_000b:  ldloc.1
+  IL_000c:  ldfld      ""decimal System.ValueTuple<decimal, decimal>.Item1""
+  IL_0011:  call       ""bool decimal.op_Equality(decimal, decimal)""
+  IL_0016:  brfalse.s  IL_002b
+  IL_0018:  ldloc.0
+  IL_0019:  ldfld      ""decimal System.ValueTuple<decimal, decimal>.Item2""
+  IL_001e:  ldloc.1
+  IL_001f:  ldfld      ""decimal System.ValueTuple<decimal, decimal>.Item2""
+  IL_0024:  call       ""bool decimal.op_Equality(decimal, decimal)""
+  IL_0029:  br.s       IL_002c
+  IL_002b:  ldc.i4.0
+  IL_002c:  stloc.2
+  IL_002d:  br.s       IL_002f
+  IL_002f:  ldloc.2
+  IL_0030:  ret
+}");
+        }
+
+        [Fact]
+        public void TestSideEffectsAreSavedToTemps()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    {
+        int i = 0;
+        System.Console.Write((i++, i++, i++) == (0, 1, 2));
+    }
+}
+";
+
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "True");
+        }
+
+        [Fact]
+        public void TestNonBoolComparisonResult_WithTrueFalseOperators()
+        {
+            var source = @"
+using static System.Console;
+public class C
+{
+    public static void Main()
+    {
+        Write($""{REPLACE}"");
+    }
+}
+public class Base
+{
+    public int I;
+    public Base(int i) { I = i; }
+}
+public class A : Base
+{
+    public A(int i) : base(i)
+    {
+        Write($""A:{i}, "");
+    }
+    public static NotBool operator ==(A a, Y y)
+    {
+        Write(""A == Y, "");
+        return new NotBool(a.I == y.I);
+    }
+    public static NotBool operator !=(A a, Y y)
+    {
+        Write(""A != Y, "");
+        return new NotBool(a.I != y.I);
+    }
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+public class X : Base
+{
+    public X(int i) : base(i)
+    {
+        Write($""X:{i}, "");
+    }
+}
+public class Y : Base
+{
+    public Y(int i) : base(i)
+    {
+        Write($""Y:{i}, "");
+    }
+    public static implicit operator Y(X x)
+    {
+        Write(""X -> "");
+        return new Y(x.I);
+    }
+}
+public class NotBool
+{
+    public bool B;
+    public NotBool(bool value)
+    {
+        B = value;
+    }
+    public static bool operator true(NotBool b)
+    {
+        Write($""NotBool.true -> {b.B}, "");
+        return b.B;
+    }
+    public static bool operator false(NotBool b)
+    {
+        Write($""NotBool.false -> {!b.B}, "");
+        return !b.B;
+    }
+}
+";
+
+            validate("(new A(1), new A(2)) == (new X(1), new Y(2))", "A:1, A:2, X:1, X -> Y:1, Y:2, A == Y, NotBool.false -> False, A == Y, NotBool.false -> False, True");
+            validate("(new A(1), new A(2)) == (new X(1), new Y(20))", "A:1, A:2, X:1, X -> Y:1, Y:20, A == Y, NotBool.false -> False, A == Y, NotBool.false -> True, False");
+
+            validate("(new A(1), new A(2)) != (new X(1), new Y(2))", "A:1, A:2, X:1, X -> Y:1, Y:2, A != Y, NotBool.true -> False, A != Y, NotBool.true -> False, False");
+            validate("(new A(1), new A(2)) != (new X(1), new Y(20))", "A:1, A:2, X:1, X -> Y:1, Y:20, A != Y, NotBool.true -> False, A != Y, NotBool.true -> True, True");
+
+            // Note: the conversion of X to Y occurs during the dynamic evaluation of A == X
+            validate("((dynamic)new A(1), new A(2)) == (new X(1), (dynamic)new Y(2))", "A:1, A:2, X:1, Y:2, X -> Y:1, A == Y, NotBool.false -> False, A == Y, NotBool.false -> False, True");
+            validate("((dynamic)new A(1), new A(2)) == (new X(1), (dynamic)new Y(20))", "A:1, A:2, X:1, Y:20, X -> Y:1, A == Y, NotBool.false -> False, A == Y, NotBool.false -> True, False");
+
+            validate("((dynamic)new A(1), new A(2)) != (new X(1), (dynamic)new Y(2))", "A:1, A:2, X:1, Y:2, X -> Y:1, A != Y, NotBool.true -> False, A != Y, NotBool.true -> False, False");
+            validate("((dynamic)new A(1), new A(2)) != (new X(1), (dynamic)new Y(20))", "A:1, A:2, X:1, Y:20, X -> Y:1, A != Y, NotBool.true -> False, A != Y, NotBool.true -> True, True");
+
+            void validate(string expression, string expected)
+            {
+                var comp = CreateStandardCompilation(source.Replace("REPLACE", expression),
+                    references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef }, options: TestOptions.DebugExe);
+
+                comp.VerifyDiagnostics();
+                CompileAndVerify(comp, expectedOutput: expected);
+            }
+        }
+
+        [Fact]
+        public void TestNonBoolComparisonResult_WithImplicitBoolConversion()
+        {
+            var source = @"
+using static System.Console;
+public class C
+{
+    public static void Main()
+    {
+        Write($""{REPLACE}"");
+    }
+}
+public class Base
+{
+    public int I;
+    public Base(int i) { I = i; }
+}
+public class A : Base
+{
+    public A(int i) : base(i)
+    {
+        Write($""A:{i}, "");
+    }
+    public static NotBool operator ==(A a, Y y)
+    {
+        Write(""A == Y, "");
+        return new NotBool(a.I == y.I);
+    }
+    public static NotBool operator !=(A a, Y y)
+    {
+        Write(""A != Y, "");
+        return new NotBool(a.I != y.I);
+    }
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+public class X : Base
+{
+    public X(int i) : base(i)
+    {
+        Write($""X:{i}, "");
+    }
+}
+public class Y : Base
+{
+    public Y(int i) : base(i)
+    {
+        Write($""Y:{i}, "");
+    }
+    public static implicit operator Y(X x)
+    {
+        Write(""X -> "");
+        return new Y(x.I);
+    }
+}
+public class NotBool
+{
+    public bool B;
+    public NotBool(bool value)
+    {
+        B = value;
+    }
+    public static implicit operator bool(NotBool b)
+    {
+        Write($""NotBool -> bool:{b.B}, "");
+        return b.B;
+    }
+}
+";
+
+            validate("(new A(1), new A(2)) == (new X(1), new Y(2))", "A:1, A:2, X:1, X -> Y:1, Y:2, A == Y, NotBool -> bool:True, A == Y, NotBool -> bool:True, True");
+            validate("(new A(1), new A(2)) == (new X(10), new Y(2))", "A:1, A:2, X:10, X -> Y:10, Y:2, A == Y, NotBool -> bool:False, False");
+            validate("(new A(1), new A(2)) == (new X(1), new Y(20))", "A:1, A:2, X:1, X -> Y:1, Y:20, A == Y, NotBool -> bool:True, A == Y, NotBool -> bool:False, False");
+
+            validate("(new A(1), new A(2)) != (new X(1), new Y(2))", "A:1, A:2, X:1, X -> Y:1, Y:2, A != Y, NotBool -> bool:False, A != Y, NotBool -> bool:False, False");
+            validate("(new A(1), new A(2)) != (new X(10), new Y(2))", "A:1, A:2, X:10, X -> Y:10, Y:2, A != Y, NotBool -> bool:True, True");
+            validate("(new A(1), new A(2)) != (new X(1), new Y(20))", "A:1, A:2, X:1, X -> Y:1, Y:20, A != Y, NotBool -> bool:False, A != Y, NotBool -> bool:True, True");
+
+            void validate(string expression, string expected)
+            {
+                var comp = CreateStandardCompilation(source.Replace("REPLACE", expression),
+                    references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugExe);
+
+                comp.VerifyDiagnostics();
+                CompileAndVerify(comp, expectedOutput: expected);
+            }
+        }
+
+        [Fact]
+        public void TestNonBoolComparisonResult_WithoutImplicitBoolConversion()
+        {
+            var source = @"
+using static System.Console;
+public class C
+{
+    public static void Main()
+    {
+        Write($""{REPLACE}"");
+    }
+}
+public class Base
+{
+    public Base(int i) { }
+}
+public class A : Base
+{
+    public A(int i) : base(i)
+        => throw null;
+    public static NotBool operator ==(A a, Y y)
+        => throw null;
+    public static NotBool operator !=(A a, Y y)
+        => throw null;
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+public class X : Base
+{
+    public X(int i) : base(i)
+        => throw null;
+}
+public class Y : Base
+{
+    public Y(int i) : base(i)
+        => throw null;
+    public static implicit operator Y(X x)
+        => throw null;
+}
+public class NotBool
+{
+}
+";
+
+            validate("(new A(1), new A(2)) == (new X(1), new Y(2))",
+                // (7,18): error CS0029: Cannot implicitly convert type 'NotBool' to 'bool'
+                //         Write($"{(new A(1), new A(2)) == (new X(1), new Y(2))}");
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "(new A(1), new A(2)) == (new X(1), new Y(2))").WithArguments("NotBool", "bool").WithLocation(7, 18),
+                // (7,18): error CS0029: Cannot implicitly convert type 'NotBool' to 'bool'
+                //         Write($"{(new A(1), new A(2)) == (new X(1), new Y(2))}");
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "(new A(1), new A(2)) == (new X(1), new Y(2))").WithArguments("NotBool", "bool").WithLocation(7, 18)
+                );
+
+            // PROTOTYPE(async-streams) Maybe the error location could be more specific when concerning an element of a tuple literal
+            validate("(new A(1), 2) != (new X(1), 2)",
+                // (7,18): error CS0029: Cannot implicitly convert type 'NotBool' to 'bool'
+                //         Write($"{(new A(1), 2) != (new X(1), 2)}");
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "(new A(1), 2) != (new X(1), 2)").WithArguments("NotBool", "bool").WithLocation(7, 18)
+                );
+
+            void validate(string expression, params DiagnosticDescription[] expected)
+            {
+                var comp = CreateStandardCompilation(source.Replace("REPLACE", expression), references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+                comp.VerifyDiagnostics(expected);
+            }
+        }
+
+        [Fact]
+        public void TestNonBoolComparisonResult_WithExplicitBoolConversion()
+        {
+            var source = @"
+using static System.Console;
+public class C
+{
+    public static void Main()
+    {
+        Write($""{(new A(1), new A(2)) == (new X(1), new Y(2))}"");
+    }
+}
+public class Base
+{
+    public int I;
+    public Base(int i) { I = i; }
+}
+public class A : Base
+{
+    public A(int i) : base(i)
+        => throw null;
+    public static NotBool operator ==(A a, Y y)
+        => throw null;
+    public static NotBool operator !=(A a, Y y)
+        => throw null;
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+public class X : Base
+{
+    public X(int i) : base(i)
+        => throw null;
+}
+public class Y : Base
+{
+    public Y(int i) : base(i)
+        => throw null;
+    public static implicit operator Y(X x)
+        => throw null;
+}
+public class NotBool
+{
+    public NotBool(bool value)
+        => throw null;
+    public static explicit operator bool(NotBool b)
+        => throw null;
+}
+";
+
+            var comp = CreateStandardCompilation(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (7,18): error CS0266: Cannot implicitly convert type 'NotBool' to 'bool'. An explicit conversion exists (are you missing a cast?)
+                //         Write($"{(new A(1), new A(2)) == (new X(1), new Y(2))}");
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "(new A(1), new A(2)) == (new X(1), new Y(2))").WithArguments("NotBool", "bool").WithLocation(7, 18),
+                // (7,18): error CS0266: Cannot implicitly convert type 'NotBool' to 'bool'. An explicit conversion exists (are you missing a cast?)
+                //         Write($"{(new A(1), new A(2)) == (new X(1), new Y(2))}");
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "(new A(1), new A(2)) == (new X(1), new Y(2))").WithArguments("NotBool", "bool").WithLocation(7, 18)
+                );
+        }
+    }
+}
+

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -108,6 +108,37 @@ class C
         }
 
         [Fact]
+        void TestWithoutValueTuple()
+        {
+            var source = @"
+class C
+{
+    static bool M()
+    {
+        return (1, 2) == (3, 4);
+    }
+}";
+            var comp = CreateStandardCompilation(source);
+
+            // PROTOTYPE(tuple-equality) See if we can relax the restriction on requiring ValueTuple types
+
+            comp.VerifyDiagnostics(
+                // (6,16): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         return (1, 2) == (3, 4);
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, 2)").WithArguments("System.ValueTuple`2").WithLocation(6, 16),
+                // (6,26): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         return (1, 2) == (3, 4);
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(3, 4)").WithArguments("System.ValueTuple`2").WithLocation(6, 26),
+                // (6,16): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         return (1, 2) == (3, 4);
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, 2)").WithArguments("System.ValueTuple`2").WithLocation(6, 16),
+                // (6,26): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         return (1, 2) == (3, 4);
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(3, 4)").WithArguments("System.ValueTuple`2").WithLocation(6, 26)
+                );
+        }
+
+        [Fact]
         void TestNestedNullableTuplesWithDifferentCardinalities()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         private static readonly MetadataReference[] s_valueTupleRefs = new[] { SystemRuntimeFacadeRef, ValueTupleRef };
 
         [Fact]
-        void TestCSharp7_2()
+        public void TestCSharp7_2()
         {
             var source = @"
 class C
@@ -66,7 +66,7 @@ class C
         }
 
         [Fact]
-        void TestTuplesWithDifferentCardinalities()
+        public void TestTuplesWithDifferentCardinalities()
         {
             var source = @"
 class C
@@ -87,7 +87,7 @@ class C
         }
 
         [Fact]
-        void TestNestedTuplesWithDifferentCardinalities()
+        public void TestNestedTuplesWithDifferentCardinalities()
         {
             var source = @"
 class C
@@ -108,7 +108,7 @@ class C
         }
 
         [Fact]
-        void TestWithoutValueTuple()
+        public void TestWithoutValueTuple()
         {
             var source = @"
 class C
@@ -139,7 +139,7 @@ class C
         }
 
         [Fact]
-        void TestNestedNullableTuplesWithDifferentCardinalities()
+        public void TestNestedNullableTuplesWithDifferentCardinalities()
         {
             var source = @"
 class C
@@ -161,7 +161,7 @@ class C
         }
 
         [Fact]
-        void TestILForSimpleEqual()
+        public void TestILForSimpleEqual()
         {
             var source = @"
 class C
@@ -209,7 +209,7 @@ class C
         }
 
         [Fact]
-        void TestILForSimpleNotEqual()
+        public void TestILForSimpleNotEqual()
         {
             var source = @"
 class C
@@ -250,7 +250,7 @@ class C
         }
 
         [Fact]
-        void TestILForSimpleEqualOnTupleLiterals()
+        public void TestILForSimpleEqualOnTupleLiterals()
         {
             var source = @"
 class C
@@ -313,7 +313,7 @@ class C
         }
 
         [Fact]
-        void TestILForNullableElementsEqualsToNull()
+        public void TestILForNullableElementsEqualsToNull()
         {
             var source = @"
 class C
@@ -356,7 +356,7 @@ class C
         }
 
         [Fact]
-        void TestILForNullableElementsNotEqualsToNull()
+        public void TestILForNullableElementsNotEqualsToNull()
         {
             var source = @"
 class C
@@ -397,7 +397,7 @@ class C
         }
 
         [Fact]
-        void TestILForNullableElementsComparedToNonNullValues()
+        public void TestILForNullableElementsComparedToNonNullValues()
         {
             var source = @"
 class C
@@ -459,7 +459,7 @@ class C
         }
 
         [Fact]
-        void TestSimpleEqualOnTypelessTupleLiteral()
+        public void TestSimpleEqualOnTypelessTupleLiteral()
         {
             var source = @"
 class C
@@ -486,7 +486,7 @@ class C
         }
 
         [Fact]
-        void TestOtherOperatorsOnTuples()
+        public void TestOtherOperatorsOnTuples()
         {
             var source = @"
 class C
@@ -518,7 +518,7 @@ class C
         }
 
         [Fact]
-        void TestTypelessTuples()
+        public void TestTypelessTuples()
         {
             var source = @"
 class C
@@ -550,7 +550,7 @@ class C
         }
 
         [Fact]
-        void TestSimpleTypelessTupleAndTupleType()
+        public void TestSimpleTypelessTupleAndTupleType()
         {
             var source = @"
 class C
@@ -576,7 +576,7 @@ class C
         }
 
         [Fact]
-        void TestNestedTypelessTupleAndTupleType()
+        public void TestNestedTypelessTupleAndTupleType()
         {
             var source = @"
 class C
@@ -603,7 +603,7 @@ class C
         }
 
         [Fact]
-        void TestTypelessTupleAndTupleType2()
+        public void TestTypelessTupleAndTupleType2()
         {
             var source = @"
 class C
@@ -629,7 +629,7 @@ class C
         }
 
         [Fact]
-        void TestTypedTupleAndDefault()
+        public void TestTypedTupleAndDefault()
         {
             var source = @"
 class C
@@ -649,7 +649,7 @@ class C
         }
 
         [Fact]
-        void TestMixedTupleLiteralsAndTypes()
+        public void TestMixedTupleLiteralsAndTypes()
         {
             var source = @"
 class C
@@ -676,7 +676,7 @@ class C
         }
 
         [Fact]
-        void TestFailedInference()
+        public void TestFailedInference()
         {
             var source = @"
 class C
@@ -710,7 +710,7 @@ class C
         }
 
         [Fact]
-        void TestFailedConversion()
+        public void TestFailedConversion()
         {
             var source = @"
 class C
@@ -747,7 +747,7 @@ class C
         }
 
         [Fact]
-        void TestDynamic()
+        public void TestDynamic()
         {
             var source = @"
 public class C
@@ -769,7 +769,7 @@ public class C
         }
 
         [Fact]
-        void TestDynamic_WithTypelessExpression()
+        public void TestDynamic_WithTypelessExpression()
         {
             var source = @"
 public class C
@@ -793,7 +793,7 @@ public class C
         }
 
         [Fact]
-        void TestDynamic_WithBadType()
+        public void TestDynamic_WithBadType()
         {
             var source = @"
 public class C
@@ -818,7 +818,7 @@ public class C
         }
 
         [Fact]
-        void TestDynamic_WithNull()
+        public void TestDynamic_WithNull()
         {
             var source = @"
 public class C
@@ -837,7 +837,7 @@ public class C
         }
 
         [Fact]
-        void TestBadConstraintOnTuple()
+        public void TestBadConstraintOnTuple()
         {
             var source = @"
 ref struct S
@@ -865,7 +865,7 @@ ref struct S
         }
 
         [Fact]
-        void TestErrorInTuple()
+        public void TestErrorInTuple()
         {
             var source = @"
 public class C
@@ -887,7 +887,7 @@ public class C
         }
 
         [Fact]
-        void TempTest()
+        public void TestWithTypelessTuple()
         {
             var source = @"
 public class C
@@ -1022,7 +1022,7 @@ Operator '!=' cannot be applied to operands of type 'System.ValueTuple<int,int>'
         }
 
         [Fact]
-        public void TestComparisonWithDeconstruction()
+        public void TestComparisonWithDeconstructionResult()
         {
             var source = @"
 public class C
@@ -1048,6 +1048,31 @@ public class C
             comp.VerifyDiagnostics();
 
             CompileAndVerify(comp, expectedOutput: @"True True False True True False");
+        }
+
+        [Fact]
+        public void TestComparisonWithDeconstruction()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        var b1 = (1, 2) == new C();
+    }
+    public void Deconstruct(out int x, out int y)
+    {
+        x = 1;
+        y = 2;
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,18): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and 'C'
+                //         var b1 = (1, 2) == new C();
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(1, 2) == new C()").WithArguments("==", "(int, int)", "C").WithLocation(6, 18)
+                );
         }
 
         [Fact]
@@ -1336,6 +1361,103 @@ ValueTuple2
 Y:8
 A == Y
 A == Y
+A == Y
+A == Y
+True");
+        }
+
+        [Fact]
+        public void TestEvaluationOrderOnTupleType3()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        System.Console.WriteLine($""{GetTuple() == (new X(6), new Y(7))}"");
+    }
+    public static (A, A) GetTuple()
+    {
+        System.Console.WriteLine($""GetTuple"");
+        return (new A(30), new A(40));
+    }
+}
+namespace System
+{
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            System.Console.WriteLine(""ValueTuple2"");
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+    public struct ValueTuple<T1, T2, T3>
+    {
+        public ValueTuple(T1 item1, T2 item2, T3 item3)
+        {
+            // ValueTuple'3 required (constructed in bound tree), but not emitted
+            throw null;
+        }
+    }
+}
+public class Base
+{
+    public int I;
+    public Base(int i) { I = i; }
+}
+public class A : Base
+{
+    public A(int i) : base(i)
+    {
+        System.Console.WriteLine($""A:{i}"");
+    }
+    public static bool operator ==(A a, Y y)
+    {
+        System.Console.WriteLine(""A == Y"");
+        return true;
+    }
+    public static bool operator !=(A a, Y y)
+        => throw null;
+    public override bool Equals(object o)
+        => throw null;
+    public override int GetHashCode()
+        => throw null;
+}
+public class X : Base
+{
+    public X(int i) : base(i)
+    {
+        System.Console.WriteLine($""X:{i}"");
+    }
+}
+public class Y : Base
+{
+    public Y(int i) : base(i)
+    {
+        System.Console.WriteLine($""Y:{i}"");
+    }
+    public static implicit operator Y(X x)
+    {
+        System.Console.Write(""X -> "");
+        return new Y(x.I);
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput:
+@"GetTuple
+A:30
+A:40
+ValueTuple2
+X:6
+X -> Y:6
+Y:7
 A == Y
 A == Y
 True");
@@ -2075,79 +2197,6 @@ class C
   IL_00db:  call       ""void System.Console.Write(string)""
   IL_00e0:  nop
   IL_00e1:  ret
-}");
-        }
-
-        [Fact]
-        public void TestOnNullableVsNullableTuples_WithImplicitCustomConversion_NoTuples()
-        {
-            var source = @"
-struct C
-{
-    int _value;
-    public C(int v) { _value = v; }
-
-    public static void Main()
-    {
-        Compare(null, new C(20));
-    }
-    private static void Compare(int? nt1, C? nt2)
-    {
-        System.Console.Write($""{nt1 == nt2} "");
-    }
-    public static implicit operator int(C c)
-    {
-        System.Console.Write($""Convert{c._value} "");
-        return c._value;
-    }
-}
-";
-            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "Convert20 False");
-
-            verifier.VerifyIL("C.Compare", @"{
-  // Code size      100 (0x64)
-  .maxstack  3
-  .locals init (int? V_0,
-                int? V_1,
-                C? V_2,
-                int? V_3)
-  IL_0000:  nop
-  IL_0001:  ldstr      ""{0} ""
-  IL_0006:  ldarg.0
-  IL_0007:  stloc.0
-  IL_0008:  ldarg.1
-  IL_0009:  stloc.2
-  IL_000a:  ldloca.s   V_2
-  IL_000c:  call       ""bool C?.HasValue.get""
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloca.s   V_3
-  IL_0015:  initobj    ""int?""
-  IL_001b:  ldloc.3
-  IL_001c:  br.s       IL_002f
-  IL_001e:  ldloca.s   V_2
-  IL_0020:  call       ""C C?.GetValueOrDefault()""
-  IL_0025:  call       ""int C.op_Implicit(C)""
-  IL_002a:  newobj     ""int?..ctor(int)""
-  IL_002f:  stloc.1
-  IL_0030:  ldloca.s   V_0
-  IL_0032:  call       ""int int?.GetValueOrDefault()""
-  IL_0037:  ldloca.s   V_1
-  IL_0039:  call       ""int int?.GetValueOrDefault()""
-  IL_003e:  beq.s      IL_0043
-  IL_0040:  ldc.i4.0
-  IL_0041:  br.s       IL_0053
-  IL_0043:  ldloca.s   V_0
-  IL_0045:  call       ""bool int?.HasValue.get""
-  IL_004a:  ldloca.s   V_1
-  IL_004c:  call       ""bool int?.HasValue.get""
-  IL_0051:  ceq
-  IL_0053:  box        ""bool""
-  IL_0058:  call       ""string string.Format(string, object)""
-  IL_005d:  call       ""void System.Console.Write(string)""
-  IL_0062:  nop
-  IL_0063:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -2926,12 +2926,12 @@ public class NotBool
 
             var comp = CreateStandardCompilation(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (7,18): error CS0266: Cannot implicitly convert type 'NotBool' to 'bool'. An explicit conversion exists (are you missing a cast?)
+                // (7,18): error CS0029: Cannot implicitly convert type 'NotBool' to 'bool'
                 //         Write($"{(new A(1), new A(2)) == (new X(1), new Y(2))}");
-                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "(new A(1), new A(2)) == (new X(1), new Y(2))").WithArguments("NotBool", "bool").WithLocation(7, 18),
-                // (7,18): error CS0266: Cannot implicitly convert type 'NotBool' to 'bool'. An explicit conversion exists (are you missing a cast?)
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "(new A(1), new A(2)) == (new X(1), new Y(2))").WithArguments("NotBool", "bool").WithLocation(7, 18),
+                // (7,18): error CS0029: Cannot implicitly convert type 'NotBool' to 'bool'
                 //         Write($"{(new A(1), new A(2)) == (new X(1), new Y(2))}");
-                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "(new A(1), new A(2)) == (new X(1), new Y(2))").WithArguments("NotBool", "bool").WithLocation(7, 18)
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "(new A(1), new A(2)) == (new X(1), new Y(2))").WithArguments("NotBool", "bool").WithLocation(7, 18)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -592,7 +592,7 @@ class C
         }
 
         [Fact]
-        public void TestSimpleTypelessTupleAndTupleType()
+        public void TestSimpleTupleAndTupleType()
         {
             var source = @"
 class C
@@ -618,7 +618,7 @@ class C
         }
 
         [Fact]
-        public void TestNestedTypelessTupleAndTupleType()
+        public void TestNestedTupleAndTupleType()
         {
             var source = @"
 class C
@@ -645,7 +645,7 @@ class C
         }
 
         [Fact]
-        public void TestTypelessTupleAndTupleType2()
+        public void TestTypelessTupleAndTupleType()
         {
             var source = @"
 class C

--- a/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
+++ b/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
@@ -28,5 +28,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         PrivateProtected,
         PEVerifyCompat,
         RefConditionalOperator,
+        TupleEquality,
     }
 }


### PR DESCRIPTION
Only the last commit in this PR is new. The rest comes from https://github.com/dotnet/roslyn/pull/23356

This PR tries to factor more code between `BindSimpleBinaryOperator` and `BindTupleBinaryOperator`.
It fixes a potential problem with diagnostics (although I don't think it can be covered presently).
As a side-effect, this also fixes a bug with a custom operator== in a nested situation (the custom operator should prevail there, as it does at the top-level).

I tried moving the tuple logic into `BinaryOperatorOverloadResolution`, but I don't think that's possible. For one thing, this method is also used for compound assignment and conditional expressions. 
More importantly, we should try tuple equality binding when this method doesn't return a viable result, OR when it returns an "unacceptable" object equality. I think this latter case must remain outside of `BinaryOperatorOverloadResolution`.