### PR TITLE
Follow-up on try/catch/finally implementation

### DIFF
--- a/src/Compilers/Core/Portable/Operations/BasicBlock.cs
+++ b/src/Compilers/Core/Portable/Operations/BasicBlock.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Operations
                                 }
 
                                 builder.Add(leavingRegions[i + 1].Regions.Last());
-                                Debug.Assert(builder.Last().Kind == ControlFlowGraph.RegionKind.Handler);
+                                Debug.Assert(builder.Last().Kind == ControlFlowGraph.RegionKind.Finally);
                             }
                         }
 

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraph.Region.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraph.Region.cs
@@ -36,24 +36,29 @@ namespace Microsoft.CodeAnalysis.Operations
             Filter,
 
             /// <summary>
-            /// Region representing either <see cref="ITryOperation.Finally"/>, or <see cref="ICatchClauseOperation.Handler"/>
+            /// Region representing <see cref="ICatchClauseOperation.Handler"/>
             /// </summary>
-            Handler,
+            Catch,
 
             /// <summary>
-            /// Region representing a union of a <see cref="Filter"/> and the corresponding catch <see cref="Handler"/> regions. 
+            /// Region representing a union of a <see cref="Filter"/> and the corresponding catch <see cref="Catch"/> regions. 
             /// Doesn't contain any <see cref="BasicBlock"/>s directly.
             /// </summary>
             FilterAndHandler,
 
             /// <summary>
-            /// Region representing a union of a <see cref="Try"/> and all corresponding catch <see cref="Handler"/>
+            /// Region representing a union of a <see cref="Try"/> and all corresponding catch <see cref="Catch"/>
             /// and <see cref="FilterAndHandler"/> regions. Doesn't contain any <see cref="BasicBlock"/>s directly.
             /// </summary>
             TryAndCatch,
 
             /// <summary>
-            /// Region representing a union of a <see cref="Try"/> and corresponding finally <see cref="Handler"/>
+            /// Region representing <see cref="ITryOperation.Finally"/>
+            /// </summary>
+            Finally,
+
+            /// <summary>
+            /// Region representing a union of a <see cref="Try"/> and corresponding finally <see cref="Finally"/>
             /// region. Doesn't contain any <see cref="BasicBlock"/>s directly.
             /// 
             /// An <see cref="ITryOperation"/> that has a set of <see cref="ITryOperation.Catches"/> and a <see cref="ITryOperation.Finally"/> 
@@ -79,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Operations
             public Region Enclosing { get; private set; }
 
             /// <summary>
-            /// Target exception type for <see cref="RegionKind.Filter"/>, <see cref="RegionKind.Handler"/>, 
+            /// Target exception type for <see cref="RegionKind.Filter"/>, <see cref="RegionKind.Catch"/>, 
             /// <see cref="RegionKind.FilterAndHandler "/>
             /// </summary>
             public ITypeSymbol ExceptionType { get; }
@@ -132,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Operations
                     case RegionKind.FilterAndHandler:
                         Debug.Assert(Regions.Length == 2);
                         Debug.Assert(Regions[0].Kind == (kind == RegionKind.TryAndFinally ? RegionKind.Try : RegionKind.Filter));
-                        Debug.Assert(Regions[1].Kind == RegionKind.Handler);
+                        Debug.Assert(Regions[1].Kind == (kind == RegionKind.TryAndFinally ? RegionKind.Finally : RegionKind.Catch));
                         Debug.Assert(Regions[0].FirstBlockOrdinal == firstBlockOrdinal);
                         Debug.Assert(Regions[1].LastBlockOrdinal == lastBlockOrdinal);
                         Debug.Assert(Regions[0].LastBlockOrdinal + 1 == Regions[1].FirstBlockOrdinal);
@@ -150,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Operations
                             Debug.Assert(previousLast + 1 == r.FirstBlockOrdinal);
                             previousLast = r.LastBlockOrdinal;
 
-                            Debug.Assert(r.Kind == RegionKind.FilterAndHandler || r.Kind == RegionKind.Handler);
+                            Debug.Assert(r.Kind == RegionKind.FilterAndHandler || r.Kind == RegionKind.Catch);
                         }
 
                         Debug.Assert(previousLast == lastBlockOrdinal);
@@ -160,7 +165,8 @@ namespace Microsoft.CodeAnalysis.Operations
                     case RegionKind.Locals:
                     case RegionKind.Try:
                     case RegionKind.Filter:
-                    case RegionKind.Handler:
+                    case RegionKind.Catch:
+                    case RegionKind.Finally:
                         previousLast = firstBlockOrdinal - 1;
 
                         foreach (Region r in Regions)

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -162,7 +162,8 @@ namespace Microsoft.CodeAnalysis.Operations
                     case ControlFlowGraph.RegionKind.Root:
                     case ControlFlowGraph.RegionKind.Filter:
                     case ControlFlowGraph.RegionKind.Try:
-                    case ControlFlowGraph.RegionKind.Handler:
+                    case ControlFlowGraph.RegionKind.Catch:
+                    case ControlFlowGraph.RegionKind.Finally:
                     case ControlFlowGraph.RegionKind.Locals:
 
                         if (region.Regions?.Count == 1)
@@ -173,37 +174,8 @@ namespace Microsoft.CodeAnalysis.Operations
                                 Debug.Assert(region.Kind != ControlFlowGraph.RegionKind.Root);
 
                                 // Transfer all content of the sub-region into the current region
-#if DEBUG
-                                subRegion.AboutToFree();
-#endif 
-
                                 region.Locals = region.Locals.Concat(subRegion.Locals);
-                                region.Regions.Clear();
-
-                                int firstBlockToMove = subRegion.FirstBlock.Ordinal;
-
-                                if (subRegion.HasRegions)
-                                {
-                                    foreach (RegionBuilder r in subRegion.Regions)
-                                    {
-                                        for (int i = firstBlockToMove; i < r.FirstBlock.Ordinal; i++)
-                                        {
-                                            Debug.Assert(regionMap[blocks[i]] == subRegion);
-                                            regionMap[blocks[i]] = region;
-                                        }
-
-                                        region.Add(r);
-                                        firstBlockToMove = r.LastBlock.Ordinal + 1;
-                                    }
-                                }
-
-                                for (int i = firstBlockToMove; i <= subRegion.LastBlock.Ordinal; i++)
-                                {
-                                    Debug.Assert(regionMap[blocks[i]] == subRegion);
-                                    regionMap[blocks[i]] = region;
-                                }
-
-                                subRegion.Free();
+                                MergeSubRegionAndFree(region, subRegion, blocks, regionMap);
                                 result = true;
                                 break;
                             }
@@ -249,6 +221,45 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
 
+        private static void MergeSubRegionAndFree(RegionBuilder enclosing, RegionBuilder subRegion, ArrayBuilder<BasicBlock> blocks, PooledDictionary<BasicBlock, RegionBuilder> regionMap)
+        {
+            Debug.Assert(subRegion.Enclosing == enclosing);
+
+#if DEBUG
+            subRegion.AboutToFree();
+#endif
+
+            int firstBlockToMove = subRegion.FirstBlock.Ordinal;
+
+            if (subRegion.HasRegions)
+            {
+                foreach (RegionBuilder r in subRegion.Regions)
+                {
+                    for (int i = firstBlockToMove; i < r.FirstBlock.Ordinal; i++)
+                    {
+                        Debug.Assert(regionMap[blocks[i]] == subRegion);
+                        regionMap[blocks[i]] = enclosing;
+                    }
+
+                    firstBlockToMove = r.LastBlock.Ordinal + 1;
+                }
+
+                enclosing.ReplaceRegion(subRegion, subRegion.Regions);
+            }
+            else
+            {
+                enclosing.Remove(subRegion);
+            }
+
+            for (int i = firstBlockToMove; i <= subRegion.LastBlock.Ordinal; i++)
+            {
+                Debug.Assert(regionMap[blocks[i]] == subRegion);
+                regionMap[blocks[i]] = enclosing;
+            }
+
+            subRegion.Free();
+        }
+
         /// <summary>
         /// Do a pass to eliminate blocks without statements that can be merged with predecessor(s).
         /// Returns true if any blocks were eliminated
@@ -285,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 {
                     RegionBuilder currentRegion = regionMap[block];
                     Debug.Assert(currentRegion.Kind == ControlFlowGraph.RegionKind.Filter ||
-                                 (currentRegion.Kind == ControlFlowGraph.RegionKind.Handler && currentRegion.Enclosing.Kind == ControlFlowGraph.RegionKind.TryAndFinally));
+                                 currentRegion.Kind == ControlFlowGraph.RegionKind.Finally);
                     Debug.Assert(block == currentRegion.LastBlock);
                 }
 #endif
@@ -303,6 +314,49 @@ namespace Microsoft.CodeAnalysis.Operations
                     if (currentRegion.FirstBlock == currentRegion.LastBlock)
                     {
                         Debug.Assert(currentRegion.FirstBlock == block);
+                        Debug.Assert(!currentRegion.HasRegions);
+
+                        // Remove Try/Finally if Finally is empty
+                        if (currentRegion.Kind == ControlFlowGraph.RegionKind.Finally &&
+                            block.Statements.IsEmpty && block.InternalConditional.Condition == null &&
+                            block.InternalNext.Destination == null && block.InternalNext.Flags == BasicBlock.BranchFlags.StructuredExceptionHandling &&
+                            block.Predecessors.IsEmpty)
+                        {
+                            // Nothing usefull is happening in this finally, let's remove it
+                            RegionBuilder tryAndFinally = currentRegion.Enclosing;
+                            Debug.Assert(tryAndFinally.Kind == ControlFlowGraph.RegionKind.TryAndFinally);
+                            Debug.Assert(tryAndFinally.Regions.Count == 2);
+
+                            RegionBuilder @try = tryAndFinally.Regions.First();
+                            Debug.Assert(@try.Kind == ControlFlowGraph.RegionKind.Try);
+                            Debug.Assert(tryAndFinally.Regions.Last() == currentRegion);
+
+                            // If .try region has locals, let's convert it to .locals, otherwise drop it
+                            if (@try.Locals.IsEmpty)
+                            {
+                                i = @try.FirstBlock.Ordinal - 1; // restart at the first block of removed .try region
+                                MergeSubRegionAndFree(tryAndFinally, @try, blocks, regionMap);
+                            }
+                            else
+                            {
+                                // PROTOTYPE(dataflow): this code path is unreachable at the moment because we get here before we add locals
+                                //                      to the .try region. But I think we can hit this code path when there is an explicit 
+                                //                      goto at the end of .try once we have handling for gotos. 
+                                @try.Kind = ControlFlowGraph.RegionKind.Locals;
+                                i--; // restart at the block that was following the tryAndFinally
+                            }
+
+                            MergeSubRegionAndFree(tryAndFinally, currentRegion, blocks, regionMap);
+
+                            RegionBuilder tryAndFinallyEnclosing = tryAndFinally.Enclosing;
+                            MergeSubRegionAndFree(tryAndFinallyEnclosing, tryAndFinally, blocks, regionMap);
+
+                            count--;
+                            Debug.Assert(regionMap[block] == tryAndFinallyEnclosing);
+                            removeBlock(block, tryAndFinallyEnclosing);
+                            anyRemoved = true;
+                        }
+
                         continue;
                     }
 
@@ -1458,7 +1512,7 @@ namespace Microsoft.CodeAnalysis.Operations
                         Debug.Assert(filterRegion.FirstBlock.Predecessors.IsEmpty);
                     }
 
-                    var handlerRegion = new RegionBuilder(ControlFlowGraph.RegionKind.Handler, catchClause.ExceptionType,
+                    var handlerRegion = new RegionBuilder(ControlFlowGraph.RegionKind.Catch, catchClause.ExceptionType,
                                                           haveFilter ? default : catchClause.Locals);
                     EnterRegion(handlerRegion);
 
@@ -1497,7 +1551,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 Debug.Assert(_currentRegion.Kind == ControlFlowGraph.RegionKind.Try);
                 LeaveRegion();
 
-                var finallyRegion = new RegionBuilder(ControlFlowGraph.RegionKind.Handler);
+                var finallyRegion = new RegionBuilder(ControlFlowGraph.RegionKind.Finally);
                 EnterRegion(finallyRegion);
                 AppendNewBlock(new BasicBlock(BasicBlockKind.Block));
                 VisitStatement(operation.Finally);

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -52,14 +52,15 @@ Microsoft.CodeAnalysis.Operations.ControlFlowGraph.Region.LastBlockOrdinal.get -
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.Region.Locals.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ILocalSymbol>
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.Region.Regions.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Operations.ControlFlowGraph.Region>
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
+Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.Catch = 4 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.Filter = 3 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.FilterAndHandler = 5 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
-Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.Handler = 4 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
+Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.Finally = 7 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.Locals = 1 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.Root = 0 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.Try = 2 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.TryAndCatch = 6 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
-Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.TryAndFinally = 7 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
+Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind.TryAndFinally = 8 -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.RegionKind
 Microsoft.CodeAnalysis.Operations.ControlFlowGraph.Root.get -> Microsoft.CodeAnalysis.Operations.ControlFlowGraph.Region
 Microsoft.CodeAnalysis.Operations.ICaughtExceptionOperation
 Microsoft.CodeAnalysis.Operations.ICoalesceOperation.ValueConversion.get -> Microsoft.CodeAnalysis.Operations.CommonConversion

--- a/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
@@ -244,7 +244,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                         enterRegion(".catch {R" + regionMap[region] + "}" + $" ({region.ExceptionType?.ToTestDisplayString() ?? "null"})");
                         break;
 
-                    case ControlFlowGraph.RegionKind.Handler:
+                    case ControlFlowGraph.RegionKind.Finally:
+                        Assert.Null(region.ExceptionType);
+                        enterRegion(".finally {R" + regionMap[region] + "}");
+                        break;
+
+                    case ControlFlowGraph.RegionKind.Catch:
                         switch (region.Enclosing.Kind)
                         {
                             case ControlFlowGraph.RegionKind.FilterAndHandler:
@@ -254,11 +259,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                             case ControlFlowGraph.RegionKind.TryAndCatch:
                                 enterRegion(".catch {R" + regionMap[region] + "}" + $" ({region.ExceptionType?.ToTestDisplayString() ?? "null"})");
                                 break;
-                            case ControlFlowGraph.RegionKind.TryAndFinally:
-                                Assert.Null(region.ExceptionType);
-                                enterRegion(".finally {R" + regionMap[region] + "}");
-                                break;
-
                             default:
                                 Assert.False(true, $"Unexpected region kind {region.Enclosing.Kind}");
                                 break;
@@ -305,16 +305,16 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     case ControlFlowGraph.RegionKind.Locals:
                     case ControlFlowGraph.RegionKind.Filter:
                     case ControlFlowGraph.RegionKind.Try:
+                    case ControlFlowGraph.RegionKind.Finally:
                     case ControlFlowGraph.RegionKind.FilterAndHandler:
                         indent -= 4;
                         appendLine("}");
                         break;
-                    case ControlFlowGraph.RegionKind.Handler:
+                    case ControlFlowGraph.RegionKind.Catch:
                         switch (region.Enclosing.Kind)
                         {
                             case ControlFlowGraph.RegionKind.FilterAndHandler:
                             case ControlFlowGraph.RegionKind.TryAndCatch:
-                            case ControlFlowGraph.RegionKind.TryAndFinally:
                                 goto endRegion;
 
                             default:
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
                         break;
 
-                        endRegion:
+endRegion:
                         goto case ControlFlowGraph.RegionKind.Filter;
 
                     case ControlFlowGraph.RegionKind.TryAndCatch:


### PR DESCRIPTION
- Split RegionKind.Handler into RegionKind.Catch and RegionKind.Finally
- Improve control flow graph packing - eliminate empty finally.
