### PR TITLE
Use IsNullable=null for types from unannotated assemblies

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -248,13 +248,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbolWithAnnotations declType = BindType(typeSyntax, diagnostics, out isVar, out aliasOpt);
             if (isVar)
             {
-                declType = TypeSymbolWithAnnotations.Create(operandType);
+                declType = TypeSymbolWithAnnotations.Create(Compilation, operandType);
             }
 
             if (declType == (object)null)
             {
                 Debug.Assert(hasErrors);
-                declType = TypeSymbolWithAnnotations.Create(this.CreateErrorType("var"));
+                declType = TypeSymbolWithAnnotations.Create(Compilation, this.CreateErrorType("var"));
             }
 
             var boundDeclType = new BoundTypeExpression(typeSyntax, aliasOpt, inferredType: isVar, type: declType.TypeSymbol);

--- a/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ReportInferenceFailure(inferenceDiagnostics);
                     }
 
-                    type = fieldSymbol.SetType(TypeSymbolWithAnnotations.Create(type), inferenceDiagnostics);
+                    type = fieldSymbol.SetType(TypeSymbolWithAnnotations.Create(this.VariableSymbol.ContainingModule, type), inferenceDiagnostics);
                     inferenceDiagnostics.Free();
 
                     return new BoundFieldAccess(this.Syntax,

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
         }
 
-        protected override SynthesizedAttributeData SynthesizeNullableAttribute(WellKnownMember member, ImmutableArray<TypedConstant> arguments = default)
+        internal override SynthesizedAttributeData SynthesizeNullableAttribute(WellKnownMember member, ImmutableArray<TypedConstant> arguments)
         {
             if ((object)_lazyNullableAttribute != null)
             {

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -79,6 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 {
                     return true;
                 }
+                // PROTOTYPE(NullableReferenceTypes): The call to `SourceModule.UtilizesNullableReferenceTypes`
+                // seems incorrect. `Compilation.NeedsGeneratedNullableAttribute` should be sufficient.
                 if (SourceModule.UtilizesNullableReferenceTypes)
                 {
                     // Don't report any errors. They should be reported during binding.

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -42,7 +42,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private Dictionary<FieldSymbol, NamedTypeSymbol> _fixedImplementationTypes;
 
         private bool _needsGeneratedIsReadOnlyAttribute_Value;
-        private bool _needsGeneratedNullableAttribute_Value;
 
         private bool _needsGeneratedAttributes_IsFrozen;
 
@@ -76,7 +75,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             get
             {
                 _needsGeneratedAttributes_IsFrozen = true;
-                return Compilation.NeedsGeneratedNullableAttribute || _needsGeneratedNullableAttribute_Value;
+                if (Compilation.NeedsGeneratedNullableAttribute)
+                {
+                    return true;
+                }
+                if (SourceModule.UtilizesNullableReferenceTypes)
+                {
+                    // Don't report any errors. They should be reported during binding.
+                    return Compilation.CheckIfNullableAttributeShouldBeEmbedded(diagnosticsOpt: null, locationOpt: null);
+                }
+                return false;
             }
         }
 
@@ -1508,10 +1516,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return SynthesizeNullableAttribute(constructor, arguments);
         }
 
-        protected virtual SynthesizedAttributeData SynthesizeNullableAttribute(WellKnownMember member, ImmutableArray<TypedConstant> arguments)
+        internal virtual SynthesizedAttributeData SynthesizeNullableAttribute(WellKnownMember member, ImmutableArray<TypedConstant> arguments)
         {
             // For modules, this attribute should be present. Only assemblies generate and embed this type.
-            return Compilation.TrySynthesizeAttribute(member, arguments);
+            // PROTOTYPE(NullableReferenceTypes): Should not be optional.
+            return Compilation.TrySynthesizeAttribute(member, arguments, isOptionalUse: true);
         }
 
         protected virtual SynthesizedAttributeData TrySynthesizeIsReadOnlyAttribute()
@@ -1545,17 +1554,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal void EnsureNullableAttributeExists()
         {
             Debug.Assert(!_needsGeneratedAttributes_IsFrozen);
-
-            if (_needsGeneratedNullableAttribute_Value || Compilation.NeedsGeneratedNullableAttribute)
-            {
-                return;
-            }
-
-            // Don't report any errors. They should be reported during binding.
-            if (Compilation.CheckIfNullableAttributeShouldBeEmbedded(diagnosticsOpt: null, locationOpt: null))
-            {
-                _needsGeneratedNullableAttribute_Value = true;
-            }
+            // PROTOTYPE(NullableReferenceTypes): Remove method if not needed.
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -935,7 +935,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 while (oldTypeArg.TypeSymbol != newTypeArg.TypeSymbol);
 
-                Debug.Assert((object)oldTypeArg == newTypeArg);
+                // PROTOTYPE(NullableReferenceTypes): Is this weaker assert sufficient?
+                //Debug.Assert((object)oldTypeArg == newTypeArg);
+                Debug.Assert(oldTypeArg.Equals(newTypeArg, TypeCompareKind.CompareNullableModifiersForReferenceTypes | TypeCompareKind.UnknownNullableModifierMatchesAny));
 
                 builder.Add(newTypeArg);
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool? isNullable = type.IsNullable;
             if (typeSymbol.TypeKind == TypeKind.Array && isNullable.HasValue)
             {
-                visitor.VisitArrayType((IArrayTypeSymbol)typeSymbol, isNullable: type.IsNullable);
+                visitor.VisitArrayType((IArrayTypeSymbol)typeSymbol, isNullable: isNullable);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -11,44 +11,42 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class SymbolDisplayVisitor
     {
-        private void VisitTypeSymbolWithAnnotations(TypeSymbolWithAnnotations type, AbstractSymbolDisplayVisitor visitor = null)
+        private void VisitTypeSymbolWithAnnotations(TypeSymbolWithAnnotations type, AbstractSymbolDisplayVisitor visitorOpt = null)
         {
-            if (visitor == null)
+            var visitor = (SymbolDisplayVisitor)(visitorOpt ?? this.NotFirstVisitor);
+            var typeSymbol = type.TypeSymbol;
+            bool? isNullable = type.IsNullable;
+            if (typeSymbol.TypeKind == TypeKind.Array && isNullable.HasValue)
             {
-                visitor = this.NotFirstVisitor;
-            }
-
-            Debug.Assert(visitor is SymbolDisplayVisitor);
-
-            if (type.IsNullable == true)
-            {
-                var typeSymbol = type.TypeSymbol;
-
-                if (typeSymbol.TypeKind == TypeKind.Array)
-                {
-                    ((SymbolDisplayVisitor)visitor).VisitArrayType((IArrayTypeSymbol)typeSymbol, isNullable: true);
-                }
-                else
-                {
-                    typeSymbol.Accept(visitor);
-                    if (!typeSymbol.IsNullableType())
-                    {
-                        AddPunctuation(SyntaxKind.QuestionToken);
-                    }
-                }
+                visitor.VisitArrayType((IArrayTypeSymbol)typeSymbol, isNullable: type.IsNullable);
             }
             else
             {
-                type.TypeSymbol.Accept(visitor);
+                typeSymbol.Accept(visitor);
+                switch (isNullable)
+                {
+                    case true:
+                        if (!typeSymbol.IsNullableType())
+                        {
+                            AddPunctuation(SyntaxKind.QuestionToken);
+                        }
+                        break;
+                    case false:
+                        if (format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier))
+                        {
+                            AddPunctuation(SyntaxKind.ExclamationToken);
+                        }
+                        break;
+                }
             }
         }
 
         public override void VisitArrayType(IArrayTypeSymbol symbol)
         {
-            VisitArrayType(symbol, isNullable: false);
+            VisitArrayType(symbol, isNullable: null);
         }
 
-        private void VisitArrayType(IArrayTypeSymbol symbol, bool isNullable)
+        private void VisitArrayType(IArrayTypeSymbol symbol, bool? isNullable)
         {
             if (TryAddAlias(symbol, builder))
             {
@@ -100,12 +98,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 AddArrayRank(arrayType);
 
-                if (isNullable)
+                switch (isNullable)
                 {
-                    AddPunctuation(SyntaxKind.QuestionToken);
+                    case true:
+                        AddPunctuation(SyntaxKind.QuestionToken);
+                        break;
+                    case false:
+                        if (format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier))
+                        {
+                            AddPunctuation(SyntaxKind.ExclamationToken);
+                        }
+                        break;
                 }
 
-                isNullable = (arrayType as ArrayTypeSymbol)?.ElementType.IsNullable == true;
+                isNullable = (arrayType as ArrayTypeSymbol)?.ElementType.IsNullable;
                 arrayType = arrayType.ElementType as IArrayTypeSymbol;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
             }
 
-            return TypeSymbolWithAnnotations.Create(result);
+            return TypeSymbolWithAnnotations.Create(result, ImmutableArray<CustomModifier>.Empty, isNullableIfReferenceType: null);
         }
 
         internal TypeSymbolWithAnnotations SubstituteType(TypeSymbolWithAnnotations previous)

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
             }
 
-            return TypeSymbolWithAnnotations.Create(result, ImmutableArray<CustomModifier>.Empty, isNullableIfReferenceType: null);
+            return TypeSymbolWithAnnotations.Create(result, isNullableIfReferenceType: null);
         }
 
         internal TypeSymbolWithAnnotations SubstituteType(TypeSymbolWithAnnotations previous)

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override ImmutableArray<TypeSymbolWithAnnotations> TypeArgumentsNoUseSiteDiagnostics
             {
-                get { return this.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations); }
+                get { return GetTypeParametersAsTypeArguments(); }
             }
 
             public override ImmutableArray<Symbol> GetMembers(string name)

--- a/src/Compilers/CSharp/Portable/Symbols/ConstructedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstructedNamedTypeSymbol.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ImmutableArray<TypeSymbolWithAnnotations> TypeArgumentsNoUseSiteDiagnostics
         {
-            get { return TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations); }
+            get { return GetTypeParametersAsTypeArguments(); }
         }
 
         public override NamedTypeSymbol ConstructedFrom

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal virtual TypeSymbolWithAnnotations Substitute(AbstractTypeMap typeMap)
         {
-            return TypeSymbolWithAnnotations.Create((ErrorTypeSymbol)typeMap.SubstituteNamedType(this));
+            return TypeSymbolWithAnnotations.Create((ErrorTypeSymbol)typeMap.SubstituteNamedType(this), ImmutableArray<CustomModifier>.Empty, isNullableIfReferenceType: null);
         }
 
         /// <summary>
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations);
+                return GetTypeParametersAsTypeArguments();
             }
         }
 
@@ -658,7 +658,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ImmutableArray<TypeSymbolWithAnnotations> TypeArgumentsNoUseSiteDiagnostics
         {
-            get { return this.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations); }
+            get { return GetTypeParametersAsTypeArguments(); }
         }
 
         public override NamedTypeSymbol ConstructedFrom

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal virtual TypeSymbolWithAnnotations Substitute(AbstractTypeMap typeMap)
         {
-            return TypeSymbolWithAnnotations.Create((ErrorTypeSymbol)typeMap.SubstituteNamedType(this), ImmutableArray<CustomModifier>.Empty, isNullableIfReferenceType: null);
+            return TypeSymbolWithAnnotations.Create((ErrorTypeSymbol)typeMap.SubstituteNamedType(this), isNullableIfReferenceType: null);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -30,5 +30,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // No NullableAttribute applied to the target symbol, or flags do not line-up, return unchanged metadataType.
             return metadataType;
         }
+
+        internal static TypeSymbolWithAnnotations TransformOrEraseNullability(
+            TypeSymbolWithAnnotations metadataType,
+            EntityHandle targetSymbolToken,
+            PEModuleSymbol containingModule)
+        {
+            if (containingModule.UtilizesNullableReferenceTypes)
+            {
+                return NullableTypeDecoder.TransformType(metadataType, targetSymbolToken, containingModule);
+            }
+            return metadataType.SetUnknownNullabilityForReferenceTypes();
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         /// returns the type transformed to have IsNullable set to true or false
         /// (but not null) for each reference type in the type.
         /// </summary>
-        private static TypeSymbolWithAnnotations TransformType(
+        internal static TypeSymbolWithAnnotations TransformType(
             TypeSymbolWithAnnotations metadataType,
             EntityHandle targetSymbolToken,
             PEModuleSymbol containingModule)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -8,7 +8,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {
     internal static class NullableTypeDecoder
     {
-        internal static TypeSymbolWithAnnotations TransformType(
+        /// <summary>
+        /// If the type reference has an associated NullableAttribute, this method
+        /// returns the type transformed to have IsNullable set to true or false
+        /// (but not null) for each reference type in the type.
+        /// </summary>
+        private static TypeSymbolWithAnnotations TransformType(
             TypeSymbolWithAnnotations metadataType,
             EntityHandle targetSymbolToken,
             PEModuleSymbol containingModule)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -99,11 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, handle, moduleSymbol);
 
                 var type = TypeSymbolWithAnnotations.Create(typeSymbol);
-
-                if (moduleSymbol.UtilizesNullableReferenceTypes)
-                {
-                    type = NullableTypeDecoder.TransformType(type, handle, moduleSymbol);
-                }
+                type = NullableTypeDecoder.TransformOrEraseNullability(type, handle, moduleSymbol);
 
                 _eventType = type;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -215,11 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, _handle, moduleSymbol);
 
                 TypeSymbolWithAnnotations type = TypeSymbolWithAnnotations.Create(typeSymbol, customModifiersArray);
-
-                if (moduleSymbol.UtilizesNullableReferenceTypes)
-                {
-                    type = NullableTypeDecoder.TransformType(type, _handle, moduleSymbol);
-                }
+                type = NullableTypeDecoder.TransformOrEraseNullability(type, _handle, moduleSymbol);
 
                 _lazyIsVolatile = isVolatile;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -215,6 +215,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, _handle, moduleSymbol);
 
                 TypeSymbolWithAnnotations type = TypeSymbolWithAnnotations.Create(typeSymbol, customModifiersArray);
+                // PROTOTYPE(NullableReferenceTypes): Avoid setting IsNullable in TypeSymbolWithAnnotations.Create
+                // only to undo that in TransformOrEraseNullability. Same comment applies to other uses of TransformOrEraseNullability.
                 type = NullableTypeDecoder.TransformOrEraseNullability(type, _handle, moduleSymbol);
 
                 _lazyIsVolatile = isVolatile;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -700,9 +700,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                // PROTOTYPE(NullableReferenceTypes): Remove PEModule.UtilizesNullableReferenceTypes if not needed.
-                //return Module.UtilizesNullableReferenceTypes();
-                return true;
+                return _module.UtilizesNullableReferenceTypes();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2360,7 +2360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 get
                 {
                     // This is always the instance type, so the type arguments are the same as the type parameters.
-                    return this.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations);
+                    return GetTypeParametersAsTypeArguments();
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -458,12 +458,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         TypeSymbol decodedType = new MetadataDecoder(moduleSymbol, this).GetTypeOfToken(token);
                         var result = (NamedTypeSymbol)DynamicTypeDecoder.TransformType(decodedType, 0, _handle, moduleSymbol);
                         result = (NamedTypeSymbol)TupleTypeDecoder.DecodeTupleTypesIfApplicable(result, _handle, moduleSymbol);
-
-                        if (moduleSymbol.UtilizesNullableReferenceTypes)
-                        {
-                            result = (NamedTypeSymbol)NullableTypeDecoder.TransformType(TypeSymbolWithAnnotations.Create(result), _handle, moduleSymbol).TypeSymbol;
-                        }
-
+                        result = (NamedTypeSymbol)NullableTypeDecoder.TransformOrEraseNullability(TypeSymbolWithAnnotations.Create(result), _handle, moduleSymbol).TypeSymbol;
                         return result;
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -458,7 +458,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         TypeSymbol decodedType = new MetadataDecoder(moduleSymbol, this).GetTypeOfToken(token);
                         var result = (NamedTypeSymbol)DynamicTypeDecoder.TransformType(decodedType, 0, _handle, moduleSymbol);
                         result = (NamedTypeSymbol)TupleTypeDecoder.DecodeTupleTypesIfApplicable(result, _handle, moduleSymbol);
-                        result = (NamedTypeSymbol)NullableTypeDecoder.TransformOrEraseNullability(TypeSymbolWithAnnotations.Create(result), _handle, moduleSymbol).TypeSymbol;
+
+                        // PROTOTYPE(NullableReferenceTypes): Should call NullableTypeDecoder.TransformOrEraseNullability
+                        // here (see StaticNullChecking.UnannotatedAssemblies_09) but TransformOrEraseNullability results in
+                        // a StackOverflowException when building Roslyn.sln.
+                        if (moduleSymbol.UtilizesNullableReferenceTypes)
+                        {
+                            result = (NamedTypeSymbol)NullableTypeDecoder.TransformType(TypeSymbolWithAnnotations.Create(result), _handle, moduleSymbol).TypeSymbol;
+                        }
                         return result;
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -278,6 +278,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             out bool isBad)
         {
             var typeWithModifiers = TypeSymbolWithAnnotations.Create(type, CSharpCustomModifier.Convert(customModifiers));
+            // PROTOTYPE(NullableReferenceTypes): Avoid setting IsNullable in TypeSymbolWithAnnotations.Create
+            // only to undo that in SetUnknownNullabilityForReferenceTypesIfNecessary. Same comment applies
+            // to other uses of SetUnknownNullabilityForReferenceTypesIfNecessary.
             typeWithModifiers = typeWithModifiers.SetUnknownNullabilityForReferenceTypesIfNecessary(moduleSymbol);
 
             if (customModifiers.IsDefaultOrEmpty && refCustomModifiers.IsDefaultOrEmpty)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -241,10 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 var typeSymbol = DynamicTypeDecoder.TransformType(type.TypeSymbol, countOfCustomModifiers, handle, moduleSymbol, refKind);
                 typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, handle, moduleSymbol);
                 type = type.Update(typeSymbol, type.CustomModifiers);
-                if (moduleSymbol.UtilizesNullableReferenceTypes)
-                {
-                    type = NullableTypeDecoder.TransformType(type, handle, moduleSymbol);
-                }
+                type = NullableTypeDecoder.TransformOrEraseNullability(type, _handle, moduleSymbol);
                 _type = type;
             }
 
@@ -281,6 +278,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             out bool isBad)
         {
             var typeWithModifiers = TypeSymbolWithAnnotations.Create(type, CSharpCustomModifier.Convert(customModifiers));
+            typeWithModifiers = typeWithModifiers.SetUnknownNullabilityForReferenceTypesIfNecessary(moduleSymbol);
+
             if (customModifiers.IsDefaultOrEmpty && refCustomModifiers.IsDefaultOrEmpty)
             {
                 return new PEParameterSymbol(moduleSymbol, containingSymbol, ordinal, isByRef, typeWithModifiers, handle, 0, out isBad);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -170,11 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             originalPropertyType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(originalPropertyType, handle, moduleSymbol);
 
             var propertyType = TypeSymbolWithAnnotations.Create(originalPropertyType, typeCustomModifiers);
-
-            if (moduleSymbol.UtilizesNullableReferenceTypes)
-            {
-                propertyType = NullableTypeDecoder.TransformType(propertyType, handle, moduleSymbol);
-            }
+            propertyType = NullableTypeDecoder.TransformOrEraseNullability(propertyType, handle, moduleSymbol);
 
             _propertyType = propertyType;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                                                                                constraintHandle,
                                                                                moduleSymbol);
 
-                    symbolsBuilder.Add(TypeSymbolWithAnnotations.Create(typeSymbol));
+                    symbolsBuilder.Add(TypeSymbolWithAnnotations.Create(moduleSymbol, typeSymbol));
                 }
 
                 return symbolsBuilder.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1070,6 +1070,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal ImmutableArray<TypeSymbolWithAnnotations> GetTypeParametersAsTypeArguments()
         {
+            // PROTOTYPE(NullableReferenceTypes): Set IsNullable=null always, even in C#8,
+            // and set TypeSymbolWithAnnotations.WithCustomModifiers.Is() => false.
             return this.TypeParameters.SelectAsArray((typeParameter, module) => TypeSymbolWithAnnotations.Create(module, typeParameter), ContainingModule);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1070,7 +1070,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal ImmutableArray<TypeSymbolWithAnnotations> GetTypeParametersAsTypeArguments()
         {
-            return this.TypeParameters.SelectAsArray(tp => TypeSymbolWithAnnotations.Create(tp.ContainingModule, tp));
+            return this.TypeParameters.SelectAsArray((typeParameter, module) => TypeSymbolWithAnnotations.Create(module, typeParameter), ContainingModule);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -913,7 +913,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsErrorType = type => (object)type != null && type.IsErrorType();
 
-        internal NamedTypeSymbol ConstructWithoutModifiers(ImmutableArray<TypeSymbol> typeArguments, bool unbound)
+        private NamedTypeSymbol ConstructWithoutModifiers(ImmutableArray<TypeSymbol> typeArguments, bool unbound)
         {
             ImmutableArray<TypeSymbolWithAnnotations> modifiedArguments;
 
@@ -1066,6 +1066,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return count;
+        }
+
+        internal ImmutableArray<TypeSymbolWithAnnotations> GetTypeParametersAsTypeArguments()
+        {
+            return this.TypeParameters.SelectAsArray(tp => TypeSymbolWithAnnotations.Create(tp.ContainingModule, tp));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -82,14 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             get
             {
                 // This is always the instance type, so the type arguments are the same as the type parameters.
-                if (Arity > 0)
-                {
-                    return this.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations);
-                }
-                else
-                {
-                    return ImmutableArray<TypeSymbolWithAnnotations>.Empty;
-                }
+                return GetTypeParametersAsTypeArguments();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 
             // Preserve nullable modifiers as well.
-            // PROTOTYPE(NullableReferenceTypes): Set unknown nullability otherwise? 
+            // PROTOTYPE(NullableReferenceTypes): Set unknown nullability otherwise.
             if (containingAssembly.Modules[0].UtilizesNullableReferenceTypes)
             {
                 var flagsBuilder = ArrayBuilder<bool>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -89,6 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 
             // Preserve nullable modifiers as well.
+            // PROTOTYPE(NullableReferenceTypes): Set unknown nullability otherwise? 
             if (containingAssembly.Modules[0].UtilizesNullableReferenceTypes)
             {
                 var flagsBuilder = ArrayBuilder<bool>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -89,18 +89,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 
             // Preserve nullable modifiers as well.
-            // TODO: Do this only when feature is enabled?
-            var flagsBuilder = ArrayBuilder<bool>.GetInstance();
-            destinationType.AddNullableTransforms(flagsBuilder);
-            int position = 0;
-            int length = flagsBuilder.Count;
-            bool transformResult = resultType.ApplyNullableTransforms(flagsBuilder.ToImmutableAndFree(), ref position, out resultType);
-            Debug.Assert(transformResult && position == length);
+            if (containingAssembly.Modules[0].UtilizesNullableReferenceTypes)
+            {
+                var flagsBuilder = ArrayBuilder<bool>.GetInstance();
+                destinationType.AddNullableTransforms(flagsBuilder);
+                int position = 0;
+                int length = flagsBuilder.Count;
+                bool transformResult = resultType.ApplyNullableTransforms(flagsBuilder.ToImmutableAndFree(), ref position, out resultType);
+                Debug.Assert(transformResult && position == length);
 
-            Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames)); // Same custom modifiers as source type.
-            Debug.Assert(resultType.Equals(destinationType,
-                                           TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | // Same object/dynamic and tuple names as destination type.
-                                           TypeCompareKind.CompareNullableModifiersForReferenceTypes)); // Same nullability as destination type.
+                Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames)); // Same custom modifiers as source type.
+                Debug.Assert(resultType.Equals(destinationType,
+                                               TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | // Same object/dynamic and tuple names as destination type.
+                                               TypeCompareKind.CompareNullableModifiersForReferenceTypes)); // Same nullability as destination type.
+            }
 
             return resultType;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (isVar)
                 {
                     diagnostics.Add(ErrorCode.ERR_RecursivelyTypedVariable, this.ErrorLocation, this);
-                    type = TypeSymbolWithAnnotations.Create(binder.CreateErrorType("var"));
+                    type = TypeSymbolWithAnnotations.Create(compilation, binder.CreateErrorType("var"));
                 }
 
                 SetType(compilation, diagnostics, type);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics: diagnostics);
 
             _lazyIsVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
-            _lazyReturnType = TypeSymbolWithAnnotations.Create(bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            _lazyReturnType = TypeSymbolWithAnnotations.Create(this.DeclaringCompilation, bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
 
             var location = this.Locations[0];
             if (MethodKind == MethodKind.StaticConstructor && (_lazyParameters.Length != 0))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -42,15 +42,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DelegateDeclarationSyntax syntax,
             DiagnosticBag diagnostics)
         {
+            var compilation = delegateType.DeclaringCompilation;
             Binder binder = delegateType.GetBinder(syntax.ParameterList);
             RefKind refKind;
             TypeSyntax returnTypeSyntax = syntax.ReturnType.SkipRef(out refKind);
             var returnType = binder.BindType(returnTypeSyntax, diagnostics);
 
             // reuse types to avoid reporting duplicate errors if missing:
-            var voidType = binder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax);
-            var objectType = binder.GetSpecialType(SpecialType.System_Object, diagnostics, syntax);
-            var intPtrType = binder.GetSpecialType(SpecialType.System_IntPtr, diagnostics, syntax);
+            var voidType = TypeSymbolWithAnnotations.Create(compilation, binder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            var objectType = TypeSymbolWithAnnotations.Create(compilation, binder.GetSpecialType(SpecialType.System_Object, diagnostics, syntax));
+            var intPtrType = TypeSymbolWithAnnotations.Create(compilation, binder.GetSpecialType(SpecialType.System_IntPtr, diagnostics, syntax));
 
             if (returnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
@@ -72,8 +73,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // WinRT delegates don't have Begin/EndInvoke methods
                 !delegateType.IsCompilationOutputWinMdObj())
             {
-                var iAsyncResultType = binder.GetSpecialType(SpecialType.System_IAsyncResult, diagnostics, syntax);
-                var asyncCallbackType = binder.GetSpecialType(SpecialType.System_AsyncCallback, diagnostics, syntax);
+                var iAsyncResultType = TypeSymbolWithAnnotations.Create(compilation, binder.GetSpecialType(SpecialType.System_IAsyncResult, diagnostics, syntax));
+                var asyncCallbackType = TypeSymbolWithAnnotations.Create(compilation, binder.GetSpecialType(SpecialType.System_AsyncCallback, diagnostics, syntax));
 
                 // (3) BeginInvoke
                 symbols.Add(new BeginInvokeMethod(invoke, iAsyncResultType, objectType, asyncCallbackType, syntax));
@@ -194,15 +195,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             internal Constructor(
                 SourceMemberContainerTypeSymbol delegateType,
-                TypeSymbol voidType,
-                TypeSymbol objectType,
-                TypeSymbol intPtrType,
+                TypeSymbolWithAnnotations voidType,
+                TypeSymbolWithAnnotations objectType,
+                TypeSymbolWithAnnotations intPtrType,
                 DelegateDeclarationSyntax syntax)
-                : base(delegateType, TypeSymbolWithAnnotations.Create(voidType), syntax, MethodKind.Constructor, DeclarationModifiers.Public)
+                : base(delegateType, voidType, syntax, MethodKind.Constructor, DeclarationModifiers.Public)
             {
                 InitializeParameters(ImmutableArray.Create<ParameterSymbol>(
-                    SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(objectType), 0, RefKind.None, "object"),
-                    SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(intPtrType), 1, RefKind.None, "method")));
+                    SynthesizedParameterSymbol.Create(this, objectType, 0, RefKind.None, "object"),
+                    SynthesizedParameterSymbol.Create(this, intPtrType, 1, RefKind.None, "method")));
             }
 
             public override string Name
@@ -333,11 +334,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             internal BeginInvokeMethod(
                 InvokeMethod invoke,
-                TypeSymbol iAsyncResultType,
-                TypeSymbol objectType,
-                TypeSymbol asyncCallbackType,
+                TypeSymbolWithAnnotations iAsyncResultType,
+                TypeSymbolWithAnnotations objectType,
+                TypeSymbolWithAnnotations asyncCallbackType,
                 DelegateDeclarationSyntax syntax)
-                : base((SourceNamedTypeSymbol)invoke.ContainingType, TypeSymbolWithAnnotations.Create(iAsyncResultType), syntax, MethodKind.Ordinary, DeclarationModifiers.Virtual | DeclarationModifiers.Public)
+                : base((SourceNamedTypeSymbol)invoke.ContainingType, iAsyncResultType, syntax, MethodKind.Ordinary, DeclarationModifiers.Virtual | DeclarationModifiers.Public)
             {
                 var parameters = ArrayBuilder<ParameterSymbol>.GetInstance();
                 foreach (SourceParameterSymbol p in invoke.Parameters)
@@ -347,8 +348,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 int paramCount = invoke.ParameterCount;
-                parameters.Add(SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(asyncCallbackType), paramCount, RefKind.None, GetUniqueParameterName(parameters, "callback")));
-                parameters.Add(SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(objectType), paramCount + 1, RefKind.None, GetUniqueParameterName(parameters, "object")));
+                parameters.Add(SynthesizedParameterSymbol.Create(this, asyncCallbackType, paramCount, RefKind.None, GetUniqueParameterName(parameters, "callback")));
+                parameters.Add(SynthesizedParameterSymbol.Create(this, objectType, paramCount + 1, RefKind.None, GetUniqueParameterName(parameters, "object")));
 
                 InitializeParameters(parameters.ToImmutableAndFree());
             }
@@ -378,7 +379,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal EndInvokeMethod(
                 InvokeMethod invoke,
-                TypeSymbol iAsyncResultType,
+                TypeSymbolWithAnnotations iAsyncResultType,
                 DelegateDeclarationSyntax syntax)
                 : base((SourceNamedTypeSymbol)invoke.ContainingType, invoke.ReturnType, syntax, MethodKind.Ordinary, DeclarationModifiers.Virtual | DeclarationModifiers.Public)
             {
@@ -396,7 +397,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
                 }
 
-                parameters.Add(SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(iAsyncResultType), ordinal++, RefKind.None, GetUniqueParameterName(parameters, "result")));
+                parameters.Add(SynthesizedParameterSymbol.Create(this, iAsyncResultType, ordinal++, RefKind.None, GetUniqueParameterName(parameters, "result")));
                 InitializeParameters(parameters.ToImmutableAndFree());
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // reuse types to avoid reporting duplicate errors if missing:
             var voidType = TypeSymbolWithAnnotations.Create(compilation, binder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            // PROTOTYPE(NullableReferenceTypes): Should the 'object' parameter be considered nullable?
             var objectType = TypeSymbolWithAnnotations.Create(compilation, binder.GetSpecialType(SpecialType.System_Object, diagnostics, syntax));
             var intPtrType = TypeSymbolWithAnnotations.Create(compilation, binder.GetSpecialType(SpecialType.System_IntPtr, diagnostics, syntax));
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // EventRegistrationToken add_E(EventDelegate d);
 
                         // Leave the returns void bit in this.flags false.
-                        _lazyReturnType = TypeSymbolWithAnnotations.Create(eventTokenType);
+                        _lazyReturnType = TypeSymbolWithAnnotations.Create(compilation, eventTokenType);
 
                         var parameter = new SynthesizedAccessorValueParameterSymbol(this, _event.Type, 0);
                         _lazyParameters = ImmutableArray.Create<ParameterSymbol>(parameter);
@@ -78,10 +78,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         TypeSymbol voidType = compilation.GetSpecialType(SpecialType.System_Void);
                         Binder.ReportUseSiteDiagnostics(voidType, diagnostics, this.Location);
-                        _lazyReturnType = TypeSymbolWithAnnotations.Create(voidType);
+                        _lazyReturnType = TypeSymbolWithAnnotations.Create(compilation, voidType);
                         this.SetReturnsVoid(returnsVoid: true);
 
-                        var parameter = new SynthesizedAccessorValueParameterSymbol(this, TypeSymbolWithAnnotations.Create(eventTokenType), 0);
+                        var parameter = new SynthesizedAccessorValueParameterSymbol(this, TypeSymbolWithAnnotations.Create(compilation, eventTokenType), 0);
                         _lazyParameters = ImmutableArray.Create<ParameterSymbol>(parameter);
                     }
                 }
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     TypeSymbol voidType = compilation.GetSpecialType(SpecialType.System_Void);
                     Binder.ReportUseSiteDiagnostics(voidType, diagnostics, this.Location);
-                    _lazyReturnType = TypeSymbolWithAnnotations.Create(voidType);
+                    _lazyReturnType = TypeSymbolWithAnnotations.Create(compilation, voidType);
                     this.SetReturnsVoid(returnsVoid: true);
 
                     var parameter = new SynthesizedAccessorValueParameterSymbol(this, _event.Type, 0);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -512,7 +512,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // update the lazyType only if it contains value last seen by the current thread:
-            if ((object)Interlocked.CompareExchange(ref _lazyType, type.WithModifiers(this.RequiredCustomModifiers), null) == null)
+            if ((object)Interlocked.CompareExchange(ref _lazyType, type.WithModifiers(this.RequiredCustomModifiers).SetUnknownNullabilityForReferenceTypesIfNecessary(ContainingModule), null) == null)
             {
                 TypeChecks(type.TypeSymbol, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -512,7 +512,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // update the lazyType only if it contains value last seen by the current thread:
-            if ((object)Interlocked.CompareExchange(ref _lazyType, type.WithModifiers(this.RequiredCustomModifiers).SetUnknownNullabilityForReferenceTypesIfNecessary(ContainingModule), null) == null)
+            if ((object)Interlocked.CompareExchange(
+                ref _lazyType,
+                type.WithModifiers(this.RequiredCustomModifiers).SetUnknownNullabilityForReferenceTypesIfNecessary(ContainingModule),
+                null) == null)
             {
                 TypeChecks(type.TypeSymbol, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -611,6 +611,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (UtilizesNullableReferenceTypes)
             {
+                // PROTOTYPE(NullableReferenceTypes): Where do we ensure
+                //Compilation.NeedsGeneratedNullableAttribute is set?
                 AddSynthesizedAttribute(
                     ref attributes,
                     moduleBuilder.SynthesizeNullableAttribute(WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctor, ImmutableArray<TypedConstant>.Empty));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -608,6 +608,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         WellKnownMember.System_Security_UnverifiableCodeAttribute__ctor));
                 }
             }
+
+            if (UtilizesNullableReferenceTypes)
+            {
+                AddSynthesizedAttribute(
+                    ref attributes,
+                    moduleBuilder.SynthesizeNullableAttribute(WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctor, ImmutableArray<TypedConstant>.Empty));
+            }
         }
 
         internal override bool UtilizesNullableReferenceTypes

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -611,8 +611,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (UtilizesNullableReferenceTypes)
             {
-                // PROTOTYPE(NullableReferenceTypes): Where do we ensure
-                //Compilation.NeedsGeneratedNullableAttribute is set?
+                // PROTOTYPE(NullableReferenceTypes): Ensure Compilation.NeedsGeneratedNullableAttribute is set.
                 AddSynthesizedAttribute(
                     ref attributes,
                     moduleBuilder.SynthesizeNullableAttribute(WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctor, ImmutableArray<TypedConstant>.Empty));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -364,11 +364,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override ImmutableArray<TypeSymbolWithAnnotations> TypeArgumentsNoUseSiteDiagnostics
+        internal sealed override ImmutableArray<TypeSymbolWithAnnotations> TypeArgumentsNoUseSiteDiagnostics
         {
             get
             {
-                return TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations);
+                return GetTypeParametersAsTypeArguments();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -374,7 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else
             {
                 var binder = GetBinder();
-                return TypeSymbolWithAnnotations.Create(binder.GetSpecialType(SpecialType.System_Void, diagnostics, this.GetSyntax()));
+                return TypeSymbolWithAnnotations.Create(ContainingModule, binder.GetSpecialType(SpecialType.System_Void, diagnostics, this.GetSyntax()));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -751,9 +751,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return "";
         }
 
+        private static readonly SymbolDisplayFormat s_debuggerDisplayFormat = SymbolDisplayFormat.TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier);
+
         internal string GetDebuggerDisplay()
         {
-            return $"{this.Kind} {this.ToDisplayString(SymbolDisplayFormat.TestFormat)}";
+            return $"{this.Kind} {this.ToDisplayString(s_debuggerDisplayFormat)}";
         }
 
         internal virtual void AddDeclarationDiagnostics(DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -751,7 +751,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return "";
         }
 
-        private static readonly SymbolDisplayFormat s_debuggerDisplayFormat = SymbolDisplayFormat.TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier);
+        private static readonly SymbolDisplayFormat s_debuggerDisplayFormat =
+            SymbolDisplayFormat.TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier);
 
         internal string GetDebuggerDisplay()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -175,8 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         internal static TypeSymbolWithAnnotations Create(CSharpCompilation compilation, TypeSymbol typeSymbol)
         {
-            bool? isNullableIfReferenceType = compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) ? (bool?)false : null;
-            return Create(typeSymbol, ImmutableArray<CustomModifier>.Empty, isNullableIfReferenceType: isNullableIfReferenceType);
+            return Create(compilation.SourceModule, typeSymbol);
         }
 
         internal static TypeSymbolWithAnnotations Create(ModuleSymbol module, TypeSymbol typeSymbol)

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -187,7 +187,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // member signatures visible outside the assembly. Consider overriding, implementing, NoPIA embedding, etc.
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol)
         {
-            return Create(typeSymbol, ImmutableArray<CustomModifier>.Empty);
+            if (typeSymbol is null)
+            {
+                return null;
+            }
+
+            // PROTOTYPE(NullableReferenceTypes): Consider if it makes
+            // sense to cache and reuse instances, at least for definitions.
+            return new WithoutCustomModifiers(typeSymbol);
         }
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
@@ -648,6 +655,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             public override TypeSymbol AsTypeSymbolOnly() => _typeSymbol;
+
+            // PROTOTYPE(NullableReferenceTypes): Use WithCustomModifiers.Is() => false
+            // and set IsNullable=null always for GetTypeParametersAsTypeArguments.
             public override bool Is(TypeSymbol other) => _typeSymbol.Equals(other, TypeCompareKind.CompareNullableModifiersForReferenceTypes);
 
             protected sealed override TypeSymbolWithAnnotations DoUpdate(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -184,7 +184,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Create(typeSymbol, ImmutableArray<CustomModifier>.Empty, isNullableIfReferenceType: isNullableIfReferenceType);
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Remove this overload.
+        // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
+        // member signatures visible outside the assembly. Consider overriding, implementing, NoPIA embedding, etc.
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol)
         {
             return Create(typeSymbol, ImmutableArray<CustomModifier>.Empty);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ImmutableArray<TypeSymbolWithAnnotations> TypeArgumentsNoUseSiteDiagnostics
         {
-            get { return TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations); }
+            get { return GetTypeParametersAsTypeArguments(); }
         }
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => false;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else
             {
                 var systemVoid = Binder.GetSpecialType(compilation, SpecialType.System_Void, DummySyntax(), diagnostics);
-                return new ScriptEntryPoint(containingType, TypeSymbolWithAnnotations.Create(systemVoid));
+                return new ScriptEntryPoint(containingType, TypeSymbolWithAnnotations.Create(compilation, systemVoid));
             }
         }
 
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override ImmutableArray<ParameterSymbol> Parameters => _parameters;
 
-            public override TypeSymbolWithAnnotations ReturnType => TypeSymbolWithAnnotations.Create(_getAwaiterGetResultCall.Type);
+            public override TypeSymbolWithAnnotations ReturnType => TypeSymbolWithAnnotations.Create(ContainingModule, _getAwaiterGetResultCall.Type);
 
             internal override BoundBlock CreateBody(DiagnosticBag diagnostics)
             {
@@ -495,7 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 Debug.Assert(containingType.IsSubmissionClass);
                 Debug.Assert(returnType.SpecialType != SpecialType.System_Void);
-                _parameters = ImmutableArray.Create<ParameterSymbol>(SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(submissionArrayType), 0, RefKind.None, "submissionArray"));
+                _parameters = ImmutableArray.Create<ParameterSymbol>(SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(ContainingModule, submissionArrayType), 0, RefKind.None, "submissionArray"));
                 _returnType = returnType;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override TypeSymbolWithAnnotations ReturnType
         {
-            get { return TypeSymbolWithAnnotations.Create(ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
+            get { return TypeSymbolWithAnnotations.Create(ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
         }
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override TypeSymbolWithAnnotations ReturnType
         {
-            get { return TypeSymbolWithAnnotations.Create(_returnType); }
+            get { return TypeSymbolWithAnnotations.Create(_returnType).SetUnknownNullabilityForReferenceTypesIfNecessary(ContainingModule); }
         }
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return TypeSymbolWithAnnotations.Create(ContainingAssembly.GetSpecialType(SpecialType.System_Void));
+                return TypeSymbolWithAnnotations.Create(ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1400,6 +1400,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override TypeSymbol SetUnknownNullabilityForReferenceTypes()
+        {
+            var underlyingType = (NamedTypeSymbol)_underlyingType.SetUnknownNullabilityForReferenceTypes();
+            if ((object)underlyingType == _underlyingType)
+            {
+                return this;
+            }
+            var elementTypes = _elementTypes.SelectAsArray(t => t.SetUnknownNullabilityForReferenceTypes());
+            return new TupleTypeSymbol(_locations, underlyingType, _elementLocations, _elementNames, elementTypes, _errorPositions);
+        }
+
         #region Use-Site Diagnostics
 
         internal override DiagnosticInfo GetUseSiteDiagnostic()

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1407,8 +1407,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return this;
             }
-            var elementTypes = _elementTypes.SelectAsArray(t => t.SetUnknownNullabilityForReferenceTypes());
-            return new TupleTypeSymbol(_locations, underlyingType, _elementLocations, _elementNames, elementTypes, _errorPositions);
+            return this.WithUnderlyingType(underlyingType);
         }
 
         #region Use-Site Diagnostics

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -6495,7 +6495,8 @@ public class C
             CleanupAllGeneratedFiles(rsp);
         }
 
-        [Fact, WorkItem(530024, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530024")]
+        // PROTOTYPE(NullableReferenceTypes): Do not emit [module: NullablAttribute] if no nullable types.
+        [Fact(Skip = "TODO"), WorkItem(530024, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530024")]
         public void NoStdLib()
         {
             var src = Temp.CreateFile("a.cs");

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -6495,8 +6495,7 @@ public class C
             CleanupAllGeneratedFiles(rsp);
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Do not emit [module: NullablAttribute] if no nullable types.
-        [Fact(Skip = "TODO"), WorkItem(530024, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530024")]
+        [Fact, WorkItem(530024, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530024")]
         public void NoStdLib()
         {
             var src = Temp.CreateFile("a.cs");
@@ -6517,7 +6516,8 @@ public class C
             // Bug#15021: breaking change - empty source no error with /nostdlib
             src.WriteAllText("namespace System { }");
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
-            exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/nostdlib", "/t:library", "/runtimemetadataversion:v4.0.30319", src.ToString() }).Run(outWriter);
+            // PROTOTYPE(NullableReferenceTypes): Do not emit [module: NullableAttribute] if no nullable types. For now, use /langversion:7.
+            exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/nostdlib", "/t:library", "/runtimemetadataversion:v4.0.30319", "/langversion:7", src.ToString() }).Run(outWriter);
             Assert.Equal(0, exitCode);
             Assert.Equal("", outWriter.ToString().Trim());
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -15,15 +15,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class AttributeTests_Nullable : CSharpTestBase
     {
         // An empty project should not require System.Attribute.
-        // PROTOTYPE(NullableReferenceTypes): Do not emit [module: NullablAttribute] if no nullable types.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void EmptyProject_MissingAttribute()
         {
             var source = "";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            // PROTOTYPE(NullableReferenceTypes): Do not emit [module: NullableAttribute] if no nullable types,
+            // or change the missing System.Attribute error to a warning in this case.
             comp.VerifyEmitDiagnostics(
                 // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
-                Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1));
+                Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Attribute' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Attribute' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Boolean' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Boolean").WithLocation(1, 1));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -15,7 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class AttributeTests_Nullable : CSharpTestBase
     {
         // An empty project should not require System.Attribute.
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): Do not emit [module: NullablAttribute] if no nullable types.
+        [Fact(Skip = "TODO")]
         public void EmptyProject_MissingAttribute()
         {
             var source = "";
@@ -225,7 +226,8 @@ class C
 {
     public object F = new object();
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            // C# 7.0: No NullableAttribute.
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
             CompileAndVerify(comp, symbolValidator: module =>
             {
                 var assembly = module.ContainingAssembly;
@@ -238,10 +240,23 @@ class C
                     "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
                     "System.Diagnostics.DebuggableAttribute");
             });
+            // C# 8.0: NullableAttribute included always.
+            comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var assembly = module.ContainingAssembly;
+                var type = assembly.GetTypeByMetadataName("C");
+                var field = (FieldSymbol)type.GetMembers("F").Single();
+                AssertNoNullableAttribute(field.GetAttributes());
+                AssertNullableAttribute(module.GetAttributes());
+                AssertAttributes(assembly.GetAttributes(),
+                    "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
+                    "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
+                    "System.Diagnostics.DebuggableAttribute");
+            });
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Should generate [module: Nullable].
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void EmitAttribute_Module()
         {
             var source =
@@ -261,6 +276,32 @@ class C
                     "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
                     "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
                     "System.Diagnostics.DebuggableAttribute");
+            });
+        }
+
+        [Fact]
+        public void EmitAttribute_NetModule()
+        {
+            var source =
+@"public class C
+{
+    public object? F = new object();
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            comp.VerifyEmitDiagnostics(
+                // (3,20): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
+                //     public object? F = new object();
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "F").WithArguments("System.Runtime.CompilerServices.NullableAttribute").WithLocation(3, 20));
+        }
+
+        [Fact]
+        public void EmitAttribute_NetModuleNoDeclarations()
+        {
+            var source = "";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            CompileAndVerify(comp, verify: Verification.Skipped, symbolValidator: module =>
+            {
+                AssertAttributes(module.GetAttributes());
             });
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
@@ -2205,6 +2205,7 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = tru
     null
 ";
 
+            // PROTOTYPE(NullableReferenceTypes): Why are two errors reported for missing System.Nullable`1.
             var expectedDiagnostics = new DiagnosticDescription[] {
                 // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // class P
@@ -2409,6 +2410,7 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = nul
     null
 ";
 
+            // PROTOTYPE(NullableReferenceTypes): Why are two errors reported for missing System.Nullable`1.
             var expectedDiagnostics = new DiagnosticDescription[] {
                 // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // class P

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
@@ -2212,12 +2212,15 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = tru
                 // (4,12): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     static P M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(4, 12),
-                // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     P(bool? x = true)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
                 // (9,7): error CS0518: Predefined type 'System.Boolean' is not defined or imported
                 //     P(bool? x = true)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool").WithArguments("System.Boolean").WithLocation(9, 7),
+                // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     P(bool? x = true)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
+                // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     P(bool? x = true)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
                 // (9,5): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //     P(bool? x = true)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"P(bool? x = true)
@@ -2413,12 +2416,15 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = nul
                 // (4,12): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     static P M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(4, 12),
-                // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     P(bool? x = null)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
                 // (9,7): error CS0518: Predefined type 'System.Boolean' is not defined or imported
                 //     P(bool? x = null)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool").WithArguments("System.Boolean").WithLocation(9, 7),
+                // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     P(bool? x = null)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
+                // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     P(bool? x = null)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
                 // (9,5): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //     P(bool? x = null)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"P(bool? x = null)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -29888,7 +29888,7 @@ class H
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             compilation.GetDeclarationDiagnostics().Verify(
                 // (3,24): error CS7019: Type of 'x1' cannot be inferred since its initializer directly or indirectly refers to the definition.
@@ -29926,7 +29926,7 @@ class H
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -29964,7 +29964,7 @@ class H
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -30002,7 +30002,7 @@ class H
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -30021,7 +30021,7 @@ class H
             var x1 = (FieldSymbol)model.GetDeclaredSymbol(x1Decl.VariableDesignation());
             Assert.Equal("System.Int32", x1.Type.ToTestDisplayString());
 
-            compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
             tree = compilation.SyntaxTrees.Single();
             model = compilation.GetSemanticModel(tree);
             x1Decl = GetOutVarDeclarations(tree, "x1").Single();
@@ -30055,7 +30055,7 @@ class H
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -30072,7 +30072,7 @@ class H
                 Diagnostic(ErrorCode.ERR_RecursivelyTypedVariable, "x1").WithArguments("x1").WithLocation(3, 32)
                 );
 
-            compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
             tree = compilation.SyntaxTrees.Single();
             model = compilation.GetSemanticModel(tree);
 
@@ -30109,7 +30109,7 @@ class H
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             compilation.VerifyDiagnostics(
                 // (2,24): error CS8197: Cannot infer the type of implicitly-typed out variable 'x1'.
@@ -30149,7 +30149,7 @@ class H
     public static void M(object a) {}
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
             compilation.VerifyDiagnostics(
                 // (2,10): error CS7019: Type of 'x1' cannot be inferred since its initializer directly or indirectly refers to the definition.
                 // H.M((var x1, int x2));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -29888,7 +29888,7 @@ class H
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
             compilation.GetDeclarationDiagnostics().Verify(
                 // (3,24): error CS7019: Type of 'x1' cannot be inferred since its initializer directly or indirectly refers to the definition.
@@ -29926,6 +29926,8 @@ class H
     }
 }
 ";
+            // `skipUsesIsNullable: true` is necessary to avoid visiting symbols eagerly in CreateCompilation,
+            // which would result in `ERR_RecursivelyTypedVariable` reported on the other local (field).
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             var tree = compilation.SyntaxTrees.Single();
@@ -29964,6 +29966,8 @@ class H
     }
 }
 ";
+            // `skipUsesIsNullable: true` is necessary to avoid visiting symbols eagerly in CreateCompilation,
+            // which would result in `ERR_RecursivelyTypedVariable` reported on the other local (field).
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             var tree = compilation.SyntaxTrees.Single();
@@ -30002,6 +30006,8 @@ class H
     }
 }
 ";
+            // `skipUsesIsNullable: true` is necessary to avoid visiting symbols eagerly in CreateCompilation,
+            // which would result in `ERR_RecursivelyTypedVariable` reported on the other local (field).
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             var tree = compilation.SyntaxTrees.Single();
@@ -30055,6 +30061,8 @@ class H
     }
 }
 ";
+            // `skipUsesIsNullable: true` is necessary to avoid visiting symbols eagerly in CreateCompilation,
+            // which would result in `ERR_RecursivelyTypedVariable` reported on the other local (field).
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
 
             var tree = compilation.SyntaxTrees.Single();
@@ -30109,7 +30117,7 @@ class H
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
             compilation.VerifyDiagnostics(
                 // (2,24): error CS8197: Cannot infer the type of implicitly-typed out variable 'x1'.
@@ -30149,7 +30157,7 @@ class H
     public static void M(object a) {}
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script, skipUsesIsNullable: true);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
             compilation.VerifyDiagnostics(
                 // (2,10): error CS7019: Type of 'x1' cannot be inferred since its initializer directly or indirectly refers to the definition.
                 // H.M((var x1, int x2));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -176,17 +176,22 @@ class C
         }
 
         [Fact]
-        public void ReferenceTypesFromUnannotatedAssembliesAreNotNullable()
+        public void UnannotatedAssemblies_00()
+        {
+            var comp = CreateStandardCompilation("", parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+            var systemNamespace = comp.GetMember<NamedTypeSymbol>("System.Object").ContainingNamespace;
+            VerifyNoNullability(systemNamespace);
+        }
+
+        [Fact]
+        public void UnannotatedAssemblies_01()
         {
             var source0 =
 @"public class A
 {
     public static void F(string s) { }
 }";
-            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular7);
-            comp0.VerifyDiagnostics();
-            var ref0 = comp0.EmitToImageReference();
-
             var source1 =
 @"class B
 {
@@ -196,11 +201,433 @@ class C
         A.F(null);
     }
 }";
-            var comp1 = CreateStandardCompilation(source1, references: new[] { ref0 }, parseOptions: TestOptions.Regular8);
+            TypeSymbolWithAnnotations getParameterType(Compilation c) => c.GetMember<MethodSymbol>("A.F").Parameters[0].Type;
+
+            // 7.0 library
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular7);
+            comp0.VerifyDiagnostics();
+            var compRefs0 = new MetadataReference[] { new CSharpCompilationReference(comp0) };
+            var metadataRefs0 = new[] { comp0.EmitToImageReference() };
+            Assert.Equal(null, getParameterType(comp0).IsNullable);
+
+            // ... used in 7.0.
+            var comp1 = CreateStandardCompilation(source1, references: compRefs0, parseOptions: TestOptions.Regular7);
+            comp1.VerifyDiagnostics();
+            Assert.Equal(null, getParameterType(comp1).IsNullable);
+            comp1 = CreateStandardCompilation(source1, references: metadataRefs0, parseOptions: TestOptions.Regular7);
+            comp1.VerifyDiagnostics();
+            Assert.Equal(null, getParameterType(comp1).IsNullable);
+
+            // ... used in 8.0.
+            comp1 = CreateStandardCompilation(source1, references: compRefs0, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics();
+            Assert.Equal(null, getParameterType(comp1).IsNullable);
+            comp1 = CreateStandardCompilation(source1, references: metadataRefs0, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics();
+            Assert.Equal(null, getParameterType(comp1).IsNullable);
+
+            // 8.0 library
+            comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular8);
+            comp0.VerifyDiagnostics();
+            compRefs0 = new MetadataReference[] { new CSharpCompilationReference(comp0) };
+            metadataRefs0 = new[] { comp0.EmitToImageReference() };
+            Assert.Equal(false, getParameterType(comp0).IsNullable);
+
+            // ... used in 7.0.
+            comp1 = CreateStandardCompilation(source1, references: compRefs0, parseOptions: TestOptions.Regular7);
+            comp1.VerifyDiagnostics();
+            Assert.Equal(false, getParameterType(comp1).IsNullable);
+            comp1 = CreateStandardCompilation(source1, references: metadataRefs0, parseOptions: TestOptions.Regular7);
+            comp1.VerifyDiagnostics();
+            Assert.Equal(false, getParameterType(comp1).IsNullable);
+
+            // ... used in 8.0.
+            comp1 = CreateStandardCompilation(source1, references: compRefs0, parseOptions: TestOptions.Regular8);
             comp1.VerifyDiagnostics(
                 // (6,13): warning CS8600: Cannot convert null to non-nullable reference.
                 //         A.F(null);
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 13));
+            Assert.Equal(false, getParameterType(comp1).IsNullable);
+            comp1 = CreateStandardCompilation(source1, references: metadataRefs0, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics(
+                // (6,13): warning CS8600: Cannot convert null to non-nullable reference.
+                //         A.F(null);
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 13));
+            Assert.Equal(false, getParameterType(comp1).IsNullable);
+        }
+
+        [Fact]
+        public void UnannotatedAssemblies_02()
+        {
+            var source0 =
+@"#pragma warning disable 67
+public delegate void D();
+public class C
+{
+    public object F;
+    public event D E;
+    public object P => null;
+    public object this[object o] => null;
+    public object M(object o) => null;
+}";
+            var source1 =
+@"class P
+{
+    static void F(C c)
+    {
+        object o;
+        o = c.F;
+        c.E += null;
+        o = c.P;
+        o = c[null];
+        o = c.M(null);
+    }
+}";
+
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular7);
+            comp0.VerifyDiagnostics();
+
+            void verify(Compilation c)
+            {
+                c.VerifyDiagnostics();
+                Assert.Equal(null, c.GetMember<FieldSymbol>("C.F").Type.IsNullable);
+                Assert.Equal(null, c.GetMember<EventSymbol>("C.E").Type.IsNullable);
+                Assert.Equal(null, c.GetMember<PropertySymbol>("C.P").Type.IsNullable);
+                var indexer = c.GetMember<PropertySymbol>("C.this[]");
+                Assert.Equal(null, indexer.Type.IsNullable);
+                Assert.Equal(null, indexer.Parameters[0].Type.IsNullable);
+                var method = c.GetMember<MethodSymbol>("C.M");
+                Assert.Equal(null, method.ReturnType.IsNullable);
+                Assert.Equal(null, method.Parameters[0].Type.IsNullable);
+            }
+
+            var comp1A = CreateStandardCompilation(source1, references: new MetadataReference[] { new CSharpCompilationReference(comp0) }, parseOptions: TestOptions.Regular8);
+            verify(comp1A);
+
+            var comp1B = CreateStandardCompilation(source1, references: new[] { comp0.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
+            verify(comp1B);
+        }
+
+        [Fact]
+        public void UnannotatedAssemblies_03()
+        {
+            var source =
+@"class A { }
+class B : A { }
+interface I<T> where T : A { }
+abstract class C<T> where T : A
+{
+    internal abstract void M<U>() where U : T;
+}
+class D : C<B>, I<B>
+{
+    internal override void M<T>() { }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
+            comp.VerifyDiagnostics();
+            var derivedType = comp.GetMember<NamedTypeSymbol>("D");
+            var baseType = derivedType.BaseTypeNoUseSiteDiagnostics;
+            var constraintType = baseType.TypeParameters.Single().ConstraintTypesNoUseSiteDiagnostics.Single();
+            Assert.Equal(null, constraintType.IsNullable);
+            var interfaceType = derivedType.Interfaces().Single();
+            constraintType = interfaceType.TypeParameters.Single().ConstraintTypesNoUseSiteDiagnostics.Single();
+            Assert.Equal(null, constraintType.IsNullable);
+            var method = baseType.GetMember<MethodSymbol>("M");
+            constraintType = method.TypeParameters.Single().ConstraintTypesNoUseSiteDiagnostics.Single();
+            Assert.Equal(null, constraintType.IsNullable);
+        }
+
+        [Fact]
+        public void UnannotatedAssemblies_04()
+        {
+            var source0 =
+@"public class C<T>
+{
+    public T F;
+}
+public class C
+{
+    public static C<T> Create<T>(T t) => new C<T>();
+}";
+            var source1 =
+@"class P
+{
+    static void F(object x, object? y)
+    {
+        object z;
+        z = C.Create(x).F;
+        z = C.Create(y).F;
+    }
+}";
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular7);
+            comp0.VerifyDiagnostics();
+            var comp1 = CreateStandardCompilation(source1, references: new[] { comp0.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics(
+                // (7,13): warning CS8601: Possible null reference assignment.
+                //         z = C.Create(y).F;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "C.Create(y).F").WithLocation(7, 13));
+        }
+
+        [Fact]
+        public void UnannotatedAssemblies_05()
+        {
+            var source0 =
+@"public interface I
+{
+    object F(object o);
+}";
+            var source1 =
+@"class A1 : I
+{
+    object I.F(object? o) => new object();
+}
+class A2 : I
+{
+    object? I.F(object o) => o;
+}
+class B1 : I
+{
+    public object F(object? o) => new object();
+}
+class B2 : I
+{
+    public object? F(object o) => o;
+}
+class C1
+{
+    public object F(object? o) => new object();
+}
+class C2
+{
+    public object? F(object o) => o;
+}
+class D1 : C1, I
+{
+}
+class D2 : C2, I
+{
+}
+class P
+{
+    static void F(object? x, A1 a1, A2 a2)
+    {
+        object y;
+        y = ((I)a1).F(x);
+        y = ((I)a2).F(x);
+    }
+    static void F(object? x, B1 b1, B2 b2)
+    {
+        object y;
+        y = b1.F(x);
+        y = b2.F(x);
+        y = ((I)b1).F(x);
+        y = ((I)b2).F(x);
+    }
+    static void F(object? x, D1 d1, D2 d2)
+    {
+        object y;
+        y = d1.F(x);
+        y = d2.F(x);
+        y = ((I)d1).F(x);
+        y = ((I)d2).F(x);
+    }
+}";
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular7);
+            comp0.VerifyDiagnostics();
+
+            var comp1 = CreateStandardCompilation(source1, references: new MetadataReference[] { new CSharpCompilationReference(comp0) }, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics(
+                // (43,18): warning CS8604: Possible null reference argument for parameter 'o' in 'object? B2.F(object o)'.
+                //         y = b2.F(x);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("o", "object? B2.F(object o)").WithLocation(43, 18),
+                // (43,13): warning CS8601: Possible null reference assignment.
+                //         y = b2.F(x);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b2.F(x)").WithLocation(43, 13),
+                // (51,18): warning CS8604: Possible null reference argument for parameter 'o' in 'object? C2.F(object o)'.
+                //         y = d2.F(x);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("o", "object? C2.F(object o)").WithLocation(51, 18),
+                // (51,13): warning CS8601: Possible null reference assignment.
+                //         y = d2.F(x);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "d2.F(x)").WithLocation(51, 13));
+
+            comp1 = CreateStandardCompilation(source1, references: new[] { comp0.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics(
+                // (43,18): warning CS8604: Possible null reference argument for parameter 'o' in 'object? B2.F(object o)'.
+                //         y = b2.F(x);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("o", "object? B2.F(object o)").WithLocation(43, 18),
+                // (43,13): warning CS8601: Possible null reference assignment.
+                //         y = b2.F(x);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b2.F(x)").WithLocation(43, 13),
+                // (51,18): warning CS8604: Possible null reference argument for parameter 'o' in 'object? C2.F(object o)'.
+                //         y = d2.F(x);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("o", "object? C2.F(object o)").WithLocation(51, 18),
+                // (51,13): warning CS8601: Possible null reference assignment.
+                //         y = d2.F(x);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "d2.F(x)").WithLocation(51, 13));
+        }
+
+        [Fact]
+        public void UnannotatedAssemblies_06()
+        {
+            var source0 =
+@"public interface I
+{
+    object? F(object? o);
+    object G(object o);
+}";
+            var source1 =
+@"public class A : I
+{
+    object I.F(object o) => null;
+    object I.G(object o) => null;
+}
+public class B : I
+{
+    public object F(object o) => null;
+    public object G(object o) => null;
+}
+public class C
+{
+    public object F(object o) => null;
+    public object G(object o) => null;
+}
+public class D : C
+{
+}";
+            var source2 =
+@"class P
+{
+    static void F(object o, A a)
+    {
+        ((I)a).F(o).ToString();
+        ((I)a).G(null).ToString();
+    }
+    static void F(object o, B b)
+    {
+        b.F(o).ToString();
+        b.G(null).ToString();
+        ((I)b).F(o).ToString();
+        ((I)b).G(null).ToString();
+    }
+    static void F(object o, D d)
+    {
+        d.F(o).ToString();
+        d.G(null).ToString();
+        ((I)d).F(o).ToString();
+        ((I)d).G(null).ToString();
+    }
+}";
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular8);
+            comp0.VerifyDiagnostics();
+            var ref0 = comp0.EmitToImageReference();
+
+            var comp1 = CreateStandardCompilation(source1, references: new[] { ref0 }, parseOptions: TestOptions.Regular7);
+            comp1.VerifyDiagnostics();
+            var ref1 = comp1.EmitToImageReference();
+
+            var comp2A = CreateStandardCompilation(source2, references: new[] { ref0, ref1 }, parseOptions: TestOptions.Regular7);
+            comp2A.VerifyDiagnostics();
+
+            var comp2B = CreateStandardCompilation(source2, references: new[] { ref0, ref1 }, parseOptions: TestOptions.Regular8);
+            comp2B.VerifyDiagnostics(
+                // (5,9): warning CS8602: Possible dereference of a null reference.
+                //         ((I)a).F(o).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((I)a).F(o)").WithLocation(5, 9),
+                // (6,18): warning CS8600: Cannot convert null to non-nullable reference.
+                //         ((I)a).G(null).ToString();
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 18),
+                // (12,9): warning CS8602: Possible dereference of a null reference.
+                //         ((I)b).F(o).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((I)b).F(o)").WithLocation(12, 9),
+                // (13,18): warning CS8600: Cannot convert null to non-nullable reference.
+                //         ((I)b).G(null).ToString();
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 18),
+                // (19,9): warning CS8602: Possible dereference of a null reference.
+                //         ((I)d).F(o).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((I)d).F(o)").WithLocation(19, 9),
+                // (20,18): warning CS8600: Cannot convert null to non-nullable reference.
+                //         ((I)d).G(null).ToString();
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(20, 18));
+        }
+
+        [Fact]
+        public void UnannotatedAssemblies_07()
+        {
+            var source0 =
+@"public abstract class A
+{
+    public abstract object? F(object x, object? y);
+}";
+            var source1 =
+@"public abstract class B : A
+{
+    public abstract override object F(object x, object y);
+    public abstract object G(object x, object y);
+}";
+            var source2 =
+@"class C1 : B
+{
+    public override object F(object x, object y) => x;
+    public override object G(object x, object y) => x;
+}
+class C2 : B
+{
+    public override object? F(object? x, object? y) => x;
+    public override object? G(object? x, object? y) => x;
+}
+class P
+{
+    static void F(object? x, object y, C1 c)
+    {
+        c.F(x, y).ToString();
+        c.G(x, y).ToString();
+        ((B)c).F(x, y).ToString();
+        ((B)c).G(x, y).ToString();
+        ((A)c).F(x, y).ToString();
+    }
+    static void F(object? x, object y, C2 c)
+    {
+        c.F(x, y).ToString();
+        c.G(x, y).ToString();
+        ((B)c).F(x, y).ToString();
+        ((B)c).G(x, y).ToString();
+        ((A)c).F(x, y).ToString();
+    }
+}";
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular8);
+            comp0.VerifyDiagnostics();
+            var ref0 = comp0.EmitToImageReference();
+
+            var comp1 = CreateStandardCompilation(source1, references: new[] { ref0 }, parseOptions: TestOptions.Regular7);
+            comp1.VerifyDiagnostics();
+            var ref1 = comp1.EmitToImageReference();
+
+            var comp2 = CreateStandardCompilation(source2, references: new[] { ref0, ref1 }, parseOptions: TestOptions.Regular8);
+            comp2.VerifyDiagnostics(
+                // (15,13): warning CS8604: Possible null reference argument for parameter 'x' in 'object C1.F(object x, object y)'.
+                //         c.F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("x", "object C1.F(object x, object y)").WithLocation(15, 13),
+                // (16,13): warning CS8604: Possible null reference argument for parameter 'x' in 'object C1.G(object x, object y)'.
+                //         c.G(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("x", "object C1.G(object x, object y)").WithLocation(16, 13),
+                // (19,18): warning CS8604: Possible null reference argument for parameter 'x' in 'object? A.F(object x, object? y)'.
+                //         ((A)c).F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("x", "object? A.F(object x, object? y)").WithLocation(19, 18),
+                // (19,9): warning CS8602: Possible dereference of a null reference.
+                //         ((A)c).F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A)c).F(x, y)").WithLocation(19, 9),
+                // (23,9): warning CS8602: Possible dereference of a null reference.
+                //         c.F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F(x, y)").WithLocation(23, 9),
+                // (24,9): warning CS8602: Possible dereference of a null reference.
+                //         c.G(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.G(x, y)").WithLocation(24, 9),
+                // (27,18): warning CS8604: Possible null reference argument for parameter 'x' in 'object? A.F(object x, object? y)'.
+                //         ((A)c).F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("x", "object? A.F(object x, object? y)").WithLocation(27, 18),
+                // (27,9): warning CS8602: Possible dereference of a null reference.
+                //         ((A)c).F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A)c).F(x, y)").WithLocation(27, 9));
         }
 
         [Fact]
@@ -3918,71 +4345,7 @@ public struct S2
 }
 ", parseOptions: TestOptions.Regular8, references: new[] { c0.EmitToImageReference() });
 
-            c.VerifyDiagnostics(
-                // (10,30): warning CS8604: Possible null reference argument for parameter 'a' in 'bool string.Equals(string a, string b)'.
-                //         return string.Equals(x1, y1);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("a", "bool string.Equals(string a, string b)").WithLocation(10, 30),
-                // (15,51): warning CS8604: Possible null reference argument for parameter 'location1' in 'object Interlocked.Exchange(ref object location1, object value)'.
-                //         System.Threading.Interlocked.Exchange(ref x2, y2);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("location1", "object Interlocked.Exchange(ref object location1, object value)").WithLocation(15, 51),
-                // (15,55): warning CS8604: Possible null reference argument for parameter 'value' in 'object Interlocked.Exchange(ref object location1, object value)'.
-                //         System.Threading.Interlocked.Exchange(ref x2, y2);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y2").WithArguments("value", "object Interlocked.Exchange(ref object location1, object value)").WithLocation(15, 55),
-                // (21,58): warning CS8604: Possible null reference argument for parameter 'location1' in 'object Interlocked.Exchange(ref object location1, object value)'.
-                //         return System.Threading.Interlocked.Exchange(ref x3, y3) ?? new object(); 
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x3").WithArguments("location1", "object Interlocked.Exchange(ref object location1, object value)").WithLocation(21, 58),
-                // (21,62): warning CS8604: Possible null reference argument for parameter 'value' in 'object Interlocked.Exchange(ref object location1, object value)'.
-                //         return System.Threading.Interlocked.Exchange(ref x3, y3) ?? new object(); 
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y3").WithArguments("value", "object Interlocked.Exchange(ref object location1, object value)").WithLocation(21, 62),
-                // (21,16): hidden CS8607: Expression is probably never null.
-                //         return System.Threading.Interlocked.Exchange(ref x3, y3) ?? new object(); 
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "System.Threading.Interlocked.Exchange(ref x3, y3)").WithLocation(21, 16),
-                // (26,16): hidden CS8607: Expression is probably never null.
-                //         return x4.Target ?? new object(); 
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4.Target").WithLocation(26, 16),
-                // (31,16): hidden CS8607: Expression is probably never null.
-                //         return x5.F1 ?? new object(); 
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x5.F1").WithLocation(31, 16),
-                // (36,17): warning CS8601: Possible null reference assignment.
-                //         x6.F1 = y6;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y6").WithLocation(36, 17),
-                // (41,17): warning CS8601: Possible null reference assignment.
-                //         x7.P1 = y7;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y7").WithLocation(41, 17),
-                // (46,12): warning CS8604: Possible null reference argument for parameter 'x' in 'object CL0.this[object x].get'.
-                //         x8[y8] = z8;
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y8").WithArguments("x", "object CL0.this[object x].get").WithLocation(46, 12),
-                // (46,18): warning CS8601: Possible null reference assignment.
-                //         x8[y8] = z8;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z8").WithLocation(46, 18),
-                // (51,16): hidden CS8607: Expression is probably never null.
-                //         return x9[1] ?? new object(); 
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x9[1]").WithLocation(51, 16),
-                // (56,16): hidden CS8607: Expression is probably never null.
-                //         return x10.M1().F1 ?? new object(); 
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x10.M1().F1").WithLocation(56, 16),
-                // (62,18): warning CS8601: Possible null reference assignment.
-                //         y11.F1 = z11;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z11").WithLocation(62, 18),
-                // (70,16): hidden CS8607: Expression is probably never null.
-                //         return y12.F1 ?? new object(); 
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y12.F1").WithLocation(70, 16),
-                // (77,15): hidden CS8607: Expression is probably never null.
-                //         z13 = y13 ?? new object();
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y13").WithLocation(77, 15),
-                // (84,15): hidden CS8607: Expression is probably never null.
-                //         z14 = y14 ?? new object();
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y14").WithLocation(84, 15),
-                // (92,15): hidden CS8607: Expression is probably never null.
-                //         z15 = y15.F2 ?? new object();
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y15.F2").WithLocation(92, 15),
-                // (103,19): hidden CS8607: Expression is probably never null.
-                //             z16 = y16 ?? new object();
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y16").WithLocation(103, 19),
-                // (111,15): hidden CS8607: Expression is probably never null.
-                //         z17 = y17.F2 ?? new object();
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y17.F2").WithLocation(111, 15)
-                );
+            c.VerifyDiagnostics();
         }
 
         // PROTOTYPE(NullableReferenceTypes): Conversions: NullCoalescingOperator
@@ -4333,15 +4696,9 @@ class C
                 // (16,21): warning CS8601: Possible null reference assignment.
                 //         object y1 = x1;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(16, 21),
-                // (24,21): hidden CS8607: Expression is probably never null.
-                //         object z2 = x2 ?? new object();
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x2").WithLocation(24, 21),
                 // (31,21): warning CS8601: Possible null reference assignment.
                 //         object y3 = x3;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3").WithLocation(31, 21),
-                // (39,21): hidden CS8607: Expression is probably never null.
-                //         object z4 = x4 ?? new object();
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4").WithLocation(39, 21),
                 // (46,21): warning CS8601: Possible null reference assignment.
                 //         object y5 = x5;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x5").WithLocation(46, 21),
@@ -4530,71 +4887,7 @@ class B3 : IA2
 }
 ", parseOptions: TestOptions.Regular8, references: new[] { c0.EmitToImageReference() });
 
-            c.VerifyDiagnostics(
-                // (8,29): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                //     public override string? P2 { get; set; }
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "P2").WithLocation(8, 29),
-                // (9,42): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                //     public override event System.Action? E1;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E1").WithLocation(9, 42),
-                // (10,29): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
-                //     public override string? M3(string? x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M3").WithLocation(10, 29),
-                // (10,29): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                //     public override string? M3(string? x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("x").WithLocation(10, 29),
-                // (15,42): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                //     public override event System.Action? E4
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E4").WithLocation(15, 42),
-                // (21,29): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                //     public override string? this[string? x]
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "this").WithLocation(21, 29),
-                // (21,29): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                //     public override string? this[string? x]
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "this").WithArguments("x").WithLocation(21, 29),
-                // (39,33): warning CS8612: Nullability of reference types in type doesn't match implicitly implemented member 'event Action IA2.E8'.
-                //     public event System.Action? E8
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation, "E8").WithArguments("event Action IA2.E8").WithLocation(39, 33),
-                // (45,20): warning CS8613: Nullability of reference types in return type doesn't match implicitly implemented member 'string IA2.M7(string x)'.
-                //     public string? M7(string? x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnImplicitImplementation, "M7").WithArguments("string IA2.M7(string x)").WithLocation(45, 20),
-                // (45,20): warning CS8614: Nullability of reference types in type of parameter 'x' doesn't match implicitly implemented member 'string IA2.M7(string x)'.
-                //     public string? M7(string? x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnImplicitImplementation, "M7").WithArguments("x", "string IA2.M7(string x)").WithLocation(45, 20),
-                // (37,20): warning CS8612: Nullability of reference types in type doesn't match implicitly implemented member 'string IA2.P6'.
-                //     public string? P6 { get; set; }
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation, "P6").WithArguments("string IA2.P6").WithLocation(37, 20),
-                // (51,20): warning CS8612: Nullability of reference types in type doesn't match implicitly implemented member 'string IA2.this[string x]'.
-                //     public string? this[string? x]
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation, "this").WithArguments("string IA2.this[string x]").WithLocation(51, 20),
-                // (51,20): warning CS8614: Nullability of reference types in type of parameter 'x' doesn't match implicitly implemented member 'string IA2.this[string x]'.
-                //     public string? this[string? x]
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnImplicitImplementation, "this").WithArguments("x", "string IA2.this[string x]").WithLocation(51, 20),
-                // (38,33): warning CS8612: Nullability of reference types in type doesn't match implicitly implemented member 'event Action IA2.E5'.
-                //     public event System.Action? E5;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation, "E5").WithArguments("event Action IA2.E5").WithLocation(38, 33),
-                // (67,17): warning CS8615: Nullability of reference types in type doesn't match implemented member 'string IA2.P6'.
-                //     string? IA2.P6 { get; set; }
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation, "P6").WithArguments("string IA2.P6").WithLocation(67, 17),
-                // (69,30): warning CS8615: Nullability of reference types in type doesn't match implemented member 'event Action IA2.E5'.
-                //     event System.Action? IA2.E5
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation, "E5").WithArguments("event Action IA2.E5").WithLocation(69, 30),
-                // (75,30): warning CS8615: Nullability of reference types in type doesn't match implemented member 'event Action IA2.E8'.
-                //     event System.Action? IA2.E8
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation, "E8").WithArguments("event Action IA2.E8").WithLocation(75, 30),
-                // (86,17): warning CS8615: Nullability of reference types in type doesn't match implemented member 'string IA2.this[string x]'.
-                //     string? IA2.this[string? x]
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation, "this").WithArguments("string IA2.this[string x]").WithLocation(86, 17),
-                // (86,17): warning CS8617: Nullability of reference types in type of parameter 'x' doesn't match implemented member 'string IA2.this[string x]'.
-                //     string? IA2.this[string? x]
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation, "this").WithArguments("x", "string IA2.this[string x]").WithLocation(86, 17),
-                // (81,17): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'string IA2.M7(string x)'.
-                //     string? IA2.M7(string? x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M7").WithArguments("string IA2.M7(string x)").WithLocation(81, 17),
-                // (81,17): warning CS8617: Nullability of reference types in type of parameter 'x' doesn't match implemented member 'string IA2.M7(string x)'.
-                //     string? IA2.M7(string? x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation, "M7").WithArguments("x", "string IA2.M7(string x)").WithLocation(81, 17)
-                );
+            c.VerifyDiagnostics();
         }
 
         [Fact]
@@ -7909,15 +8202,6 @@ class C
 ", parseOptions: TestOptions.Regular8, references: new[] { notAnnotated.EmitToImageReference() });
 
             c.VerifyDiagnostics(
-                // (10,29): warning CS8600: Cannot convert null to non-nullable reference.
-                //                     p1.F1 = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 29),
-                // (11,26): warning CS8600: Cannot convert null to non-nullable reference.
-                //                     p1 = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 26),
-                // (12,28): warning CS8600: Cannot convert null to non-nullable reference.
-                //                     return null; // 1
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 28),
                 // (20,29): warning CS8600: Cannot convert null to non-nullable reference.
                 //                     p2.F1 = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(20, 29),
@@ -17323,6 +17607,32 @@ class C
                 // (17,11): warning CS8602: Possible dereference of a null reference.
                 //         w?.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".F").WithLocation(17, 11));
+        }
+
+        [Fact]
+        public void ConstrainedToTypeParameter_01()
+        {
+            var source =
+@"class C<T, U> where U : T
+{
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
+            comp.VerifyDiagnostics();
+            comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ConstrainedToTypeParameter_02()
+        {
+            var source =
+@"class C<T> where T : C<T>
+{
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
+            comp.VerifyDiagnostics();
+            comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -658,7 +658,9 @@ class P
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A)c).F(x, y)").WithLocation(27, 9));
         }
 
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): Should call NullableTypeDecoder.TransformOrEraseNullability
+        // in PENamedTypeSymbol.MakeDeclaredBaseType.
+        [Fact(Skip = "TODO")]
         public void UnannotatedAssemblies_09()
         {
             var source0 =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -337,8 +337,37 @@ class D : C<B>, I<B>
             Assert.Equal(null, constraintType.IsNullable);
         }
 
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): Return type and parameter types of explicit implementations have nullability set.
+        [Fact(Skip = "TODO")]
         public void UnannotatedAssemblies_04()
+        {
+            var source =
+@"interface I<T>
+{
+    I<object[]> F();
+}
+class C : I<string>
+{
+    I<object[]> I<string>.F() => null;
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
+            comp.VerifyDiagnostics();
+            var type = comp.GetMember<NamedTypeSymbol>("C");
+            var interfaceType = type.Interfaces().Single();
+            var typeArg = interfaceType.TypeArgumentsNoUseSiteDiagnostics.Single();
+            Assert.Equal(null, typeArg.IsNullable);
+            var method = type.GetMember<MethodSymbol>("I<System.String>.F");
+            Assert.Equal(null, method.ReturnType.IsNullable);
+            typeArg = ((NamedTypeSymbol)method.ReturnType.TypeSymbol).TypeArgumentsNoUseSiteDiagnostics.Single();
+            Assert.Equal(null, typeArg.IsNullable);
+            var parameter = method.Parameters.Single();
+            Assert.Equal(null, parameter.Type.IsNullable);
+            typeArg = ((NamedTypeSymbol)parameter.Type.TypeSymbol).TypeArgumentsNoUseSiteDiagnostics.Single();
+            Assert.Equal(null, typeArg.IsNullable);
+        }
+
+        [Fact]
+        public void UnannotatedAssemblies_05()
         {
             var source0 =
 @"public class C<T>
@@ -369,7 +398,7 @@ public class C
         }
 
         [Fact]
-        public void UnannotatedAssemblies_05()
+        public void UnannotatedAssemblies_06()
         {
             var source0 =
 @"public interface I
@@ -467,7 +496,7 @@ class P
         }
 
         [Fact]
-        public void UnannotatedAssemblies_06()
+        public void UnannotatedAssemblies_07()
         {
             var source0 =
 @"public interface I
@@ -551,7 +580,7 @@ public class D : C
         }
 
         [Fact]
-        public void UnannotatedAssemblies_07()
+        public void UnannotatedAssemblies_08()
         {
             var source0 =
 @"public abstract class A

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -659,6 +659,36 @@ class P
         }
 
         [Fact]
+        public void UnannotatedAssemblies_09()
+        {
+            var source0 =
+@"public abstract class A<T>
+{
+    public T F;
+}
+public sealed class B : A<object>
+{
+}";
+            var source1 =
+@"class C
+{
+    static void Main()
+    {
+        B b = new B();
+        b.F = null;
+    }
+}";
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular7);
+            comp0.VerifyDiagnostics();
+
+            var comp1 = CreateStandardCompilation(source1, references: new MetadataReference[] { new CSharpCompilationReference(comp0) }, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics();
+
+            comp1 = CreateStandardCompilation(source1, references: new[] { comp0.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void InheritedValueConstraintForNullable1_01()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -337,18 +337,17 @@ class D : C<B>, I<B>
             Assert.Equal(null, constraintType.IsNullable);
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Return type and parameter types of explicit implementations have nullability set.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void UnannotatedAssemblies_04()
         {
             var source =
 @"interface I<T>
 {
-    I<object[]> F();
+    I<object[]> F(I<T> t);
 }
 class C : I<string>
 {
-    I<object[]> I<string>.F() => null;
+    I<object[]> I<string>.F(I<string> s) => null;
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
             comp.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -137,13 +137,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Nullable
             var source =
 @"class C
 {
-    static void F()
+    static void F(string s)
     {
         var a = new[] { new object(), (string)null };
         a[0].ToString();
-        var b = new[] { (object)null, string.Empty };
+        var b = new[] { (object)null, s };
         b[0].ToString();
-        var c = new[] { string.Empty, (object)null };
+        var c = new[] { s, (object)null };
         c[0].ToString();
         var d = new[] { (string)null, new object() };
         d[0].ToString();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -299,9 +299,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             var source =
 @"class C
 {
-    static void Main()
+    static void F(string str)
     {
-        var s = string.Empty;
+        var s = str;
         s.ToString();
         s = null;
         s.ToString();
@@ -676,11 +676,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             var source =
 @"class C
 {
-    static void Main()
+    static void F(string str)
     {
-        var s = new[] { string.Empty };
+        var s = new[] { str };
         s[0].ToString();
-        var t = new[] { string.Empty, null };
+        var t = new[] { str, null };
         t[0].ToString();
         var u = new[] { 1, null };
         u[0].ToString();
@@ -1564,9 +1564,6 @@ static class E
                 references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
-                //         t.y.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.y").WithLocation(10, 9),
                 // (11,15): warning CS8600: Cannot convert null to non-nullable reference.
                 //         t.x = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 15));

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5780,6 +5780,75 @@ class C
         }
 
         [Fact]
+        public void NullableReferenceTypes()
+        {
+            var source =
+@"class A<T>
+{
+}
+class B
+{
+    static object F1(object? o) => null!;
+    static object?[] F2(object[]? o) => null;
+    static A<object>? F3(A<object?> o) => null;
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            var formatWithoutNonNullableModifier = new SymbolDisplayFormat(
+                memberOptions: SymbolDisplayMemberOptions.IncludeParameters | SymbolDisplayMemberOptions.IncludeType | SymbolDisplayMemberOptions.IncludeModifiers,
+                parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeParamsRefOut,
+                genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+            var formatWithNonNullableModifier = formatWithoutNonNullableModifier.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier);
+
+            var method = comp.GetMember<MethodSymbol>("B.F1");
+            Verify(
+                SymbolDisplay.ToDisplayParts(method, formatWithoutNonNullableModifier),
+                "static object F1(object? o)",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation);
+            Verify(
+                SymbolDisplay.ToDisplayParts(method, formatWithNonNullableModifier),
+                "static object! F1(object? o)",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation);
+
+            method = comp.GetMember<MethodSymbol>("B.F2");
+            Verify(
+                SymbolDisplay.ToDisplayParts(method, formatWithoutNonNullableModifier),
+                "static object?[] F2(object[]? o)");
+            Verify(
+                SymbolDisplay.ToDisplayParts(method, formatWithNonNullableModifier),
+                "static object?[]! F2(object![]? o)");
+
+            method = comp.GetMember<MethodSymbol>("B.F3");
+            Verify(
+                SymbolDisplay.ToDisplayParts(method, formatWithoutNonNullableModifier),
+                "static A<object>? F3(A<object?> o)");
+            Verify(
+                SymbolDisplay.ToDisplayParts(method, formatWithNonNullableModifier),
+                "static A<object!>? F3(A<object?>! o)");
+        }
+
+        [Fact]
         [CompilerTrait(CompilerFeature.LocalFunctions)]
         public void LocalFunction()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -3082,7 +3082,10 @@ class B: A
 {
     public override I<T> F<T>() { return null; }
 }";
-            CompileAndVerify(source);
+            // PROTOTYPE(NullableReferenceTypes): Return type and parameter types of
+            // overridden generic methods have nullability set.
+            var comp = CreateStandardCompilation(source, skipUsesIsNullable: true);
+            CompileAndVerify(comp);
         }
 
         [WorkItem(542264, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542264")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CompletionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CompletionTests.cs
@@ -25,7 +25,7 @@ class A {
     public int F(int x, int y) {}
 }
 ";
-            var comp = CreateCompilation(text);
+            var comp = CreateCompilation(text, skipUsesIsNullable: true);
             var global = comp.GlobalNamespace;
 
             var a = global.GetMember<NamedTypeSymbol>("A");
@@ -65,7 +65,7 @@ class A {
     object P { get; set; }
     object this[object o] { get { return null; } set { } }
 }";
-            var comp = CreateStandardCompilation(text);
+            var comp = CreateStandardCompilation(text, skipUsesIsNullable: true);
             var global = comp.GlobalNamespace;
 
             var a = global.GetMember<NamedTypeSymbol>("A");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
@@ -1354,8 +1354,7 @@ public class C : I<byte, char>
 }
 ";
             var ilRef = CompileIL(il, prependDefaultHeader: false);
-            // PROTOTYPE(NullableReferenceTypes): Return type and parameter types of explicit implementations have nullability set.
-            var comp = CreateCompilation(source, new[] { MscorlibRef, SystemCoreRef, ilRef }, skipUsesIsNullable: true);
+            var comp = CreateCompilation(source, new[] { MscorlibRef, SystemCoreRef, ilRef });
             comp.VerifyDiagnostics();
 
             var global = comp.GlobalNamespace;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
@@ -1354,7 +1354,8 @@ public class C : I<byte, char>
 }
 ";
             var ilRef = CompileIL(il, prependDefaultHeader: false);
-            var comp = CreateCompilation(source, new[] { MscorlibRef, SystemCoreRef, ilRef });
+            // PROTOTYPE(NullableReferenceTypes): Return type and parameter types of explicit implementations have nullability set.
+            var comp = CreateCompilation(source, new[] { MscorlibRef, SystemCoreRef, ilRef }, skipUsesIsNullable: true);
             comp.VerifyDiagnostics();
 
             var global = comp.GlobalNamespace;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -13,7 +13,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class TypeTests : CSharpTestBase
     {
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): StackOverflowException in
+        // SetUnknownNullabilityForReferenceTypes.
+        [Fact(Skip = "TODO")]
         public void Bug18280()
         {
             string brackets = "[][][][][][][][][][][][][][][][][][][][]";

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -2393,7 +2393,6 @@ namespace Microsoft.CodeAnalysis
             return _lazyContainsNoPiaLocalTypes == ThreeState.True;
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Remove if not needed.
         internal bool UtilizesNullableReferenceTypes()
         {
             if (_lazyUtilizesNullableReferenceTypes == ThreeState.Unknown)

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
@@ -49,5 +49,10 @@ namespace Microsoft.CodeAnalysis
         ///   b) not setting this option will produce "int[][,]".
         /// </summary>
         ReverseArrayRankSpecifiers = 1 << 5,
+
+        /// <summary>
+        /// Append '!' to non-nullable reference types.
+        /// </summary>
+        IncludeNonNullableTypeModifier = 1 << 6,
     }
 }

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayFormat.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayFormat.cs
@@ -729,5 +729,25 @@ namespace Microsoft.CodeAnalysis
         {
             return this.WithLocalOptions(this.LocalOptions & ~options);
         }
+
+        /// <summary>
+        /// Creates a copy of the SymbolDisplayFormat but with replaced set of <seealso cref="SymbolDisplayCompilerInternalOptions"/>.
+        /// </summary>
+        internal SymbolDisplayFormat WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions options)
+        {
+            return new SymbolDisplayFormat(
+                options,
+                this.GlobalNamespaceStyle,
+                this.TypeQualificationStyle,
+                this.GenericsOptions,
+                this.MemberOptions,
+                this.ParameterOptions,
+                this.DelegateStyle,
+                this.ExtensionMethodStyle,
+                this.PropertyStyle,
+                this.LocalOptions,
+                this.KindOptions,
+                this.MiscellaneousOptions);
+        }
     }
 }

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Metadata.Tools;
@@ -267,7 +268,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             IEnumerable<SyntaxTree> source,
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
-            string assemblyName = "")
+            string assemblyName = "",
+            bool skipUsesIsNullable = false)
         {
             var refs = new List<MetadataReference>();
             if (references != null)
@@ -275,7 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                 refs.AddRange(references);
             }
             refs.Add(MscorlibRef_v4_0_30316_17626);
-            return CreateCompilation(source, refs, options, assemblyName);
+            return CreateCompilation(source, refs, options, assemblyName, skipUsesIsNullable);
         }
 
         public static CSharpCompilation CreateCompilationWithMscorlib46(
@@ -331,13 +333,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             string sourceFileName = "",
-            string assemblyName = "")
+            string assemblyName = "",
+            bool skipUsesIsNullable = false)
         {
             return CreateCompilationWithMscorlib45(
                 new SyntaxTree[] { Parse(source, sourceFileName, parseOptions) },
                 references,
                 options,
-                assemblyName);
+                assemblyName,
+                skipUsesIsNullable: skipUsesIsNullable);
         }
 
         public static CSharpCompilation CreateCompilationWithMscorlib45(
@@ -361,13 +365,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             string assemblyName = "",
-            string sourceFileName = "")
+            string sourceFileName = "",
+            bool skipUsesIsNullable = false)
         {
             return CreateStandardCompilation(
                 new[] { Parse(text, sourceFileName, parseOptions) },
                 references: references,
                 options: options,
-                assemblyName: assemblyName);
+                assemblyName: assemblyName,
+                skipUsesIsNullable: skipUsesIsNullable);
         }
 
         public static CSharpCompilation CreateCompilationWithMscorlib45AndCSruntime(
@@ -418,13 +424,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             IEnumerable<SyntaxTree> trees,
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
-            string assemblyName = "")
+            string assemblyName = "",
+            bool skipUsesIsNullable = false)
         {
             if (CoreClrShim.IsRunningOnCoreClr)
             {
                 references = references?.Except(s_desktopRefsToRemove);
             }
-            return CreateCompilation(trees, (references != null) ? s_stdRefs.Concat(references) : s_stdRefs, options, assemblyName);
+            return CreateCompilation(trees, (references != null) ? s_stdRefs.Concat(references) : s_stdRefs, options, assemblyName, skipUsesIsNullable: skipUsesIsNullable);
         }
 
         public static CSharpCompilation CreateCompilationWithMscorlibAndSystemCore(
@@ -472,9 +479,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
-            string assemblyName = "")
+            string assemblyName = "",
+            bool skipUsesIsNullable = false)
         {
-            return CreateCompilation(new[] { Parse(source, options: parseOptions) }, references, options, assemblyName);
+            return CreateCompilation(new[] { Parse(source, options: parseOptions) }, references, options, assemblyName, skipUsesIsNullable: skipUsesIsNullable);
         }
 
         public static CSharpCompilation CreateCompilation(
@@ -491,7 +499,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             IEnumerable<SyntaxTree> trees,
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
-            string assemblyName = "")
+            string assemblyName = "",
+            bool skipUsesIsNullable = false)
         {
             if (options == null)
             {
@@ -510,7 +519,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                 references,
                 options);
             CompilationExtensions.ValidateIOperations(createCompilationLambda);
-            return createCompilationLambda();
+            var compilation = createCompilationLambda();
+            if (!skipUsesIsNullable && !IsNullableEnabled(compilation))
+            {
+                VerifyNoNullability(compilation.SourceModule.GlobalNamespace);
+            }
+            return compilation;
+        }
+
+        internal static bool IsNullableEnabled(CSharpCompilation compilation)
+        {
+            var trees = compilation.SyntaxTrees;
+            if (trees.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+            var options = (CSharpParseOptions)trees[0].Options;
+            return options.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking);
+        }
+
+        internal static void VerifyNoNullability(Symbol symbol)
+        {
+            var builder = ArrayBuilder<Symbol>.GetInstance();
+            UsesIsNullableVisitor.GetUses(builder, symbol);
+            var symbols = builder.ToImmutableAndFree();
+            // Use AssertEx.Equal(Empty, symbols) rather than Assert.True(symbols.IsEmpty)
+            // so  the exception message includes the list of symbols.
+            AssertEx.Equal(ImmutableArray<Symbol>.Empty, symbols);
         }
 
         public static CSharpCompilation CreateCompilation(

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -520,6 +520,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                 options);
             CompilationExtensions.ValidateIOperations(createCompilationLambda);
             var compilation = createCompilationLambda();
+            // 'skipUsesIsNullable' may need to be set for some tests, particularly those that want to verify
+            // symbols are created lazily, since 'UsesIsNullableVisitor' will eagerly visit all members.
             if (!skipUsesIsNullable && !IsNullableEnabled(compilation))
             {
                 VerifyNoNullability(compilation.SourceModule.GlobalNamespace);

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -522,6 +522,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             var compilation = createCompilationLambda();
             // 'skipUsesIsNullable' may need to be set for some tests, particularly those that want to verify
             // symbols are created lazily, since 'UsesIsNullableVisitor' will eagerly visit all members.
+            // PROTOTYPE(NullableReferenceTypes): Remove skipUsesIsNullable and call VerifyNoNullability
+            // on a separate Compilation instance created with createCompilationLambda.
             if (!skipUsesIsNullable && !IsNullableEnabled(compilation))
             {
                 VerifyNoNullability(compilation.SourceModule.GlobalNamespace);

--- a/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
@@ -10,25 +10,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 {
     internal sealed class UsesIsNullableVisitor : CSharpSymbolVisitor<bool>
     {
-        private readonly PooledHashSet<TypeSymbol> _visited;
         private readonly ArrayBuilder<Symbol> _builder;
 
         private UsesIsNullableVisitor(ArrayBuilder<Symbol> builder)
         {
-            _visited = PooledHashSet<TypeSymbol>.GetInstance();
             _builder = builder;
-        }
-
-        private void Free()
-        {
-            _visited.Free();
         }
 
         internal static void GetUses(ArrayBuilder<Symbol> builder, Symbol symbol)
         {
             var visitor = new UsesIsNullableVisitor(builder);
             visitor.Visit(symbol);
-            visitor.Free();
         }
 
         public override bool VisitNamespace(NamespaceSymbol symbol)
@@ -121,10 +113,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         private bool UsesIsNullable(TypeSymbol type)
         {
             if (type is null)
-            {
-                return false;
-            }
-            if (!_visited.Add(type))
             {
                 return false;
             }

--- a/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
+{
+    internal sealed class UsesIsNullableVisitor : CSharpSymbolVisitor<bool>
+    {
+        private readonly PooledHashSet<TypeSymbol> _visited;
+        private readonly ArrayBuilder<Symbol> _builder;
+
+        private UsesIsNullableVisitor(ArrayBuilder<Symbol> builder)
+        {
+            _visited = PooledHashSet<TypeSymbol>.GetInstance();
+            _builder = builder;
+        }
+
+        private void Free()
+        {
+            _visited.Free();
+        }
+
+        internal static void GetUses(ArrayBuilder<Symbol> builder, Symbol symbol)
+        {
+            var visitor = new UsesIsNullableVisitor(builder);
+            visitor.Visit(symbol);
+            visitor.Free();
+        }
+
+        public override bool VisitNamespace(NamespaceSymbol symbol)
+        {
+            return VisitList(symbol.GetMembers());
+        }
+
+        public override bool VisitNamedType(NamedTypeSymbol symbol)
+        {
+            // PROTOTYPE(NullableReferenceTypes): Check BaseType and Interfaces type arguments.
+            if (AddIfUsesIsNullable(symbol, symbol.TypeParameters))
+            {
+                return true;
+            }
+            return VisitList(symbol.GetMembers());
+        }
+
+        public override bool VisitMethod(MethodSymbol symbol)
+        {
+            return AddIfUsesIsNullable(symbol, symbol.TypeParameters) ||
+                AddIfUsesIsNullable(symbol, symbol.ReturnType) ||
+                VisitList(symbol.Parameters);
+        }
+
+        public override bool VisitProperty(PropertySymbol symbol)
+        {
+            return AddIfUsesIsNullable(symbol, symbol.Type) ||
+                VisitList(symbol.Parameters);
+        }
+
+        public override bool VisitEvent(EventSymbol symbol)
+        {
+            return AddIfUsesIsNullable(symbol, symbol.Type);
+        }
+
+        public override bool VisitField(FieldSymbol symbol)
+        {
+            return AddIfUsesIsNullable(symbol, symbol.Type);
+        }
+
+        private bool VisitList<TSymbol>(ImmutableArray<TSymbol> symbols) where TSymbol : Symbol
+        {
+            bool result = false;
+            foreach (var symbol in symbols)
+            {
+                if (this.Visit(symbol))
+                {
+                    result = true;
+                }
+            }
+            return result;
+        }
+
+        private bool AddIfUsesIsNullable(Symbol symbol, ImmutableArray<TypeParameterSymbol> typeParameters)
+        {
+            foreach (var type in typeParameters)
+            {
+                if (UsesIsNullable(type))
+                {
+                    _builder.Add(symbol);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private bool AddIfUsesIsNullable(Symbol symbol, TypeSymbolWithAnnotations type)
+        {
+            if (UsesIsNullable(type))
+            {
+                _builder.Add(symbol);
+                return true;
+            }
+            return false;
+        }
+
+        private bool UsesIsNullable(TypeSymbolWithAnnotations type)
+        {
+            if (type is null)
+            {
+                return false;
+            }
+            var typeSymbol = type.TypeSymbol;
+            return (type.IsNullable != null && type.IsReferenceType) ||
+                UsesIsNullable(type.TypeSymbol);
+        }
+
+        // Should use TypeSymbolExtensions.VisitType if/when that
+        // method supports TypeSymbolWithAnnotations.
+        private bool UsesIsNullable(TypeSymbol type)
+        {
+            if (type is null)
+            {
+                return false;
+            }
+            if (!_visited.Add(type))
+            {
+                return false;
+            }
+            switch (type.TypeKind)
+            {
+                case TypeKind.Class:
+                case TypeKind.Delegate:
+                case TypeKind.Interface:
+                case TypeKind.Struct:
+                case TypeKind.Enum:
+                    if (UsesIsNullable(type.ContainingType))
+                    {
+                        return true;
+                    }
+                    break;
+            }
+            switch (type.TypeKind)
+            {
+                case TypeKind.Array:
+                    return UsesIsNullable(((ArrayTypeSymbol)type).ElementType);
+                case TypeKind.Class:
+                case TypeKind.Delegate:
+                case TypeKind.Error:
+                case TypeKind.Interface:
+                case TypeKind.Struct:
+                    return UsesIsNullable(((NamedTypeSymbol)type).TypeArgumentsNoUseSiteDiagnostics);
+                case TypeKind.Dynamic:
+                case TypeKind.Enum:
+                    return false;
+                case TypeKind.Pointer:
+                    return UsesIsNullable(((PointerTypeSymbol)type).PointedAtType);
+                case TypeKind.TypeParameter:
+                    // PROTOTYPE(NullableReferenceTypes): Nullability for constraint types is not being erased.
+                    //return UsesIsNullable(((TypeParameterSymbol)type).ConstraintTypesNoUseSiteDiagnostics);
+                    return false;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(type.TypeKind);
+            }
+        }
+
+        private bool UsesIsNullable(ImmutableArray<TypeSymbolWithAnnotations> types)
+        {
+            return types.Any(t => UsesIsNullable(t));
+        }
+    }
+}

--- a/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
@@ -8,6 +8,9 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 {
+    /// <summary>
+    /// Returns the set of members that contain reference types with IsNullable set.
+    /// </summary>
     internal sealed class UsesIsNullableVisitor : CSharpSymbolVisitor<bool>
     {
         private readonly ArrayBuilder<Symbol> _builder;
@@ -108,8 +111,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                 UsesIsNullable(type.TypeSymbol);
         }
 
-        // Should use TypeSymbolExtensions.VisitType if/when that
-        // method supports TypeSymbolWithAnnotations.
         private bool UsesIsNullable(TypeSymbol type)
         {
             if (type is null)

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Iterator/AddYieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Iterator/AddYieldTests.cs
@@ -333,7 +333,9 @@ class Program
             await TestInRegularAndScriptAsync(initial, expected);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        // PROTOTYPE(NullableReferenceTypes): Assert in CustomModifierUtils.CopyMethodCustomModifiers
+        // fails with difference in nullability in D<W>.P1.
+        [Fact(Skip = "TODO"), Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public async Task TestAddYieldNoTypeArguments()
         {
             var initial =

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -6435,9 +6435,10 @@ public class Test
             });
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Use C#8 to compile expressions.
-        // (Expression below currently reports "CS0453: The type 'object' must be a non-nullable
-        // value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'".)
+        // PROTOTYPE(NullableReferenceTypes): Expression below currently reports
+        // "CS0453: The type 'object' must be a non-nullable value type ... 'Nullable<T>'"
+        // because CSharpCompilationExtensions.IsFeatureEnabled() fails when there
+        // the Compilation contains no syntax trees.
         [Fact(Skip = "TODO")]
         public void EmitNullableAttribute_LambdaParameters()
         {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -6435,7 +6435,10 @@ public class Test
             });
         }
 
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): Use C#8 to compile expressions.
+        // (Expression below currently reports "CS0453: The type 'object' must be a non-nullable
+        // value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'".)
+        [Fact(Skip = "TODO")]
         public void EmitNullableAttribute_LambdaParameters()
         {
             var source =


### PR DESCRIPTION
Treat reference types from unannotated assemblies (and from compilations compiled with C#7) as "null oblivious".

`IsNullable` is set to `null` for reference types in member signatures for PE symbols and for source symbols compiled when `LanguageVersion < Latest`. 

Many of the changes in the PR are simply passing the `ContainingModule` to `TypeSymbolWithAnnotations.Create()` so that method can determine whether to set `IsNullable` for the resulting type.

There are still several cases where reference types have `IsNullable` set (incorrectly) in member signatures when `LanguageVersion < Latest`:
- Type parameter constraint types
- Type arguments in parameter and return types for explicit implementations
- Type arguments in parameter and return types of overridden generic methods

The incorrect `IsNullable` state is not observable within that project (nullable warnings are not generated if feature is not enabled), and it is not observable when referencing the generated assembly in another project (no `[Nullable]` attributes are emitted). But it is observable when referencing such a project from a C#8 project through a project-to-project reference.
