### PR TITLE
Fixes NullReferenceException in NewLineUserSettingFormattingRule

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -19,10 +19,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 return true;
             }
+            if (node.Parent == null)
+            {
+                return false;
+            }
 
             var parentKind = node.Parent.Kind();
 
-            switch (parentKind.GetValueOrDefault())
+            switch (parentKind)
             {
                 case SyntaxKind.IfStatement:
                 case SyntaxKind.ElseClause:

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -11,12 +11,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         private bool IsControlBlock(SyntaxNode node)
         {
+            if (node == null)
+            {
+                return false;
+            }
             if (node.Kind() == SyntaxKind.SwitchStatement)
             {
                 return true;
             }
 
-            var parentKind = node?.Parent.Kind();
+            var parentKind = node.Parent.Kind();
+
             switch (parentKind.GetValueOrDefault())
             {
                 case SyntaxKind.IfStatement:

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting.Rules;
@@ -11,22 +12,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         private bool IsControlBlock(SyntaxNode node)
         {
-            if (node == null)
-            {
-                return false;
-            }
+            Debug.Assert(node != null);
+
             if (node.Kind() == SyntaxKind.SwitchStatement)
             {
                 return true;
             }
-            if (node.Parent == null)
-            {
-                return false;
-            }
 
-            var parentKind = node.Parent.Kind();
+            var parentKind = node.Parent?.Kind();
 
-            switch (parentKind)
+            switch (parentKind.GetValueOrDefault())
             {
                 case SyntaxKind.IfStatement:
                 case SyntaxKind.ElseClause:

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -8029,5 +8029,5 @@ class C
         {
             await Formatter.FormatAsync(SyntaxFactory.StructDeclaration("S"), DefaultWorkspace);
         }
-}
+    }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -8022,5 +8022,12 @@ class C
 }";
             await AssertFormatAsync(code, code);
         }
-    }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(25098, "https://github.com/dotnet/roslyn/issues/25098")]
+        public async Task FormatSingleStructDeclaration()
+        {
+            await Formatter.FormatAsync(SyntaxFactory.StructDeclaration("S"), DefaultWorkspace);
+        }
+}
 }


### PR DESCRIPTION
The method checked if "node" was null *after* calling `Kind` on it, which threw a null reference exception. This PR performs the null check *before* anything else.

### Bugs this fixes
- Issue #25098

### Workarounds
- Making sure all nodes are non-null, which is a problem considering nodes can be empty without their parent being invalid.
- Using [Ryder](https://github.com/6A/Ryder), I was able to [avoid the error](https://gist.github.com/6A/3ee85d7204c31907aac89eb912e16f40).

### Performance impact
- None, the null check was only moved.

### How was the bug found?
- Exception thrown when working with the latest release of Roslyn.