### PR TITLE
Fixed a bug where errors from previous analyzer leaking to next analyzer for Workspace Analyzers

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -306,9 +306,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             // create listener/service/analyzer
             var listener = new AsynchronousOperationListener();
             var service = new MyDiagnosticAnalyzerService(new DiagnosticAnalyzer[] {
-                new LeakProjectFrontAnalyzer(),
                 new LeakDocumentAnalyzer(),
-                new LeakProjectEndAnalyzer()
+                new LeakProjectAnalyzer()
             }, listener, project.Language);
 
             var called = false;
@@ -526,16 +525,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
         }
 
-        private class LeakProjectFrontAnalyzer : ProjectDiagnosticAnalyzer
+        private class LeakProjectAnalyzer : ProjectDiagnosticAnalyzer
         {
-            private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor("projectFront", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);
-            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
-            public override Task<ImmutableArray<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken) => SpecializedTasks.Default<ImmutableArray<Diagnostic>>();
-        }
-
-        private class LeakProjectEndAnalyzer : ProjectDiagnosticAnalyzer
-        {
-            private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor("projectEnd", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);
+            private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor("project", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
             public override Task<ImmutableArray<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken) => SpecializedTasks.Default<ImmutableArray<Diagnostic>>();
         }

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var project = workspace.AddProject(
                           ProjectInfo.Create(
                               ProjectId.CreateNewId(),
-                              VersionStamp.Create(), 
+                              VersionStamp.Create(),
                               "Dummy",
                               "Dummy",
                               LanguageNames.CSharp));
@@ -279,6 +279,58 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             Assert.Equal(analyzers[4].GetType(), typeof(Priority10Analyzer));
             Assert.Equal(analyzers[5].GetType(), typeof(Priority15Analyzer));
             Assert.Equal(analyzers[6].GetType(), typeof(Priority20Analyzer));
+        }
+
+        [Fact]
+        public async Task TestHostAnalyzerErrorNotLeaking()
+        {
+            var workspace = new AdhocWorkspace();
+
+            var projectId = ProjectId.CreateNewId();
+            var project = workspace.AddProject(
+                          ProjectInfo.Create(
+                              projectId,
+                              VersionStamp.Create(),
+                              "Dummy",
+                              "Dummy",
+                              LanguageNames.CSharp,
+                              documents: new[] {
+                                  DocumentInfo.Create(
+                                      DocumentId.CreateNewId(projectId),
+                                      "test.cs",
+                                      loader: TextLoader.From(TextAndVersion.Create(SourceText.From("class A {}"), VersionStamp.Create(), filePath: "test.cs")),
+                                      filePath: "test.cs")}));
+
+            workspace.Options = workspace.Options.WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, project.Language, true);
+
+            // create listener/service/analyzer
+            var listener = new AsynchronousOperationListener();
+            var service = new MyDiagnosticAnalyzerService(new DiagnosticAnalyzer[] {
+                new LeakProjectFrontAnalyzer(),
+                new LeakDocumentAnalyzer(),
+                new LeakProjectEndAnalyzer()
+            }, listener, project.Language);
+
+            var called = false;
+            service.DiagnosticsUpdated += (s, e) =>
+            {
+                if (e.Diagnostics.Length == 0)
+                {
+                    return;
+                }
+
+                var liveId = (LiveDiagnosticUpdateArgsId)e.Id;
+                Assert.IsNotType<ProjectDiagnosticAnalyzer>(liveId.Analyzer);
+
+                called = true;
+            };
+
+            var incrementalAnalyzer = (DiagnosticIncrementalAnalyzer)service.CreateIncrementalAnalyzer(workspace);
+            await incrementalAnalyzer.AnalyzeProjectAsync(project, semanticsChanged: true, InvocationReasons.Reanalyze, CancellationToken.None);
+
+            await listener.CreateWaitTask();
+
+            Assert.True(called);
         }
 
         private static Document GetDocumentFromIncompleteProject(AdhocWorkspace workspace)
@@ -454,6 +506,38 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
             public override Task<ImmutableArray<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken)
                 => Task.FromResult(ImmutableArray<Diagnostic>.Empty);
+        }
+
+        private class LeakDocumentAnalyzer : DocumentDiagnosticAnalyzer
+        {
+            internal static readonly DiagnosticDescriptor s_syntaxRule = new DiagnosticDescriptor("leak", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_syntaxRule);
+
+            public override async Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
+            {
+                var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                return ImmutableArray.Create(Diagnostic.Create(s_syntaxRule, root.GetLocation()));
+            }
+
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeSemanticsAsync(Document document, CancellationToken cancellationToken)
+            {
+                return SpecializedTasks.Default<ImmutableArray<Diagnostic>>();
+            }
+        }
+
+        private class LeakProjectFrontAnalyzer : ProjectDiagnosticAnalyzer
+        {
+            private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor("projectFront", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken) => SpecializedTasks.Default<ImmutableArray<Diagnostic>>();
+        }
+
+        private class LeakProjectEndAnalyzer : ProjectDiagnosticAnalyzer
+        {
+            private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor("projectEnd", "test", "test", "test", DiagnosticSeverity.Error, isEnabledByDefault: true);
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken) => SpecializedTasks.Default<ImmutableArray<Diagnostic>>();
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -329,10 +329,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                     // create result map
                     var version = await GetDiagnosticVersionAsync(project, cancellationToken).ConfigureAwait(false);
-                    var builder = new DiagnosticAnalysisResultBuilder(project, version);
 
                     foreach (var analyzer in ideAnalyzers)
                     {
+                        var builder = new DiagnosticAnalysisResultBuilder(project, version);
+
                         if (analyzer is DocumentDiagnosticAnalyzer documentAnalyzer)
                         {
                             foreach (var document in project.Documents)


### PR DESCRIPTION
### Customer scenario

User is editing a typescript file and same error shows up twice in error list some times.

### Bugs this fixes

typescript team reported the issue. will add bug number once I get the number.

### Workarounds, if any

No workaround

### Risk

No risk

### Performance impact

No impact

### Is this a regression from a previous update?

No

### Root cause analysis

when we build error map for Document/ProjectDiagnosticAnalyzer, we didn't clear errors from previous analyzer which caused the errors to be merged to next analyzer. 

we didn't notice this issue since most of people uses just 1 Document/ProjectDiagnosticAnalyzer.

### How was the bug found?

Dogfooding
