### PR TITLE
Publish symbol packages to prodcon feed

### DIFF
--- a/src/Tools/MicroBuild/PublishBlobAssets.proj
+++ b/src/Tools/MicroBuild/PublishBlobAssets.proj
@@ -10,13 +10,29 @@
   This is for the internal orchestrated build scenarios and will likely never be run on a
   developer's machine.  The official build definition builds this file directly.
   -->
-  <Import Project="$(NuGetPackageRoot)\Microsoft.DotNet.Build.Tasks.Feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
+  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.props" />
+  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
 
   <ItemGroup>
-    <ItemsToPush Include="$(OutputPath)\NuGet\**\*.nupkg" />
+    <PackagesToPublish Include="$(OutputPath)\NuGet\**\*.nupkg" />
   </ItemGroup>
 
   <Target Name="Build">
+    <PropertyGroup>
+      <SymbolPackagesDir>$(RepoRoot)Binaries\SymbolPackages\</SymbolPackagesDir>
+    </PropertyGroup>
+
+    <!--
+      We expect .nupkg to contain Portable PDBs. Such packages can act as symbol packages since they have the same structure.
+      We just need to rename them to *.symbols.nupkg.
+    -->
+    <ItemGroup>
+      <SymbolPackagesToPublish Include="@(PackagesToPublish->'$(SymbolPackagesDir)%(Filename).symbols.nupkg')"/>
+    </ItemGroup>
+
+    <MakeDir Directories="$(SymbolPackagesDir)" />
+    <Copy SourceFiles="@(PackagesToPublish)" DestinationFiles="@(SymbolPackagesToPublish)" />
+    
     <PushToBlobFeed ExpectedFeedUrl="$(PB_PublishBlobFeedUrl)"
                     AccountKey="$(PB_PublishBlobFeedKey)"
                     ItemsToPush="@(ItemsToPush)"


### PR DESCRIPTION
Infrastructure only change.

Since our nuget packages already contain Portable PDB they can act as symbol packages once renamed to .symbols.nupkg. This change published renamed packages to dotnet prodcon feed so that the orchestrated build can extract symbols from them.