### PR TITLE
Check generic construction diagnostics for stackalloc to span conversions

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -97,3 +97,4 @@ Example: `Func<int> f = default(TypedReference).GetHashCode; // new error CS0123
     This is changed in 15.6 to now produce an error that the variable is not definitely assigned.
 
 - Visual Studio 2017 version 15.7: https://github.com/dotnet/roslyn/issues/19792 C# compiler will now reject [IsReadOnly] symbols that should have an [InAttribute] modreq, but don't.
+- Visual Studio 2017 version 15.7: https://github.com/dotnet/roslyn/pull/25131 C# compiler will now check `stackalloc T [count]` expressions to see if T matches constraints of `Span<T>`.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3127,7 +3127,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var spanType = GetWellKnownType(WellKnownType.System_Span_T, diagnostics, node);
                 if (!spanType.IsErrorType())
                 {
-                    type = spanType.Construct(elementType);
+                    type = ConstructNamedType(
+                        type: spanType,
+                        typeSyntax: node.Type,
+                        typeArgumentsSyntax: default,
+                        typeArguments: ImmutableArray.Create(elementType),
+                        basesBeingResolved: null,
+                        diagnostics: diagnostics);
                 }
             }
 


### PR DESCRIPTION
Closes #25086
Closes #25038

There is a bug in C# 15.5, where during the conversion of a `stackalloc` expression to a `Span<T>` object creation, the type parameter construction and constraints matching were not checked during binding.

Fixing this for 15.7 is a breaking change, because an expression of `stackalloc T [count]` would be legal even if `T` was not legal to initialize `Span<T>` with. We would previously emit IL even if it would cause run time exceptions. do believe that the scope is small enough for us to take the breaking change though.