### PR TITLE
AreLocalsZeroed property moved from MethodSymbol to Symbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
@@ -206,6 +206,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         /// <summary>
         /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
         /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -266,6 +266,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         /// <summary>
         /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
         /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.

--- a/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -28,6 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override bool IsSealed => false;
         public override bool IsStatic => false;
         public override bool IsVirtual => false;
+        public override bool AreLocalsZeroed => throw ExceptionUtilities.Unreachable;
         public override SymbolKind Kind => SymbolKind.Discard;
         public override ImmutableArray<Location> Locations => ImmutableArray<Location>.Empty;
         internal override ObsoleteAttributeData ObsoleteAttributeData => null;

--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -253,6 +253,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract bool MustCallMethodsDirectly { get; }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         #region Use-Site Diagnostics
 
         internal override DiagnosticInfo GetUseSiteDiagnostic()

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -188,6 +188,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitField(this);
         }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         /// <summary>
         /// Returns false because field can't be abstract.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/LabelSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LabelSymbol.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -76,6 +77,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 return false;
+            }
+        }
+
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -137,6 +137,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         /// <summary>
         /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
         /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1222,11 +1222,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// Returns true if locals are to be initialized
-        /// </summary>
-        public abstract bool AreLocalsZeroed { get; }
-
-        /// <summary>
         /// If this is a method of a tuple type, return corresponding underlying method from the
         /// tuple underlying type. Otherwise, null.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -114,6 +114,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         /// <summary>
         /// Returns false because module can't be declared as 'static'.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -124,6 +125,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 return this.IsGlobalNamespace;
+            }
+        }
+
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -362,6 +362,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         /// <summary>
         /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
         /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.

--- a/src/Compilers/CSharp/Portable/Symbols/PreprocessingSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PreprocessingSymbol.cs
@@ -113,6 +113,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         internal override ObsoleteAttributeData ObsoleteAttributeData
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -50,6 +50,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         /// <summary>
         /// Indicates whether or not the property returns by reference
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
@@ -113,6 +113,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         /// <summary>
         /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
         /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -371,6 +371,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         public abstract bool IsExtern { get; }
 
         /// <summary>
+        /// Returns true if locals are to be initialized
+        /// </summary>
+        public abstract bool AreLocalsZeroed { get; }
+
+        /// <summary>
         /// Returns true if this symbol was automatically created by the compiler, and does not
         /// have an explicit corresponding source code declaration.  
         /// 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -524,6 +524,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #endregion
 
+        public override bool AreLocalsZeroed
+        {
+            get
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
         /// <summary>
         /// Is this a symbol for an anonymous type (including delegate).
         /// </summary>


### PR DESCRIPTION
This change is needed in order to support future changes (AreLocalsZeroed property in TypeSymbols, AssemblySymbols, ...).