### PR TITLE
Localization test failures VB CodeGenRefReturnTests.RefReturnLateBoundCall

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
@@ -1111,10 +1111,14 @@ public class B
 "Module M
     Sub Main()
         Dim a = New A()
+        Dim saveCulture = System.Threading.Thread.CurrentThread.CurrentCulture
+        System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture
         Try
             F(New B(), a)
         Catch e As System.Exception
             System.Console.Write(e.Message)
+        Finally
+            System.Threading.Thread.CurrentThread.CurrentCulture = saveCulture
         End Try
     End Sub
     Sub F(b As B, a As Object)


### PR DESCRIPTION
### Customer scenario

Running unit test CodeGenRefReturnTests.RefReturnLateBoundCall on non English machines fails due to localization issues. The recommended fix by @AlekseyTs was:

> Modify code in the Main function above to change to invariant culture and restore at the end. The same way as it is done in Spilling_ExceptionInArrayAccess unit test for example.

This PR fixes the test as proposed with the deviation that it sets and restores the `CurrentThread.CurrentCulture` instead of `CurrentThread.CurrentUICulture`. See also #24602 for more details.

With this change in place the unit test does not fail on a German machine.

### Bugs this fixes

#24602 

### Workarounds, if any

Ignore test failure.

### Risk

Low. Test only change.

### Performance impact

None. Test only.

### Is this a regression from a previous update?

No.

### Root cause analysis

Test only fails on non English machines. 

### How was the bug found?

Reported by contributor

### Test documentation updated?

No.
