### PR TITLE
Jenkins embedded pdb

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -119,7 +119,8 @@
 
       Developer build:
        - Build Windows PDBs in order to provide stack traces in xUnit on .NET Framework (4.7.1)
-       - TODO: Use embedded PDBs once .NET Framework 4.7.2 is released and xUnit runner includes configuration switch to enable Portable PDBs
+       - TODO: https://github.com/dotnet/roslyn/issues/25184
+         Use embedded PDBs once .NET Framework 4.7.2 is released and xUnit runner includes configuration switch to enable Portable PDBs
     -->
     <RoslynDebugType Condition="'$(RoslynDebugType)' == ''">full</RoslynDebugType>
     <RoslynDebugType Condition="'$(OfficialBuild)' == 'true'">portable</RoslynDebugType>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -118,10 +118,12 @@
        - Embed PDBs to make it easier to debug Jenkins crash dumps.
 
       Developer build:
-       - Embed PDBs to be consistent with Jenkins builds.
+       - Build Windows PDBs in order to provide stack traces in xUnit on .NET Framework (4.7.1)
+       - TODO: Use embedded PDBs once .NET Framework 4.7.2 is released and xUnit runner includes configuration switch to enable Portable PDBs
     -->
+    <RoslynDebugType Condition="'$(RoslynDebugType)' == ''">full</RoslynDebugType>
     <RoslynDebugType Condition="'$(OfficialBuild)' == 'true'">portable</RoslynDebugType>
-    <RoslynDebugType Condition="'$(OfficialBuild)' != 'true'">full</RoslynDebugType>
+    <RoslynDebugType Condition="'$(JenkinsBuild)' == 'true'">embedded</RoslynDebugType>
 
     <!-- 
       The source root path used for deterministic normalization of source paths.


### PR DESCRIPTION
Infrastructure only change.

[This change](https://github.com/dotnet/roslyn/commit/754630280a1f5c092b107909a2f7e829d8892e4e#diff-5784754bb70e21737b84a68a33ddef69) accidentally turned embedded PDBs off on Jenkins. Turn it back on to streamline Jenkins crash dump investigations.