### PR TITLE
Implement a generic topological sort algorithm

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
+{
+    public class TopologicalSortTests
+    {
+        [Fact]
+        public void Test01()
+        {
+            int[][] successors = new int[][]
+            {
+                /* 0 */ new int[] { }, // 0 has no successors
+                /* 1 */ new int[] { },
+                /* 2 */ new int[] { 3 },
+                /* 3 */ new int[] { 1 },
+                /* 4 */ new int[] { 0, 1 },
+                /* 5 */ new int[] { 0, 2 },
+            };
+
+            var sorted = TopologicalSort.IterativeSort<int>(new[] { 4, 5 }, x => successors[x]);
+            AssertTopologicallySorted(sorted, successors, "Test01");
+            Assert.Equal(6, sorted.Length);
+            Assert.Equal(4, sorted[0]);
+            Assert.Equal(5, sorted[1]);
+            Assert.Equal(2, sorted[2]);
+            Assert.Equal(3, sorted[3]);
+            Assert.Equal(1, sorted[4]);
+            Assert.Equal(0, sorted[5]);
+        }
+
+        [Fact]
+        public void Test02()
+        {
+            int[][] successors = new int[][]
+            {
+                /* 0 */ new int[] { },
+                /* 1 */ new int[] { 2, 4 },
+                /* 2 */ new int[] { },
+                /* 3 */ new int[] { 2, 5 },
+                /* 4 */ new int[] { 2, 3 },
+                /* 5 */ new int[] { 2, },
+                /* 6 */ new int[] { 2, 7 },
+                /* 7 */ new int[] { }
+            };
+
+            var sorted = TopologicalSort.IterativeSort<int>(new[] { 1, 6 }, x => successors[x]);
+            AssertTopologicallySorted(sorted, successors, "Test02");
+            Assert.Equal(7, sorted.Length);
+            Assert.Equal(1, sorted[0]);
+            Assert.Equal(4, sorted[1]);
+            Assert.Equal(3, sorted[2]);
+            Assert.Equal(5, sorted[3]);
+            Assert.Equal(6, sorted[4]);
+            Assert.Equal(7, sorted[5]);
+            Assert.Equal(2, sorted[6]);
+        }
+
+        [Fact]
+        public void TestCycle()
+        {
+            int[][] successors = new int[][]
+            {
+                /* 0 */ new int[] { },
+                /* 1 */ new int[] { 2, 4 },
+                /* 2 */ new int[] { },
+                /* 3 */ new int[] { 2, 5 },
+                /* 4 */ new int[] { 2, 3 },
+                /* 5 */ new int[] { 2, 1 },
+                /* 6 */ new int[] { 2, 7 },
+                /* 7 */ new int[] { }
+            };
+
+            // 1 -> 4 -> 3 -> 5 -> 1
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var sorted = TopologicalSort.IterativeSort<int>(new[] { 1 }, x => successors[x]);
+            });
+        }
+
+        [Theory]
+        [InlineData(1984142830)]
+        [InlineData(107329897)]
+        [InlineData(136826316)]
+        [InlineData(808774716)]
+        [InlineData(729791148)]
+        [InlineData(770911997)]
+        [InlineData(1786285961)]
+        [InlineData(321110113)]
+        [InlineData(1686926633)]
+        [InlineData(787934201)]
+        [InlineData(745939035)]
+        [InlineData(1075862430)]
+        [InlineData(428872484)]
+        [InlineData(489337268)]
+        [InlineData(1976108951)]
+        [InlineData(428397397)]
+        [InlineData(1921108202)]
+        [InlineData(926330127)]
+        [InlineData(364136202)]
+        [InlineData(1893034696)]
+        public void TestRandom(int seed)
+        {
+            int numberOfNodes = 100;
+            Random random = new Random(seed);
+
+            // First, we produce a list of integers representing a possible (reversed)
+            // topological sort of the graph we will construct
+            var possibleSort = Enumerable.Range(0, numberOfNodes).ToArray();
+            shuffle(possibleSort);
+
+            // Then we produce a set of edges that is consistent with that possible topological sort
+            int[][] successors = new int[numberOfNodes][];
+            for (int i = numberOfNodes-1; i >= 0; i--)
+            {
+                successors[possibleSort[i]] = randomSubset((int)Math.Sqrt(i), i);
+            }
+
+            // Perform a topological sort and check it.
+            var sorted = TopologicalSort.IterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), x => successors[x]);
+            Assert.Equal(numberOfNodes, sorted.Length);
+            AssertTopologicallySorted(sorted, successors, $"TestRandom(seed: {seed})");
+
+            // Now we modify the graph to add an edge from the last node to the first node, which
+            // probably induces a cycle.  Since the graph is random, it is possible that this does
+            // not induce a cycle. However, by the construction of the graph it is almost certain
+            // that a cycle is induced. Nevertheless, to avoid flakiness in the tests, we do not
+            // test with actual random graphs, but with graphs based on pseudo-random sequences using
+            // random seeds hardcoded into the tests. That way we are testing on the same graphs each
+            // time.
+            successors[possibleSort[0]] = successors[possibleSort[0]].Concat(new int[] { possibleSort[numberOfNodes - 1] }).ToArray();
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                TopologicalSort.IterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), x => successors[x]);
+            });
+
+            // where
+            void shuffle(int[] data)
+            {
+                int length = data.Length;
+                for (int t = 0; t < length - 1; t++)
+                {
+                    var tmp = data[t];
+                    int r = random.Next(t, length);
+                }
+            }
+
+            int[] randomSubset(int count, int limit)
+            {
+                // We don't worry about duplicate values. That's all part of the test,
+                // as the topological sort should tolerate duplcate edges.
+                var result = new int[count];
+                for (int i = 0; i < count; i++)
+                {
+                    result[i] = possibleSort[random.Next(0, limit)];
+                }
+
+                return result;
+            }
+        }
+
+        [Fact(Skip =
+@"There is little additional coverage of this test over what is offered by TestRandom.
+However, we are keeping it in the source as it may be useful to developers who change the topological sort algorithm in the future.")]
+        public void TestLots()
+        {
+            Random random = new Random(1893034696);
+            const int count = 100000;
+
+            // Test lots more pseudo-random graphs using many different seeds.
+            for (int i = 0; i < count; i++)
+            {
+                TestRandom(random.Next());
+            }
+        }
+
+        private void AssertTopologicallySorted(ImmutableArray<int> sorted, int[][] successors, string message = null)
+        {
+            var seen = new HashSet<int>();
+            for (int i = sorted.Length - 1; i >= 0; i--)
+            {
+                var n = sorted[i];
+                foreach (var succ in successors[n])
+                {
+                    Assert.True(seen.Contains(succ), message);
+                }
+
+                seen.Add(n);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
-using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Collections
 {

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
@@ -147,8 +147,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 int length = data.Length;
                 for (int t = 0; t < length - 1; t++)
                 {
-                    var tmp = data[t];
                     int r = random.Next(t, length);
+                    if (t != r)
+                    {
+                        var tmp = data[t];
+                        data[t] = data[r];
+                        data[r] = tmp;
+                    }
                 }
             }
 

--- a/src/Compilers/Core/Portable/Collections/HashSetExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/HashSetExtensions.cs
@@ -24,5 +24,11 @@ namespace Microsoft.CodeAnalysis
 
             return hashSet.Add(item);
         }
+
+        internal static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> kvp, out TKey key, out TValue value)
+        {
+            key = kvp.Key;
+            value = kvp.Value;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Collections/HashSetExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/HashSetExtensions.cs
@@ -24,11 +24,5 @@ namespace Microsoft.CodeAnalysis
 
             return hashSet.Add(item);
         }
-
-        internal static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> kvp, out TKey key, out TValue value)
-        {
-            key = kvp.Key;
-            value = kvp.Value;
-        }
     }
 }

--- a/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
+++ b/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
@@ -78,7 +78,6 @@ namespace Microsoft.CodeAnalysis
             toCount.AddRange(nodes);
             while (toCount.Count != 0)
             {
-                
                 var n = toCount.Pop();
                 if (!counted.Add(n))
                 {

--- a/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
+++ b/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
@@ -26,13 +27,13 @@ namespace Microsoft.CodeAnalysis
         public static ImmutableArray<TNode> IterativeSort<TNode>(IEnumerable<TNode> nodes, Func<TNode, IEnumerable<TNode>> successors)
         {
             // First, count the predecessors of each node
-            PooledDictionary<TNode, int> predecessorCounts = PredecessorCounts(nodes, successors);
+            PooledDictionary<TNode, int> predecessorCounts = PredecessorCounts(nodes, successors, out ImmutableArray<TNode> allNodes);
 
             // Initialize the ready set with those nodes that have no predecessors
             var ready = ArrayBuilder<TNode>.GetInstance();
-            foreach ((TNode node, int count) in predecessorCounts)
+            foreach (TNode node in allNodes)
             {
-                if (count == 0)
+                if (predecessorCounts[node] == 0)
                 {
                     ready.Push(node);
                 }
@@ -56,13 +57,10 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            // At this point all the predecessor counts should be zero, otherwise there was a cycle
-            foreach ((TNode node, int count) in predecessorCounts)
+            // At this point all the nodes should have been output, otherwise there was a cycle
+            if (predecessorCounts.Count != resultBuilder.Count)
             {
-                if (count != 0)
-                {
-                    throw new ArgumentException("Cycle in the input graph");
-                }
+                throw new ArgumentException("Cycle in the input graph");
             }
 
             predecessorCounts.Free();
@@ -70,11 +68,15 @@ namespace Microsoft.CodeAnalysis
             return resultBuilder.ToImmutable();
         }
 
-        private static PooledDictionary<TNode, int> PredecessorCounts<TNode>(IEnumerable<TNode> nodes, Func<TNode, IEnumerable<TNode>> successors)
+        private static PooledDictionary<TNode, int> PredecessorCounts<TNode>(
+            IEnumerable<TNode> nodes,
+            Func<TNode, IEnumerable<TNode>> successors,
+            out ImmutableArray<TNode> allNodes)
         {
             var predecessorCounts = PooledDictionary<TNode, int>.GetInstance();
             var counted = PooledHashSet<TNode>.GetInstance();
             var toCount = ArrayBuilder<TNode>.GetInstance();
+            var allNodesBuilder = ArrayBuilder<TNode>.GetInstance();
             toCount.AddRange(nodes);
             while (toCount.Count != 0)
             {
@@ -84,6 +86,7 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
+                allNodesBuilder.Add(n);
                 if (!predecessorCounts.ContainsKey(n))
                 {
                     predecessorCounts.Add(n, 0);
@@ -105,6 +108,7 @@ namespace Microsoft.CodeAnalysis
 
             counted.Free();
             toCount.Free();
+            allNodes = allNodesBuilder.ToImmutableAndFree();
             return predecessorCounts;
         }
     }

--- a/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
+++ b/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A helper class that contains a topological sort algorithm.
+    /// </summary>
+    internal static class TopologicalSort
+    {
+        /// <summary>
+        /// Produce a topological sort of a given directed acyclic graph, given a set of nodes which include all nodes
+        /// that have no predecessors. Any nodes not in the given set, but reachable through successors, will be added
+        /// to the result. This is an iterative rather than recursive implementation, so it is unlikely to cause a stack
+        /// overflow.
+        /// </summary>
+        /// <typeparam name="TNode">The type of the node</typeparam>
+        /// <param name="nodes">Any subset of the nodes that includes all nodes with no predecessors</param>
+        /// <param name="successors">A function mapping a node to its set of successors</param>
+        /// <returns>A list of all reachable nodes, in which each node always precedes its successors</returns>
+        public static ImmutableArray<TNode> IterativeSort<TNode>(IEnumerable<TNode> nodes, Func<TNode, IEnumerable<TNode>> successors)
+        {
+            // First, count the predecessors of each node
+            PooledDictionary<TNode, int> predecessorCounts = PredecessorCounts(nodes, successors);
+
+            // Initialize the ready set with those nodes that have no predecessors
+            var ready = ArrayBuilder<TNode>.GetInstance();
+            foreach ((TNode node, int count) in predecessorCounts)
+            {
+                if (count == 0)
+                {
+                    ready.Push(node);
+                }
+            }
+
+            // Process the ready set. Output a node, and decrement the predecessor count of its successors.
+            var resultBuilder = ImmutableArray.CreateBuilder<TNode>();
+            while (ready.Count != 0)
+            {
+                var node = ready.Pop();
+                resultBuilder.Add(node);
+                foreach (var succ in successors(node))
+                {
+                    var count = predecessorCounts[succ];
+                    Debug.Assert(count != 0);
+                    predecessorCounts[succ] = count - 1;
+                    if (count == 1)
+                    {
+                        ready.Push(succ);
+                    }
+                }
+            }
+
+            // At this point all the predecessor counts should be zero, otherwise there was a cycle
+            foreach ((TNode node, int count) in predecessorCounts)
+            {
+                if (count != 0)
+                {
+                    throw new ArgumentException("Cycle in the input graph");
+                }
+            }
+
+            predecessorCounts.Free();
+            ready.Free();
+            return resultBuilder.ToImmutable();
+        }
+
+        private static PooledDictionary<TNode, int> PredecessorCounts<TNode>(IEnumerable<TNode> nodes, Func<TNode, IEnumerable<TNode>> successors)
+        {
+            var predecessorCounts = PooledDictionary<TNode, int>.GetInstance();
+            var counted = PooledHashSet<TNode>.GetInstance();
+            var toCount = ArrayBuilder<TNode>.GetInstance();
+            toCount.AddRange(nodes);
+            while (toCount.Count != 0)
+            {
+                
+                var n = toCount.Pop();
+                if (!counted.Add(n))
+                {
+                    continue;
+                }
+
+                if (!predecessorCounts.ContainsKey(n))
+                {
+                    predecessorCounts.Add(n, 0);
+                }
+
+                foreach (var succ in successors(n))
+                {
+                    toCount.Push(succ);
+                    if (predecessorCounts.TryGetValue(succ, out int succPredecessorCount))
+                    {
+                        predecessorCounts[succ] = succPredecessorCount + 1;
+                    }
+                    else
+                    {
+                        predecessorCounts.Add(succ, 1);
+                    }
+                }
+            }
+
+            counted.Free();
+            toCount.Free();
+            return predecessorCounts;
+        }
+    }
+}


### PR DESCRIPTION
The implementation of pattern-matching will require nodes of the decision dag be generated and processed iteratively using a worklist-based algorithm, as a recursive implementation would overflow the compiler's execution stack for a large switch statement. To facilitate those algorithms, the nodes of the dag will have to be topologically sorted. There are topological sort algorithms in a few places in Roslyn, but they all use Tarjan's recursive algorithm. That works for things like the class inheritance hierarchy or the dependencies between projects because those graphs are of moderate size. However, a large switch statement in C# would produce a decision dag large enough that a recursive algorithm would overflow the execution stack of the compiler. This PR implements a generic topological sort algorithm that is not recursive. It needs to be generic because it will be used both in the production of the decision dag (in which it works with abstract representations of the decision state) and in processing the decision dag itself.

@cston Can you review this, please?
@dotnet/roslyn-compiler Which of you have your college algorithms class still fresh in your mind?
