### PR TITLE
Localization test failures VB Fix creation of diagnostic in VisualBasicParseOptions.ValidateOptions

### DIFF
--- a/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
@@ -252,7 +252,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If Not PreprocessorSymbols.IsDefaultOrEmpty Then
                 For Each symbol In PreprocessorSymbols
                     If Not IsValidIdentifier(symbol.Key) OrElse SyntaxFacts.GetKeywordKind(symbol.Key) <> SyntaxKind.None Then
-                        builder.Add(Diagnostic.Create(MessageProvider.Instance, ERRID.ERR_ConditionalCompilationConstantNotValid, VBResources.ERR_ExpectedIdentifier, symbol.Key))
+                        builder.Add(Diagnostic.Create(ErrorFactory.ErrorInfo(ERRID.ERR_ConditionalCompilationConstantNotValid,
+                                                                             ErrorFactory.ErrorInfo(ERRID.ERR_ExpectedIdentifier),
+                                                                             symbol.Key)))
                     Else
                         Debug.Assert(SyntaxFactory.ParseTokens(symbol.Key).Select(Function(t) t.Kind).SequenceEqual({SyntaxKind.IdentifierToken, SyntaxKind.EndOfFileToken}))
                     End If

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
@@ -363,10 +363,10 @@ BC31030: Conditional compilation constant '2' is not valid: Identifier expected.
 ~
 </errors>)
 
-            Assert.Equal(diagnostics(0).Arguments, {"Identifier expected.", "2"})
+            Assert.Equal("2", diagnostics(0).Arguments(1))
             Assert.True(diagnostics(0).Location.SourceTree.Equals(syntaxTree2)) ' Syntax tree parse options are reported in CompilationStage.Parse
 
-            Assert.Equal(diagnostics(1).Arguments, {"Identifier expected.", "1"})
+            Assert.Equal("1", diagnostics(1).Arguments(1))
             Assert.Null(diagnostics(1).Location.SourceTree) ' Compilation parse options are reported in CompilationStage.Declare
         End Sub
 
@@ -399,10 +399,10 @@ BC31030: Conditional compilation constant '2' is not valid: Identifier expected.
 ~
 </errors>)
 
-            Assert.Equal(diagnostics(0).Arguments, {"Identifier expected.", "2"})
+            Assert.Equal("2", diagnostics(0).Arguments(1))
             Assert.True(diagnostics(0).Location.SourceTree.Equals(syntaxTree)) ' Syntax tree parse options are reported in CompilationStage.Parse
 
-            Assert.Equal(diagnostics(1).Arguments, {"Identifier expected.", "1"})
+            Assert.Equal("1", diagnostics(1).Arguments(1))
             Assert.Null(diagnostics(1).Location.SourceTree) ' Compilation parse options are reported in CompilationStage.Declare
         End Sub
 


### PR DESCRIPTION
### Customer scenario

Running unit test `Microsoft.CodeAnalysis.VisualBasic.UnitTests.GetDiagnosticsTests.CompilingCodeWithInvalidPreProcessorSymbolsShouldProvideDiagnostics` and about 6 others on non English machines failed due to localization issues. The root cause was that the diagnostic for error `ERR_ConditionalCompilationConstantNotValid` wasn't created properly.

The solution was proposed by @AlekseyTs in #24604 
> Alternatively, for consistency with other places where the same diagnostics is created (that is the approach I would prefer), we should be able to call Diagnostic.Create overload that takes DiagnosticInfo. Like this:

```CS
Diagnostic.Create(ErrorFactory.ErrorInfo(ERRID.ERR_ConditionalCompilationConstantNotValid,
                                            ErrorFactory.ErrorInfo(ERRID.ERR_ExpectedIdentifier),
                                            symbol.Key))
```

With this change in place the unit tests do not fail on a German machine.

### Bugs this fixes

Fixes #24604 

### Workarounds, if any

Ignore test failures.

### Risk

Low. 

### Performance impact

Low.

### Is this a regression from a previous update?

No.

### Root cause analysis

Diagnostics are meant to be localization neutral. This diagnostic was created with eager localized arguments.

### How was the bug found?

Contributor reported.

### Test documentation updated?

No.