### PR TITLE
Managed core targets

### DIFF
--- a/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
@@ -15,6 +15,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
+    <None Include="Microsoft.Managed.Core.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Microsoft.CSharp.Core.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -1,17 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
-          BeforeTargets="CoreCompile"
-          Condition="'@(ReferencePathWithRefAssemblies)' == ''">
-    <!-- Common targets should populate this item from dev15.3, but this file
-         may be used (via NuGet package) on earlier MSBuilds. If the
-         adjusted-for-reference-assemblies item is not populated, just use
-         the older item's contents. -->
-    <ItemGroup>
-      <ReferencePathWithRefAssemblies Include="@(ReferencePath)" />
-    </ItemGroup>
-  </Target>
+  <Import Project="Microsoft.Managed.Core.targets"/>
 
   <Target Name="CoreCompile"
           Inputs="$(MSBuildAllProjects);
@@ -36,7 +26,7 @@
                    $(NonExistentFile);
                    @(CustomAdditionalCompileOutputs)"
           Returns="@(CscCommandLineArgs)"
-          DependsOnTargets="$(CoreCompileDependsOn)">
+          DependsOnTargets="$(CoreCompileDependsOn);_BeforeVBCSCoreCompile">
     <!-- These two compiler warnings are raised when a reference is bound to a different version
              than specified in the assembly reference version number.  MSBuild raises the same warning in this case,
              so the compiler warning would be redundant. -->
@@ -49,12 +39,6 @@
       <NoWarn Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(VisualStudioVersion)' != '' AND '$(VisualStudioVersion)' &gt; '10.0'">$(NoWarn);2008</NoWarn>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetingClr2Framework)' == 'true'">
-      <ReferencePathWithRefAssemblies>
-        <EmbedInteropTypes />
-      </ReferencePathWithRefAssemblies>
-    </ItemGroup>
-
     <PropertyGroup>
       <!-- If the user has specified AppConfigForCompiler, we'll use it. If they have not, but they set UseAppConfigForCompiler,
                  then we'll use AppConfig -->
@@ -62,22 +46,6 @@
 
       <!-- If we are targeting winmdobj we want to specifically the pdbFile property since we do not want it to collide with the output of winmdexp-->
       <PdbFile Condition="'$(PdbFile)' == '' AND '$(OutputType)' == 'winmdobj' AND '$(_DebugSymbolsProduced)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
-    </PropertyGroup>
-
-    <!-- Prefer32Bit was introduced in .NET 4.5. Set it to false if we are targeting 4.0 -->
-    <PropertyGroup Condition="('$(TargetFrameworkVersion)' == 'v4.0')">
-      <Prefer32Bit>false</Prefer32Bit>
-    </PropertyGroup>
-
-    <!-- TODO: Remove this ItemGroup once it has been moved to "_GenerateCompileInputs" target in Microsoft.Common.CurrentVersion.targets.
-         https://github.com/dotnet/roslyn/issues/12223 -->
-    <ItemGroup Condition="('$(AdditionalFileItemNames)' != '')">
-      <AdditionalFileItems Include="$(AdditionalFileItemNames)" />
-      <AdditionalFiles Include="@(%(AdditionalFileItems.Identity))" />
-    </ItemGroup>
-
-    <PropertyGroup Condition="'$(UseSharedCompilation)' == ''">
-      <UseSharedCompilation>true</UseSharedCompilation>
     </PropertyGroup>
 
     <!-- Condition is to filter out the _CoreCompileResourceInputs so that it doesn't pass in culture resources to the compiler -->

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Common targets for managed compilers.
+  -->
+
+  <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
+          BeforeTargets="CoreCompile"
+          Condition="'@(ReferencePathWithRefAssemblies)' == ''">
+    <!-- Common targets should populate this item from dev15.3, but this file
+         may be used (via NuGet package) on earlier MSBuilds. If the
+         adjusted-for-reference-assemblies item is not populated, just use
+         the older item's contents. -->
+    <ItemGroup>
+      <ReferencePathWithRefAssemblies Include="@(ReferencePath)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_BeforeVBCSCoreCompile">
+    <ItemGroup Condition="'$(TargetingClr2Framework)' == 'true'">
+      <ReferencePathWithRefAssemblies>
+        <EmbedInteropTypes />
+      </ReferencePathWithRefAssemblies>
+    </ItemGroup>
+
+    <!-- Prefer32Bit was introduced in .NET 4.5. Set it to false if we are targeting 4.0 -->
+    <PropertyGroup Condition="('$(TargetFrameworkVersion)' == 'v4.0')">
+      <Prefer32Bit>false</Prefer32Bit>
+    </PropertyGroup>
+
+    <!-- TODO: Remove this ItemGroup once it has been moved to "_GenerateCompileInputs" target in Microsoft.Common.CurrentVersion.targets.
+         https://github.com/dotnet/roslyn/issues/12223 -->
+    <ItemGroup Condition="('$(AdditionalFileItemNames)' != '')">
+      <AdditionalFileItems Include="$(AdditionalFileItemNames)" />
+      <AdditionalFiles Include="@(%(AdditionalFileItems.Identity))" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(UseSharedCompilation)' == ''">
+      <UseSharedCompilation>true</UseSharedCompilation>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -1,17 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
-          BeforeTargets="CoreCompile"
-          Condition="'@(ReferencePathWithRefAssemblies)' == ''">
-    <!-- Common targets should populate this item from dev15.3, but this file
-         may be used (via NuGet package) on earlier MSBuilds. If the
-         adjusted-for-reference-assemblies item is not populated, just use
-         the older item's contents. -->
-    <ItemGroup>
-      <ReferencePathWithRefAssemblies Include="@(ReferencePath)" />
-    </ItemGroup>
-  </Target>
+  <Import Project="Microsoft.Managed.Core.targets"/>
 
   <Target Name="CoreCompile"
           Inputs="$(MSBuildAllProjects);
@@ -36,7 +26,7 @@
                    $(NonExistentFile);
                    @(CustomAdditionalCompileOutputs)"
           Returns="@(VbcCommandLineArgs)"
-          DependsOnTargets="$(CoreCompileDependsOn)">
+          DependsOnTargets="$(CoreCompileDependsOn);_BeforeVBCSCoreCompile">
     <PropertyGroup>
       <_NoWarnings Condition="'$(WarningLevel)' == '0'">true</_NoWarnings>
       <_NoWarnings Condition="'$(WarningLevel)' == '1'">false</_NoWarnings>
@@ -45,28 +35,6 @@
     <PropertyGroup>
       <!-- If we are targeting winmdobj we want to specifically the pdbFile property since we do not want it to collide with the output of winmdexp-->
       <PdbFile Condition="'$(PdbFile)' == '' AND '$(OutputType)' == 'winmdobj' AND '$(DebugSymbols)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
-    </PropertyGroup>
-
-    <ItemGroup Condition="'$(TargetingClr2Framework)' == 'true'">
-      <ReferencePathWithRefAssemblies>
-        <EmbedInteropTypes />
-      </ReferencePathWithRefAssemblies>
-    </ItemGroup>
-
-    <!-- Prefer32Bit was introduced in .NET 4.5. Set it to false if we are targeting 4.0 -->
-    <PropertyGroup Condition="('$(TargetFrameworkVersion)' == 'v4.0')">
-      <Prefer32Bit>false</Prefer32Bit>
-    </PropertyGroup>
-
-    <!-- TODO: Remove this ItemGroup once it has been moved to "_GenerateCompileInputs" target in Microsoft.Common.CurrentVersion.targets.
-         https://github.com/dotnet/roslyn/issues/12223 -->
-    <ItemGroup Condition="('$(AdditionalFileItemNames)' != '')">
-      <AdditionalFileItems Include="$(AdditionalFileItemNames)" />
-      <AdditionalFiles Include="@(%(AdditionalFileItems.Identity))" />
-    </ItemGroup>
-
-    <PropertyGroup Condition="'$(UseSharedCompilation)' == ''">
-      <UseSharedCompilation>true</UseSharedCompilation>
     </PropertyGroup>
 
     <!-- Condition is to filter out the _CoreCompileResourceInputs so that it doesn't pass in culture resources to the compiler -->

--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -93,6 +93,9 @@
     <Folder Include="My Project\" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\Compilers\Core\MSBuildTask\Microsoft.Managed.Core.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="..\..\Compilers\Core\MSBuildTask\Microsoft.CSharp.Core.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
@@ -51,6 +51,7 @@
     <file src="Dlls\MSBuildTask\netcoreapp2.0\Microsoft.Build.Tasks.CodeAnalysis.pdb*" target="lib\netcoreapp2.0" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.Build.Tasks.CodeAnalysis.dll" target="lib\net46" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.Build.Tasks.CodeAnalysis.pdb*" target="lib\net46" />
+    <file src="Dlls\MSBuildTask\net46\Microsoft.Managed.targets" target="contentFiles\any\any" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.CSharp.Core.targets" target="contentFiles\any\any" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.VisualBasic.Core.targets" target="contentFiles\any\any" />
     <file src="$thirdPartyNoticesPath$" target="" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
@@ -51,7 +51,7 @@
     <file src="Dlls\MSBuildTask\netcoreapp2.0\Microsoft.Build.Tasks.CodeAnalysis.pdb*" target="lib\netcoreapp2.0" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.Build.Tasks.CodeAnalysis.dll" target="lib\net46" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.Build.Tasks.CodeAnalysis.pdb*" target="lib\net46" />
-    <file src="Dlls\MSBuildTask\net46\Microsoft.Managed.targets" target="contentFiles\any\any" />
+    <file src="Dlls\MSBuildTask\net46\Microsoft.Managed.Core.targets" target="contentFiles\any\any" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.CSharp.Core.targets" target="contentFiles\any\any" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.VisualBasic.Core.targets" target="contentFiles\any\any" />
     <file src="$thirdPartyNoticesPath$" target="" />

--- a/src/NuGet/Microsoft.NETCore.Compilers.nuspec
+++ b/src/NuGet/Microsoft.NETCore.Compilers.nuspec
@@ -27,6 +27,7 @@
 
     <!-- Targets and task files -->
     <file src="Dlls/MSBuildTask/netcoreapp2.0/Microsoft.Build.Tasks.CodeAnalysis.dll" target="tools" />
+    <file src="Dlls/MSbuildTask/netcoreapp2.0/Microsoft.Managed.Core.targets" target="tools" />
     <file src="Dlls/MSbuildTask/netcoreapp2.0/Microsoft.CSharp.Core.targets" target="tools" />
     <file src="Dlls/MSbuildTask/netcoreapp2.0/Microsoft.VisualBasic.Core.targets" target="tools" />
     <!-- N.B.: The backslashes below cannot be replaced with forward slashes. 

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -50,6 +50,7 @@
     <file src="Exes\VBCSCompiler\net46\VBCSCompiler.exe" target="tools" />
     <file src="Exes\VBCSCompiler\net46\VBCSCompiler.exe.config" target="tools" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.Build.Tasks.CodeAnalysis.dll" target="tools" />
+    <file src="Dlls\MSbuildTask\net46\Microsoft.Managed.Core.targets" target="tools" />
     <file src="Dlls\MSbuildTask\net46\Microsoft.CSharp.Core.targets" target="tools" />
     <file src="Dlls\MSbuildTask\net46\Microsoft.VisualBasic.Core.targets" target="tools" />
 

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -822,6 +822,7 @@ Public Class BuildDevDivInsertionFiles
         add("Dlls\CSharpResultProvider.Portable\Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ResultProvider.vsdconfig")
         add("Dlls\FunctionResolver\Microsoft.CodeAnalysis.ExpressionEvaluator.FunctionResolver.vsdconfig")
         add("Dlls\ServicesVisualStudio\Microsoft.VisualStudio.LanguageServices.vsdconfig")
+        add("Dlls\MSBuildTask\net46\Microsoft.Managed.Core.targets")
         add("Dlls\MSBuildTask\net46\Microsoft.CSharp.Core.targets")
         add("Dlls\MSBuildTask\net46\Microsoft.VisualBasic.Core.targets")
         add("Dlls\CSharpCompilerTestUtilities\Roslyn.Compilers.CSharp.Test.Utilities.dll")

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -21,6 +21,7 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Exes\csi\net46\csi.rsp
     file source=$(OutputPath)\Exes\vbc\net46\vbc.rsp
 
+    file source=$(OutputPath)\Dlls\MSBuildTask\net46\Microsoft.Managed.Core.targets
     file source=$(OutputPath)\Dlls\MSBuildTask\net46\Microsoft.VisualBasic.Core.targets
     file source=$(OutputPath)\Dlls\MSBuildTask\net46\Microsoft.CSharp.Core.targets
 

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -48,6 +48,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\Compilers\Core\MSBuildTask\Microsoft.Managed.Core.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="..\..\Compilers\Core\MSBuildTask\Microsoft.CSharp.Core.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Move common parts of Microsoft.CSharp.Core.targets and Microsoft.VisualBasic.Core.targets to Microsoft.Managed.Core.targets

This change will allow us to add more logic that is shared between the compilers without having two copies. For example, calculating PathMap from SourceRoots.

<details><summary>Ask Mode template </summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Refactoring, no change in behavior.

### Bugs this fixes


### Workarounds, if any


### Risk

Small.

### Performance impact

Small.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

### Test documentation updated?

</details>
