### PR TITLE
Offer hidden UseImplicitType/UseExplicitType diagnostic

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -54,6 +54,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicit
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithNone),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithNone));
 
+        private IDictionary<OptionKey, object> ImplicitTypeNoneEnforcement() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithNone));
+
+        private IDictionary<OptionKey, object> ImplicitTypeInfoEnforcement() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo));
+
         private IDictionary<OptionKey, object> Options(OptionKey option, object value)
         {
             var options = new Dictionary<OptionKey, object>();
@@ -1436,8 +1446,20 @@ class C
         [|var|] n1 = new C();
     }
 }";
+            await TestDiagnosticInfoAsync(source,
+                options: ExplicitTypeNoneEnforcement(),
+                diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
+
+            // non-vocal preference for implicit type, ok to refactor to explicit type
+            await TestDiagnosticInfoAsync(source,
+                options: ImplicitTypeNoneEnforcement(),
+                diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
+
+            // vocal preference for implicit type, cannot refactor to explicit type
             await TestMissingInRegularAndScriptAsync(source,
-                new TestParameters(options: ExplicitTypeNoneEnforcement()));
+                new TestParameters(options: ImplicitTypeInfoEnforcement()));
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
@@ -147,7 +147,7 @@ class Program
     static void F()
     {
         {|FixAllInDocument:var|} i1 = 0;
-        Program p1 = new Program();
+        var p1 = new Program();
     }
 }
         </Document>
@@ -170,6 +170,7 @@ class Program
     </Project>
 </Workspace>";
 
+            // FixAll doesn't fix hidden diagnostics
             await TestInRegularAndScriptAsync(input, expected, options: options, fixAllActionEquivalenceKey: fixAllActionId);
         }
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
@@ -52,9 +52,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 }
             }
 
-            public bool ShouldNotify() =>
-                GetDiagnosticSeverityPreference() != DiagnosticSeverity.Hidden;
-
             private void Initialize(SyntaxNode declaration, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
             {
                 this.TypeStylePreference = GetCurrentTypeStylePreferences(optionSet);

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -53,7 +53,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
         {
             TypeSyntax declaredType;
             State state = null;
-            var shouldAnalyze = false;
             var declarationStatement = context.Node;
             var options = context.Options;
             var syntaxTree = context.Node.SyntaxTree;
@@ -63,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             {
                 return;
             }
-            
+
             var semanticModel = context.SemanticModel;
 
             if (declarationStatement.IsKind(SyntaxKind.VariableDeclaration))
@@ -71,39 +70,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 var declaration = (VariableDeclarationSyntax)declarationStatement;
                 declaredType = declaration.Type;
 
-                shouldAnalyze = ShouldAnalyzeVariableDeclaration(declaration, semanticModel, cancellationToken);
-
-                if (shouldAnalyze)
+                if (!ShouldAnalyzeVariableDeclaration(declaration, semanticModel, cancellationToken))
                 {
-                    state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: true, cancellationToken: cancellationToken);
-                    shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+                    return;
                 }
+
+                state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: true, cancellationToken: cancellationToken);
             }
             else if (declarationStatement.IsKind(SyntaxKind.ForEachStatement))
             {
                 var declaration = (ForEachStatementSyntax)declarationStatement;
                 declaredType = declaration.Type;
 
-                shouldAnalyze = ShouldAnalyzeForEachStatement(declaration, semanticModel, cancellationToken);
-
-                if (shouldAnalyze)
+                if (!ShouldAnalyzeForEachStatement(declaration, semanticModel, cancellationToken))
                 {
-                    state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
-                    shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+                    return;
                 }
+
+                state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
             }
             else if (declarationStatement.IsKind(SyntaxKind.DeclarationExpression))
             {
-                var declaration = (DeclarationExpressionSyntax) declarationStatement;
+                var declaration = (DeclarationExpressionSyntax)declarationStatement;
                 declaredType = declaration.Type;
 
-                shouldAnalyze = ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
-
-                if (shouldAnalyze)
+                if (!ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken))
                 {
-                    state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
-                    shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+                    return;
                 }
+
+                state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
             }
             else
             {
@@ -111,15 +107,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 return;
             }
 
-            if (shouldAnalyze)
+            var severity = state.GetDiagnosticSeverityPreference();
+            var isStylePreferred = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+            if (!isStylePreferred && severity != DiagnosticSeverity.Hidden)
             {
-                Debug.Assert(state != null, "analyzing a declaration and state is null.");
-                if (TryAnalyzeVariableDeclaration(declaredType, semanticModel, optionSet, cancellationToken, out var diagnosticSpan))
-                {
-                    // The severity preference is not Hidden, as indicated by shouldAnalyze.
-                    var descriptor = GetDescriptorWithSeverity(state.GetDiagnosticSeverityPreference());
-                    context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, diagnosticSpan));
-                }
+                // One of the two analyzers (Implicit/Explicit) cares, but we're not it
+                // Let's not offer a Hidden diagnostic in this case, since this goes against vocal preference (non-Hidden) from the other analyzer
+                return;
+            }
+
+            Debug.Assert(state != null, "analyzing a declaration and state is null.");
+            if (TryAnalyzeVariableDeclaration(declaredType, semanticModel, optionSet, cancellationToken, out var diagnosticSpan))
+            {
+                var descriptor = GetDescriptorWithSeverity(isStylePreferred ? severity : DiagnosticSeverity.Hidden);
+                context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, diagnosticSpan));
             }
         }
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
@@ -55,13 +55,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
         protected override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
         {
             var stylePreferences = state.TypeStylePreference;
-            var shouldNotify = state.ShouldNotify();
-
-            // If notification preference is None, don't offer the suggestion.
-            if (!shouldNotify)
-            {
-                return false;
-            }
 
             if (state.IsInIntrinsicTypeContext)
             {

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -59,13 +59,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
         protected override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
         {
             var stylePreferences = state.TypeStylePreference;
-            var shouldNotify = state.ShouldNotify();
-
-            // If notification preference is None, don't offer the suggestion.
-            if (!shouldNotify)
-            {
-                return false;
-            }
 
             if (state.IsInIntrinsicTypeContext)
             {

--- a/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -39,7 +39,8 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
         {
             var root = editor.OriginalRoot;
 
-            foreach (var diagnostic in diagnostics)
+            var relevantDiagnostics = diagnostics.Length > 1 ? diagnostics.Where(d => d.Severity != DiagnosticSeverity.Hidden) : diagnostics;
+            foreach (var diagnostic in relevantDiagnostics)
             {
                 var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
                 await HandleDeclarationAsync(document, editor, node, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
### Customer scenario
You would like to invoke `UseExplicitType` on a `var` and `UseImplicitType` on a type, but that only comes up if you have an explicit and vocal preference in your options.
With this PR, if the preference for `var` vs. explicit type is not vocal (it's set to "None", rather than "Info", "Warning" or "Error"), then it's ok to fix the code either way.

### Open issue
There is an open issue with desired FixAll behavior. If you have a vocal preference for explicit built-in types, but a non-vocal preference for `var` otherwise, then FixAll on a built-in type will change other locations to `var` as well, which were not built-in types. 
~~We may be able to avoid this by using distinct diagnostics for the three preferences ("for implicit types", "where apparent" and "where possible").~~ (Update: I think I found another solution, making FixAll skip hidden diagnostics)

@CyrusNajmabadi @sharwell Please advise.

A completely different approach is also possible (I've prototyped it [here](https://github.com/jcouv/roslyn/commit/20888a4ea7f79d45270c2769736087a1a34d24da)). But it lacks coordination with the TypeStyle analyzers/fixers, so it can offer a redundant action.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24896
Fixes https://github.com/dotnet/roslyn/issues/24227

### Workarounds, if any
You can also fix the code by hand.

### Risk & Performance impact
This increases the number of `var`s and types where analysis is performed (is there a fix to offer?), for users that did not change the default (hidden preference for explicit types).

### Is this a regression from a previous update?
No.