### PR TITLE
Add refactoring for UseExplicitType

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeTests.cs
@@ -1,0 +1,257 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseExplicitType;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.Options;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitType
+{
+    [Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+    public class UseExplicitTypeTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new UseExplicitTypeCodeRefactoringProvider();
+
+        private readonly CodeStyleOption<bool> onWithNone = new CodeStyleOption<bool>(true, NotificationOption.None);
+        private readonly CodeStyleOption<bool> offWithNone = new CodeStyleOption<bool>(false, NotificationOption.None);
+        private readonly CodeStyleOption<bool> onWithInfo = new CodeStyleOption<bool>(true, NotificationOption.Suggestion);
+        private readonly CodeStyleOption<bool> offWithInfo = new CodeStyleOption<bool>(false, NotificationOption.Suggestion);
+
+        private IDictionary<OptionKey, object> PreferExplicitTypeWithInfo() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo));
+
+        private IDictionary<OptionKey, object> PreferExplicitTypeWithNone() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithNone));
+
+        private IDictionary<OptionKey, object> PreferImplicitTypeWithNone() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithNone));
+
+
+        [Fact]
+        public async Task TestIntLocalDeclaration()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        var[||] i = 0;
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        int i = 0;
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithNone());
+            await TestInRegularAndScriptAsync(code, expected, options: PreferExplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+        }
+
+        [Fact]
+        public async Task TestIntLocalDeclaration_Multiple()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        var[||] i = 0, j = j;
+    }
+}";
+
+
+            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+        }
+
+        [Fact]
+        public async Task TestIntLocalDeclaration_NoInitializer()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        var[||] i;
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code);
+        }
+
+        [Fact]
+        public async Task TestIntForLoop()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        for (var[||] i = 0;;) { }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        for (int i = 0;;) { }
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithNone());
+        }
+
+        [Fact]
+        public async Task TestInDispose()
+        {
+            var code = @"
+class C : System.IDisposable
+{
+    static void Main()
+    {
+        using (var[||] c = new C()) { }
+    }
+}";
+
+            var expected = @"
+class C : System.IDisposable
+{
+    static void Main()
+    {
+        using (C c = new C()) { }
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithNone());
+        }
+
+        [Fact]
+        public async Task TestTypelessVarLocalDeclaration()
+        {
+            var code = @"
+class var
+{
+    static void Main()
+    {
+        var[||] i = null;
+    }
+}";
+            await TestMissingInRegularAndScriptAsync(code, options: PreferImplicitTypeWithNone());
+        }
+
+        [Fact]
+        public async Task TestIntForeachLoop()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var[||] i in new[] { 0 }) { }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        foreach (int i in new[] { 0 }) { }
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithNone());
+        }
+
+        [Fact]
+        public async Task TestIntDeconstruction()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        var[||] (i, j) = (0, 1);
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        (int i, int j) = (0, 1);
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithNone());
+        }
+
+        [Fact]
+        public async Task TestIntDeconstruction2()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        (var[||] i, var j) = (0, 1);
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        (int i, var j) = (0, 1);
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithNone());
+            await TestInRegularAndScriptAsync(code, expected, options: PreferExplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+        }
+
+        [Fact]
+        public async Task TestWithAnonymousType()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        [|var|] x = new { Amount = 108, Message = ""Hello"" };
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, options: PreferImplicitTypeWithNone());
+        }
+
+        private Task TestMissingInRegularAndScriptAsync(string initialMarkup, IDictionary<OptionKey, object> options)
+        {
+            return TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: options));
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeTests.cs
@@ -66,6 +66,30 @@ class C
         }
 
         [Fact]
+        public async Task TestForeachInsideLocalDeclaration()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        System.Action notThisLocal = () => { foreach (var[||] i in new int[0]) { } };
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        System.Action notThisLocal = () => { foreach (int[||] i in new int[0]) { } };
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithNone());
+        }
+
+        [Fact]
         public async Task TestIntLocalDeclaration_Multiple()
         {
             var code = @"

--- a/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeTests.cs
@@ -90,6 +90,23 @@ class C
         }
 
         [Fact]
+        public async Task TestInVarPattern()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        _ = 0 is var[||] i;
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+        }
+
+        [Fact]
         public async Task TestIntLocalDeclaration_Multiple()
         {
             var code = @"

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -463,7 +463,7 @@ class Program
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         [WorkItem(23752, "https://github.com/dotnet/roslyn/issues/23752")]
-        public async Task OnDeconstructionVar()
+        public async Task OnDeconstructionVarParens()
         {
             await TestInRegularAndScriptAsync(
 @"using System;
@@ -480,6 +480,29 @@ class Program
     void M()
     {
         (int x, string y) = new Program();
+    }
+    void Deconstruct(out int i, out string s) { i = 1; s = ""hello""; }
+}", options: ExplicitTypeEverywhere());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        public async Task OnDeconstructionVar()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+class Program
+{
+    void M()
+    {
+        ([|var|] x, var y) = new Program();
+    }
+    void Deconstruct(out int i, out string s) { i = 1; s = ""hello""; }
+}", @"using System;
+class Program
+{
+    void M()
+    {
+        (int x, var y) = new Program();
     }
     void Deconstruct(out int i, out string s) { i = 1; s = ""hello""; }
 }", options: ExplicitTypeEverywhere());

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -497,6 +497,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 }
             }
 
+            Assert.True(actions.Length > 0, "No action produced");
             Assert.InRange(index, 0, actions.Length - 1);
 
             var action = actions[index];

--- a/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitType/UseExplicitTypeCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitType/UseExplicitTypeCodeRefactoringProvider.cs
@@ -44,6 +44,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseExplicitType
             var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
             var declaration = GetDeclaration(root, textSpan);
+            if (declaration == null)
+            {
+                return;
+            }
+
             Debug.Assert(declaration.IsKind(SyntaxKind.VariableDeclaration, SyntaxKind.ForEachStatement, SyntaxKind.DeclarationExpression));
 
             var declaredType = s_useExplicitTypeHelper.FindAnalyzableType(declaration, semanticModel, cancellationToken);

--- a/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitType/UseExplicitTypeCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitType/UseExplicitTypeCodeRefactoringProvider.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.CSharp.TypeStyle;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
+using System.Diagnostics;
+using static Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle.CSharpTypeStyleDiagnosticAnalyzerBase;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseExplicitType
+{
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.UseExplicitType), Shared]
+    internal partial class UseExplicitTypeCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        private static readonly CSharpUseExplicitTypeHelper s_useExplicitTypeHelper = new CSharpUseExplicitTypeHelper();
+
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var textSpan = context.Span;
+            var cancellationToken = context.CancellationToken;
+
+            if (!textSpan.IsEmpty)
+            {
+                return;
+            }
+
+            if (document.Project.Solution.Workspace.Kind == WorkspaceKind.MiscellaneousFiles)
+            {
+                return;
+            }
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+
+            var declaration = GetDeclaration(root, textSpan);
+            Debug.Assert(declaration.IsKind(SyntaxKind.VariableDeclaration, SyntaxKind.ForEachStatement, SyntaxKind.DeclarationExpression));
+
+            TypeSyntax declaredType = s_useExplicitTypeHelper.CanOfferFix(declaration, semanticModel, cancellationToken);
+            if (declaredType == null)
+            {
+                return;
+            }
+
+            State state = State.Generate(declaration, semanticModel, optionSet,
+                isVariableDeclarationContext: declaration.IsKind(SyntaxKind.VariableDeclaration), cancellationToken: cancellationToken);
+
+            // UseExplicitType analyzer/fixer already gives an action in this case
+            if (s_useExplicitTypeHelper.IsStylePreferred(semanticModel, optionSet, state, cancellationToken))
+            {
+                return;
+            }
+
+            Debug.Assert(state != null, "analyzing a declaration and state is null.");
+            if (!s_useExplicitTypeHelper.TryAnalyzeVariableDeclaration(declaredType, semanticModel, optionSet, cancellationToken))
+            {
+                return;
+            }
+
+            MakeRefactoring(context, document, declaredType, textSpan, cancellationToken);
+        }
+
+        private static SyntaxNode GetDeclaration(SyntaxNode root, TextSpan textSpan)
+        {
+            // Ex:
+            // var (x, y) = ...
+            // (var x, ...) = ...
+            // foreach (var (x, y) in ...) ...
+            var declarationExpression = root.FindToken(textSpan.Start).GetAncestor<DeclarationExpressionSyntax>();
+            if (declarationExpression != null)
+            {
+                return declarationExpression;
+            }
+
+            // Ex:
+            // var x = ...;
+            // var x;
+            // for (var x ... ) ...
+            // using (var x = ...) ...
+            var localDeclaration = root.FindToken(textSpan.Start).GetAncestor<VariableDeclarationSyntax>();
+            if (localDeclaration != null)
+            {
+                return localDeclaration;
+            }
+
+            // Ex:
+            // foreach (var x in ...) ...
+            var foreachStatement = root.FindToken(textSpan.Start).GetAncestor<ForEachStatementSyntax>();
+            if (foreachStatement != null)
+            {
+                return foreachStatement;
+            }
+
+            return null;
+        }
+
+        private static void MakeRefactoring(CodeRefactoringContext context, Document document, TypeSyntax typeName, TextSpan textSpan, CancellationToken cancellationToken)
+        {
+            if (!typeName.IsParentKind(SyntaxKind.DeclarationExpression))
+            {
+            }
+
+            if (typeName.OverlapsHiddenPosition(cancellationToken))
+            {
+                return;
+            }
+
+            if (!typeName.Span.IntersectsWith(textSpan.Start))
+            {
+                return;
+            }
+
+            context.RegisterRefactoring(
+                new MyCodeAction(
+                    CSharpFeaturesResources.Use_explicit_type,
+                    c => UpdateDocumentAsync(document, typeName, c)));
+        }
+
+        private static async Task<Document> UpdateDocumentAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var editor = new SyntaxEditor(root, document.Project.Solution.Workspace);
+
+            await UseExplicitTypeCodeFixProvider.HandleDeclarationAsync(document, editor, node, cancellationToken).ConfigureAwait(false);
+
+            var newRoot = editor.GetChangedRoot();
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
+                base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitType/UseExplicitTypeCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitType/UseExplicitTypeCodeRefactoringProvider.cs
@@ -85,36 +85,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseExplicitType
 
         private static SyntaxNode GetDeclaration(SyntaxNode root, TextSpan textSpan)
         {
-            // Ex:
-            // var (x, y) = ...
-            // (var x, ...) = ...
-            // foreach (var (x, y) in ...) ...
-            var declarationExpression = root.FindToken(textSpan.Start).GetAncestor<DeclarationExpressionSyntax>();
-            if (declarationExpression != null)
-            {
-                return declarationExpression;
-            }
-
-            // Ex:
-            // var x = ...;
-            // var x;
-            // for (var x ... ) ...
-            // using (var x = ...) ...
-            var localDeclaration = root.FindToken(textSpan.Start).GetAncestor<VariableDeclarationSyntax>();
-            if (localDeclaration != null)
-            {
-                return localDeclaration;
-            }
-
-            // Ex:
-            // foreach (var x in ...) ...
-            var foreachStatement = root.FindToken(textSpan.Start).GetAncestor<ForEachStatementSyntax>();
-            if (foreachStatement != null)
-            {
-                return foreachStatement;
-            }
-
-            return null;
+            var token = root.FindToken(textSpan.Start);
+            return token.Parent?.FirstAncestorOrSelf<SyntaxNode>(
+                a => a.IsKind(SyntaxKind.DeclarationExpression, SyntaxKind.VariableDeclaration, SyntaxKind.ForEachStatement));
         }
 
         private static async Task<Document> UpdateDocumentAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -27,26 +27,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             switch (node)
             {
                 case VariableDeclarationSyntax variableDeclaration:
-                    if (ShouldAnalyzeVariableDeclaration(variableDeclaration, semanticModel, cancellationToken))
-                    {
-                        return variableDeclaration.Type;
-                    }
-                    break;
-
+                    return ShouldAnalyzeVariableDeclaration(variableDeclaration, semanticModel, cancellationToken)
+                        ? variableDeclaration.Type
+                        : null;
                 case ForEachStatementSyntax forEachStatement:
-                    if (ShouldAnalyzeForEachStatement(forEachStatement, semanticModel, cancellationToken))
-                    {
-                        return forEachStatement.Type;
-                    }
-                    break;
-
+                    return ShouldAnalyzeForEachStatement(forEachStatement, semanticModel, cancellationToken)
+                        ? forEachStatement.Type
+                        : null;
                 case DeclarationExpressionSyntax declarationExpression:
-                    if (ShouldAnalyzeDeclarationExpression(declarationExpression, semanticModel, cancellationToken))
-                    {
-                        return declarationExpression.Type;
-                    }
-                    break;
+                    return ShouldAnalyzeDeclarationExpression(declarationExpression, semanticModel, cancellationToken)
+                        ? declarationExpression.Type
+                        : null;
             }
+
             return null;
         }
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
@@ -8,26 +8,12 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle.CSharpTypeStyleDiagnosticAnalyzerBase;
 
 namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal sealed class CSharpUseExplicitTypeDiagnosticAnalyzer : CSharpTypeStyleDiagnosticAnalyzerBase
+    internal sealed class CSharpUseExplicitTypeHelper : CSharpTypeStyleHelper
     {
-        private static readonly LocalizableString s_Title =
-            new LocalizableResourceString(nameof(CSharpFeaturesResources.Use_explicit_type), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
-
-        private static readonly LocalizableString s_Message =
-            new LocalizableResourceString(nameof(CSharpFeaturesResources.Use_explicit_type_instead_of_var), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
-
-        public CSharpUseExplicitTypeDiagnosticAnalyzer()
-            : base(diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
-                   title: s_Title,
-                   message: s_Message)
-        {
-        }
-
         protected override bool ShouldAnalyzeVariableDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             if (!variableDeclaration.Type.IsVar)
@@ -52,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             return base.ShouldAnalyzeForEachStatement(forEachStatement, semanticModel, cancellationToken);
         }
 
-        protected override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
+        internal override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
         {
             var stylePreferences = state.TypeStylePreference;
             var shouldNotify = state.ShouldNotify();
@@ -77,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             }
         }
 
-        protected override bool TryAnalyzeVariableDeclaration(TypeSyntax typeName, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
+        internal override bool TryAnalyzeVariableDeclaration(TypeSyntax typeName, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
         {
             // var (x, y) = e;
             // foreach (var (x, y) in e) ...
@@ -123,6 +109,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             return true;
         }
 
+        protected override bool ShouldAnalyzeDeclarationExpression(DeclarationExpressionSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (!declaration.Type.IsVar)
+            {
+                // If the type is not 'var', this analyze has no work to do
+                return false;
+            }
+
+            // The base analyzer may impose further limitations
+            return base.ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
+        }
+
         /// <summary>
         /// Analyzes the assignment expression and rejects a given declaration if it is unsuitable for explicit typing.
         /// </summary>
@@ -152,17 +150,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             var initializerTypeInfo = semanticModel.GetTypeInfo(initializer, cancellationToken);
             return !initializerTypeInfo.Type.IsErrorType();
         }
+    }
 
-        protected override bool ShouldAnalyzeDeclarationExpression(DeclarationExpressionSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal sealed class CSharpUseExplicitTypeDiagnosticAnalyzer : CSharpTypeStyleDiagnosticAnalyzerBase
+    {
+        private static readonly LocalizableString s_Title =
+            new LocalizableResourceString(nameof(CSharpFeaturesResources.Use_explicit_type), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
+
+        private static readonly LocalizableString s_Message =
+            new LocalizableResourceString(nameof(CSharpFeaturesResources.Use_explicit_type_instead_of_var), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
+
+        private static readonly CSharpUseExplicitTypeHelper s_Helper = new CSharpUseExplicitTypeHelper();
+        protected override CSharpTypeStyleHelper Helper => s_Helper;
+
+        public CSharpUseExplicitTypeDiagnosticAnalyzer()
+            : base(diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
+                   title: s_Title,
+                   message: s_Message)
         {
-            if (!declaration.Type.IsVar)
-            {
-                // If the type is not 'var', this analyze has no work to do
-                return false;
-            }
-
-            // The base analyzer may impose further limitations
-            return base.ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
@@ -77,10 +77,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             }
         }
 
-        protected override bool TryAnalyzeVariableDeclaration(TypeSyntax typeName, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken, out TextSpan issueSpan)
+        protected override bool TryAnalyzeVariableDeclaration(TypeSyntax typeName, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
         {
-            issueSpan = default;
-
             // var (x, y) = e;
             // foreach (var (x, y) in e) ...
             if (typeName.IsParentKind(SyntaxKind.DeclarationExpression))
@@ -88,7 +86,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 var parent = (DeclarationExpressionSyntax)typeName.Parent;
                 if (parent.Designation.IsKind(SyntaxKind.ParenthesizedVariableDesignation))
                 {
-                    issueSpan = typeName.Span;
                     return true;
                 }
             }
@@ -123,7 +120,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 }
             }
 
-            issueSpan = typeName.Span;
             return true;
         }
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -12,26 +11,12 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
-using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle.CSharpTypeStyleDiagnosticAnalyzerBase;
 
 namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal sealed class CSharpUseImplicitTypeDiagnosticAnalyzer : CSharpTypeStyleDiagnosticAnalyzerBase
+    internal sealed class CSharpUseImplicitTypeHelper : CSharpTypeStyleHelper
     {
-        private static readonly LocalizableString s_Title =
-            new LocalizableResourceString(nameof(CSharpFeaturesResources.Use_implicit_type), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
-
-        private static readonly LocalizableString s_Message =
-            new LocalizableResourceString(nameof(CSharpFeaturesResources.use_var_instead_of_explicit_type), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
-
-        public CSharpUseImplicitTypeDiagnosticAnalyzer()
-            : base(diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
-                   title: s_Title,
-                   message: s_Message)
-        {
-        }
-
         protected override bool ShouldAnalyzeVariableDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             if (variableDeclaration.Type.IsVar)
@@ -56,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             return base.ShouldAnalyzeForEachStatement(forEachStatement, semanticModel, cancellationToken);
         }
 
-        protected override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
+        internal override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
         {
             var stylePreferences = state.TypeStylePreference;
             var shouldNotify = state.ShouldNotify();
@@ -81,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             }
         }
 
-        protected override bool TryAnalyzeVariableDeclaration(TypeSyntax typeName, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
+        internal override bool TryAnalyzeVariableDeclaration(TypeSyntax typeName, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
         {
             Debug.Assert(!typeName.IsVar, "'var' special case should have prevented analysis of this variable.");
 
@@ -216,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             OptionSet optionSet,
             CancellationToken cancellationToken)
         {
-            var expression = GetInitializerExpression(initializer);
+            var expression = CSharpTypeStyleDiagnosticAnalyzerBase.GetInitializerExpression(initializer);
 
             // var cannot be assigned null
             if (expression.IsKind(SyntaxKind.NullLiteralExpression))
@@ -264,6 +249,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
             // The base analyzer may impose further limitations
             return base.ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
+        }
+    }
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal sealed class CSharpUseImplicitTypeDiagnosticAnalyzer : CSharpTypeStyleDiagnosticAnalyzerBase
+    {
+        private static readonly LocalizableString s_Title =
+            new LocalizableResourceString(nameof(CSharpFeaturesResources.Use_implicit_type), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
+
+        private static readonly LocalizableString s_Message =
+            new LocalizableResourceString(nameof(CSharpFeaturesResources.use_var_instead_of_explicit_type), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
+
+        private static readonly CSharpUseImplicitTypeHelper s_Helper = new CSharpUseImplicitTypeHelper();
+        protected override CSharpTypeStyleHelper Helper => s_Helper;
+
+        public CSharpUseImplicitTypeDiagnosticAnalyzer()
+            : base(diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                   title: s_Title,
+                   message: s_Message)
+        {
         }
     }
 }

--- a/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
             }
         }
 
-        private async Task HandleDeclarationAsync(
+        internal static async Task HandleDeclarationAsync(
             Document document, SyntaxEditor editor, 
             SyntaxNode node, CancellationToken cancellationToken)
         {
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
             }
         }
 
-        private ExpressionSyntax GenerateTupleDeclaration(ITypeSymbol typeSymbol, ParenthesizedVariableDesignationSyntax parensDesignation)
+        private static ExpressionSyntax GenerateTupleDeclaration(ITypeSymbol typeSymbol, ParenthesizedVariableDesignationSyntax parensDesignation)
         {
             Debug.Assert(typeSymbol.IsTupleType);
             var elements = ((INamedTypeSymbol)typeSymbol).TupleElements;

--- a/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
@@ -20,5 +20,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         public const string SimplifyLambda = "Simplify Lambda Code Action Provider";
         public const string ConvertToInterpolatedString = "Convert To Interpolated String Code Action Provider";
         public const string MoveTypeToFile = "Move Type To File Code Action Provider";
+        public const string UseExplicitType = "Use Explicit Type Code Action Provider";
     }
 }


### PR DESCRIPTION
### Customer scenario
I want to change a `var` into a spelled type, regardless of style preferences.

### Open issue
This PR is an alternative to PR https://github.com/dotnet/roslyn/pull/25204 which extend the UseExplicitType analyzer/fixer to achieve something similar.
This code refactoring lacks coordination with UseExplicitType, so it can offer a redundant action.
I'm still looking for ways to share more logic between UseExplicitType analyzer and this new refactoring. That may solve that issue...

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24896
Fixes https://github.com/dotnet/roslyn/issues/24227

### Workarounds, if any
You can always fix the code by hand.

### Risk & Performance impact
Low. The analysis is similar to that done in UseExplicitType (and shares some of its code where possible).

### Is this a regression from a previous update?
No.