### PR TITLE
Localization test failures Return FormattableString for BoundTupleExpression.Display

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -4,6 +4,8 @@ using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -82,17 +84,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 
                 builder.Append('(');
-                builder.Append(arguments[0].Display);
+                builder.Append("{0}");
 
-                for(int i = 1; i < arguments.Length; i++)
+                for (int i = 1; i < arguments.Length; i++)
                 {
-                    builder.Append(", ");
-                    builder.Append(arguments[i].Display);
+                    builder.Append(", {" + i + "}");
                 }
 
                 builder.Append(')');
 
-                return pooledBuilder.ToStringAndFree();
+                var format = pooledBuilder.ToStringAndFree();
+                var argumentDisplays = arguments.Select(a => a.Display).ToArray();
+                return FormattableStringFactory.Create(format, argumentDisplays);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -81,20 +79,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var pooledBuilder = PooledStringBuilder.GetInstance();
                 var builder = pooledBuilder.Builder;
                 var arguments = this.Arguments;
-
+                var argumentDisplays = new object[arguments.Length];
 
                 builder.Append('(');
                 builder.Append("{0}");
+                argumentDisplays[0] = arguments[0].Display;
 
                 for (int i = 1; i < arguments.Length; i++)
                 {
                     builder.Append(", {" + i + "}");
+                    argumentDisplays[i] = arguments[i].Display;
                 }
 
                 builder.Append(')');
 
                 var format = pooledBuilder.ToStringAndFree();
-                var argumentDisplays = arguments.Select(a => a.Display).ToArray();
                 return FormattableStringFactory.Create(format, argumentDisplays);
             }
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -150,9 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal partial class BoundStackAllocArrayCreation
     {
         public override object Display
-        {
-            get { return string.Format(MessageID.IDS_StackAllocExpression.Localize().ToString(), ElementType, Count.Syntax); }
-        }
+            => ErrorFacts.GetMessageFormat(MessageID.IDS_StackAllocExpression, ElementType.ToDisplayString(), Count.Syntax.ToString());
     }
 
     internal partial class BoundPassByCopy

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal partial class BoundStackAllocArrayCreation
     {
         public override object Display
-            => ErrorFacts.GetMessageFormat(MessageID.IDS_StackAllocExpression, ElementType.ToDisplayString(), Count.Syntax.ToString());
+            => FormattableStringFactory.Create("stackalloc {0}[{1}]", ElementType, Count.Syntax.ToString());
     }
 
     internal partial class BoundPassByCopy

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -11088,15 +11088,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to stackalloc {0}[{1}].
-        /// </summary>
-        internal static string IDS_StackAllocExpression {
-            get {
-                return ResourceManager.GetString("IDS_StackAllocExpression", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &lt;text&gt;.
         /// </summary>
         internal static string IDS_Text {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5217,9 +5217,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_StackAllocConversionNotPossible" xml:space="preserve">
     <value>Conversion of a stackalloc expression of type '{0}' to type '{1}' is not possible.</value>
   </data>
-  <data name="IDS_StackAllocExpression" xml:space="preserve">
-    <value>stackalloc {0}[{1}]</value>
-  </data>
   <data name="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne" xml:space="preserve">
     <value>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -85,6 +85,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new LocalizableResourceString(code.ToString(), ResourceManager, typeof(ErrorFacts));
         }
 
+        public static LocalizableResourceString GetMessageFormat(MessageID code, params string[] formatArguments)
+        {
+            return new LocalizableResourceString(code.ToString(), ResourceManager, typeof(ErrorFacts), formatArguments);
+        }
+
         public static LocalizableResourceString GetTitle(ErrorCode code)
         {
             return new LocalizableResourceString(code.ToString() + s_titleSuffix, ResourceManager, typeof(ErrorFacts));

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -85,11 +85,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new LocalizableResourceString(code.ToString(), ResourceManager, typeof(ErrorFacts));
         }
 
-        public static LocalizableResourceString GetMessageFormat(MessageID code, params string[] formatArguments)
-        {
-            return new LocalizableResourceString(code.ToString(), ResourceManager, typeof(ErrorFacts), formatArguments);
-        }
-
         public static LocalizableResourceString GetTitle(ErrorCode code)
         {
             return new LocalizableResourceString(code.ToString() + s_titleSuffix, ResourceManager, typeof(ErrorFacts));

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureRefStructs = MessageBase + 12726,
         IDS_FeatureReadOnlyStructs = MessageBase + 12727,
         IDS_FeatureRefExtensionMethods = MessageBase + 12728,
-        IDS_StackAllocExpression = MessageBase + 12729,
+        // IDS_StackAllocExpression = MessageBase + 12729,
         IDS_FeaturePrivateProtected = MessageBase + 12730,
         IDS_FeatureRefConditional = MessageBase + 12731,
     }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8525,11 +8525,6 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <target state="translated">Převod výrazu stackalloc typu {0} na typ {1} není možný.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">První parametr rozšiřující metody ref {0} musí být typem hodnoty nebo obecným typem omezeným na strukturu.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8525,11 +8525,6 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <target state="translated">Die Umwandlung eines stackalloc-Ausdrucks vom Typ "{0}" in den Typ "{1}" ist nicht möglich.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">Der erste Parameter einer ref-Erweiterungsmethode "{0}" muss ein Werttyp oder ein generischer Typ sein, der auf die Struktur eingeschränkt ist.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8525,11 +8525,6 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <target state="translated">La conversión de una expresión stackalloc del tipo "{0}" al tipo "{1}" no es posible.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">El primer parámetro de un método de extensión "ref" "{0}" debe ser un tipo de valor o un tipo genérico restringido a struct.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8525,11 +8525,6 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <target state="translated">La conversion d'une expression stackalloc de type '{0}' en type '{1}' n'est pas possible.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">Le premier paramètre d'une méthode d'extension 'ref' '{0}' doit être un type valeur ou un type générique limité à struct.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8525,11 +8525,6 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <target state="translated">Non è possibile eseguire la conversione di un'espressione stackalloc di tipo '{0}' nel tipo '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">Il primo parametro di un metodo di estensione 'ref' '{0}' deve essere un tipo valore o un tipo generico vincolato a struct.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8525,11 +8525,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="translated">型 '{0}' の stackalloc 式を型 '{1}' に変換することはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">ref' 拡張メソッド '{0}' の最初のパラメーターは、値型または構造体に制限されたジェネリック型でなければなりません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8525,11 +8525,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="translated">{0}' 형식 stackalloc 식을 '{1}' 형식으로 변환할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">ref' 확장 메서드 '{0}'의 첫 번째 매개 변수는 값 형식이거나 구조체의 제약을 받는 제네릭 형식이어야 합니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8525,11 +8525,6 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <target state="translated">Konwersja wyrażenia stackalloc typu „{0}” na typ „{1}” nie jest możliwa.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">Pierwszy parametr metody rozszerzenia „ref” „{0}” musi być typem wartości lub typem ogólnym ograniczonym do struktury.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8525,11 +8525,6 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <target state="translated">A conversão de uma expressão stackalloc do tipo '{0}' para o tipo '{1}' não é possível.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">O primeiro parâmetro de um método de extensão "ref" "{0}" deve ser um tipo de valor ou um tipo genérico restrito a struct.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8525,11 +8525,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="translated">Невозможно преобразовать выражение stackalloc типа "{0}" в тип "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">Первый параметр метода расширения "ref" "{0}" должен иметь тип значения или универсальный тип, ограниченный структурой.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8525,11 +8525,6 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <target state="translated">{0}' türünde bir stackalloc ifadesinin türü, '{1}' türüne dönüştürülemez.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">ref' genişletme metodu '{0}' için ilk parametre, değer türünde veya struct ile kısıtlanmış genel türde olmalıdır.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8525,11 +8525,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="translated">不能将 stackalloc 表达式的类型从“{0}”转换为“{1}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">"ref" 扩展方法“{0}”的第一个参数必须是值类型或受结构约束的泛型类型。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8525,11 +8525,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="translated">類型 '{0}' 的 stackalloc 運算式不可能轉換成類型 '{1}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="IDS_StackAllocExpression">
-        <source>stackalloc {0}[{1}]</source>
-        <target state="translated">stackalloc {0}[{1}]</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RefExtensionMustBeValueTypeOrConstrainedToOne">
         <source>The first parameter of a 'ref' extension method '{0}' must be a value type or a generic type constrained to struct.</source>
         <target state="translated">ref' 擴充方法 '{0}' 的第一個參數，必須是限制為結構的實值型別或泛型型別。</target>

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
-                if (arg is FormattableString)
+                if (arg is IFormattable)
                 {
                     continue;
                 }

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
@@ -102,6 +102,11 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
+                if (arg is FormattableString)
+                {
+                    continue;
+                }
+
                 var type = arg.GetType();
                 if (type == typeof(string) || type == typeof(AssemblyIdentity))
                 {


### PR DESCRIPTION
### Customer scenario

Running unit test `OverloadResolutionTests.GenericInferenceOnInErrTuples` on non English machines failed due to localization issues. The root cause was that `BoundTupleExpression.Display` returned a string instead of a localizable string. The PR implements the solution proposed by @AlekseyTs in #24603. 
As noted in #24603 `BoundStackAllocArrayCreation.Display` a few lines down needs also to be fixed. This will be done once the fix `BoundTupleExpression.Display` is reviewed as being valid.

### Bugs this fixes

Fixes #24603 

### Workarounds, if any

Ignore test failures.

### Risk

The proposed solution requires to allow `FormattableString` types in `DiagnosticInfo.Arguments`. This might lead to unwanted code patterns in respect to DiagnosticInfo and localizability in the future.

### Performance impact

Low.

### Is this a regression from a previous update?

### Root cause analysis

Localization wasn't tested before.

### How was the bug found?

Contributor reported.

### Test documentation updated?

No.
