### PR TITLE
Move more test projects to net461

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -429,7 +429,6 @@
       This target is used to copy referenced projects to a sub-directory vs. the direct output 
       directory of the build. Useful when the referenced project is an EXE and the referencing 
       project uses an incompatible targetframework
-
   -->  
   <Target Name="CopyReferencedProjectsToDependenciesDirectory" Condition="'@(RoslynReferenceToDependencyDirectory)' != ''"  AfterTargets="ResolveProjectReferences">
     <PropertyGroup>
@@ -440,7 +439,6 @@
       <Content Include="@(_RoslynReferenceContent)" Link="dependency\%(_RoslynReferenceContent.Filename)%(_RoslynReferenceContent.Extension)" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
-  
 
   <!-- Count PublicAPIs as AdditionalFiles to get them to analyzers. This is working around
        https://github.com/dotnet/project-system/issues/2160 where AdditionalFileItemNames

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -425,6 +425,23 @@
       Condition="'$(UsingMicrosoftNETSdk)' == ''" />
   </Target> 
 
+  <!-- 
+      This target is used to copy referenced projects to a sub-directory vs. the direct output 
+      directory of the build. Useful when the referenced project is an EXE and the referencing 
+      project uses an incompatible targetframework
+
+  -->  
+  <Target Name="CopyReferencedProjectsToDependenciesDirectory" Condition="'@(RoslynReferenceToDependencyDirectory)' != ''"  AfterTargets="ResolveProjectReferences">
+    <PropertyGroup>
+      <_RoslynReferenceOutputPath>@(RoslynReferenceToDependencyDirectory->'%(RootDir)%(Directory)')</_RoslynReferenceOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <_RoslynReferenceContent Include="$(_RoslynReferenceOutputPath)*.*" />
+      <Content Include="@(_RoslynReferenceContent)" Link="dependency\%(_RoslynReferenceContent.Filename)%(_RoslynReferenceContent.Extension)" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
+  
+
   <!-- Count PublicAPIs as AdditionalFiles to get them to analyzers. This is working around
        https://github.com/dotnet/project-system/issues/2160 where AdditionalFileItemNames
        isn't fully supported yet in the new project system. Removal of this hack is tracked

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -69,6 +69,7 @@
     <InternalsVisibleTo Include="VBCSCompiler" />
     <InternalsVisibleTo Include="VBCSCompilerPortable" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.UnitTests" />
+    <InternalsVisibleToTest Include="Roslyn.Compilers.CompilerServer.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.CSharp.CommandLine.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.CSharp.Emit.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.CSharp.WinRT.UnitTests" />

--- a/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
+++ b/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
@@ -15,7 +15,7 @@
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\..\Test\Utilities\Portable\TestUtilities.csproj" />
     <ProjectReference Include="..\..\..\Test\Utilities\CSharp\CSharpCompilerTestUtilities.csproj" />
-    <ProjectReference Include="..\..\csc\csc.csproj" ReferenceOutputAssembly="false" OutputItemType="TaskWithDependencyResolvedProjectReferencePath" />
+    <ProjectReference Include="..\..\csc\csc.csproj" ReferenceOutputAssembly="false" OutputItemType="RoslynReferenceToDependencyDirectory" />
     <ProjectReference Include="..\..\..\Core\Portable\CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\Test\Resources\Core\CompilerTestResources.csproj" />
     <ProjectReference Include="..\..\Portable\CSharpCodeAnalysis.csproj" />
@@ -55,25 +55,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Target Name="CopyTestProjects" AfterTargets="ResolveProjectReferences">
-    <!-- In TypeLoader, the following logic is used for loading assemblies on .NET Core:
-            - if the simple name of the assembly exists in the same folder as msbuild.exe, then that assembly gets loaded, indifferent of the user specified path
-            - otherwise, the assembly from the user specified path is loaded, if it exists.
-            
-          So the custom tasks we are testing can't be in test output folder, because on .NET Core that would affect the loading behavior.  So this
-          target puts them in subfolders of the test output folder instead.    
-    -->
-
-    <Error Condition="'@(TaskWithDependencyResolvedProjectReferencePath)' == ''" Text="Couldn't find TaskWithDependencyResolvedProjectReferencePath item for TaskWithDependency" />
-    
-    <PropertyGroup>
-      <TaskWithDependencyOutputPath>@(TaskWithDependencyResolvedProjectReferencePath->'%(RootDir)%(Directory)')</TaskWithDependencyOutputPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <TaskWithDependencyContentContent Include="$(TaskWithDependencyOutputPath)*.*" />
-      <Content Include="@(TaskWithDependencyContentContent)" Link="csc\%(TaskWithDependencyContentContent.Filename)%(TaskWithDependencyContentContent.Extension)" CopyToOutputDirectory="PreserveNewest" />
-    </ItemGroup>
-    
-  </Target>
-  
 </Project>

--- a/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
+++ b/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
@@ -8,20 +8,15 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests</RootNamespace>
     <AssemblyName>Roslyn.Compilers.CSharp.CommandLine.UnitTests</AssemblyName>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>$(RoslynDesktopRuntimeIdentifier)</RuntimeIdentifier>
     <RoslynProjectType>UnitTest</RoslynProjectType>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\..\Test\Utilities\Portable\TestUtilities.csproj" />
     <ProjectReference Include="..\..\..\Test\Utilities\CSharp\CSharpCompilerTestUtilities.csproj" />
-    <ProjectReference Include="..\..\csc\csc.csproj" >
-      <Aliases>CscExe</Aliases>
-    </ProjectReference>
+    <ProjectReference Include="..\..\csc\csc.csproj" ReferenceOutputAssembly="false" OutputItemType="TaskWithDependencyResolvedProjectReferencePath" />
     <ProjectReference Include="..\..\..\Core\Portable\CodeAnalysis.csproj" />
-    <ProjectReference Include="..\..\..\Server\VBCSCompiler\VBCSCompiler.csproj">
-      <Aliases>VBCSCompiler</Aliases>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\Test\Resources\Core\CompilerTestResources.csproj" />
     <ProjectReference Include="..\..\Portable\CSharpCodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\VisualBasic\Portable\BasicCodeAnalysis.vbproj" />
@@ -46,11 +41,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>CommandLineTestResources.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\csc\csc.rsp">
-      <Link>csc.rsp</Link>
-    </None>
+    <AssemblyVersionAttribute Include="Microsoft.CodeAnalysis.CommitHashAttribute">
+      <_Parameter1>$(CommitHashDisplay)</_Parameter1>
+    </AssemblyVersionAttribute>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
@@ -61,4 +54,26 @@
       <LastGenOutput>CommandLineTestResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
+  <Target Name="CopyTestProjects" AfterTargets="ResolveProjectReferences">
+    <!-- In TypeLoader, the following logic is used for loading assemblies on .NET Core:
+            - if the simple name of the assembly exists in the same folder as msbuild.exe, then that assembly gets loaded, indifferent of the user specified path
+            - otherwise, the assembly from the user specified path is loaded, if it exists.
+            
+          So the custom tasks we are testing can't be in test output folder, because on .NET Core that would affect the loading behavior.  So this
+          target puts them in subfolders of the test output folder instead.    
+    -->
+
+    <Error Condition="'@(TaskWithDependencyResolvedProjectReferencePath)' == ''" Text="Couldn't find TaskWithDependencyResolvedProjectReferencePath item for TaskWithDependency" />
+    
+    <PropertyGroup>
+      <TaskWithDependencyOutputPath>@(TaskWithDependencyResolvedProjectReferencePath->'%(RootDir)%(Directory)')</TaskWithDependencyOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <TaskWithDependencyContentContent Include="$(TaskWithDependencyOutputPath)*.*" />
+      <Content Include="@(TaskWithDependencyContentContent)" Link="csc\%(TaskWithDependencyContentContent.Filename)%(TaskWithDependencyContentContent.Extension)" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+    
+  </Target>
+  
 </Project>

--- a/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
+++ b/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
@@ -54,5 +54,4 @@
       <LastGenOutput>CommandLineTestResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
 </Project>

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
     {
         private static readonly string s_CSharpCompilerExecutable = Path.Combine(
             Path.GetDirectoryName(typeof(CommandLineTests).GetTypeInfo().Assembly.Location),
-            @"dependency\csc.exe");
+            Path.Combine("dependency", "csc.exe"));
         private static readonly string s_defaultSdkDirectory = RuntimeEnvironment.GetRuntimeDirectory();
         private readonly string _baseDirectory = TempRoot.Root;
         private static readonly string s_compilerVersion = typeof(CommandLineTests).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -37,9 +37,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
     {
         private static readonly string s_CSharpCompilerExecutable = Path.Combine(
             Path.GetDirectoryName(typeof(CommandLineTests).GetTypeInfo().Assembly.Location),
-            @"csc\csc.exe");
+            @"dependency\csc.exe");
         private static readonly string s_defaultSdkDirectory = RuntimeEnvironment.GetRuntimeDirectory();
-        private static bool s_haveHookedResolve;
         private readonly string _baseDirectory = TempRoot.Root;
         private static readonly string s_compilerVersion = typeof(CommandLineTests).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
         private static readonly string s_compilerCommitHash = typeof(CommandLineTests).Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;

--- a/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
@@ -1,18 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-extern alias VBCSCompiler;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using VBCSCompiler.Microsoft.CodeAnalysis.CompilerServer;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-
 using static Roslyn.Test.Utilities.SharedResourceHelpers;
 using System.Reflection;
 
@@ -196,53 +193,6 @@ public class C { }").Path;
                                     touchedBase);
 
             CleanupAllGeneratedFiles(sourcePath);
-        }
-
-        [ConditionalFact(typeof(WindowsOnly))]
-        public void TrivialMetadataCaching()
-        {
-            List<String> filelist = new List<string>();
-
-            // Do the following compilation twice.
-            // The compiler server API should hold on to the mscorlib bits
-            // in memory, but the file tracker should still map that it was
-            // touched.
-            for (int i = 0; i < 2; i++)
-            {
-                var source1 = Temp.CreateFile().WriteAllText(helloWorldCS).Path;
-                var touchedDir = Temp.CreateDirectory();
-                var touchedBase = Path.Combine(touchedDir.Path, "touched");
-
-                filelist.Add(source1);
-                var outWriter = new StringWriter();
-                var cmd = new CSharpCompilerServer(
-                    DesktopCompilerServerHost.SharedAssemblyReferenceProvider,
-                    new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
-                    new BuildPaths(null, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
-                    s_libDirectory,
-                    new TestAnalyzerAssemblyLoader());
-
-                List<string> expectedReads;
-                List<string> expectedWrites;
-                BuildTouchedFiles(cmd,
-                                  Path.ChangeExtension(source1, "exe"),
-                                  out expectedReads,
-                                  out expectedWrites);
-
-                var exitCode = cmd.Run(outWriter);
-
-                Assert.Equal(string.Empty, outWriter.ToString().Trim());
-                Assert.Equal(0, exitCode);
-
-                AssertTouchedFilesEqual(expectedReads,
-                                        expectedWrites,
-                                        touchedBase);
-            }
-
-            foreach (String f in filelist)
-            {
-                CleanupAllGeneratedFiles(f);
-            }
         }
 
         /// <summary>

--- a/src/Compilers/Core/MSBuildTaskTests/MSBuildTaskTests.csproj
+++ b/src/Compilers/Core/MSBuildTaskTests/MSBuildTaskTests.csproj
@@ -18,10 +18,8 @@
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Test\PdbUtilities\PdbUtilities.csproj" />
     <ProjectReference Include="..\..\..\Test\Utilities\Portable\TestUtilities.csproj" />
-    <ProjectReference Include="..\..\CSharp\csc\csc.csproj" />
     <ProjectReference Include="..\..\CSharp\Portable\CSharpCodeAnalysis.csproj" />
     <ProjectReference Include="..\..\Test\Resources\Core\CompilerTestResources.csproj" />
-    <ProjectReference Include="..\..\VisualBasic\vbc\vbc.csproj" />
     <ProjectReference Include="..\MSBuildTask\MSBuildTask.csproj" />
     <ProjectReference Include="..\Portable\CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\VisualBasic\Portable\BasicCodeAnalysis.vbproj" />

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,7 +15,7 @@ using Microsoft.CodeAnalysis.CompilerServer;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
 {
-    public class TouchedFileLoggingTests : CSharpTestBase
+    public class TouchedFileLoggingTests : TestBase
     {
         private static readonly string s_libDirectory = Environment.GetEnvironmentVariable("LIB");
         private readonly string _baseDirectory = TempRoot.Root;

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -29,7 +29,7 @@ class C
     }
 }";
 
-        [ConditionalFact(typeof(WindowsOnly))]
+        [ConditionalFact(typeof(DesktopOnly))]
         public void TrivialMetadataCaching()
         {
             List<String> filelist = new List<string>();

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using static Roslyn.Test.Utilities.SharedResourceHelpers;
+using System.Reflection;
+using Microsoft.CodeAnalysis.CompilerServer;
+
+namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
+{
+    public class TouchedFileLoggingTests : CSharpTestBase
+    {
+        private static readonly string s_libDirectory = Environment.GetEnvironmentVariable("LIB");
+        private readonly string _baseDirectory = TempRoot.Root;
+        private const string helloWorldCS = @"using System;
+
+class C
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine(""Hello, world"");
+    }
+}";
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void TrivialMetadataCaching()
+        {
+            List<String> filelist = new List<string>();
+
+            // Do the following compilation twice.
+            // The compiler server API should hold on to the mscorlib bits
+            // in memory, but the file tracker should still map that it was
+            // touched.
+            for (int i = 0; i < 2; i++)
+            {
+                var source1 = Temp.CreateFile().WriteAllText(helloWorldCS).Path;
+                var touchedDir = Temp.CreateDirectory();
+                var touchedBase = Path.Combine(touchedDir.Path, "touched");
+
+                filelist.Add(source1);
+                var outWriter = new StringWriter();
+                var cmd = new CSharpCompilerServer(
+                    DesktopCompilerServerHost.SharedAssemblyReferenceProvider,
+                    new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
+                    new BuildPaths(null, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
+                    s_libDirectory,
+                    new TestAnalyzerAssemblyLoader());
+
+                List<string> expectedReads;
+                List<string> expectedWrites;
+                BuildTouchedFiles(cmd,
+                                  Path.ChangeExtension(source1, "exe"),
+                                  out expectedReads,
+                                  out expectedWrites);
+
+                var exitCode = cmd.Run(outWriter);
+
+                Assert.Equal(string.Empty, outWriter.ToString().Trim());
+                Assert.Equal(0, exitCode);
+
+                AssertTouchedFilesEqual(expectedReads,
+                                        expectedWrites,
+                                        touchedBase);
+            }
+
+            foreach (String f in filelist)
+            {
+                CleanupAllGeneratedFiles(f);
+            }
+        }
+
+        /// <summary>
+        /// Builds the expected base of touched files.
+        /// Adds a hook for temporary file creation as well,
+        /// so this method must be called before the execution of
+        /// Csc.Run.
+        /// </summary>
+        private static void BuildTouchedFiles(CSharpCompiler cmd,
+                                              string outputPath,
+                                              out List<string> expectedReads,
+                                              out List<string> expectedWrites)
+        {
+            expectedReads = cmd.Arguments.MetadataReferences
+                .Select(r => r.Reference).ToList();
+
+            foreach (var file in cmd.Arguments.SourceFiles)
+            {
+                expectedReads.Add(file.Path);
+            }
+
+            var writes = new List<string>();
+            writes.Add(outputPath);
+
+            expectedWrites = writes;
+        }
+
+        private static void AssertTouchedFilesEqual(
+            List<string> expectedReads,
+            List<string> expectedWrites,
+            string touchedFilesBase)
+        {
+            var touchedReadPath = touchedFilesBase + ".read";
+            var touchedWritesPath = touchedFilesBase + ".write";
+
+            var expected = expectedReads.Select(s => s.ToUpperInvariant()).OrderBy(s => s);
+            Assert.Equal(string.Join("\r\n", expected),
+                         File.ReadAllText(touchedReadPath).Trim());
+
+            expected = expectedWrites.Select(s => s.ToUpperInvariant()).OrderBy(s => s);
+            Assert.Equal(string.Join("\r\n", expected),
+                         File.ReadAllText(touchedWritesPath).Trim());
+        }
+
+        private class TestAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
+        {
+            public void AddDependencyLocation(string fullPath)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Assembly LoadFromPath(string fullPath)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerTests.csproj
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerTests.csproj
@@ -20,7 +20,6 @@
     <ProjectReference Include="..\..\CSharp\csc\csc.csproj">
       <Aliases>csc</Aliases>
     </ProjectReference>
-    <ProjectReference Include="..\..\Test\Utilities\CSharp\CSharpCompilerTestUtilities.csproj" />
     <ProjectReference Include="..\..\VisualBasic\vbc\vbc.csproj">
       <Aliases>vbc</Aliases>
     </ProjectReference>

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerTests.csproj
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerTests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\CSharp\csc\csc.csproj">
       <Aliases>csc</Aliases>
     </ProjectReference>
+    <ProjectReference Include="..\..\Test\Utilities\CSharp\CSharpCompilerTestUtilities.csproj" />
     <ProjectReference Include="..\..\VisualBasic\vbc\vbc.csproj">
       <Aliases>vbc</Aliases>
     </ProjectReference>

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -20,8 +20,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         {
         }
 
+        public MockCSharpCompiler(string responseFile, BuildPaths buildPaths, string[] args)
+            :this(responseFile, buildPaths, args, ImmutableArray<DiagnosticAnalyzer>.Empty, RuntimeUtilities.CreateAnalyzerAssemblyLoader())
+        {
+        }
+
         public MockCSharpCompiler(string responseFile, string workingDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers, AnalyzerAssemblyLoader loader)
-            : base(CSharpCommandLineParser.Default, responseFile, args, CreateBuildPaths(workingDirectory), Environment.GetEnvironmentVariable("LIB"), loader)
+            : this(responseFile, CreateBuildPaths(workingDirectory), args, analyzers, loader)
+        {
+        }
+
+        public MockCSharpCompiler(string responseFile, BuildPaths buildPaths, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers, AnalyzerAssemblyLoader loader)
+            : base(CSharpCommandLineParser.Default, responseFile, args, buildPaths, Environment.GetEnvironmentVariable("LIB"), loader)
         {
             _analyzers = analyzers;
         }

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         }
 
         public MockCSharpCompiler(string responseFile, BuildPaths buildPaths, string[] args)
-            :this(responseFile, buildPaths, args, ImmutableArray<DiagnosticAnalyzer>.Empty, RuntimeUtilities.CreateAnalyzerAssemblyLoader())
+            : this(responseFile, buildPaths, args, ImmutableArray<DiagnosticAnalyzer>.Empty, RuntimeUtilities.CreateAnalyzerAssemblyLoader())
         {
         }
 

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicCompilerTestUtilities.vbproj
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicCompilerTestUtilities.vbproj
@@ -9,7 +9,7 @@
     <AssemblyName>Roslyn.Compilers.VisualBasic.Test.Utilities</AssemblyName>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
     <Nonshipping>true</Nonshipping>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\..\Test\PdbUtilities\PdbUtilities.csproj" />

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -16,11 +16,19 @@ Friend Class MockVisualBasicCompiler
     End Sub
 
     Public Sub New(responseFile As String, baseDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
-        MyClass.New(responseFile, baseDirectory, args, If(analyzer Is Nothing, ImmutableArray(Of DiagnosticAnalyzer).Empty, ImmutableArray.Create(analyzer)))
+        MyClass.New(responseFile, CreateBuildPaths(baseDirectory, Path.GetTempPath()), args, analyzer)
+    End Sub
+
+    Public Sub New(responseFile As String, buildPaths As BuildPaths, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
+        MyClass.New(responseFile, buildPaths, args, If(analyzer Is Nothing, ImmutableArray(Of DiagnosticAnalyzer).Empty, ImmutableArray.Create(analyzer)))
     End Sub
 
     Public Sub New(responseFile As String, workingDirectory As String, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
-        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, CreateBuildPaths(workingDirectory, Path.GetTempPath()), Environment.GetEnvironmentVariable("LIB"), New DesktopAnalyzerAssemblyLoader())
+        MyClass.New(responseFile, CreateBuildPaths(workingDirectory, Path.GetTempPath()), args, analyzers)
+    End Sub
+
+    Public Sub New(responseFile As String, buildPaths As BuildPaths, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
+        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, buildPaths, Environment.GetEnvironmentVariable("LIB"), New DesktopAnalyzerAssemblyLoader())
 
         _analyzers = analyzers
     End Sub

--- a/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
@@ -7,7 +7,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputType>Library</OutputType>
     <AssemblyName>Roslyn.Compilers.VisualBasic.CommandLine.UnitTests</AssemblyName>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>$(RoslynDesktopRuntimeIdentifier)</RuntimeIdentifier>
     <RoslynProjectType>UnitTest</RoslynProjectType>
     <RootNamespace></RootNamespace>
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\..\..\Server\VBCSCompiler\VBCSCompiler.csproj" />
     <ProjectReference Include="..\..\..\Core\Portable\CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\Test\Utilities\VisualBasic\BasicCompilerTestUtilities.vbproj" />
-    <ProjectReference Include="..\..\vbc\vbc.csproj" />
+    <ProjectReference Include="..\..\vbc\vbc.csproj" ReferenceOutputAssembly="false" OutputItemType="RoslynReferenceToDependencyDirectory" />
     <ProjectReference Include="..\..\Portable\BasicCodeAnalysis.vbproj" />
     <ProjectReference Include="..\..\..\Test\Resources\Core\CompilerTestResources.csproj" />
   </ItemGroup>
@@ -70,11 +70,11 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>CommandLineTestResources.Designer.vb</LastGenOutput>
     </EmbeddedResource>
+    <AssemblyVersionAttribute Include="Microsoft.CodeAnalysis.CommitHashAttribute">
+      <_Parameter1>$(CommitHashDisplay)</_Parameter1>
+    </AssemblyVersionAttribute>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\vbc\vbc.rsp">
-      <Link>vbc.rsp</Link>
-    </None>
     <None Include="My Project\Application.myapp">
       <Generator>MyApplicationCodeGenerator</Generator>
       <LastGenOutput>Application.Designer.vb</LastGenOutput>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
         Private ReadOnly _baseDirectory As String = TempRoot.Root
         Private Shared ReadOnly s_basicCompilerExecutable As String = Path.Combine(
             Path.GetDirectoryName(GetType(CommandLineTests).Assembly.Location),
-            "dependency\vbc.exe")
+            Path.Combine("dependency", "vbc.exe"))
         Private Shared ReadOnly s_defaultSdkDirectory As String = RuntimeEnvironment.GetRuntimeDirectory()
         Private Shared ReadOnly s_compilerVersion As String = FileVersionInfo.GetVersionInfo(GetType(CommandLineTests).Assembly.Location).FileVersion
         Private Shared ReadOnly s_compilerShortCommitHash As String =


### PR DESCRIPTION
This moves more of our test projects to target net461. There is a larger effort to get our tests onto either net461 or netcoreapp2.0. Doing so would allow us to remove netstandard1.3, and a large number of `#if`, from our core test utility projects. 

The key change here is having our compiler command line tests move the referenced compiler into a sub-directory instead of placing it directly into the output directory. This allows them to have different facades and hence different target frameworks. Before when they were in the same directory they shared facades and hence had to have the same target framework. 