### PR TITLE
Fix typo in Microsoft.NETCore.Compilers props file

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
@@ -33,7 +33,7 @@
   <Target Name="MakeCompilerScriptsExecutable"
           Condition="'$(BuildingProject)' == 'true' AND
                      '$(OS)' != 'Windows_NT' AND
-                     ('$(CscToolPath)' != '' OR '$(VbcToolPath) != '')"
+                     ('$(CscToolPath)' != '' OR '$(VbcToolPath)' != '')"
           BeforeTargets="CoreCompile">
     <Exec Command="chmod +x &quot;$(CscToolPath)/$(CscToolExe)&quot; &quot;$(VbcToolPath)/$(VbcToolExe)&quot;" />
   </Target>


### PR DESCRIPTION
### Customer scenario

Install the Microsoft.NETCore.Compilers package into a .NET Core project and build. The build fails because there is an MSBuild syntax error in the default props file from the package.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/25219

### Workarounds, if any

None

### Risk

This props file is only used in this package.

### Performance impact

None

### Is this a regression from a previous update?

No, this package has never been public before.

### Root cause analysis

This package isn't tested in any of our unit tests. I tested the package manually, but must have made a typo after testing it.

### How was the bug found?

Found in this PR when trying to bring in a new compiler https://github.com/dotnet/roslyn/pull/25179
