### PR TITLE
Skip CSharpBuild.BuildWithCommandLine while failures are investigated.

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
@@ -38,7 +38,7 @@ class Program
             // TODO: Validate build works as expected
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Build)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18204"), Trait(Traits.Feature, Traits.Features.Build)]
         public void BuildWithCommandLine()
         {
             VisualStudio.SolutionExplorer.SaveAll();


### PR DESCRIPTION
Infra-only change. Disabled CSharpBuild.BuildWithCommandLine until the failures are investigated (https://github.com/dotnet/roslyn/issues/18204), as it's failing repeatedly. @dotnet/roslyn-infrastructure for review. FYI @jinujoseph @sharwell @chborl.