### PR TITLE
Added tls security settings for successful vswhere download.

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -50,6 +50,7 @@ param (
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 function Print-Usage() {
     Write-Host "Usage: build.ps1"


### PR DESCRIPTION
Infra-only change. TLS settings need to updated to unblock signed build. @jaredpar @dotnet/roslyn-infrastructure please review.