### PR TITLE
Handle return statements with no expression in CSharpAsAndNullCheckDi…

### DIFF
--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -115,6 +115,20 @@ $@"class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        [WorkItem(25237, "https://github.com/dotnet/roslyn/issues/25237")]
+        public async Task TestMissingOnReturnStatement()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        [|return;|]
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
         public async Task TestMissingOnIsExpression()
         {
             await TestMissingInRegularAndScriptAsync(

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -423,6 +423,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                         continue;
                     case SyntaxKind.ReturnStatement:
                         node = ((ReturnStatementSyntax)node).Expression;
+                        if (node == null)
+                        {
+                            return null;
+                        }
+
                         continue;
                     case SyntaxKind.LocalDeclarationStatement:
                         var declarators = ((LocalDeclarationStatementSyntax)node).Declaration.Variables;

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -413,6 +413,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
         {
             while (true)
             {
+                if (node == null)
+                {
+                    return null;
+                }
+
                 switch (node.Kind())
                 {
                     case SyntaxKind.WhileStatement:
@@ -423,23 +428,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                         continue;
                     case SyntaxKind.ReturnStatement:
                         node = ((ReturnStatementSyntax)node).Expression;
-                        if (node == null)
-                        {
-                            return null;
-                        }
-
                         continue;
                     case SyntaxKind.LocalDeclarationStatement:
                         var declarators = ((LocalDeclarationStatementSyntax)node).Declaration.Variables;
                         // We require this to be the only declarator in the declaration statement
                         // to simplify definitive assignment check and the code fix for now
-                        var value = declarators.Count == 1 ? declarators[0].Initializer?.Value : null;
-                        if (value == null)
-                        {
-                            return null;
-                        }
-
-                        node = value;
+                        node = declarators.Count == 1 ? declarators[0].Initializer?.Value : null;
                         continue;
                     case SyntaxKind.ParenthesizedExpression:
                         node = ((ParenthesizedExpressionSyntax)node).Expression;


### PR DESCRIPTION
…agnosticAnalyzer.GetLeftmostCondition

Fixes #25237

<details><summary>Ask Mode template</summary>

### Customer scenario

Open a C# source file which has a void method with a `return;` statement.  The built-in IDE analyzer `CSharpAsAndNullCheckDiagnosticAnalyzer` throws a NullReferenceException producing an AD0001 diagnostic in the error list. Multiple instances of this diagnostic can easily show up in a normal C# solution.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/25237

### Workarounds, if any

Disable [IDE0019](http://source.roslyn.io/#Microsoft.CodeAnalysis.Features/Diagnostics/Analyzers/IDEDiagnosticIds.cs,25) using a ruleset entry for every project that has return statements with no expression.

### Risk

Low risk. Fix involves just adding a null check.

### Performance impact

None

### Is this a regression from a previous update?

Yes, recent regression introduced in https://github.com/dotnet/roslyn/commit/10726d10d8a88af000c925fa5e3f5776dd7cbf4d#diff-64e1a867f5d1363da7ca518cdb658623.

### Root cause analysis

Missing unit tests. A regression test has been added with the PR. Verified the NRE on the added unit test before the fix.

### How was the bug found?

Dogfooding.

### Test documentation updated?

N/A
</details>
