### PR TITLE
RoRoslynNuGetMoniker update for 15.7-vs-deps

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -18,7 +18,7 @@
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
-    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta1</RoslynNuGetMoniker> 
+    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta2</RoslynNuGetMoniker> 
 
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>


### PR DESCRIPTION
Updated RoslynNuGetMoniker version for 15.7-vs-deps, due to creation of 15.7-preview1-vs-deps
