### PR TITLE
Harden against errors reading active statement properties

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.cs
@@ -30,7 +30,6 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                 // TODO: return empty outside of debug session.
                 // https://github.com/dotnet/roslyn/issues/24325
 
-                bool completed = false;
                 int unexpectedError = 0;
                 var completion = new TaskCompletionSource<ImmutableArray<ActiveStatementDebugInfo>>();
                 var builders = default(ArrayBuilder<ArrayBuilder<ActiveStatementDebugInfo>>);
@@ -39,10 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 
                 var workList = DkmWorkList.Create(CompletionRoutine: _ =>
                 {
-                    if (!completed)
-                    {
-                        completion.TrySetException(new InvalidOperationException($"Unexpected error enumerating active statements: 0x{unexpectedError:X8}"));
-                    }
+                    completion.TrySetException(new InvalidOperationException($"Unexpected error enumerating active statements: 0x{unexpectedError:X8}"));
                 });
 
                 void CancelWork()
@@ -59,7 +55,6 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                         // workList.Cancel();
 
                         // make sure we cancel with the token we received from the caller:
-                        completed = true;
                         completion.TrySetCanceled(cancellationToken);
                     }
                 }
@@ -145,8 +140,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                                             // the last active statement of the last runtime has been processed:
                                             if (Interlocked.Decrement(ref pendingRuntimes) == 0)
                                             {
-                                                completed = true;
-                                                completion.SetResult(builders.ToFlattenedImmutableArrayAndFree());
+                                                completion.TrySetResult(builders.ToFlattenedImmutableArrayAndFree());
                                             }
                                         }
                                     });

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.cs
@@ -30,11 +30,20 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                 // TODO: return empty outside of debug session.
                 // https://github.com/dotnet/roslyn/issues/24325
 
-                var workList = DkmWorkList.Create(CompletionRoutine: null);
+                bool completed = false;
+                int unexpectedError = 0;
                 var completion = new TaskCompletionSource<ImmutableArray<ActiveStatementDebugInfo>>();
                 var builders = default(ArrayBuilder<ArrayBuilder<ActiveStatementDebugInfo>>);
                 int pendingRuntimes = 0;
                 int runtimeCount = 0;
+
+                var workList = DkmWorkList.Create(CompletionRoutine: _ =>
+                {
+                    if (!completed)
+                    {
+                        completion.TrySetException(new InvalidOperationException($"Unexpected error enumerating active statements: 0x{unexpectedError:X8}"));
+                    }
+                });
 
                 void CancelWork()
                 {
@@ -50,6 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                         // workList.Cancel();
 
                         // make sure we cancel with the token we received from the caller:
+                        completed = true;
                         completion.TrySetCanceled(cancellationToken);
                     }
                 }
@@ -73,8 +83,15 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                                     return;
                                 }
 
+                                if (activeStatementsResult.ErrorCode != 0)
+                                {
+                                    unexpectedError = activeStatementsResult.ErrorCode;
+                                    return;
+                                }
+
                                 // group active statement by instruction and aggregate flags and threads:
                                 var instructionMap = PooledDictionary<ActiveInstructionId, (DkmInstructionSymbol Symbol, ArrayBuilder<Guid> Threads, int Index, ActiveStatementFlags Flags)>.GetInstance();
+
                                 GroupActiveStatementsByInstructionId(instructionMap, activeStatementsResult.ActiveStatements);
 
                                 int pendingStatements = instructionMap.Count;
@@ -93,10 +110,16 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                                             return;
                                         }
 
-                                        var position = sourcePositionResult.SourcePosition;
+                                        int errorCode = sourcePositionResult.ErrorCode;
+                                        if (errorCode != 0)
+                                        {
+                                            unexpectedError = errorCode;
+                                        }
+
+                                        DkmSourcePosition position;
                                         string documentNameOpt;
                                         LinePositionSpan span;
-                                        if (sourcePositionResult.ErrorCode == 0 && position != null)
+                                        if (errorCode == 0 && (position = sourcePositionResult.SourcePosition) != null)
                                         {
                                             documentNameOpt = position.DocumentName;
                                             span = ToLinePositionSpan(position.TextSpan);
@@ -122,6 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                                             // the last active statement of the last runtime has been processed:
                                             if (Interlocked.Decrement(ref pendingRuntimes) == 0)
                                             {
+                                                completed = true;
                                                 completion.SetResult(builders.ToFlattenedImmutableArrayAndFree());
                                             }
                                         }


### PR DESCRIPTION
### Customer scenario

VS hangs when he debugger fails to retrieve source location for an active statement.

### Bugs this fixes

VSO [575014](https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=575014)
(dup VSO [576255](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/576255))


### Workarounds, if any

None.

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

The debugger dispatcher throws an exception when the source location of an active statement is not available, instead of returning null as our code expected. The exception caused an async task to never complete. When the debugger then queried for the result of the task it hang.

### How did we miss it?  What tests are we adding to guard against it in the future?

We tested the affected scenario manually before making a change in the code that was addressing another issue. We have not rerun all manual tests again with the corrected (broken) code.

### How was the bug found?

Dogfooding.

### Test documentation updated?

Yes, added new test scenario: https://github.com/dotnet/roslyn/issues/25279