### PR TITLE
Remove NFW causing delays

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -1220,6 +1220,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                     if (_projectsReferencingMe.Count > 0)
                     {
+                        // We shouldn't be able to get here, but for reasons we don't entirely
+                        // understand we sometimes do. We've long assumed that by the time a project is
+                        // disconnected, all references to that project have been removed. However, it
+                        // appears that this isn't always true when closing a solution (which includes
+                        // reloading the solution, or opening a different solution) or when reloading a
+                        // project that has changed on disk, or when deleting a project from a
+                        // solution.
+                        
                         // Clear just so we don't cause a leak
                         _projectsReferencingMe.Clear();
                     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -1220,8 +1220,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                     if (_projectsReferencingMe.Count > 0)
                     {
-                        FatalError.ReportWithoutCrash(new Exception("We still have projects referencing us. That's not expected."));
-
                         // Clear just so we don't cause a leak
                         _projectsReferencingMe.Clear();
                     }


### PR DESCRIPTION
Remove a non-fatal Watson report that was triggering frequently and
causing UI delays. We expected that all references to a project would be
removed before the project itself was unloaded, and this report was
added to help us diagnose the rare occasion when that did not occur. It
turns out that it happens quite frequently: when a solution closes, when
a project changes externally and needs to be reloaded, and when a
project is deleted from the solution. We're getting a lot more of these
events than expected, and worse, collecting the Watson data sometimes
causes long pauses in the UI.

We do not have a concrete plan for dealing with the underlying issue,
but the data we've already collected from these reports demonstrates the
scope of the problem and collecting more won't help at this point. Since
the collection itself is causing problems, it's time to just remove it.

<details><summary>Ask Mode Template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

While reloading, closing, or switching solutions, or reloading a project that changed on disk, the user experiences lengthy UI delays.

### Bugs this fixes

Fixes [VS 572174](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/572174)

### Workarounds, if any

None.

### Risk

Low.

### Performance impact

Improves performance by eliminating hangs.

### Is this a regression from a previous update?

Yes. The non-fatal Watson was added in the 15.6 previews to collect further data.

### Root cause analysis

We expected that the underlying issue triggering the non-fatal Watson would occur infrequently, especially as we had fixed the known causes. It turns out that the remaining causes triggered this much more frequently than expected.

### How was the bug found?

PerfWatson reports.

### Test documentation updated?

No.

</details>
