### PR TITLE
Select specific overload in DebugDirectoryExtensions reflection

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Reflection.PortableExecutable;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;

--- a/src/Compilers/CSharp/Test/Emit/PDB/PortablePdbTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PortablePdbTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Reflection.PortableExecutable;
 using Roslyn.Test.Utilities;
 using Xunit;
 

--- a/src/Compilers/Core/Portable/PEWriter/DebugDirectoryExtensions.cs
+++ b/src/Compilers/Core/Portable/PEWriter/DebugDirectoryExtensions.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Roslyn.Utilities;
 
-namespace System.Reflection.PortableExecutable
+namespace Roslyn.Reflection.PortableExecutable
 {
     // TODO: move to SRM: https://github.com/dotnet/roslyn/issues/24712
     internal static class DebugDirectoryExtensions
@@ -21,7 +25,9 @@ namespace System.Reflection.PortableExecutable
             {
                 var type = typeof(DebugDirectoryBuilder).GetTypeInfo();
                 s_dataBuilderField = type.GetDeclaredField("_dataBuilder");
-                s_addEntry = (Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>)type.GetDeclaredMethod("AddEntry").CreateDelegate(typeof(Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>));
+                s_addEntry = (Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>)
+                    type.GetDeclaredMethod("AddEntry", typeof(DebugDirectoryEntryType), typeof(uint), typeof(uint), typeof(int)).
+                    CreateDelegate(typeof(Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>));
             }
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
+using Roslyn.Reflection.PortableExecutable;
 using static Microsoft.CodeAnalysis.SigningUtilities;
 using EmitContext = Microsoft.CodeAnalysis.Emit.EmitContext;
 

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PortablePdbTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PortablePdbTests.vb
@@ -8,6 +8,7 @@ Imports System.Text
 Imports Microsoft.CodeAnalysis.Debugging
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Roslyn.Reflection.PortableExecutable
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.PDB

--- a/src/Test/PdbUtilities/Pdb/PdbValidation.cs
+++ b/src/Test/PdbUtilities/Pdb/PdbValidation.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.DiaSymReader;
 using Microsoft.DiaSymReader.Tools;
 using Microsoft.Metadata.Tools;
+using Roslyn.Reflection.PortableExecutable;
 using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;


### PR DESCRIPTION
### Customer scenario

Roslyn doesn't work with the latest CoreFX build.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/25278

### Workarounds, if any

None.

### Risk

Small. 

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

DotNet SDK insertion.

### Test documentation updated?

