### PR TITLE
Include additional information about the found and expected character.

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxTreeExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTreeExtensions.cs
@@ -42,7 +42,8 @@ namespace Microsoft.CodeAnalysis
             var span = node.FullSpan;
             var textSpanOpt = span.Intersection(fullSpan);
             int index;
-
+            char found = default;
+            char expected = default;
             if (textSpanOpt == null)
             {
                 index = 0;
@@ -52,6 +53,11 @@ namespace Microsoft.CodeAnalysis
                 var fromText = text.ToString(textSpanOpt.Value);
                 var fromNode = node.ToFullString();
                 index = FindFirstDifference(fromText, fromNode);
+                if (index >= 0)
+                {
+                    found = fromNode[index];
+                    expected = fromText[index];
+                }
             }
 
             if (index >= 0)
@@ -63,11 +69,7 @@ namespace Microsoft.CodeAnalysis
                     var position = text.Lines.GetLinePosition(index);
                     var line = text.Lines[position.Line];
                     var allText = text.ToString(); // Entire document as string to allow inspecting the text in the debugger.
-                    message = string.Format("Unexpected difference at offset {0}: Line {1}, Column {2} \"{3}\"",
-                        index,
-                        position.Line + 1,
-                        position.Character + 1,
-                        line.ToString());
+                    message = $"Unexpected difference at offset {index}: Line {position.Line + 1}, Column {position.Character + 1} \"{line.ToString()}\"  (Found: [{found}] Expected: [{expected}])";
                 }
                 else
                 {


### PR DESCRIPTION
Include additional information about the found and expected character, when there is an unexpected difference. *I found it useful to see, what was missing during parsing.*