### PR TITLE
Restore semantic model functionality in tuple comparisons

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -22,15 +22,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
         {
             // PROTOTYPE(tuple-equality) Block in expression tree
-
             TupleBinaryOperatorInfo.Multiple operators = BindTupleBinaryOperatorNestedInfo(node, kind, left, right, diagnostics);
 
-            // PROTOTYPE(tuple-equality) We'll save the converted nodes separately, for the semantic model
-            //BoundExpression convertedLeft = GenerateConversionForAssignment(operators.LeftConvertedType, left, diagnostics);
-            //BoundExpression convertedRight = GenerateConversionForAssignment(operators.RightConvertedType, right, diagnostics);
+            TypeSymbol leftConvertedTypeOpt = operators.LeftConvertedTypeOpt;
+            BoundExpression convertedLeft = leftConvertedTypeOpt is null
+                ? left
+                : GenerateConversionForAssignment(leftConvertedTypeOpt, left, diagnostics);
+
+            TypeSymbol rightConvertedTypeOpt = operators.RightConvertedTypeOpt;
+            BoundExpression convertedRight = rightConvertedTypeOpt is null
+                ? right
+                : GenerateConversionForAssignment(rightConvertedTypeOpt, right, diagnostics);
 
             TypeSymbol resultType = GetSpecialType(SpecialType.System_Boolean, diagnostics, node);
-            return new BoundTupleBinaryOperator(node, left, right, kind, operators, resultType);
+
+            return new BoundTupleBinaryOperator(node, left, right, convertedLeft, convertedRight, kind, operators, resultType);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -96,9 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BindTupleBinaryOperatorNestedInfo(node, kind, left, right, diagnostics);
             }
 
-            bool leftNull = left.IsLiteralNull();
-            bool rightNull = right.IsLiteralNull();
-            if (leftNull && rightNull)
+            if (left.IsLiteralNull() && right.IsLiteralNull())
             {
                 return new TupleBinaryOperatorInfo.NullNull(kind);
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -322,8 +322,11 @@
 
     <Field Name="Left" Type="BoundExpression"/>
     <Field Name="Right" Type="BoundExpression"/>
+
+    <!-- Converted nodes are meant for semantic model use only -->
     <Field Name="ConvertedLeft" Type="BoundExpression" SkipInVisitor="true"/>
     <Field Name="ConvertedRight" Type="BoundExpression" SkipInVisitor="true"/>
+
     <Field Name="OperatorKind" Type="BinaryOperatorKind"/>
     <Field Name="Operators" Type="TupleBinaryOperatorInfo.Multiple"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -322,6 +322,8 @@
 
     <Field Name="Left" Type="BoundExpression"/>
     <Field Name="Right" Type="BoundExpression"/>
+    <Field Name="ConvertedLeft" Type="BoundExpression" SkipInVisitor="true"/>
+    <Field Name="ConvertedRight" Type="BoundExpression" SkipInVisitor="true"/>
     <Field Name="OperatorKind" Type="BinaryOperatorKind"/>
     <Field Name="Operators" Type="TupleBinaryOperatorInfo.Multiple"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
@@ -7,6 +7,14 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
+
+    internal enum TupleBinaryOperatorInfoKind
+    {
+        Single,
+        NullNull,
+        Multiple
+    }
+
     /// <summary>
     /// A tree of binary operators for tuple comparisons.
     ///
@@ -16,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal abstract class TupleBinaryOperatorInfo
     {
-        internal abstract KindEnum InfoKind { get; }
+        internal abstract TupleBinaryOperatorInfoKind InfoKind { get; }
         internal readonly TypeSymbol LeftConvertedTypeOpt;
         internal readonly TypeSymbol RightConvertedTypeOpt;
 #if DEBUG
@@ -57,8 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(Kind.IsUserDefined() == ((object)MethodSymbolOpt != null));
             }
 
-            internal override KindEnum InfoKind
-                => KindEnum.Single;
+            internal override TupleBinaryOperatorInfoKind InfoKind
+                => TupleBinaryOperatorInfoKind.Single;
 
             public override string ToString()
                 => $"binaryOperatorKind: {Kind}";
@@ -97,8 +105,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Operators = operators;
             }
 
-            internal override KindEnum InfoKind
-                => KindEnum.Multiple;
+            internal override TupleBinaryOperatorInfoKind InfoKind
+                => TupleBinaryOperatorInfoKind.Multiple;
 
 #if DEBUG
             internal override TreeDumperNode DumpCore()
@@ -120,14 +128,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             internal readonly BinaryOperatorKind Kind;
 
-            internal NullNull(BinaryOperatorKind kind, TypeSymbol leftConvertedTypeOpt, TypeSymbol rightConvertedTypeOpt)
-                : base(leftConvertedTypeOpt, rightConvertedTypeOpt)
+            internal NullNull(BinaryOperatorKind kind)
+                : base(leftConvertedTypeOpt: null, rightConvertedTypeOpt: null)
             {
                 Kind = kind;
             }
 
-            internal override KindEnum InfoKind
-                => KindEnum.NullNull;
+            internal override TupleBinaryOperatorInfoKind InfoKind
+                => TupleBinaryOperatorInfoKind.NullNull;
 
 #if DEBUG
             internal override TreeDumperNode DumpCore()
@@ -135,13 +143,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new TreeDumperNode("nullnull", value: Kind, children: null);
             }
 #endif
-        }
-
-        internal enum KindEnum
-        {
-            Single,
-            NullNull,
-            Multiple
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Holds the information for an element-wise comparison (like `a == b`)
+        /// Holds the information for an element-wise comparison (like `a == b` as part of `(a, ...) == (b, ...)`)
         /// </summary>
         internal class Single : TupleBinaryOperatorInfo
         {
@@ -112,6 +112,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 #endif
         }
 
+        /// <summary>
+        /// Represents an element-wise null/null comparison.
+        /// For instance, `(null, ...) == (null, ...)`.
+        /// </summary>
         internal class NullNull : TupleBinaryOperatorInfo
         {
             internal readonly BinaryOperatorKind Kind;

--- a/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal abstract class TupleBinaryOperatorInfo
     {
-        internal abstract bool IsSingle();
+        internal abstract KindEnum InfoKind { get; }
         internal readonly TypeSymbol LeftConvertedTypeOpt;
         internal readonly TypeSymbol RightConvertedTypeOpt;
 #if DEBUG
@@ -57,8 +57,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(Kind.IsUserDefined() == ((object)MethodSymbolOpt != null));
             }
 
-            internal override bool IsSingle()
-                => true;
+            internal override KindEnum InfoKind
+                => KindEnum.Single;
 
             public override string ToString()
                 => $"binaryOperatorKind: {Kind}";
@@ -97,8 +97,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Operators = operators;
             }
 
-            internal override bool IsSingle()
-                => false;
+            internal override KindEnum InfoKind
+                => KindEnum.Multiple;
 
 #if DEBUG
             internal override TreeDumperNode DumpCore()
@@ -110,6 +110,34 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new TreeDumperNode("nested", null, sub);
             }
 #endif
+        }
+
+        internal class NullNull : TupleBinaryOperatorInfo
+        {
+            internal readonly BinaryOperatorKind Kind;
+
+            internal NullNull(BinaryOperatorKind kind, TypeSymbol leftConvertedTypeOpt, TypeSymbol rightConvertedTypeOpt)
+                : base(leftConvertedTypeOpt, rightConvertedTypeOpt)
+            {
+                Kind = kind;
+            }
+
+            internal override KindEnum InfoKind
+                => KindEnum.NullNull;
+
+#if DEBUG
+            internal override TreeDumperNode DumpCore()
+            {
+                return new TreeDumperNode("nullnull", value: Kind, children: null);
+            }
+#endif
+        }
+
+        internal enum KindEnum
+        {
+            Single,
+            NullNull,
+            Multiple
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -256,6 +256,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw ExceptionUtilities.Unreachable;
             }
 
+            public override BoundNode VisitTupleBinaryOperator(BoundTupleBinaryOperator node)
+            {
+                // We skip the unconverted left and right, they are only meant for lowering
+                this.Visit(node.ConvertedLeft);
+                this.Visit(node.ConvertedRight);
+                return null;
+            }
+
             protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
             {
                 return false;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -51,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression ReplaceTerminalElementsWithTemps(BoundExpression expr, TupleBinaryOperatorInfo operators, ArrayBuilder<BoundExpression> initEffects, ArrayBuilder<LocalSymbol> temps)
         {
-            if (!operators.IsSingle())
+            if (operators.InfoKind == TupleBinaryOperatorInfo.KindEnum.Multiple)
             {
                 // Example:
                 // in `(expr1, expr2) == (..., ...)` we need to save `expr1` and `expr2`
@@ -80,13 +81,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression left, BoundExpression right, TypeSymbol boolType,
             ArrayBuilder<LocalSymbol> temps, BinaryOperatorKind operatorKind)
         {
-            if (@operator.IsSingle())
+            switch (@operator.InfoKind)
             {
-                return RewriteTupleSingleOperator((TupleBinaryOperatorInfo.Single)@operator, left, right, boolType, operatorKind);
-            }
-            else
-            {
-                return RewriteTupleNestedOperators((TupleBinaryOperatorInfo.Multiple)@operator, left, right, boolType, temps, operatorKind);
+                case TupleBinaryOperatorInfo.KindEnum.Multiple:
+                    return RewriteTupleNestedOperators((TupleBinaryOperatorInfo.Multiple)@operator, left, right, boolType, temps, operatorKind);
+
+                case TupleBinaryOperatorInfo.KindEnum.Single:
+                    return RewriteTupleSingleOperator((TupleBinaryOperatorInfo.Single)@operator, left, right, boolType, operatorKind);
+
+                case TupleBinaryOperatorInfo.KindEnum.NullNull:
+                    var nullnull = (TupleBinaryOperatorInfo.NullNull)@operator;
+                    return new BoundLiteral(left.Syntax, ConstantValue.Create(nullnull.Kind == BinaryOperatorKind.Equal), boolType);
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(@operator.InfoKind);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression ReplaceTerminalElementsWithTemps(BoundExpression expr, TupleBinaryOperatorInfo operators, ArrayBuilder<BoundExpression> initEffects, ArrayBuilder<LocalSymbol> temps)
         {
-            if (operators.InfoKind == TupleBinaryOperatorInfo.KindEnum.Multiple)
+            if (operators.InfoKind == TupleBinaryOperatorInfoKind.Multiple)
             {
                 // Example:
                 // in `(expr1, expr2) == (..., ...)` we need to save `expr1` and `expr2`
@@ -83,13 +83,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             switch (@operator.InfoKind)
             {
-                case TupleBinaryOperatorInfo.KindEnum.Multiple:
+                case TupleBinaryOperatorInfoKind.Multiple:
                     return RewriteTupleNestedOperators((TupleBinaryOperatorInfo.Multiple)@operator, left, right, boolType, temps, operatorKind);
 
-                case TupleBinaryOperatorInfo.KindEnum.Single:
+                case TupleBinaryOperatorInfoKind.Single:
                     return RewriteTupleSingleOperator((TupleBinaryOperatorInfo.Single)@operator, left, right, boolType, operatorKind);
 
-                case TupleBinaryOperatorInfo.KindEnum.NullNull:
+                case TupleBinaryOperatorInfoKind.NullNull:
                     var nullnull = (TupleBinaryOperatorInfo.NullNull)@operator;
                     return new BoundLiteral(left.Syntax, ConstantValue.Create(nullnull.Kind == BinaryOperatorKind.Equal), boolType);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -342,17 +342,16 @@ class C
             var tupleY = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().Last();
             Assert.Equal("(y, y)", tupleY.ToString());
 
-            // PROTOTYPE(tuple-equality)
-            return;
+            var lastY = tupleY.Arguments[1].Expression;
+            Assert.Equal("y", lastY.ToString());
 
-            //var tupleYSymbol = model.GetTypeInfo(tupleY);
-            //Assert.Equal("(System.Byte, System.Byte)", tupleYSymbol.Type.ToTestDisplayString());
-            //Assert.Equal("(System.Int32, System.Int32)", tupleYSymbol.ConvertedType.ToTestDisplayString());
+            var ySymbol = model.GetTypeInfo(lastY);
+            Assert.Equal("System.Byte", ySymbol.Type.ToTestDisplayString());
+            Assert.Equal("System.Int32", ySymbol.ConvertedType.ToTestDisplayString());
 
-            //var y = tupleY.Arguments[0].Expression;
-            //var ySymbol = model.GetTypeInfo(y);
-            //Assert.Equal("System.Byte", ySymbol.Type.ToTestDisplayString());
-            //Assert.Equal("System.Int32", ySymbol.ConvertedType.ToTestDisplayString());
+            var tupleYSymbol = model.GetTypeInfo(tupleY);
+            Assert.Equal("(System.Byte, System.Byte)", tupleYSymbol.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)", tupleYSymbol.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -591,21 +591,19 @@ class C
 }";
             var comp = CompileAndVerify(source);
             comp.VerifyDiagnostics();
+
             var tree = comp.Compilation.SyntaxTrees.First();
             var model = comp.Compilation.GetSemanticModel(tree);
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            var symbol1 = model.GetTypeInfo(tuple1);
+            Assert.Null(symbol1.Type);
+            Assert.Equal("(System.String, System.Int64)", symbol1.ConvertedType.ToTestDisplayString());
 
-            //var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
-            //var symbol1 = model.GetTypeInfo(tuple1);
-            //Assert.Null(symbol1.Type);
-            //Assert.Equal("(System.String, System.Int64)", symbol1.ConvertedType.ToTestDisplayString());
-
-            //var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
-            //var symbol2 = model.GetTypeInfo(tuple2);
-            //Assert.Equal("(System.String, System.Int32)", symbol2.Type.ToTestDisplayString());
-            //Assert.Equal("(System.String, System.Int64)", symbol2.ConvertedType.ToTestDisplayString());
+            var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            var symbol2 = model.GetTypeInfo(tuple2);
+            Assert.Equal("(System.String, System.Int32)", symbol2.Type.ToTestDisplayString());
+            Assert.Equal("(System.String, System.Int64)", symbol2.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]
@@ -656,23 +654,20 @@ class C
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "True");
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
 
-            //var tree = comp.SyntaxTrees[0];
-            //var model = comp.GetSemanticModel(tree);
+            var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            Assert.Equal("(s, null)", tuple1.ToString());
+            var tupleType1 = model.GetTypeInfo(tuple1);
+            Assert.Null(tupleType1.Type);
+            Assert.Equal("(System.String, System.String)", tupleType1.ConvertedType.ToTestDisplayString());
 
-            //var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
-            //Assert.Equal("(s, null)", tuple1.ToString());
-            //var tupleType1 = model.GetTypeInfo(tuple1);
-            //Assert.Null(tupleType1.Type);
-            //Assert.Equal("(System.String, System.String)", tupleType1.ConvertedType.ToTestDisplayString());
-
-            //var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
-            //Assert.Equal("(null, s)", tuple2.ToString());
-            //var tupleType2 = model.GetTypeInfo(tuple2);
-            //Assert.Null(tupleType2.Type);
-            //Assert.Equal("(System.String, System.String)", tupleType2.ConvertedType.ToTestDisplayString());
+            var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(null, s)", tuple2.ToString());
+            var tupleType2 = model.GetTypeInfo(tuple2);
+            Assert.Null(tupleType2.Type);
+            Assert.Equal("(System.String, System.String)", tupleType2.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]
@@ -707,17 +702,14 @@ class C
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "True");
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
 
-            //var tree = comp.SyntaxTrees[0];
-            //var model = comp.GetSemanticModel(tree);
-
-            //var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
-            //Assert.Equal("(1L, 2)", tuple.ToString());
-            //var tupleType = model.GetTypeInfo(tuple);
-            //Assert.Equal("(System.Int64, System.Int32)", tupleType.Type.ToTestDisplayString());
-            //Assert.Equal("(System.Int64, System.Int64)", tupleType.ConvertedType.ToTestDisplayString());
+            var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(1L, 2)", tuple.ToString());
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Equal("(System.Int64, System.Int32)", tupleType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int64, System.Int64)", tupleType.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]
@@ -737,17 +729,14 @@ class C
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "True");
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
 
-            //var tree = comp.SyntaxTrees[0];
-            //var model = comp.GetSemanticModel(tree);
-
-            //var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(3);
-            //Assert.Equal("(1L, t2)", tuple.ToString());
-            //var tupleType = model.GetTypeInfo(tuple);
-            //Assert.Equal("(System.Int64, (System.Int32, System.String) t2)", tupleType.Type.ToTestDisplayString());
-            //Assert.Equal("(System.Int64, (System.Int64, System.String))", tupleType.ConvertedType.ToTestDisplayString());
+            var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(3);
+            Assert.Equal("(1L, t2)", tuple.ToString());
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Equal("(System.Int64, (System.Int32, System.String) t2)", tupleType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int64, (System.Int64, System.String))", tupleType.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]
@@ -768,17 +757,14 @@ class C
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "TrueFalseTrue");
 
-            // PROTOTYPE(tuple-equality) Semantic model: check type on last tuple and its elements (should be typeless)
-            return;
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
 
-            //var tree = comp.SyntaxTrees[0];
-            //var model = comp.GetSemanticModel(tree);
-
-            //var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
-            //Assert.Equal("(null, null)", tuple.ToString());
-            //var tupleType = model.GetTypeInfo(tuple);
-            //Assert.Null(tupleType.Type);
-            //Assert.Equal("(System.String, System.String)", tupleType.ConvertedType.ToTestDisplayString());
+            var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(null, null)", tuple.ToString());
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Null(tupleType.Type);
+            Assert.Equal("(System.String, System.String)", tupleType.ConvertedType.ToTestDisplayString());
         }
 
         [Fact(Skip = "PROTOTYPE(tuple-equality) Default")]
@@ -980,23 +966,20 @@ class C
                 Diagnostic(ErrorCode.ERR_BadBinaryOps, "(null, null, null) == (null, () => { }, Main)").WithArguments("==", "<null>", "method group").WithLocation(6, 30)
                 );
 
-            // PROTOTYPE(tuple-equality) Semantic model: check that null and tuples are typeless
-            return;
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
 
-            //var tree = comp.SyntaxTrees[0];
-            //var model = comp.GetSemanticModel(tree);
+            var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            Assert.Equal("(null, null, null)", tuple1.ToString());
+            var tupleType1 = model.GetTypeInfo(tuple1);
+            Assert.Null(tupleType1.Type);
+            Assert.Null(tupleType1.ConvertedType);
 
-            //var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
-            //Assert.Equal("(null, null)", tuple1.ToString());
-            //var tupleType1 = model.GetTypeInfo(tuple1);
-            //Assert.Null(tupleType1.Type);
-            //Assert.Equal("(System.Object, ?)", tupleType1.ConvertedType.ToTestDisplayString());
-
-            //var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
-            //Assert.Equal("(null, () => { })", tuple2.ToString());
-            //var tupleType2 = model.GetTypeInfo(tuple2);
-            //Assert.Null(tupleType2.Type);
-            //Assert.Equal("(System.Object, ?)", tupleType2.ConvertedType.ToTestDisplayString());
+            var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(null, () => { }, Main)", tuple2.ToString());
+            var tupleType2 = model.GetTypeInfo(tuple2);
+            Assert.Null(tupleType2.Type);
+            Assert.Null(tupleType2.ConvertedType);
         }
 
         [Fact]
@@ -1023,20 +1006,17 @@ class C
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            Assert.Equal("(s, s)", tuple1.ToString());
+            var tupleType1 = model.GetTypeInfo(tuple1);
+            Assert.Equal("(System.String, System.String)", tupleType1.Type.ToTestDisplayString());
+            Assert.Equal("(System.String, System.String)", tupleType1.ConvertedType.ToTestDisplayString());
 
-            //var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
-            //Assert.Equal("(s, s)", tuple1.ToString());
-            //var tupleType1 = model.GetTypeInfo(tuple1);
-            //Assert.Equal("(System.String, System.String)", tupleType1.Type.ToTestDisplayString());
-            //Assert.Equal("(System.Object, System.String)", tupleType1.ConvertedType.ToTestDisplayString());
-
-            //var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
-            //Assert.Equal("(1, () => { })", tuple2.ToString());
-            //var tupleType2 = model.GetTypeInfo(tuple2);
-            //Assert.Null(tupleType2.Type);
-            //Assert.Equal("(System.Object, ?)", tupleType2.ConvertedType.ToTestDisplayString());
+            var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(1, () => { })", tuple2.ToString());
+            var tupleType2 = model.GetTypeInfo(tuple2);
+            Assert.Null(tupleType2.Type);
+            Assert.Null(tupleType2.ConvertedType);
         }
 
         [Fact]
@@ -1156,7 +1136,21 @@ public class C
             var comp = CreateCompilation(source, references: new[] { CSharpRef, SystemCoreRef }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "True");
-            // PROTOTYPE(tuple-equality) verify converted type on null
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var tuple1 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            Assert.Equal("(d1, null)", tuple1.ToString());
+            var tupleType1 = model.GetTypeInfo(tuple1);
+            Assert.Null(tupleType1.Type);
+            Assert.Equal("(dynamic, dynamic)", tupleType1.ConvertedType.ToTestDisplayString());
+
+            var tuple2 = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(1);
+            Assert.Equal("(null, d2)", tuple2.ToString());
+            var tupleType2 = model.GetTypeInfo(tuple2);
+            Assert.Null(tupleType2.Type);
+            Assert.Equal("(dynamic, dynamic)", tupleType2.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]
@@ -2345,113 +2339,71 @@ class C
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
+            var nt1 = comparison.Left;
+            var nt1Type = model.GetTypeInfo(nt1);
+            Assert.Equal("nt1", nt1.ToString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int64)?", nt1Type.ConvertedType.ToTestDisplayString());
 
-//            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
-//            var nt1 = comparison.Left;
-//            var nt1Type = model.GetTypeInfo(nt1);
-//            Assert.Equal("nt1", nt1.ToString());
-//            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.Type.ToTestDisplayString());
-//            Assert.Equal("(System.Int32, System.Int64)?", nt1Type.ConvertedType.ToTestDisplayString());
+            var nt2 = comparison.Right;
+            var nt2Type = model.GetTypeInfo(nt2);
+            Assert.Equal("nt2", nt2.ToString());
+            Assert.Equal("(System.Byte, System.Int64)?", nt2Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int64)?", nt2Type.ConvertedType.ToTestDisplayString());
 
-//            var nt2 = comparison.Right;
-//            var nt2Type = model.GetTypeInfo(nt2);
-//            Assert.Equal("nt2", nt2.ToString());
-//            Assert.Equal("(System.Byte, System.Int64)?", nt2Type.Type.ToTestDisplayString());
-//            Assert.Equal("(System.Int32, System.Int64)?", nt2Type.ConvertedType.ToTestDisplayString());
-
-//            verifier.VerifyIL("C.Compare", @"{
-//  // Code size      217 (0xd9)
-//  .maxstack  3
-//  .locals init ((int, long)? V_0,
-//                bool V_1,
-//                System.ValueTuple<int, long> V_2,
-//                (int, long)? V_3,
-//                System.ValueTuple<int, long> V_4,
-//                (int, int)? V_5,
-//                (int, long)? V_6,
-//                System.ValueTuple<int, int> V_7,
-//                (byte, long)? V_8,
-//                System.ValueTuple<byte, long> V_9)
-//  IL_0000:  nop
-//  IL_0001:  ldstr      ""{0} ""
-//  IL_0006:  ldarg.0
-//  IL_0007:  stloc.s    V_5
-//  IL_0009:  ldloca.s   V_5
-//  IL_000b:  call       ""bool (int, int)?.HasValue.get""
-//  IL_0010:  brtrue.s   IL_001e
-//  IL_0012:  ldloca.s   V_6
-//  IL_0014:  initobj    ""(int, long)?""
-//  IL_001a:  ldloc.s    V_6
-//  IL_001c:  br.s       IL_0040
-//  IL_001e:  ldloca.s   V_5
-//  IL_0020:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
-//  IL_0025:  stloc.s    V_7
-//  IL_0027:  ldloc.s    V_7
-//  IL_0029:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-//  IL_002e:  ldloc.s    V_7
-//  IL_0030:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-//  IL_0035:  conv.i8
-//  IL_0036:  newobj     ""System.ValueTuple<int, long>..ctor(int, long)""
-//  IL_003b:  newobj     ""(int, long)?..ctor((int, long))""
-//  IL_0040:  stloc.0
-//  IL_0041:  ldloca.s   V_0
-//  IL_0043:  call       ""bool (int, long)?.HasValue.get""
-//  IL_0048:  stloc.1
-//  IL_0049:  ldarg.1
-//  IL_004a:  stloc.s    V_8
-//  IL_004c:  ldloca.s   V_8
-//  IL_004e:  call       ""bool (byte, long)?.HasValue.get""
-//  IL_0053:  brtrue.s   IL_0061
-//  IL_0055:  ldloca.s   V_6
-//  IL_0057:  initobj    ""(int, long)?""
-//  IL_005d:  ldloc.s    V_6
-//  IL_005f:  br.s       IL_0082
-//  IL_0061:  ldloca.s   V_8
-//  IL_0063:  call       ""(byte, long) (byte, long)?.GetValueOrDefault()""
-//  IL_0068:  stloc.s    V_9
-//  IL_006a:  ldloc.s    V_9
-//  IL_006c:  ldfld      ""byte System.ValueTuple<byte, long>.Item1""
-//  IL_0071:  ldloc.s    V_9
-//  IL_0073:  ldfld      ""long System.ValueTuple<byte, long>.Item2""
-//  IL_0078:  newobj     ""System.ValueTuple<int, long>..ctor(int, long)""
-//  IL_007d:  newobj     ""(int, long)?..ctor((int, long))""
-//  IL_0082:  stloc.3
-//  IL_0083:  ldloc.1
-//  IL_0084:  ldloca.s   V_3
-//  IL_0086:  call       ""bool (int, long)?.HasValue.get""
-//  IL_008b:  beq.s      IL_0090
-//  IL_008d:  ldc.i4.0
-//  IL_008e:  br.s       IL_00c8
-//  IL_0090:  ldloc.1
-//  IL_0091:  brtrue.s   IL_0096
-//  IL_0093:  ldc.i4.1
-//  IL_0094:  br.s       IL_00c8
-//  IL_0096:  ldloca.s   V_0
-//  IL_0098:  call       ""(int, long) (int, long)?.GetValueOrDefault()""
-//  IL_009d:  stloc.2
-//  IL_009e:  ldloca.s   V_3
-//  IL_00a0:  call       ""(int, long) (int, long)?.GetValueOrDefault()""
-//  IL_00a5:  stloc.s    V_4
-//  IL_00a7:  ldloc.2
-//  IL_00a8:  ldfld      ""int System.ValueTuple<int, long>.Item1""
-//  IL_00ad:  ldloc.s    V_4
-//  IL_00af:  ldfld      ""int System.ValueTuple<int, long>.Item1""
-//  IL_00b4:  bne.un.s   IL_00c7
-//  IL_00b6:  ldloc.2
-//  IL_00b7:  ldfld      ""long System.ValueTuple<int, long>.Item2""
-//  IL_00bc:  ldloc.s    V_4
-//  IL_00be:  ldfld      ""long System.ValueTuple<int, long>.Item2""
-//  IL_00c3:  ceq
-//  IL_00c5:  br.s       IL_00c8
-//  IL_00c7:  ldc.i4.0
-//  IL_00c8:  box        ""bool""
-//  IL_00cd:  call       ""string string.Format(string, object)""
-//  IL_00d2:  call       ""void System.Console.Write(string)""
-//  IL_00d7:  nop
-//  IL_00d8:  ret
-//}");
+            verifier.VerifyIL("C.Compare", @"{
+  // Code size      105 (0x69)
+  .maxstack  3
+  .locals init ((int, int)? V_0,
+                (byte, long)? V_1,
+                bool V_2,
+                System.ValueTuple<int, int> V_3,
+                System.ValueTuple<byte, long> V_4)
+  IL_0000:  nop
+  IL_0001:  ldstr      ""{0} ""
+  IL_0006:  ldarg.0
+  IL_0007:  stloc.0
+  IL_0008:  ldarg.1
+  IL_0009:  stloc.1
+  IL_000a:  ldloca.s   V_0
+  IL_000c:  call       ""bool (int, int)?.HasValue.get""
+  IL_0011:  stloc.2
+  IL_0012:  ldloc.2
+  IL_0013:  ldloca.s   V_1
+  IL_0015:  call       ""bool (byte, long)?.HasValue.get""
+  IL_001a:  beq.s      IL_001f
+  IL_001c:  ldc.i4.0
+  IL_001d:  br.s       IL_0058
+  IL_001f:  ldloc.2
+  IL_0020:  brtrue.s   IL_0025
+  IL_0022:  ldc.i4.1
+  IL_0023:  br.s       IL_0058
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
+  IL_002c:  stloc.3
+  IL_002d:  ldloca.s   V_1
+  IL_002f:  call       ""(byte, long) (byte, long)?.GetValueOrDefault()""
+  IL_0034:  stloc.s    V_4
+  IL_0036:  ldloc.3
+  IL_0037:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_003c:  ldloc.s    V_4
+  IL_003e:  ldfld      ""byte System.ValueTuple<byte, long>.Item1""
+  IL_0043:  bne.un.s   IL_0057
+  IL_0045:  ldloc.3
+  IL_0046:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_004b:  conv.i8
+  IL_004c:  ldloc.s    V_4
+  IL_004e:  ldfld      ""long System.ValueTuple<byte, long>.Item2""
+  IL_0053:  ceq
+  IL_0055:  br.s       IL_0058
+  IL_0057:  ldc.i4.0
+  IL_0058:  box        ""bool""
+  IL_005d:  call       ""string string.Format(string, object)""
+  IL_0062:  call       ""void System.Console.Write(string)""
+  IL_0067:  nop
+  IL_0068:  ret
+}");
         }
 
         [Fact]
@@ -2487,116 +2439,75 @@ class C
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "True False False Convert4 Convert4 True Convert5 False Convert6 Convert20 False ");
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
 
-//            var tree = comp.SyntaxTrees.First();
-//            var model = comp.GetSemanticModel(tree);
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
+            var nt1 = comparison.Left;
+            var nt1Type = model.GetTypeInfo(nt1);
+            Assert.Equal("nt1", nt1.ToString());
+            Assert.Equal("(C, System.Int32)?", nt1Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.ConvertedType.ToTestDisplayString());
 
-//            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
-//            var nt1 = comparison.Left;
-//            var nt1Type = model.GetTypeInfo(nt1);
-//            Assert.Equal("nt1", nt1.ToString());
-//            Assert.Equal("(C, System.Int32)?", nt1Type.Type.ToTestDisplayString());
-//            Assert.Equal("(System.Int32, System.Int32)?", nt1Type.ConvertedType.ToTestDisplayString());
+            var nt2 = comparison.Right;
+            var nt2Type = model.GetTypeInfo(nt2);
+            Assert.Equal("nt2", nt2.ToString());
+            Assert.Equal("(System.Int32, C)?", nt2Type.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", nt2Type.ConvertedType.ToTestDisplayString());
 
-//            var nt2 = comparison.Right;
-//            var nt2Type = model.GetTypeInfo(nt2);
-//            Assert.Equal("nt2", nt2.ToString());
-//            Assert.Equal("(System.Int32, C)?", nt2Type.Type.ToTestDisplayString());
-//            Assert.Equal("(System.Int32, System.Int32)?", nt2Type.ConvertedType.ToTestDisplayString());
-//            verifier.VerifyIL("C.Compare", @"{
-//  // Code size      226 (0xe2)
-//  .maxstack  3
-//  .locals init ((int, int)? V_0,
-//                bool V_1,
-//                System.ValueTuple<int, int> V_2,
-//                (int, int)? V_3,
-//                System.ValueTuple<int, int> V_4,
-//                (C, int)? V_5,
-//                (int, int)? V_6,
-//                System.ValueTuple<C, int> V_7,
-//                (int, C)? V_8,
-//                System.ValueTuple<int, C> V_9)
-//  IL_0000:  nop
-//  IL_0001:  ldstr      ""{0} ""
-//  IL_0006:  ldarg.0
-//  IL_0007:  stloc.s    V_5
-//  IL_0009:  ldloca.s   V_5
-//  IL_000b:  call       ""bool (C, int)?.HasValue.get""
-//  IL_0010:  brtrue.s   IL_001e
-//  IL_0012:  ldloca.s   V_6
-//  IL_0014:  initobj    ""(int, int)?""
-//  IL_001a:  ldloc.s    V_6
-//  IL_001c:  br.s       IL_0044
-//  IL_001e:  ldloca.s   V_5
-//  IL_0020:  call       ""(C, int) (C, int)?.GetValueOrDefault()""
-//  IL_0025:  stloc.s    V_7
-//  IL_0027:  ldloc.s    V_7
-//  IL_0029:  ldfld      ""C System.ValueTuple<C, int>.Item1""
-//  IL_002e:  call       ""int C.op_Implicit(C)""
-//  IL_0033:  ldloc.s    V_7
-//  IL_0035:  ldfld      ""int System.ValueTuple<C, int>.Item2""
-//  IL_003a:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
-//  IL_003f:  newobj     ""(int, int)?..ctor((int, int))""
-//  IL_0044:  stloc.0
-//  IL_0045:  ldloca.s   V_0
-//  IL_0047:  call       ""bool (int, int)?.HasValue.get""
-//  IL_004c:  stloc.1
-//  IL_004d:  ldarg.1
-//  IL_004e:  stloc.s    V_8
-//  IL_0050:  ldloca.s   V_8
-//  IL_0052:  call       ""bool (int, C)?.HasValue.get""
-//  IL_0057:  brtrue.s   IL_0065
-//  IL_0059:  ldloca.s   V_6
-//  IL_005b:  initobj    ""(int, int)?""
-//  IL_0061:  ldloc.s    V_6
-//  IL_0063:  br.s       IL_008b
-//  IL_0065:  ldloca.s   V_8
-//  IL_0067:  call       ""(int, C) (int, C)?.GetValueOrDefault()""
-//  IL_006c:  stloc.s    V_9
-//  IL_006e:  ldloc.s    V_9
-//  IL_0070:  ldfld      ""int System.ValueTuple<int, C>.Item1""
-//  IL_0075:  ldloc.s    V_9
-//  IL_0077:  ldfld      ""C System.ValueTuple<int, C>.Item2""
-//  IL_007c:  call       ""int C.op_Implicit(C)""
-//  IL_0081:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
-//  IL_0086:  newobj     ""(int, int)?..ctor((int, int))""
-//  IL_008b:  stloc.3
-//  IL_008c:  ldloc.1
-//  IL_008d:  ldloca.s   V_3
-//  IL_008f:  call       ""bool (int, int)?.HasValue.get""
-//  IL_0094:  beq.s      IL_0099
-//  IL_0096:  ldc.i4.0
-//  IL_0097:  br.s       IL_00d1
-//  IL_0099:  ldloc.1
-//  IL_009a:  brtrue.s   IL_009f
-//  IL_009c:  ldc.i4.1
-//  IL_009d:  br.s       IL_00d1
-//  IL_009f:  ldloca.s   V_0
-//  IL_00a1:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
-//  IL_00a6:  stloc.2
-//  IL_00a7:  ldloca.s   V_3
-//  IL_00a9:  call       ""(int, int) (int, int)?.GetValueOrDefault()""
-//  IL_00ae:  stloc.s    V_4
-//  IL_00b0:  ldloc.2
-//  IL_00b1:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-//  IL_00b6:  ldloc.s    V_4
-//  IL_00b8:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-//  IL_00bd:  bne.un.s   IL_00d0
-//  IL_00bf:  ldloc.2
-//  IL_00c0:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-//  IL_00c5:  ldloc.s    V_4
-//  IL_00c7:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-//  IL_00cc:  ceq
-//  IL_00ce:  br.s       IL_00d1
-//  IL_00d0:  ldc.i4.0
-//  IL_00d1:  box        ""bool""
-//  IL_00d6:  call       ""string string.Format(string, object)""
-//  IL_00db:  call       ""void System.Console.Write(string)""
-//  IL_00e0:  nop
-//  IL_00e1:  ret
-//}");
+            verifier.VerifyIL("C.Compare", @"{
+  // Code size      114 (0x72)
+  .maxstack  3
+  .locals init ((C, int)? V_0,
+                (int, C)? V_1,
+                bool V_2,
+                System.ValueTuple<C, int> V_3,
+                System.ValueTuple<int, C> V_4)
+  IL_0000:  nop
+  IL_0001:  ldstr      ""{0} ""
+  IL_0006:  ldarg.0
+  IL_0007:  stloc.0
+  IL_0008:  ldarg.1
+  IL_0009:  stloc.1
+  IL_000a:  ldloca.s   V_0
+  IL_000c:  call       ""bool (C, int)?.HasValue.get""
+  IL_0011:  stloc.2
+  IL_0012:  ldloc.2
+  IL_0013:  ldloca.s   V_1
+  IL_0015:  call       ""bool (int, C)?.HasValue.get""
+  IL_001a:  beq.s      IL_001f
+  IL_001c:  ldc.i4.0
+  IL_001d:  br.s       IL_0061
+  IL_001f:  ldloc.2
+  IL_0020:  brtrue.s   IL_0025
+  IL_0022:  ldc.i4.1
+  IL_0023:  br.s       IL_0061
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""(C, int) (C, int)?.GetValueOrDefault()""
+  IL_002c:  stloc.3
+  IL_002d:  ldloca.s   V_1
+  IL_002f:  call       ""(int, C) (int, C)?.GetValueOrDefault()""
+  IL_0034:  stloc.s    V_4
+  IL_0036:  ldloc.3
+  IL_0037:  ldfld      ""C System.ValueTuple<C, int>.Item1""
+  IL_003c:  call       ""int C.op_Implicit(C)""
+  IL_0041:  ldloc.s    V_4
+  IL_0043:  ldfld      ""int System.ValueTuple<int, C>.Item1""
+  IL_0048:  bne.un.s   IL_0060
+  IL_004a:  ldloc.3
+  IL_004b:  ldfld      ""int System.ValueTuple<C, int>.Item2""
+  IL_0050:  ldloc.s    V_4
+  IL_0052:  ldfld      ""C System.ValueTuple<int, C>.Item2""
+  IL_0057:  call       ""int C.op_Implicit(C)""
+  IL_005c:  ceq
+  IL_005e:  br.s       IL_0061
+  IL_0060:  ldc.i4.0
+  IL_0061:  box        ""bool""
+  IL_0066:  call       ""string string.Format(string, object)""
+  IL_006b:  call       ""void System.Console.Write(string)""
+  IL_0070:  nop
+  IL_0071:  ret
+}");
         }
 
         [Fact]
@@ -2656,21 +2567,18 @@ class C
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
+            var tuple = comparison.Left;
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Equal("(1, 2)", tuple.ToString());
+            Assert.Equal("(System.Int32, System.Int32)", tupleType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", tupleType.ConvertedType.ToTestDisplayString());
 
-            //var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
-            //var tuple = comparison.Left;
-            //var tupleType = model.GetTypeInfo(tuple);
-            //Assert.Equal("(1, 2)", tuple.ToString());
-            //Assert.Equal("(System.Int32, System.Int32)", tupleType.Type.ToTestDisplayString());
-            //Assert.Equal("(System.Int32, System.Int32)?", tupleType.ConvertedType.ToTestDisplayString());
-
-            //var nt = comparison.Right;
-            //var ntType = model.GetTypeInfo(nt);
-            //Assert.Equal("nt", nt.ToString());
-            //Assert.Equal("(System.Byte, System.Int32)?", ntType.Type.ToTestDisplayString());
-            //Assert.Equal("(System.Int32, System.Int32)?", ntType.ConvertedType.ToTestDisplayString());
+            var nt = comparison.Right;
+            var ntType = model.GetTypeInfo(nt);
+            Assert.Equal("nt", nt.ToString());
+            Assert.Equal("(System.Byte, System.Int32)?", ntType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", ntType.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]
@@ -2703,25 +2611,22 @@ class C
 
             var verifier = CompileAndVerify(comp, expectedOutput: "False False Convert1 True Convert1 True Convert10 False Convert10 False");
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
 
-            //var tree = comp.SyntaxTrees.First();
-            //var model = comp.GetSemanticModel(tree);
+            var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().First();
+            Assert.Equal("(1, 2) == nt", comparison.ToString());
+            var tuple = comparison.Left;
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Equal("(1, 2)", tuple.ToString());
+            Assert.Equal("(System.Int32, System.Int32)", tupleType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", tupleType.ConvertedType.ToTestDisplayString());
 
-            //var comparison = tree.GetCompilationUnitRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().First();
-            //Assert.Equal("(1, 2) == nt", comparison.ToString());
-            //var tuple = comparison.Left;
-            //var tupleType = model.GetTypeInfo(tuple);
-            //Assert.Equal("(1, 2)", tuple.ToString());
-            //Assert.Equal("(System.Int32, System.Int32)", tupleType.Type.ToTestDisplayString());
-            //Assert.Equal("(System.Int32, System.Int32)?", tupleType.ConvertedType.ToTestDisplayString());
-
-            //var nt = comparison.Right;
-            //var ntType = model.GetTypeInfo(nt);
-            //Assert.Equal("nt", nt.ToString());
-            //Assert.Equal("(C, System.Int32)?", ntType.Type.ToTestDisplayString());
-            //Assert.Equal("(System.Int32, System.Int32)?", ntType.ConvertedType.ToTestDisplayString());
+            var nt = comparison.Right;
+            var ntType = model.GetTypeInfo(nt);
+            Assert.Equal("nt", nt.ToString());
+            Assert.Equal("(C, System.Int32)?", ntType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)?", ntType.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]
@@ -2806,8 +2711,16 @@ class C
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "True False False True");
-            // PROTOTYPE(tuple-equality) Semantic model: check type of null
-        }
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var lastNull = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().Last();
+            Assert.Equal("null", lastNull.ToString());
+            var nullType = model.GetTypeInfo(lastNull);
+            Assert.Null(nullType.Type);
+            Assert.Null(nullType.ConvertedType); // In nullable-null comparison, the null literal remains typeless
+         }
 
         [Fact]
         public void TestOnLongTuple()
@@ -2892,18 +2805,15 @@ class C
                 Diagnostic(ErrorCode.ERR_BadBinaryOps, "t.Rest == t.Rest").WithArguments("==", "ValueTuple<int?>", "ValueTuple<int?>").WithLocation(18, 16)
                 );
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var comparison = tree.GetRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Last();
+            Assert.Equal("t.Rest == t.Rest", comparison.ToString());
 
-            //var tree = comp.SyntaxTrees.First();
-            //var model = comp.GetSemanticModel(tree);
-            //var comparison = tree.GetRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Last();
-            //Assert.Equal("t.Rest == t.Rest", comparison.ToString());
-
-            //var left = model.GetTypeInfo(comparison.Left);
-            //Assert.Equal("ValueTuple<System.Int32?>", left.Type.ToTestDisplayString());
-            //Assert.Equal("System.Object", left.ConvertedType.ToTestDisplayString());
-            //Assert.True(left.Type.IsTupleType); // PROTOTYPE(tuple-equality) Need to investigate this
+            var left = model.GetTypeInfo(comparison.Left);
+            Assert.Equal("ValueTuple<System.Int32?>", left.Type.ToTestDisplayString());
+            Assert.Equal("ValueTuple<System.Int32?>", left.ConvertedType.ToTestDisplayString());
+            Assert.True(left.Type.IsTupleType); // PROTOTYPE(tuple-equality) Need to investigate this
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -718,6 +718,11 @@ class C
                 //         _ = !t1; // error 4
                 Diagnostic(ErrorCode.ERR_BadUnaryOp, "!t1").WithArguments("!", "(int, int)").WithLocation(10, 13)
                 );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var tuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().Single();
+            Assert.Equal("(System.Int32, System.Int32)", model.GetDeclaredSymbol(tuple).ToTestDisplayString());
         }
 
         [Fact]


### PR DESCRIPTION
Two parts of this change:
- adding `ConvertedLeft` and `ConvertedRight` to the bound node for tuple comparison. Those are only used by the semantic model, but skipped by other visitors. One subtlety: They cannot be made by applying a conversion on the top-level tuple, but rather we try to give each element an converted type if we can (even if the containing tuple remains typeless).
- adding a third kind of `TupleBinaryOperatorKind` to represent `null == null` element-wise comparison while keeping such `null`s typeless.

