### PR TITLE
Give default literals a type in tuple comparisons

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -487,8 +487,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundLiteral(node, ConstantValue.Create(kind == BinaryOperatorKind.Equal), GetSpecialType(SpecialType.System_Boolean, diagnostics, node));
             }
 
-            if (GetTupleCardinality(left) > 1 &&
-                GetTupleCardinality(right) > 1 &&
+            if (IsTupleBinaryOperation(left, right) &&
                 (kind == BinaryOperatorKind.Equal || kind == BinaryOperatorKind.NotEqual))
             {
                 CheckFeatureAvailability(node, MessageID.IDS_FeatureTupleEquality, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundTupleBinaryOperator BindTupleBinaryOperator(BinaryExpressionSyntax node, BinaryOperatorKind kind,
             BoundExpression left, BoundExpression right, DiagnosticBag diagnostics)
         {
-            // PROTOTYPE(tuple-equality) Block in expression tree
             TupleBinaryOperatorInfo.Multiple operators = BindTupleBinaryOperatorNestedInfo(node, kind, left, right, diagnostics);
 
             // The converted types are only used for the semantic model, so we don't need the conversion diagnostics

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4445,7 +4445,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An expression tree may not contain a tuple binary operator.
+        ///   Looks up a localized string similar to An expression tree may not contain a tuple == or != operator.
         /// </summary>
         internal static string ERR_ExpressionTreeContainsTupleBinOp {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4445,6 +4445,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An expression tree may not contain a tuple binary operator.
+        /// </summary>
+        internal static string ERR_ExpressionTreeContainsTupleBinOp {
+            get {
+                return ResourceManager.GetString("ERR_ExpressionTreeContainsTupleBinOp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An expression tree may not contain a tuple conversion..
         /// </summary>
         internal static string ERR_ExpressionTreeContainsTupleConversion {
@@ -10269,7 +10278,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         ///                               form: /t:exe)
         /// /target:winexe                Build a Windows executable (Short form:
         ///                               /t:winexe)
-        /// /target:library        [rest of string was truncated]&quot;;.
+        /// /target:library               Bu [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string IDS_CSCHelp {
             get {
@@ -13749,7 +13758,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         ///
         ///Although C# distinguishes between out and ref, the CLR sees them as the same. When deciding which method implements the interface, the CLR just picks one.
         ///
-        ///Give the compiler some way to differentiate the methods. For example, you ca [rest of string was truncated]&quot;;.
+        ///Give the compiler some way to differentiate the methods. For example, you can gi [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string WRN_MultipleRuntimeImplementationMatches_Description {
             get {
@@ -14183,7 +14192,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         /// <summary>
         ///   Looks up a localized string similar to You have added a reference to an assembly using /link (Embed Interop Types property set to True). This instructs the compiler to embed interop type information from that assembly. However, the compiler cannot embed interop type information from that assembly because another assembly that you have referenced also references that assembly using /reference (Embed Interop Types property set to False).
         ///
-        ///To embed interop type information for both assemblies, use /link for references to each assembly (set the Em [rest of string was truncated]&quot;;.
+        ///To embed interop type information for both assemblies, use /link for references to each assembly (set the Embe [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string WRN_ReferencedAssemblyReferencesLinkedPIA_Description {
             get {
@@ -14599,7 +14608,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         /// <summary>
         ///   Looks up a localized string similar to This warning is caused when a catch() block has no specified exception type after a catch (System.Exception e) block. The warning advises that the catch() block will not catch any exceptions.
         ///
-        ///A catch() block after a catch (System.Exception e) block can catch non-CLS exceptions if the RuntimeCompatibilityAttribute is set to false in the AssemblyInfo.cs file: [assembly: RuntimeCompatibilityAttribute(WrapNonExceptionThrows = false)]. If this attribute is not set explicitly to false, all thrown non-CLS excep [rest of string was truncated]&quot;;.
+        ///A catch() block after a catch (System.Exception e) block can catch non-CLS exceptions if the RuntimeCompatibilityAttribute is set to false in the AssemblyInfo.cs file: [assembly: RuntimeCompatibilityAttribute(WrapNonExceptionThrows = false)]. If this attribute is not set explicitly to false, all thrown non-CLS excepti [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string WRN_UnreachableGeneralCatch_Description {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2176,7 +2176,7 @@ If such a class is used as a base class and if the deriving class defines a dest
     <value>An expression tree may not contain a base access</value>
   </data>
   <data name="ERR_ExpressionTreeContainsTupleBinOp" xml:space="preserve">
-    <value>An expression tree may not contain a tuple binary operator</value>
+    <value>An expression tree may not contain a tuple == or != operator</value>
   </data>
   <data name="ERR_ExpressionTreeContainsAssignment" xml:space="preserve">
     <value>An expression tree may not contain an assignment operator</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2175,6 +2175,9 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_ExpressionTreeContainsBaseAccess" xml:space="preserve">
     <value>An expression tree may not contain a base access</value>
   </data>
+  <data name="ERR_ExpressionTreeContainsTupleBinOp" xml:space="preserve">
+    <value>An expression tree may not contain a tuple binary operator</value>
+  </data>
   <data name="ERR_ExpressionTreeContainsAssignment" xml:space="preserve">
     <value>An expression tree may not contain an assignment operator</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1561,6 +1561,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DoNotUseFixedBufferAttrOnProperty = 8372,
 
         ERR_TupleSizesMismatchForBinOps = 8373,
+        ERR_ExpressionTreeContainsTupleBinOp = 8374,
         #endregion diagnostics introduced for C# 7.3
 
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -692,6 +692,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Error(ErrorCode.ERR_ExpressionTreeContainsTupleBinOp, node);
             }
+
             return base.VisitTupleBinaryOperator(node);
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -686,6 +686,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitTupleLiteral(node);
         }
 
+        public override BoundNode VisitTupleBinaryOperator(BoundTupleBinaryOperator node)
+        {
+            if (_inExpressionLambda)
+            {
+                Error(ErrorCode.ERR_ExpressionTreeContainsTupleBinOp, node);
+            }
+            return base.VisitTupleBinaryOperator(node);
+        }
+
         public override BoundNode VisitThrowExpression(BoundThrowExpression node)
         {
             if (_inExpressionLambda)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
@@ -101,6 +101,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression RewriteTupleNestedOperators(TupleBinaryOperatorInfo.Multiple operators, BoundExpression left, BoundExpression right,
             TypeSymbol boolType, ArrayBuilder<LocalSymbol> temps, BinaryOperatorKind operatorKind)
         {
+            left = Binder.GiveTupleTypeToDefaultLiteralIfNeeded(left, right.Type);
+            right = Binder.GiveTupleTypeToDefaultLiteralIfNeeded(right, left.Type);
+
             // If either left or right is nullable, produce:
             //
             //      // outer sequence

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8631,8 +8631,8 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8630,6 +8630,11 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8631,8 +8631,8 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8630,6 +8630,11 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8630,6 +8630,11 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8631,8 +8631,8 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8630,6 +8630,11 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8631,8 +8631,8 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8630,6 +8630,11 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8631,8 +8631,8 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8630,6 +8630,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8630,6 +8630,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8631,8 +8631,8 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8630,6 +8630,11 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8630,6 +8630,11 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8631,8 +8631,8 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8630,6 +8630,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8630,6 +8630,11 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8631,8 +8631,8 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8630,6 +8630,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
-        <source>An expression tree may not contain a tuple binary operator</source>
-        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <source>An expression tree may not contain a tuple == or != operator</source>
+        <target state="new">An expression tree may not contain a tuple == or != operator</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8630,6 +8630,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsTupleBinOp">
+        <source>An expression tree may not contain a tuple binary operator</source>
+        <target state="new">An expression tree may not contain a tuple binary operator</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -929,7 +929,7 @@ class C
             Assert.Equal(ConversionKind.ImplicitReference, model.GetConversion(lastNull).Kind);
         }
 
-        [Fact(Skip = "PROTOTYPE(tuple-equality) Default")]
+        [Fact]
         public void TestTypedTupleAndDefault()
         {
             var source = @"
@@ -939,17 +939,33 @@ class C
     {
         (string, string) t = (null, null);
         System.Console.Write(t == default);
+        System.Console.Write(t != default);
+
+        (string, string) t2 = (null, ""hello"");
+        System.Console.Write(t2 == default);
+        System.Console.Write(t2 != default);
     }
 }";
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics(
-                // (7,30): error CS8310: Operator '==' cannot be applied to operand 'default'
-                //         System.Console.Write(t == default);
-                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "t == default").WithArguments("==", "default").WithLocation(7, 30)
-                );
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "TrueFalseFalseTrue");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var defaultLiterals = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LiteralExpressionSyntax>()
+                .Where(e => e.Kind() == SyntaxKind.DefaultLiteralExpression);
+
+            foreach (var literal in defaultLiterals)
+            {
+                Assert.Equal("default", literal.ToString());
+                var info = model.GetTypeInfo(literal);
+                Assert.Equal("(System.String, System.String)", info.Type.ToTestDisplayString());
+                Assert.Equal("(System.String, System.String)", info.ConvertedType.ToTestDisplayString());
+            }
         }
 
-        [Fact(Skip = "PROTOTYPE(tuple-equality) Default")]
+        [Fact]
         public void TestNullableTupleAndDefault()
         {
             var source = @"
@@ -959,13 +975,138 @@ class C
     {
         (string, string)? t = (null, null);
         System.Console.Write(t == default);
+        System.Console.Write(t != default);
+        System.Console.Write(default == t);
+        System.Console.Write(default != t);
+    }
+}";
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "FalseTrueFalseTrue");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var defaultLiterals = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LiteralExpressionSyntax>()
+                .Where(e => e.Kind() == SyntaxKind.DefaultLiteralExpression);
+
+            foreach (var literal in defaultLiterals)
+            {
+                Assert.Equal("default", literal.ToString());
+                var info = model.GetTypeInfo(literal);
+                Assert.Equal("(System.String, System.String)?", info.Type.ToTestDisplayString());
+                Assert.Equal("(System.String, System.String)?", info.ConvertedType.ToTestDisplayString());
+            }
+        }
+
+        [Fact]
+        public void TestNullableTupleAndDefault_Nested()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (string, string)? t = (null, null);
+        System.Console.Write((null, t) == (null, default));
+        System.Console.Write((t, null) != (default, null));
+    }
+}";
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "FalseTrue");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var defaultLiterals = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LiteralExpressionSyntax>()
+                .Where(e => e.Kind() == SyntaxKind.DefaultLiteralExpression);
+
+            foreach (var literal in defaultLiterals)
+            {
+                Assert.Equal("default", literal.ToString());
+                var info = model.GetTypeInfo(literal);
+                Assert.Equal("(System.String, System.String)?", info.Type.ToTestDisplayString());
+                Assert.Equal("(System.String, System.String)?", info.ConvertedType.ToTestDisplayString());
+            }
+        }
+
+        [Fact]
+        public void TestNestedDefaultWithNonTupleType()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write((null, 1) == (null, default));
+        System.Console.Write((0, null) != (default, null));
+    }
+}";
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "FalseFalse");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var defaultLiterals = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LiteralExpressionSyntax>()
+                .Where(e => e.Kind() == SyntaxKind.DefaultLiteralExpression);
+
+            foreach (var literal in defaultLiterals)
+            {
+                Assert.Equal("default", literal.ToString());
+                var info = model.GetTypeInfo(literal);
+                Assert.Equal("System.Int32", info.Type.ToTestDisplayString());
+                Assert.Equal("System.Int32", info.ConvertedType.ToTestDisplayString());
+            }
+        }
+
+        [Fact]
+        public void TestAllDefaults()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write((default, default) == (default, default));
+        System.Console.Write(default == (default, default));
     }
 }";
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (7,30): error CS8310: Operator '==' cannot be applied to operand 'default'
-                //         System.Console.Write(t == default);
-                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "t == default").WithArguments("==", "default").WithLocation(7, 30)
+                // (6,30): error CS8315: Operator '==' is ambiguous on operands 'default' and 'default'
+                //         System.Console.Write((default, default) == (default, default));
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "(default, default) == (default, default)").WithArguments("==").WithLocation(6, 30),
+                // (6,30): error CS8315: Operator '==' is ambiguous on operands 'default' and 'default'
+                //         System.Console.Write((default, default) == (default, default));
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "(default, default) == (default, default)").WithArguments("==").WithLocation(6, 30),
+                // (7,30): error CS0034: Operator '==' is ambiguous on operands of type 'default' and '(default, default)'
+                //         System.Console.Write(default == (default, default));
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "default == (default, default)").WithArguments("==", "default", "(default, default)").WithLocation(7, 30)
+                );
+        }
+
+        [Fact]
+        public void TestAllDefaults_Nested()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write((null, (default, default)) == (null, (default, default)));
+    }
+}";
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (6,30): error CS8315: Operator '==' is ambiguous on operands 'default' and 'default'
+                //         System.Console.Write((null, (default, default)) == (null, (default, default)));
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "(null, (default, default)) == (null, (default, default))").WithArguments("==").WithLocation(6, 30),
+                // (6,30): error CS8315: Operator '==' is ambiguous on operands 'default' and 'default'
+                //         System.Console.Write((null, (default, default)) == (null, (default, default)));
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "(null, (default, default)) == (null, (default, default))").WithArguments("==").WithLocation(6, 30)
                 );
         }
 
@@ -985,10 +1126,48 @@ class C
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "TrueFalse");
-            // PROTOTYPE(tuple-equality) Expand this test
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var lastTuple = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TupleExpressionSyntax>().Last();
+
+            Assert.Equal("(default, default)", lastTuple.ToString());
+            Assert.Null(model.GetTypeInfo(lastTuple).Type);
+            Assert.Equal("(System.String, System.String)?", model.GetTypeInfo(lastTuple).ConvertedType.ToTestDisplayString());
+
+            var lastDefault = lastTuple.Arguments[1].Expression;
+            Assert.Equal("default", lastDefault.ToString());
+            Assert.Equal("System.String", model.GetTypeInfo(lastDefault).Type.ToTestDisplayString());
+            Assert.Equal("System.String", model.GetTypeInfo(lastDefault).ConvertedType.ToTestDisplayString());
         }
 
-        [Fact(Skip = "PROTOTYPE(tuple-equality) Default")]
+        [Fact]
+        public void TestTypelessTupleAndTupleOfDefaults()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write((null, () => 1) == (default, default));
+        System.Console.Write((null, () => 2) == default);
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,30): error CS0034: Operator '==' is ambiguous on operands of type '<null>' and 'default'
+                //         System.Console.Write((null, () => 1) == (default, default));
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "(null, () => 1) == (default, default)").WithArguments("==", "<null>", "default").WithLocation(6, 30),
+                // (6,30): error CS0019: Operator '==' cannot be applied to operands of type 'lambda expression' and 'default'
+                //         System.Console.Write((null, () => 1) == (default, default));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(null, () => 1) == (default, default)").WithArguments("==", "lambda expression", "default").WithLocation(6, 30),
+                // (7,30): error CS0034: Operator '==' is ambiguous on operands of type '(<null>, lambda expression)' and 'default'
+                //         System.Console.Write((null, () => 2) == default);
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "(null, () => 2) == default").WithArguments("==", "(<null>, lambda expression)", "default").WithLocation(7, 30)
+                );
+        }
+
+        [Fact]
         public void TestNullableStructAndDefault()
         {
             var source = @"
@@ -999,21 +1178,29 @@ struct S
         S? ns = new S();
         _ = ns == null;
         _ = s == null;
-        _ = ns == default;
-        _ = (ns, ns) == (default, default);
+        _ = ns == default; // error 1
+        _ = (ns, ns) == (null, null);
+        _ = (ns, ns) == (default, default); // errors 2 and 3
+        _ = (ns, ns) == default; // error 4
     }
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (9,13): error CS8310: Operator '==' cannot be applied to operand 'default'
-                //         _ = ns == default;
-                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "ns == default").WithArguments("==", "default").WithLocation(9, 13),
-                // (10,13): error CS8310: Operator '==' cannot be applied to operand 'default'
-                //         _ = (ns, ns) == (default, default);
-                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "(ns, ns) == (default, default)").WithArguments("==", "default").WithLocation(10, 13),
-                // (10,13): error CS8310: Operator '==' cannot be applied to operand 'default'
-                //         _ = (ns, ns) == (default, default);
-                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "(ns, ns) == (default, default)").WithArguments("==", "default").WithLocation(10, 13)
+                // (9,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'default'
+                //         _ = ns == default; // error 1
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "ns == default").WithArguments("==", "S?", "default").WithLocation(9, 13),
+                // (11,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'default'
+                //         _ = (ns, ns) == (default, default); // errors 2 and 3
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(ns, ns) == (default, default)").WithArguments("==", "S?", "default").WithLocation(11, 13),
+                // (11,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'default'
+                //         _ = (ns, ns) == (default, default); // errors 2 and 3
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(ns, ns) == (default, default)").WithArguments("==", "S?", "default").WithLocation(11, 13),
+                // (12,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'S?'
+                //         _ = (ns, ns) == default; // error 4
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(ns, ns) == default").WithArguments("==", "S?", "S?").WithLocation(12, 13),
+                // (12,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'S?'
+                //         _ = (ns, ns) == default; // error 4
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(ns, ns) == default").WithArguments("==", "S?", "S?").WithLocation(12, 13)
                 );
 
             var tree = comp.SyntaxTrees[0];
@@ -1029,16 +1216,73 @@ struct S
             Assert.Null(model.GetTypeInfo(nullLiteral2).Type);
             Assert.Equal("System.String", model.GetTypeInfo(nullLiteral2).ConvertedType.ToTestDisplayString());
 
-            // PROTOTYPE(tuple-equality) Semantic model
-            return;
+            var defaultLiterals = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LiteralExpressionSyntax>()
+                .Where(e => e.Kind() == SyntaxKind.DelegateDeclaration);
 
-            //var defaultLiteral = literals.ElementAt(2);
-            //Assert.Equal("default", defaultLiteral.ToString());
-            //Assert.Equal("System.Object", model.GetTypeInfo(defaultLiteral).ConvertedType.ToTestDisplayString());
+            foreach (var defaultLiteral in defaultLiterals)
+            {
+                Assert.Equal("default", defaultLiteral.ToString());
+                Assert.Null(model.GetTypeInfo(defaultLiteral).Type);
+                Assert.Null(model.GetTypeInfo(defaultLiteral).ConvertedType);
+            }
+        }
 
-            //var defaultLiteral2 = literals.ElementAt(3);
-            //Assert.Equal("default", defaultLiteral2.ToString());
-            //Assert.Equal("System.Object", model.GetTypeInfo(defaultLiteral2).ConvertedType.ToTestDisplayString());
+        [Fact, WorkItem(25318, "https://github.com/dotnet/roslyn/issues/25318")]
+        public void TestNullableStructAndDefault_WithComparisonOperator()
+        {
+            var source = @"
+public struct S
+{
+    static void M(string s)
+    {
+        S? ns = new S();
+        _ = ns == 1;
+        _ = (ns, ns) == (default, default);
+        _ = (ns, ns) == default;
+    }
+    public static bool operator==(S s, byte b) => throw null;
+    public static bool operator!=(S s, byte b) => throw null;
+    public override bool Equals(object other) => throw null;
+    public override int GetHashCode() => throw null;
+}";
+            var comp = CreateCompilation(source);
+
+            // https://github.com/dotnet/roslyn/issues/25318
+            // This should be allowed
+
+            comp.VerifyDiagnostics(
+                // (7,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'int'
+                //         _ = ns == 1;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "ns == 1").WithArguments("==", "S?", "int").WithLocation(7, 13),
+                // (8,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'default'
+                //         _ = (ns, ns) == (default, default);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(ns, ns) == (default, default)").WithArguments("==", "S?", "default").WithLocation(8, 13),
+                // (8,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'default'
+                //         _ = (ns, ns) == (default, default);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(ns, ns) == (default, default)").WithArguments("==", "S?", "default").WithLocation(8, 13),
+                // (9,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'S?'
+                //         _ = (ns, ns) == default;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(ns, ns) == default").WithArguments("==", "S?", "S?").WithLocation(9, 13),
+                // (9,13): error CS0019: Operator '==' cannot be applied to operands of type 'S?' and 'S?'
+                //         _ = (ns, ns) == default;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(ns, ns) == default").WithArguments("==", "S?", "S?").WithLocation(9, 13)
+                );
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var defaultLiterals = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LiteralExpressionSyntax>()
+                .Where(e => e.Kind() == SyntaxKind.DelegateDeclaration);
+
+            // Should have types
+            foreach (var defaultLiteral in defaultLiterals)
+            {
+                Assert.Equal("default", defaultLiteral.ToString());
+                Assert.Null(model.GetTypeInfo(defaultLiteral).Type);
+                Assert.Null(model.GetTypeInfo(defaultLiteral).ConvertedType);
+                // https://github.com/dotnet/roslyn/issues/25318
+                // PROTOTYPE(tuple-equality) default should become int
+            }
         }
 
         [Fact]
@@ -1666,8 +1910,7 @@ public class C
     }
 }
 ";
-            var comp = CreateCompilation(source, options: TestOptions.DebugExe,
-                references: new[] { CSharpRef, SystemCoreRef });
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, references: new[] { CSharpRef, SystemCoreRef });
             comp.VerifyDiagnostics();
 
             CompileAndVerify(comp, expectedOutput:
@@ -1705,8 +1948,7 @@ public class C
     }
 }
 ";
-            var comp = CreateCompilation(source, options: TestOptions.DebugExe,
-                references: new[] { CSharpRef, SystemCoreRef });
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, references: new[] { CSharpRef, SystemCoreRef });
             comp.VerifyDiagnostics();
 
             CompileAndVerify(comp, expectedOutput:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -3961,6 +3961,37 @@ namespace System
             // Note: tuple equality picked ahead of custom operator==
             CompileAndVerify(comp, expectedOutput: "False");
         }
+
+        [Fact]
+        public void TestInExpressionTree()
+        {
+            var source = @"
+using System;
+using System.Linq.Expressions;
+public class C
+{
+    public static void Main()
+    {
+        Expression<Func<int, bool>> expr = i => (i, i) == (i, i);
+        Expression<Func<(int, int), bool>> expr2 = t => t == t;
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (8,49): error CS8374: An expression tree may not contain a tuple binary operator
+                //         Expression<Func<int, bool>> expr = i => (i, i) == (i, i);
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsTupleBinOp, "(i, i) == (i, i)").WithLocation(8, 49),
+                // (8,49): error CS8143: An expression tree may not contain a tuple literal.
+                //         Expression<Func<int, bool>> expr = i => (i, i) == (i, i);
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsTupleLiteral, "(i, i)").WithLocation(8, 49),
+                // (8,59): error CS8143: An expression tree may not contain a tuple literal.
+                //         Expression<Func<int, bool>> expr = i => (i, i) == (i, i);
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsTupleLiteral, "(i, i)").WithLocation(8, 59),
+                // (9,57): error CS8374: An expression tree may not contain a tuple binary operator
+                //         Expression<Func<(int, int), bool>> expr2 = t => t == t;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsTupleBinOp, "t == t").WithLocation(9, 57)
+                );
+        }
     }
 }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1196,7 +1196,7 @@ MODIFIER MyType
             validate("class", "MyType", "new MyType()", "false", "System.Object");
 
             // struct MyType doesn't have an == operator
-            validate("struct", "MyType", "new MyType()", "false", "System.Object",
+            validate("struct", "MyType", "new MyType()", "false", semanticType: null,
                 // (8,14): error CS0019: Operator '==' cannot be applied to operands of type 'MyType' and 'default'
                 //         if ((x == default) != false) throw null;
                 Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "MyType", "default").WithLocation(8, 14),
@@ -1218,7 +1218,7 @@ MODIFIER MyType
                 );
 
             // struct MyType doesn't have an == operator, so no lifted == operator on MyType?
-            validate("struct", "MyType?", "null", "true", "System.Object",
+            validate("struct", "MyType?", "null", "true", semanticType: null,
                 // (8,14): error CS0019: Operator '==' cannot be applied to operands of type 'MyType?' and 'default'
                 //         if ((x == default) != true) throw null;
                 Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "MyType?", "default").WithLocation(8, 14),
@@ -1238,74 +1238,6 @@ MODIFIER MyType
                 //         if ((x != default(MyType?)) == true) throw null;
                 Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default(MyType?)").WithArguments("!=", "MyType?", "MyType?").WithLocation(15, 14)
                 );
-
-            // PROTOTYPE(tuple-equality) Default
-
-            // struct ValueTuple doesn't have an == operator
-            //validate("class", "(int, int)", "(1, 2)", "false", "System.Object",
-            //    // (8,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and 'default'
-            //    //         if ((x == default) != false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "(int, int)", "default").WithLocation(8, 14),
-            //    // (9,14): error CS0019: Operator '==' cannot be applied to operands of type 'default' and '(int, int)'
-            //    //         if ((default == x) != false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "default == x").WithArguments("==", "default", "(int, int)").WithLocation(9, 14),
-            //    // (11,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)' and 'default'
-            //    //         if ((x != default) == false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default").WithArguments("!=", "(int, int)", "default").WithLocation(11, 14),
-            //    // (12,14): error CS0019: Operator '!=' cannot be applied to operands of type 'default' and '(int, int)'
-            //    //         if ((default != x) == false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "default != x").WithArguments("!=", "default", "(int, int)").WithLocation(12, 14),
-            //    // (14,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and '(int, int)'
-            //    //         if ((x == default((int, int))) != false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default((int, int))").WithArguments("==", "(int, int)", "(int, int)").WithLocation(14, 14),
-            //    // (15,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)' and '(int, int)'
-            //    //         if ((x != default((int, int))) == false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default((int, int))").WithArguments("!=", "(int, int)", "(int, int)").WithLocation(15, 14)
-            //    );
-
-            // struct ValueTuple doesn't have an == operator
-            //validate("class", "(int, int)", "(0, 0)", "false", "System.Object",
-            //    // (8,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and 'default'
-            //    //         if ((x == default) != false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "(int, int)", "default").WithLocation(8, 14),
-            //    // (9,14): error CS0019: Operator '==' cannot be applied to operands of type 'default' and '(int, int)'
-            //    //         if ((default == x) != false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "default == x").WithArguments("==", "default", "(int, int)").WithLocation(9, 14),
-            //    // (11,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)' and 'default'
-            //    //         if ((x != default) == false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default").WithArguments("!=", "(int, int)", "default").WithLocation(11, 14),
-            //    // (12,14): error CS0019: Operator '!=' cannot be applied to operands of type 'default' and '(int, int)'
-            //    //         if ((default != x) == false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "default != x").WithArguments("!=", "default", "(int, int)").WithLocation(12, 14),
-            //    // (14,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and '(int, int)'
-            //    //         if ((x == default((int, int))) != false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default((int, int))").WithArguments("==", "(int, int)", "(int, int)").WithLocation(14, 14),
-            //    // (15,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)' and '(int, int)'
-            //    //         if ((x != default((int, int))) == false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default((int, int))").WithArguments("!=", "(int, int)", "(int, int)").WithLocation(15, 14)
-            //    );
-
-            // struct ValueTuple doesn't have an == operator, so no lifted == on ValueTuple?
-            //validate("class", "(int, int)?", "(0, 0)", "false", "System.Object",
-            //    // (8,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)?' and 'default'
-            //    //         if ((x == default) != false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "(int, int)?", "default").WithLocation(8, 14),
-            //    // (9,14): error CS0019: Operator '==' cannot be applied to operands of type 'default' and '(int, int)?'
-            //    //         if ((default == x) != false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "default == x").WithArguments("==", "default", "(int, int)?").WithLocation(9, 14),
-            //    // (11,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)?' and 'default'
-            //    //         if ((x != default) == false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default").WithArguments("!=", "(int, int)?", "default").WithLocation(11, 14),
-            //    // (12,14): error CS0019: Operator '!=' cannot be applied to operands of type 'default' and '(int, int)?'
-            //    //         if ((default != x) == false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "default != x").WithArguments("!=", "default", "(int, int)?").WithLocation(12, 14),
-            //    // (14,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)?' and '(int, int)?'
-            //    //         if ((x == default((int, int)?)) != false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default((int, int)?)").WithArguments("==", "(int, int)?", "(int, int)?").WithLocation(14, 14),
-            //    // (15,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)?' and '(int, int)?'
-            //    //         if ((x != default((int, int)?)) == false) throw null;
-            //    Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default((int, int)?)").WithArguments("!=", "(int, int)?", "(int, int)?").WithLocation(15, 14)
-            //    );
 
             void validate(string modifier, string type, string value, string equal, string semanticType, params DiagnosticDescription[] diagnostics)
             {
@@ -1336,9 +1268,74 @@ MODIFIER MyType
                 foreach (var @default in defaults)
                 {
                     Assert.Equal("default", @default.ToString());
-                    // PROTOTYPE(tuple-equality) Default
-                    //Assert.Equal(semanticType, model.GetTypeInfo(@default).Type.ToTestDisplayString());
-                    //Assert.Equal(semanticType, model.GetTypeInfo(@default).ConvertedType.ToTestDisplayString());
+                    if (semanticType is null)
+                    {
+                        Assert.Null(model.GetTypeInfo(@default).Type);
+                        Assert.Null(model.GetTypeInfo(@default).ConvertedType);
+                    }
+                    else
+                    {
+                        Assert.Equal(semanticType, model.GetTypeInfo(@default).Type.ToTestDisplayString());
+                        Assert.Equal(semanticType, model.GetTypeInfo(@default).ConvertedType.ToTestDisplayString());
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void EqualityComparison_Tuples()
+        {
+            string template = @"
+MODIFIER MyType
+{
+    static void Main()
+    {
+        TYPE x = VALUE;
+
+        if ((x == default) != EQUAL) throw null;
+        if ((default == x) != EQUAL) throw null;
+
+        if ((x != default) == EQUAL) throw null;
+        if ((default != x) == EQUAL) throw null;
+
+        if ((x == default(TYPE)) != EQUAL) throw null;
+        if ((x != default(TYPE)) == EQUAL) throw null;
+
+        System.Console.Write(""Done"");
+    }
+}
+";
+
+            validate("class", "(int, int)", "(1, 2)", "false", "(System.Int32, System.Int32)");
+            validate("class", "(int, int)", "(0, 0)", "true", "(System.Int32, System.Int32)");
+            validate("class", "(int, int)?", "null", "true", "(System.Int32, System.Int32)?");
+            validate("class", "(int, int)?", "(0, 0)", "false", "(System.Int32, System.Int32)?");
+
+            void validate(string modifier, string type, string value, string equal, string semanticType, params DiagnosticDescription[] diagnostics)
+            {
+                var source = template.Replace("MODIFIER", modifier).Replace("TYPE", type).Replace("VALUE", value).Replace("EQUAL", equal);
+                var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_3, options: TestOptions.DebugExe);
+                if (diagnostics.Length == 0)
+                {
+                    comp.VerifyDiagnostics();
+                    CompileAndVerify(comp, expectedOutput: "Done");
+                }
+                else
+                {
+                    comp.VerifyDiagnostics(diagnostics);
+                }
+
+                var tree = comp.SyntaxTrees.First();
+                var model = comp.GetSemanticModel(tree);
+                var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+                var defaults = nodes.OfType<LiteralExpressionSyntax>().Where(l => l.ToString() == "default");
+                Assert.True(defaults.Count() == 4);
+                foreach (var @default in defaults)
+                {
+                    Assert.Equal("default", @default.ToString());
+                    Assert.Equal(semanticType, model.GetTypeInfo(@default).Type.ToTestDisplayString());
+                    Assert.Equal(semanticType, model.GetTypeInfo(@default).ConvertedType.ToTestDisplayString());
                 }
             }
         }


### PR DESCRIPTION
Note:
Only the last two commits in this PR are new. The rest is the work to compute converted left/right in tuple equality (from PR https://github.com/dotnet/roslyn/pull/25297).

The second-to-last commit handles `default` being compared to a tuple (or nullable tuple).

Examples:
- `(0, 0) == default \\ true, same as default((int, int))`
- `(null, 0) == (null, default) \\ true`
- `(int, int)? nullableTuple; nullableTuple == default \\ same as default( (int, int)? )`

The last commit blocks tuple binops in expression trees.