### PR TITLE
Adjust indent block operations used for VB smart indent in argument lists

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2841,9 +2841,9 @@ End Class"
             Dim code = "
 Class C
     Sub M()
-        Console.WriteLine(""{0} + {1}"",
-            19, 23 +
-                19,
+        Method(a +
+          b, c +
+          d,
 
     End Sub
 End Class"
@@ -2851,26 +2851,7 @@ End Class"
             AssertSmartIndent(
                 code,
                 indentationLine:=6,
-                expectedIndentation:=12)
-        End Sub
-
-        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
-        Public Sub TestSmartIndentInArgumentLists4()
-            Dim code = "
-Class C
-    Sub M()
-        Console.WriteLine(""{0} + {1}"",
-            19, 23,
-                19,
-
-    End Sub
-End Class"
-
-            AssertSmartIndent(
-                code,
-                indentationLine:=6,
-                expectedIndentation:=16)
+                expectedIndentation:=13)
         End Sub
 
         <WorkItem(25323, "https://github.com/dotnet/roslyn/issues/25323")>

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2802,6 +2802,41 @@ End Class
 
         <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub TestSmartIndentInArgumentLists1()
+            Dim code = "
+Class C
+    Sub M()
+        Console.WriteLine(""{0} + {1}"",
+
+    End Sub
+End Class"
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=4,
+                expectedIndentation:=26)
+        End Sub
+
+        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub TestSmartIndentInArgumentLists2()
+            Dim code = "
+Class C
+    Sub M()
+        Console.WriteLine(""{0} + {1}"",
+            19,
+
+    End Sub
+End Class"
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=5,
+                expectedIndentation:=12)
+        End Sub
+
+        <WorkItem(25323, "https://github.com/dotnet/roslyn/issues/25323")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub TestSmartIndentAtCaseBlockEndUntabbedComment()
             Dim code = <code>Class Program
     Public Sub M()

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2835,6 +2835,44 @@ End Class"
                 expectedIndentation:=12)
         End Sub
 
+        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub TestSmartIndentInArgumentLists3()
+            Dim code = "
+Class C
+    Sub M()
+        Console.WriteLine(""{0} + {1}"",
+            19, 23 +
+                19,
+
+    End Sub
+End Class"
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=6,
+                expectedIndentation:=12)
+        End Sub
+
+        <WorkItem(3293, "https://github.com/dotnet/roslyn/issues/3293")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub TestSmartIndentInArgumentLists4()
+            Dim code = "
+Class C
+    Sub M()
+        Console.WriteLine(""{0} + {1}"",
+            19, 23,
+                19,
+
+    End Sub
+End Class"
+
+            AssertSmartIndent(
+                code,
+                indentationLine:=6,
+                expectedIndentation:=16)
+        End Sub
+
         <WorkItem(25323, "https://github.com/dotnet/roslyn/issues/25323")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub TestSmartIndentAtCaseBlockEndUntabbedComment()


### PR DESCRIPTION
Fixes #25323

### Customer scenario

Visual Basic argument lists (and other parenthesized lists, like parameter lists and type parameter lists),
have specialized smart indent behavior. Essentially, arguments after the first argument in a list are
indented to the same position as the first argument. Consider the following code.

``` VB
Sub M()
    Console.WriteLine("{0} + {1} = {2}", 19, 23, 19 + 23)
End Sub
```

If the user presses ENTER before the second argument (19), the indentation looks like so.

``` VB
Sub M()
    Console.WriteLine("{0} + {1} = {2}",
                      19, 23, 19 + 23)
End Sub
```

However, this can cause indentation issues if the user wants to ident all subsequent arguments differently. Consider the following scenario.

``` VB
Sub M()
    Console.WriteLine("{0} + {1} = {2}",
        19, 23,
        19 + 23)
End Sub
```

Now, if the user presses ENTER before the third argument (23), the indentation of the first argument will be used, even though the user had indented the second argument differently:

``` VB
Sub M()
    Console.WriteLine("{0} + {1} = {2}",
        19,
                      23,
        19 + 23)
End Sub
```

This problem occurs because a single indent block operation is created for the whole argument list using the indentation of the first argument. This change fixes the issue by creating multiple indent block operations using the indentation of the first argument, and the indentation of any argument that appears on a different line.

### Bugs this fixes

Fixes #25323

### Workarounds, if any

If the user wishes to format their argument lists in the manner described above, there really isn't a good way to workaround the issue. It's an annoyance and the editor will fight against the user's indentation.

### Risk

Low. This change is localized to indentation in argument lists.

### Performance impact

Low performance impact. Any new allocations do not happen in hot paths -- only when the user presses enter in an argument list.

### Is this a regression from a previous update?

No.

### Root cause analysis

I'm surprised we have not heard about this. This problem shows up in very simple cases where a method call has a large number of arguments. However, it is somewhat less common because many users will move the first argument to the next line and indent *all* arguments together at once.

### How was the bug found?

I was reformatting the VB classification unit tests and found this issue to be particularly frustrating.
