### PR TITLE
Implementing basic GetOperations on tuple equality

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -407,7 +407,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ImmutableArray<Location> elementLocations = elements.SelectAsArray(e => e.Syntax.Location);
 
-            // PROTOTYPE(tuple-equality) Add test for violated tuple constraint
             var tuple = TupleTypeSymbol.Create(locationOpt: null, elementTypes: convertedTypes,
                 elementLocations, elementNames: names, compilation,
                 shouldCheckConstraints: true, errorPositions: default, syntax, diagnostics);
@@ -417,7 +416,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return tuple;
             }
 
-            // PROTOTYPE(tuple-equality) check constraints
+            // Any violated constraints on nullable tuples would have been reported already
             NamedTypeSymbol nullableT = GetSpecialType(SpecialType.System_Nullable_T, diagnostics, syntax);
             return nullableT.Construct(tuple);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -323,7 +323,7 @@
     <Field Name="Left" Type="BoundExpression"/>
     <Field Name="Right" Type="BoundExpression"/>
 
-    <!-- Converted nodes are meant for semantic model use only -->
+    <!-- Converted nodes are meant for semantic model and IOperation use only -->
     <Field Name="ConvertedLeft" Type="BoundExpression" SkipInVisitor="true"/>
     <Field Name="ConvertedRight" Type="BoundExpression" SkipInVisitor="true"/>
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -126,6 +126,8 @@ namespace Microsoft.CodeAnalysis.Operations
                     return CreateBoundUnaryOperatorOperation((BoundUnaryOperator)boundNode);
                 case BoundKind.BinaryOperator:
                     return CreateBoundBinaryOperatorOperation((BoundBinaryOperator)boundNode);
+                case BoundKind.TupleBinaryOperator:
+                    return CreateBoundTupleBinaryOperatorOperation((BoundTupleBinaryOperator)boundNode);
                 case BoundKind.ConditionalOperator:
                     return CreateBoundConditionalOperatorOperation((BoundConditionalOperator)boundNode);
                 case BoundKind.NullCoalescingOperator:
@@ -1110,6 +1112,18 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isCompareText = false;
             bool isImplicit = boundBinaryOperator.WasCompilerGenerated;
             return new LazyBinaryOperatorExpression(operatorKind, leftOperand, rightOperand, isLifted, isChecked, isCompareText, operatorMethod, _semanticModel, syntax, type, constantValue, isImplicit);
+        }
+
+        private ITupleBinaryOperation CreateBoundTupleBinaryOperatorOperation(BoundTupleBinaryOperator boundTupleBinaryOperator)
+        {
+            BinaryOperatorKind operatorKind = Helper.DeriveBinaryOperatorKind(boundTupleBinaryOperator.OperatorKind);
+            Lazy<IOperation> leftOperand = new Lazy<IOperation>(() => Create(boundTupleBinaryOperator.Left));
+            Lazy<IOperation> rightOperand = new Lazy<IOperation>(() => Create(boundTupleBinaryOperator.Right));
+            SyntaxNode syntax = boundTupleBinaryOperator.Syntax;
+            ITypeSymbol type = boundTupleBinaryOperator.Type;
+            Optional<object> constantValue = ConvertToOptional(boundTupleBinaryOperator.ConstantValue);
+            bool isImplicit = boundTupleBinaryOperator.WasCompilerGenerated;
+            return new LazyTupleBinaryOperatorExpression(operatorKind, leftOperand, rightOperand, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
         private IConditionalOperation CreateBoundConditionalOperatorOperation(BoundConditionalOperator boundConditionalOperator)

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1117,8 +1117,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private ITupleBinaryOperation CreateBoundTupleBinaryOperatorOperation(BoundTupleBinaryOperator boundTupleBinaryOperator)
         {
             BinaryOperatorKind operatorKind = Helper.DeriveBinaryOperatorKind(boundTupleBinaryOperator.OperatorKind);
-            Lazy<IOperation> leftOperand = new Lazy<IOperation>(() => Create(boundTupleBinaryOperator.Left));
-            Lazy<IOperation> rightOperand = new Lazy<IOperation>(() => Create(boundTupleBinaryOperator.Right));
+            Lazy<IOperation> leftOperand = new Lazy<IOperation>(() => Create(boundTupleBinaryOperator.ConvertedLeft));
+            Lazy<IOperation> rightOperand = new Lazy<IOperation>(() => Create(boundTupleBinaryOperator.ConvertedRight));
             SyntaxNode syntax = boundTupleBinaryOperator.Syntax;
             ITypeSymbol type = boundTupleBinaryOperator.Type;
             Optional<object> constantValue = ConvertToOptional(boundTupleBinaryOperator.ConstantValue);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -4435,7 +4435,14 @@ public class C
 ";
 
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (7,55): warning CS8375: The tuple element name 'Bob' is ignored because a different name or no name is specified on the other side of the tuple == or != operator.
+                //         System.Console.Write((Alice: 0, (Bob, 2)) == (Bob: 0, (1, Other: 2)));
+                Diagnostic(ErrorCode.WRN_TupleBinopLiteralNameMismatch, "Bob: 0").WithArguments("Bob").WithLocation(7, 55),
+                // (7,67): warning CS8375: The tuple element name 'Other' is ignored because a different name or no name is specified on the other side of the tuple == or != operator.
+                //         System.Console.Write((Alice: 0, (Bob, 2)) == (Bob: 0, (1, Other: 2)));
+                Diagnostic(ErrorCode.WRN_TupleBinopLiteralNameMismatch, "Other: 2").WithArguments("Other").WithLocation(7, 67)
+                );
 
             CompileAndVerify(comp, expectedOutput: "True");
 
@@ -4448,13 +4455,13 @@ public class C
             var leftTuple = equals.Left;
             var leftInfo = model.GetTypeInfo(leftTuple);
             Assert.Equal("(System.Int32 Alice, (System.Int32 Bob, System.Int32))", leftInfo.Type.ToTestDisplayString());
-            Assert.Equal("(System.Int32, (System.Int32, System.Int32))", leftInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal("(System.Int32 Alice, (System.Int32 Bob, System.Int32))", leftInfo.ConvertedType.ToTestDisplayString());
 
             // check right tuple
             var rightTuple = equals.Right;
             var rightInfo = model.GetTypeInfo(rightTuple);
             Assert.Equal("(System.Int32 Bob, (System.Int32, System.Int32 Other))", rightInfo.Type.ToTestDisplayString());
-            Assert.Equal("(System.Int32, (System.Int32, System.Int32))", rightInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal("(System.Int32 Bob, (System.Int32, System.Int32 Other))", rightInfo.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -1695,8 +1695,12 @@ public class C
 {
     public static void Main()
     {
+        System.Globalization.CultureInfo saveUICulture = System.Threading.Thread.CurrentThread.CurrentUICulture;
+        System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+
         dynamic d1 = 1;
         dynamic d2 = 2;
+
         try
         {
             bool b = ((d1, 2) == (""hello"", d2));
@@ -1704,6 +1708,10 @@ public class C
         catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
         {
             System.Console.Write(e.Message);
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentUICulture = saveUICulture;
         }
     }
 }";
@@ -1985,24 +1993,33 @@ public class C
 {
     public static void Main()
     {
+        System.Globalization.CultureInfo saveUICulture = System.Threading.Thread.CurrentThread.CurrentUICulture;
+        System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
         dynamic d1 = (1, 1);
 
         try
         {
-            _ = d1 == (1, 1);
-        }
-        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-        {
-            System.Console.WriteLine(e.Message);
-        }
+            try
+            {
+                _ = d1 == (1, 1);
+            }
+            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+            {
+                System.Console.WriteLine(e.Message);
+            }
 
-        try
-        {
-            _ = d1 != (1, 2);
+            try
+            {
+                _ = d1 != (1, 2);
+            }
+            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+            {
+                System.Console.WriteLine(e.Message);
+            }
         }
-        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+        finally
         {
-            System.Console.WriteLine(e.Message);
+            System.Threading.Thread.CurrentThread.CurrentUICulture = saveUICulture;
         }
     }
 }
@@ -2023,24 +2040,33 @@ public class C
 {
     public static void Main()
     {
+        System.Globalization.CultureInfo saveUICulture = System.Threading.Thread.CurrentThread.CurrentUICulture;
+        System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
         dynamic d1 = (1, 1, 1);
 
         try
         {
-            _ = (2, d1) == (2, (1, 1, 1));
-        }
-        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
-        {
-            System.Console.WriteLine(e.Message);
-        }
+            try
+            {
+                _ = (2, d1) == (2, (1, 1, 1));
+            }
+            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+            {
+                System.Console.WriteLine(e.Message);
+            }
 
-        try
-        {
-            _ = (3, d1) != (3, (1, 2, 3));
+            try
+            {
+                _ = (3, d1) != (3, (1, 2, 3));
+            }
+            catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+            {
+                System.Console.WriteLine(e.Message);
+            }
         }
-        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
+        finally
         {
-            System.Console.WriteLine(e.Message);
+            System.Threading.Thread.CurrentThread.CurrentUICulture = saveUICulture;
         }
     }
 }
@@ -4367,6 +4393,9 @@ public class C
     }
     public static void PrintException(System.Func<bool> action)
     {
+        System.Globalization.CultureInfo saveUICulture = System.Threading.Thread.CurrentThread.CurrentUICulture;
+        System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+
         try
         {
             action();
@@ -4374,6 +4403,10 @@ public class C
         catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException e)
         {
             System.Console.WriteLine(e.Message);
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentUICulture = saveUICulture;
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ITupleBinaryOperatorExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ITupleBinaryOperatorExpression.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    [CompilerTrait(CompilerFeature.IOperation)]
+    public partial class IOperationTests : SemanticModelTestBase
+    {
+        [Fact]
+        public void VerifyTupleEqualityBinaryOperator()
+        {
+            var source = @"
+class C
+{
+    bool F((int, int) x, (int, int) y)
+    {
+        return /*<bind>*/x == y/*</bind>*/;
+    }
+}";
+
+            string expectedOperationTree =
+@"
+ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: 'x == y')
+  Left: 
+    IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: (System.Int32, System.Int32)) (Syntax: 'x')
+  Right: 
+    IParameterReferenceOperation: y (OperationKind.ParameterReference, Type: (System.Int32, System.Int32)) (Syntax: 'y')
+";
+
+            VerifyOperationTreeForTest<BinaryExpressionSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact]
+        public void VerifyTupleEqualityBinaryOperator2()
+        {
+            var source = @"
+class C
+{
+    bool F((int, int) x)
+    {
+        return /*<bind>*/x == (1, 2)/*</bind>*/;
+    }
+}";
+
+            string expectedOperationTree =
+@"
+ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: 'x == (1, 2)')
+  Left: 
+    IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: (System.Int32, System.Int32)) (Syntax: 'x')
+  Right: 
+    ITupleOperation (OperationKind.Tuple, Type: (System.Int32, System.Int32)) (Syntax: '(1, 2)')
+      NaturalType: (System.Int32, System.Int32)
+      Elements(2):
+          ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+          ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+";
+
+            VerifyOperationTreeForTest<BinaryExpressionSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact]
+        public void VerifyTupleEqualityBinaryOperator3()
+        {
+            var source = @"
+class C
+{
+    bool F((long, byte) y)
+    {
+        return /*<bind>*/(1, 2) != y/*</bind>*/;
+    }
+}";
+
+            string expectedOperationTree =
+@"
+ITupleBinaryOperation (BinaryOperatorKind.NotEquals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: '(1, 2) != y')
+  Left: 
+    ITupleOperation (OperationKind.Tuple, Type: (System.Int64, System.Int32)) (Syntax: '(1, 2)')
+      NaturalType: (System.Int32, System.Int32)
+      Elements(2):
+          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int64, Constant: 1, IsImplicit) (Syntax: '1')
+            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: True, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+            Operand: 
+              ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+          ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+  Right: 
+    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: (System.Int64, System.Int32), IsImplicit) (Syntax: 'y')
+      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      Operand: 
+        IParameterReferenceOperation: y (OperationKind.ParameterReference, Type: (System.Int64, System.Byte)) (Syntax: 'y')
+";
+
+            VerifyOperationTreeForTest<BinaryExpressionSyntax>(source, expectedOperationTree);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -870,7 +870,7 @@ namespace Microsoft.CodeAnalysis.Operations
     /// <summary>
     /// Represents an operation with two operands that produces a result with the same type as at least one of the operands.
     /// </summary>
-    internal abstract partial class BaseTupleBinaryOperatorExpression : Operation, ITupleBinaryOperation
+    internal abstract class BaseTupleBinaryOperatorExpression : Operation, ITupleBinaryOperation
     {
         public BaseTupleBinaryOperatorExpression(BinaryOperatorKind operatorKind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
             : base(OperationKind.BinaryOperator, semanticModel, syntax, type, constantValue, isImplicit)
@@ -921,7 +921,7 @@ namespace Microsoft.CodeAnalysis.Operations
     /// <summary>
     /// Represents an operation with two operands that produces a result with the same type as at least one of the operands.
     /// </summary>
-    internal sealed partial class TupleBinaryOperatorExpression : BaseTupleBinaryOperatorExpression, ITupleBinaryOperation
+    internal sealed class TupleBinaryOperatorExpression : BaseTupleBinaryOperatorExpression, ITupleBinaryOperation
     {
         public TupleBinaryOperatorExpression(BinaryOperatorKind operatorKind, IOperation leftOperand, IOperation rightOperand, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
             : base(operatorKind, semanticModel, syntax, type, constantValue, isImplicit)
@@ -937,7 +937,7 @@ namespace Microsoft.CodeAnalysis.Operations
     /// <summary>
     /// Represents an operation with two operands that produces a result with the same type as at least one of the operands.
     /// </summary>
-    internal sealed partial class LazyTupleBinaryOperatorExpression : BaseTupleBinaryOperatorExpression, ITupleBinaryOperation
+    internal sealed class LazyTupleBinaryOperatorExpression : BaseTupleBinaryOperatorExpression, ITupleBinaryOperation
     {
         private readonly Lazy<IOperation> _lazyLeftOperand;
         private readonly Lazy<IOperation> _lazyRightOperand;

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -884,14 +884,11 @@ namespace Microsoft.CodeAnalysis.Operations
         /// <summary>
         /// Left operand.
         /// </summary>
-        public IOperation LeftOperand => Operation.SetParentOperation(LeftOperandImpl, this);
+        public abstract IOperation LeftOperand { get; }
         /// <summary>
         /// Right operand.
         /// </summary>
-        public IOperation RightOperand => Operation.SetParentOperation(RightOperandImpl, this);
-
-        protected abstract IOperation LeftOperandImpl { get; }
-        protected abstract IOperation RightOperandImpl { get; }
+        public abstract IOperation RightOperand { get; }
 
         public override IEnumerable<IOperation> Children
         {
@@ -918,6 +915,7 @@ namespace Microsoft.CodeAnalysis.Operations
             return visitor.VisitTupleBinaryOperator(this, argument);
         }
     }
+
     /// <summary>
     /// Represents an operation with two operands that produces a result with the same type as at least one of the operands.
     /// </summary>
@@ -926,12 +924,12 @@ namespace Microsoft.CodeAnalysis.Operations
         public TupleBinaryOperatorExpression(BinaryOperatorKind operatorKind, IOperation leftOperand, IOperation rightOperand, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
             : base(operatorKind, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            LeftOperandImpl = leftOperand;
-            RightOperandImpl = rightOperand;
+            LeftOperand = SetParentOperation(leftOperand, this);
+            RightOperand = SetParentOperation(rightOperand, this);
         }
 
-        protected override IOperation LeftOperandImpl { get; }
-        protected override IOperation RightOperandImpl { get; }
+        public override IOperation LeftOperand { get; }
+        public override IOperation RightOperand { get; }
     }
 
     /// <summary>
@@ -949,8 +947,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyRightOperand = rightOperand ?? throw new System.ArgumentNullException(nameof(rightOperand));
         }
 
-        protected override IOperation LeftOperandImpl => _lazyLeftOperand.Value;
-        protected override IOperation RightOperandImpl => _lazyRightOperand.Value;
+        public override IOperation LeftOperand => SetParentOperation(_lazyLeftOperand.Value, this);
+        public override IOperation RightOperand => SetParentOperation(_lazyRightOperand.Value, this);
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/Operations/ITupleBinaryOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/ITupleBinaryOperation.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Operations
+{
+    /// <summary>
+    /// Represents a comparison of two operands that returns a bool type.
+    /// <para>
+    /// Current usage:
+    ///  (1) C# tuple binary operator expression.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    public interface ITupleBinaryOperation : IOperation
+    {
+        /// <summary>
+        /// Kind of binary operation.
+        /// </summary>
+        BinaryOperatorKind OperatorKind { get; }
+        /// <summary>
+        /// Left operand.
+        /// </summary>
+        IOperation LeftOperand { get; }
+        /// <summary>
+        /// Right operand.
+        /// </summary>
+        IOperation RightOperand { get; }
+    }
+}

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -255,6 +255,11 @@ namespace Microsoft.CodeAnalysis.Operations
             return new BinaryOperatorExpression(operation.OperatorKind, Visit(operation.LeftOperand), Visit(operation.RightOperand), operation.IsLifted, operation.IsChecked, operation.IsCompareText, operation.OperatorMethod, ((Operation)operation).SemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
         }
 
+        public override IOperation VisitTupleBinaryOperator(ITupleBinaryOperation operation, object argument)
+        {
+            return new TupleBinaryOperatorExpression(operation.OperatorKind, Visit(operation.LeftOperand), Visit(operation.RightOperand), ((Operation)operation).SemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
+        }
+
         public override IOperation VisitConditional(IConditionalOperation operation, object argument)
         {
             return new ConditionalOperation(Visit(operation.Condition), Visit(operation.WhenTrue), Visit(operation.WhenFalse), operation.IsRef, ((Operation)operation).SemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationKind.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationKind.cs
@@ -181,6 +181,8 @@ namespace Microsoft.CodeAnalysis
         ConstantPattern = 0x55,
         /// <summary>Indicates an <see cref="IDeclarationPatternOperation"/>.</summary>
         DeclarationPattern = 0x56,
+        /// <summary>Indicates an <see cref="ITupleBinaryOperation"/>.</summary>
+        TupleBinaryOperator = 0x57,
 
         // /// <summary>Indicates an <see cref="IFixedOperation"/>.</summary>
         // https://github.com/dotnet/roslyn/issues/21281

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -255,6 +255,11 @@ namespace Microsoft.CodeAnalysis.Operations
             DefaultVisit(operation);
         }
 
+        public virtual void VisitTupleBinaryOperator(ITupleBinaryOperation operation)
+        {
+            DefaultVisit(operation);
+        }
+
         public virtual void VisitConversion(IConversionOperation operation)
         {
             DefaultVisit(operation);
@@ -751,6 +756,11 @@ namespace Microsoft.CodeAnalysis.Operations
         }
 
         public virtual TResult VisitBinaryOperator(IBinaryOperation operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        public virtual TResult VisitTupleBinaryOperator(ITupleBinaryOperation operation, TArgument argument)
         {
             return DefaultVisit(operation, argument);
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -9,8 +9,15 @@ Microsoft.CodeAnalysis.MetadataImportOptions
 Microsoft.CodeAnalysis.MetadataImportOptions.All = 2 -> Microsoft.CodeAnalysis.MetadataImportOptions
 Microsoft.CodeAnalysis.MetadataImportOptions.Internal = 1 -> Microsoft.CodeAnalysis.MetadataImportOptions
 Microsoft.CodeAnalysis.MetadataImportOptions.Public = 0 -> Microsoft.CodeAnalysis.MetadataImportOptions
+Microsoft.CodeAnalysis.OperationKind.TupleBinaryOperator = 87 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation
+Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation.LeftOperand.get -> Microsoft.CodeAnalysis.IOperation
+Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation.OperatorKind.get -> Microsoft.CodeAnalysis.Operations.BinaryOperatorKind
+Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation.RightOperand.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Operations.ITupleOperation.NaturalType.get -> Microsoft.CodeAnalysis.ITypeSymbol
 abstract Microsoft.CodeAnalysis.DataFlowAnalysis.CapturedInside.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISymbol>
 abstract Microsoft.CodeAnalysis.DataFlowAnalysis.CapturedOutside.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISymbol>
 const Microsoft.CodeAnalysis.WellKnownMemberNames.DeconstructMethodName = "Deconstruct" -> string
 static Microsoft.CodeAnalysis.Diagnostic.Create(Microsoft.CodeAnalysis.DiagnosticDescriptor descriptor, Microsoft.CodeAnalysis.Location location, Microsoft.CodeAnalysis.DiagnosticSeverity effectiveSeverity, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Location> additionalLocations, System.Collections.Immutable.ImmutableDictionary<string, string> properties, params object[] messageArgs) -> Microsoft.CodeAnalysis.Diagnostic
+virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitTupleBinaryOperator(Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation operation) -> void
+virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitTupleBinaryOperator(Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation operation, TArgument argument) -> TResult

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -943,6 +943,18 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Visit(operation.RightOperand, "Right");
         }
 
+        public override void VisitTupleBinaryOperator(ITupleBinaryOperation operation)
+        {
+            LogString(nameof(ITupleBinaryOperation));
+            var kindStr = $"{nameof(BinaryOperatorKind)}.{operation.OperatorKind}";
+
+            LogString($" ({kindStr})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.LeftOperand, "Left");
+            Visit(operation.RightOperand, "Right");
+        }
+
         private void LogHasOperatorMethodExpressionCommon(IMethodSymbol operatorMethodOpt)
         {
             if (operatorMethodOpt != null)

--- a/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
@@ -632,6 +632,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             AssertEx.Equal(new[] { operation.LeftOperand, operation.RightOperand }, operation.Children);
         }
 
+        public override void VisitTupleBinaryOperator(ITupleBinaryOperation operation)
+        {
+            Assert.Equal(OperationKind.TupleBinaryOperator, operation.Kind);
+            var binaryOperationKind = operation.OperatorKind;
+
+            AssertEx.Equal(new[] { operation.LeftOperand, operation.RightOperand }, operation.Children);
+        }
+
         public override void VisitConversion(IConversionOperation operation)
         {
             Assert.Equal(OperationKind.Conversion, operation.Kind);

--- a/src/Test/Utilities/Portable/TestResource.resx
+++ b/src/Test/Utilities/Portable/TestResource.resx
@@ -301,6 +301,8 @@ namespace My
                 1.1f
             };
             var (tuple, _) = (named: 1, 2);
+            bool tupleEquality = (1, (2, 3)) == (1, (2, 3));
+            bool tupleInequality = (1, (2, 3)) != (1, (2, 3));
             int[, ,] cube = { { { 111, 112, }, { 121, 122 } }, { { 211, 212 }, { 221, 222 } } };
             int[][] jagged = { { 111 }, { 121, 122 } };
             int[][,] arr = new int[5][,]; // as opposed to new int[][5,5]


### PR DESCRIPTION
This implementation of IOperation exposes the `ConvertedLeft` and `ConvertedRight` nodes from `BoundTupleBinaryOperator`, as well as its `OperatorKind`. 
In the future (after C# 7.3), we could add the details about the element-wise operators that are involved.

Also addressing a few PROTOTYPE markers (test-only changes).