### PR TITLE
Move to the 2.1 SDK

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -420,7 +420,7 @@
       />
 
     <Error 
-      Text="The $(dotnetSdkVersion) SDK is required to build this repo but found $(NETCoreSdkVersion) instead. The correct SDK can be install here https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.0-preview1-007622/dotnet-sdk-2.2.0-preview1-007622-win-x64.exe"
+      Text="The $(dotnetSdkVersion) SDK is required to build this repo but found $(NETCoreSdkVersion) instead. The correct SDK can be install here https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$(dotnetSdkVersion)/dotnet-sdk-$(dotnetSdkVersion)-win-x64.exe"
       Condition="'$(NETCoreSdkVersion)' != '$(dotnetSdkVersion)'" />
   </Target> 
 

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -34,7 +34,7 @@
 
     <DisableTransitiveProjectReferences Condition="'$(RoslynProjectType)' == 'Vsix'">true</DisableTransitiveProjectReferences>
 
-    <!-- Disable the message indicating we are using a preview SDK. That is understood and be design 
+    <!-- Disable the message indicating we are using a preview SDK. That is understood and by design 
          https://github.com/dotnet/sdk/issues/2033 -->
     <_NETCoreSdkIsPreview>false</_NETCoreSdkIsPreview>
   </PropertyGroup>

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -34,6 +34,9 @@
 
     <DisableTransitiveProjectReferences Condition="'$(RoslynProjectType)' == 'Vsix'">true</DisableTransitiveProjectReferences>
 
+    <!-- Disable the message indicating we are using a preview SDK. That is understood and be design 
+         https://github.com/dotnet/sdk/issues/2033 -->
+    <_NETCoreSdkIsPreview>false</_NETCoreSdkIsPreview>
   </PropertyGroup>
 
   <!-- Settings for localization -->
@@ -404,6 +407,11 @@
     </PropertyGroup>
   </Target>
 
+  <!-- Guard against MSBuild picking the wrong SDK version. Its resolver does not always properly enforce
+       the SDK specified in global.json 
+       
+       https://github.com/dotnet/core-setup/issues/3805
+       -->
   <Target Name="BeforeBuild" Condition="'$(MSBuildRuntimeType)' != 'Core'">
     <ValidateBuildEnvironment
       MSBuildBinPath="$(MSBuildBinPath)"
@@ -411,18 +419,9 @@
       MSBuildMinimumDisplayVersion="MSBuild 15.3"
       />
 
-    <PropertyGroup>
-      <ShortSdkVersion Condition=" $(dotnetSdkVersion.IndexOf('-')) > 0 ">$(dotnetSdkVersion.Substring(0, $(dotnetSdkVersion.IndexOf('-'))))</ShortSdkVersion>
-      <ShortSdkVersion Condition=" $(dotnetSdkVersion.IndexOf('-')) &lt;= 0 ">$(dotnetSdkVersion)</ShortSdkVersion>
-    </PropertyGroup>
-
-    <!-- The $(UsingMicrosoftNETSdk) property is set when we are using a 2.0 SDK or newer (non-legacy). This means
-         we can depend on global.json having enforced the minimum version we require for our build. If it's not
-         set though we need to error out and provide a link to get the correct SDK installed.
-      -->
     <Error 
-      Text="The $(ShortSdkVersion) SDK is required to build this repo. It can be install here https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.0-preview1-007622/dotnet-sdk-2.2.0-preview1-007622-win-x64.exe"
-      Condition="'$(UsingMicrosoftNETSdk)' == ''" />
+      Text="The $(dotnetSdkVersion) SDK is required to build this repo but found $(NETCoreSdkVersion) instead. The correct SDK can be install here https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.0-preview1-007622/dotnet-sdk-2.2.0-preview1-007622-win-x64.exe"
+      Condition="'$(NETCoreSdkVersion)' != '$(dotnetSdkVersion)'" />
   </Target> 
 
   <!-- 

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -58,7 +58,7 @@
     <MicrosoftNetCompilersVersion>2.6.0</MicrosoftNetCompilersVersion>
     <MicrosoftNetRoslynDiagnosticsVersion>2.6.0-beta2</MicrosoftNetRoslynDiagnosticsVersion>
     <MicrosoftNetCoreILAsmVersion>2.0.0</MicrosoftNetCoreILAsmVersion>
-    <MicrosoftNETCoreCompilersVersion>2.6.0-beta3-62308-01</MicrosoftNETCoreCompilersVersion>
+    <MicrosoftNETCoreCompilersVersion>2.8.0-beta2-62712-07</MicrosoftNETCoreCompilersVersion>
     <MicrosoftNETCoreVersion>5.0.0</MicrosoftNETCoreVersion>
     <MicrosoftNETCoreAppVersion>2.0.0</MicrosoftNETCoreAppVersion>
     <MicrosoftNETCorePlatformsVersion>2.0.0</MicrosoftNETCorePlatformsVersion>

--- a/build/Targets/Tools.props
+++ b/build/Targets/Tools.props
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <dotnetRuntimeVersion>2.0.0</dotnetRuntimeVersion>
-    <dotnetSdkVersion>2.2.0-preview1-007622</dotnetSdkVersion>
+    <dotnetSdkVersion>2.1.300-preview2-008324</dotnetSdkVersion>
     <nugetExeVersion>4.3.0</nugetExeVersion>
     <monoVersion>5.8.0.88</monoVersion>
     <vsMinimumVersion>15.3</vsMinimumVersion>

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -636,6 +636,31 @@ function Stop-VSProcesses() {
     Get-Process -Name "devenv" -ErrorAction SilentlyContinue | Stop-Process
 }
 
+# Manually verify that the correct SDK is installed. This is necessary to guard 
+# against MSBuild silently downgrading to a different SDK.
+#
+# Issue tracking removing this check: https://github.com/dotnet/roslyn/issues/25378
+# Relevant issues:
+#   https://github.com/dotnet/announcements/issues/57
+#   https://github.com/dotnet/core-setup/issues/3805
+#   https://github.com/dotnet/core-setup/issues/3807
+function Check-BadDotnetSdkVersion() {
+    $all = Exec-command $dotnet "--list-sdks"
+    $sdkVersion = Get-ToolVersion "dotnetSdk"
+    $foundVersion = $false
+    foreach ($version in $all) { 
+        if ($version -match "^$sdkVersion") {
+            $foundVersion = $true
+        }
+    }
+
+    if (-not $foundVersion) { 
+        Write-Host -ForegroundColor Red "Error! Need to install the $sdkVersion version of the .NET SDK"
+        Write-Host -ForegroundColor Red "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$($sdkVersion)/dotnet-sdk-$($sdkVersion)-win-x64.exe"
+        throw "Missing $sdkVersion SDK"
+    }
+}
+
 try {
     . (Join-Path $PSScriptRoot "build-utils.ps1")
     Push-Location $repoDir
@@ -654,6 +679,8 @@ try {
     # Ensure the main output directories exist as a number of tools will fail when they don't exist. 
     Create-Directory $binariesDir
     Create-Directory $configDir 
+
+    Check-BadDotnetSdkVersion
 
     if ($cibuild) { 
         List-VSProcesses

--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -23,7 +23,7 @@ If a stack trace is displayed on .NET Framework older than 4.7.1 (e.g. by xUnit 
 1. [Visual Studio 2017 Version 15.6 Preview 4](https://www.visualstudio.com/vs/preview/)
     - Ensure C#, VB, MSBuild, .NET Core and Visual Studio Extensibility are included in the selected work loads
     - Ensure Visual Studio is on Version "15.6 Preview 4" or greater
-1. [.NET Core SDK 2.2](https://www.microsoft.com/net/download/core) (if you don't see the 2.2 SDK binaries there yet, the current previews are: [Windows x64 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.0-preview1-007622/dotnet-sdk-2.2.0-preview1-007622-win-x64.exe), [Windows x86 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.0-preview1-007622/dotnet-sdk-2.2.0-preview1-007622-win-x86.exe))
+1. [.NET Core SDK 2.2](https://www.microsoft.com/net/download/core) (if you don't see the 2.2 SDK binaries there yet, the current previews are: [Windows x64 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.300-preview2-008324/dotnet-sdk-2.1.300-preview2-008324-win-x64.exe), [Windows x86 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.300-preview2-008324/dotnet-sdk-2.1.300-preview2-008324-win-x86.exe))
 1. [PowerShell 3.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on Windows 7. The download link is under the "upgrading existing Windows PowerShell" heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln

--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -23,7 +23,7 @@ If a stack trace is displayed on .NET Framework older than 4.7.1 (e.g. by xUnit 
 1. [Visual Studio 2017 Version 15.6 Preview 4](https://www.visualstudio.com/vs/preview/)
     - Ensure C#, VB, MSBuild, .NET Core and Visual Studio Extensibility are included in the selected work loads
     - Ensure Visual Studio is on Version "15.6 Preview 4" or greater
-1. [.NET Core SDK 2.2](https://www.microsoft.com/net/download/core) (if you don't see the 2.2 SDK binaries there yet, the current previews are: [Windows x64 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.300-preview2-008324/dotnet-sdk-2.1.300-preview2-008324-win-x64.exe), [Windows x86 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.300-preview2-008324/dotnet-sdk-2.1.300-preview2-008324-win-x86.exe))
+1. [.NET Core SDK 2.1.300](https://www.microsoft.com/net/download/core) (if you don't see the 2.2 SDK binaries there yet, the current previews are: [Windows x64 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.300-preview2-008324/dotnet-sdk-2.1.300-preview2-008324-win-x64.exe), [Windows x86 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.300-preview2-008324/dotnet-sdk-2.1.300-preview2-008324-win-x86.exe))
 1. [PowerShell 3.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on Windows 7. The download link is under the "upgrading existing Windows PowerShell" heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.2.0-preview1-007622"
+    "version": "2.1.300-preview2-008324"
   }
 }

--- a/src/Compilers/Server/PortableServer/PortableServer.csproj
+++ b/src/Compilers/Server/PortableServer/PortableServer.csproj
@@ -4,8 +4,7 @@
   <PropertyGroup>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <Platforms>AnyCPU;x64</Platforms>
-    <RuntimeIdentifier>x64</RuntimeIdentifier>
+    <Platforms>AnyCPU</Platforms>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.CompilerServer</RootNamespace>
     <AssemblyName>VBCSCompilerPortable</AssemblyName>


### PR DESCRIPTION
This moves Roslyn to use the 2.1 SDK.

This may appear to be moving the SDK version backwards from 2.2 to 2.1.
In reality though it is a move forward. There was a brief time when the
SDK switched their versions to 2.2 before reverting back to 2.1. Roslyn
took a dependency on SDK in that small window.

More details available here:

https://github.com/dotnet/announcements/issues/57

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
