### PR TITLE
'unmanaged' constraint fixups for merge

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                             Error(diagnostics, ErrorCode.ERR_RefValBoundWithClass, syntax, type);
                                             continue;
                                         }
-                                        else if ((constraints & TypeParameterConstraintKind.ValueType) != 0)
+                                        else if ((constraints & TypeParameterConstraintKind.Unmanaged) != 0)
                                         {
                                             // "'{0}': cannot specify both a constraint class and the 'unmanaged' constraint"
                                             Error(diagnostics, ErrorCode.ERR_UnmanagedBoundWithClass, syntax, type);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -147,7 +147,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 if (constraints != 0 || constraintTypes.Any())
                                 {
-                                    diagnostics.Add(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, typeSyntax.GetLocation());
+                                    // TODO: VS first
+                                    diagnostics.Add(ErrorCode.ERR_UnmanagedConstraintMustBeFirst, typeSyntax.GetLocation());
                                     continue;
                                 }
 
@@ -176,12 +177,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     continue;
                                 }
 
-                                if ((constraints & TypeParameterConstraintKind.Unmanaged) != 0)
-                                {
-                                    diagnostics.Add(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, typeSyntax.GetLocation());
-                                    continue;
-                                }
-
                                 if (type.TypeKind == TypeKind.Class)
                                 {
                                     // If there is already a struct or class constraint (class constraint could be
@@ -195,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         continue;
                                     }
 
-                                    if ((constraints & (TypeParameterConstraintKind.ReferenceType | TypeParameterConstraintKind.ValueType)) != 0)
+                                    if ((constraints & (TypeParameterConstraintKind.ReferenceType)) != 0)
                                     {
                                         switch (type.SpecialType)
                                         {
@@ -208,6 +203,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                 // "'{0}': cannot specify both a constraint class and the 'class' or 'struct' constraint"
                                                 Error(diagnostics, ErrorCode.ERR_RefValBoundWithClass, syntax, type);
                                                 continue;
+                                        }
+                                    }
+                                    else if (type.SpecialType != SpecialType.System_Enum)
+                                    {
+                                        if ((constraints & TypeParameterConstraintKind.ValueType) != 0)
+                                        {
+                                            // "'{0}': cannot specify both a constraint class and the 'class' or 'struct' constraint"
+                                            Error(diagnostics, ErrorCode.ERR_RefValBoundWithClass, syntax, type);
+                                            continue;
+                                        }
+                                        else if ((constraints & TypeParameterConstraintKind.ValueType) != 0)
+                                        {
+                                            // "'{0}': cannot specify both a constraint class and the 'unmanaged' constraint"
+                                            Error(diagnostics, ErrorCode.ERR_UnmanagedBoundWithClass, syntax, type);
+                                            continue;
                                         }
                                     }
                                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -147,7 +147,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 if (constraints != 0 || constraintTypes.Any())
                                 {
-                                    // TODO: VS first
                                     diagnostics.Add(ErrorCode.ERR_UnmanagedConstraintMustBeFirst, typeSyntax.GetLocation());
                                     continue;
                                 }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -9755,11 +9755,20 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;unmanaged&apos; constraint cannot be specified with other constraints..
+        ///   Looks up a localized string similar to &apos;{0}&apos;: cannot specify both a constraint class and the &apos;unmanaged&apos; constraint.
         /// </summary>
-        internal static string ERR_UnmanagedConstraintMustBeAlone {
+        internal static string ERR_UnmanagedBoundWithClass {
             get {
-                return ResourceManager.GetString("ERR_UnmanagedConstraintMustBeAlone", resourceCulture);
+                return ResourceManager.GetString("ERR_UnmanagedBoundWithClass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;unmanaged&apos; constraint must come before any other constraints.
+        /// </summary>
+        internal static string ERR_UnmanagedConstraintMustBeFirst {
+            get {
+                return ResourceManager.GetString("ERR_UnmanagedConstraintMustBeFirst", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1329,6 +1329,9 @@
   <data name="ERR_RefValBoundWithClass" xml:space="preserve">
     <value>'{0}': cannot specify both a constraint class and the 'class' or 'struct' constraint</value>
   </data>
+  <data name="ERR_UnmanagedBoundWithClass" xml:space="preserve">
+    <value>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</value>
+  </data>
   <data name="ERR_NewBoundWithVal" xml:space="preserve">
     <value>The 'new()' constraint cannot be used with the 'struct' constraint</value>
   </data>
@@ -5267,8 +5270,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_NewBoundWithUnmanaged" xml:space="preserve">
     <value>The 'new()' constraint cannot be used with the 'unmanaged' constraint</value>
   </data>
-  <data name="ERR_UnmanagedConstraintMustBeAlone" xml:space="preserve">
-    <value>The 'unmanaged' constraint cannot be specified with other constraints.</value>
+  <data name="ERR_UnmanagedConstraintMustBeFirst" xml:space="preserve">
+    <value>The 'unmanaged' constraint must come before any other constraints</value>
   </data>
   <data name="ERR_UnmanagedConstraintNotSatisfied" xml:space="preserve">
     <value>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</value>

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -772,6 +772,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 // edit. Furthermore, comparing constraint types might lead to a cycle.
                 Debug.Assert(type.HasConstructorConstraint == other.HasConstructorConstraint);
                 Debug.Assert(type.HasValueTypeConstraint == other.HasValueTypeConstraint);
+                Debug.Assert(type.HasUnmanagedTypeConstraint == other.HasUnmanagedTypeConstraint);
                 Debug.Assert(type.HasReferenceTypeConstraint == other.HasReferenceTypeConstraint);
                 Debug.Assert(type.ConstraintTypesNoUseSiteDiagnostics.Length == other.ConstraintTypesNoUseSiteDiagnostics.Length);
                 return true;

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -224,49 +224,50 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var moduleBeingBuilt = (PEModuleBuilder)context.Module;
 
+            var seenValueType = false;
             if (this.HasUnmanagedTypeConstraint)
             {
-                var typeRef = moduleBeingBuilt.Translate(
-                    typeSymbol: moduleBeingBuilt.Compilation.GetSpecialType(SpecialType.System_ValueType),
-                    syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
-                    diagnostics: context.Diagnostics);
+                var typeRef = moduleBeingBuilt.GetSpecialType(SpecialType.System_ValueType,
+                                                                syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                                                                diagnostics: context.Diagnostics);
 
                 var modifier = CSharpCustomModifier.CreateRequired(
                     moduleBeingBuilt.Compilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_UnmanagedType));
 
+                // emit "(class [mscorlib]System.ValueType modreq([mscorlib]System.Runtime.InteropServices.UnmanagedType" pattern as "unmanaged"
                 yield return new Cci.TypeReferenceWithAttributes(new Cci.ModifiedTypeReference(typeRef, ImmutableArray.Create<Cci.ICustomModifier>(modifier)));
+
+                // do not emit another one for Dev11 similarities
+                seenValueType = true;
             }
-            else
+
+            foreach (var type in this.ConstraintTypesNoUseSiteDiagnostics)
             {
-                var seenValueType = false;
-                foreach (var type in this.ConstraintTypesNoUseSiteDiagnostics)
+                switch (type.SpecialType)
                 {
-                    switch (type.SpecialType)
-                    {
-                        case SpecialType.System_Object:
-                            // Avoid emitting unnecessary object constraint.
-                            continue;
-                        case SpecialType.System_ValueType:
-                            seenValueType = true;
-                            break;
-                    }
-                    var typeRef = moduleBeingBuilt.Translate(type,
-                                                             syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
-                                                             diagnostics: context.Diagnostics);
-
-                    yield return type.GetTypeRefWithAttributes(this.DeclaringCompilation,
-                                                               typeRef);
+                    case SpecialType.System_Object:
+                        // Avoid emitting unnecessary object constraint.
+                        continue;
+                    case SpecialType.System_ValueType:
+                        seenValueType = true;
+                        break;
                 }
+                var typeRef = moduleBeingBuilt.Translate(type,
+                                                            syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                                                            diagnostics: context.Diagnostics);
 
-                if (this.HasValueTypeConstraint && !seenValueType)
-                {
-                    // Add System.ValueType constraint to comply with Dev11 output
-                    var typeRef = moduleBeingBuilt.GetSpecialType(SpecialType.System_ValueType,
-                                                                  syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
-                                                                  diagnostics: context.Diagnostics);
+                yield return type.GetTypeRefWithAttributes(this.DeclaringCompilation,
+                                                            typeRef);
+            }
 
-                    yield return new Cci.TypeReferenceWithAttributes(typeRef);
-                }
+            if (this.HasValueTypeConstraint && !seenValueType)
+            {
+                // Add System.ValueType constraint to comply with Dev11 output
+                var typeRef = moduleBeingBuilt.GetSpecialType(SpecialType.System_ValueType,
+                                                                syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                                                                diagnostics: context.Diagnostics);
+
+                yield return new Cci.TypeReferenceWithAttributes(typeRef);
             }
         }
 
@@ -292,7 +293,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 //  add constructor constraint for value type constrained 
                 //  type parameters to comply with Dev11 output
-                return this.HasConstructorConstraint || this.HasValueTypeConstraint;
+                //  do this for "unmanaged" constraint too
+                return this.HasConstructorConstraint || this.HasValueTypeConstraint || this.HasUnmanagedTypeConstraint;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -227,9 +227,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var seenValueType = false;
             if (this.HasUnmanagedTypeConstraint)
             {
-                var typeRef = moduleBeingBuilt.GetSpecialType(SpecialType.System_ValueType,
-                                                                syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
-                                                                diagnostics: context.Diagnostics);
+                var typeRef = moduleBeingBuilt.GetSpecialType(
+                    SpecialType.System_ValueType,                  
+                    syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                    diagnostics: context.Diagnostics);
 
                 var modifier = CSharpCustomModifier.CreateRequired(
                     moduleBeingBuilt.Compilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_UnmanagedType));

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1560,10 +1560,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DoNotUseFixedBufferAttrOnProperty = 8372,
 
         ERR_NewBoundWithUnmanaged = 8373,
-        ERR_UnmanagedConstraintMustBeAlone = 8374,
+        ERR_UnmanagedConstraintMustBeFirst = 8374,
         ERR_UnmanagedConstraintNotSatisfied = 8375,
         ERR_UnmanagedConstraintWithLocalFunctions = 8376,
         ERR_ConWithUnmanagedCon = 8377,
+
+        ERR_UnmanagedBoundWithClass = 8378,
 
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -555,6 +555,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if ((typeParameter1.HasConstructorConstraint != typeParameter2.HasConstructorConstraint) ||
                 (typeParameter1.HasReferenceTypeConstraint != typeParameter2.HasReferenceTypeConstraint) ||
                 (typeParameter1.HasValueTypeConstraint != typeParameter2.HasValueTypeConstraint) ||
+                (typeParameter1.HasUnmanagedTypeConstraint != typeParameter2.HasUnmanagedTypeConstraint) ||
                 (typeParameter1.Variance != typeParameter2.Variance))
             {
                 return false;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         /// </summary>
         private DiagnosticInfo _lazyConstraintsUseSiteErrorInfo = CSDiagnosticInfo.EmptyErrorInfo; // Indicates unknown state.
 
-        private GenericParameterAttributes _lazyFlags;
+        private readonly GenericParameterAttributes _flags;
         private ThreeState _lazyHasIsUnmanagedConstraint;
         private TypeParameterBounds _lazyBounds = TypeParameterBounds.Unset;
         private ImmutableArray<TypeSymbol> _lazyDeclaredConstraintTypes;
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             // Clear the '.ctor' flag if both '.ctor' and 'valuetype' are
             // set since '.ctor' is redundant in that case.
-            _lazyFlags = ((flags & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0) ? flags : (flags & ~GenericParameterAttributes.DefaultConstructorConstraint);
+            _flags = ((flags & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0) ? flags : (flags & ~GenericParameterAttributes.DefaultConstructorConstraint);
 
             _ordinal = ordinal;
             _handle = handle;
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             }
 
                             // Drop 'System.ValueType' constraint type if the 'valuetype' constraint was also specified.
-                            if (((_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0))
+                            if (((_flags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0))
                             {
                                 continue;
                             }
@@ -225,11 +225,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
 
                 // - presence of unmanaged pattern has to be matched with `valuetype`
-                // - IsUnmanagedAttribute is alloweed iif there is an unmanaged pattern
-                if (hasUnmanagedModreqPattern && (_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0 ||
+                // - IsUnmanagedAttribute is allowed iif there is an unmanaged pattern
+                if (hasUnmanagedModreqPattern && (_flags & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0 ||
                     hasUnmanagedModreqPattern != moduleSymbol.Module.HasIsUnmanagedAttribute(_handle))
                 {
-                    // we do not recognize thse combinations as "unmanaged"
+                    // we do not recognize these combinations as "unmanaged"
                     hasUnmanagedModreqPattern = false;
                     Interlocked.CompareExchange(ref _lazyConstraintsUseSiteErrorInfo, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
                 }
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                return (_lazyFlags & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
+                return (_flags & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
             }
         }
 
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                return (_lazyFlags & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
+                return (_flags & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
             }
         }
 
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                return (_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
+                return (_flags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
             }
         }
 
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                return (VarianceKind)(_lazyFlags & GenericParameterAttributes.VarianceMask);
+                return (VarianceKind)(_flags & GenericParameterAttributes.VarianceMask);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         private DiagnosticInfo _lazyConstraintsUseSiteErrorInfo = CSDiagnosticInfo.EmptyErrorInfo; // Indicates unknown state.
 
         private GenericParameterAttributes _lazyFlags;
-        private ThreeState _lazyHasIsUnmanagedAttribute;
+        private ThreeState _lazyHasIsUnmanagedConstraint;
         private TypeParameterBounds _lazyBounds = TypeParameterBounds.Unset;
         private ImmutableArray<TypeSymbol> _lazyDeclaredConstraintTypes;
         private ImmutableArray<CSharpAttributeData> _lazyCustomAttributes;
@@ -170,12 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     Interlocked.CompareExchange(ref _lazyConstraintsUseSiteErrorInfo, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
                 }
 
-                this.GetAttributes();
-                if (_lazyHasIsUnmanagedAttribute.Value() && (_lazyFlags & (GenericParameterAttributes.ReferenceTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)) != 0)
-                {
-                    _lazyFlags = _lazyFlags & ~(GenericParameterAttributes.ReferenceTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint);
-                    _lazyConstraintsUseSiteErrorInfo = new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this);
-                }
+                bool hasUnmanagedModreqPattern = false;
 
                 if (constraints.Count > 0)
                 {
@@ -196,22 +191,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         var constraint = metadataReader.GetGenericParameterConstraint(constraintHandle);
                         var typeSymbol = tokenDecoder.DecodeGenericParameterConstraint(constraint.Type, out bool hasUnmanagedModreq);
 
-                        if (hasUnmanagedModreq != this._lazyHasIsUnmanagedAttribute.Value())
+                        if (typeSymbol.SpecialType == SpecialType.System_ValueType)
                         {
-                            // The presence of UnmanagedType modreq has to match the presence of the IsUnmanagedAttribute
-                            Interlocked.CompareExchange(ref _lazyConstraintsUseSiteErrorInfo, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
-                            continue;
+                            // recognize "(class [mscorlib]System.ValueType modreq([mscorlib]System.Runtime.InteropServices.UnmanagedType" pattern as "unmanaged"
+                            if (hasUnmanagedModreq)
+                            {
+                                hasUnmanagedModreqPattern = true;
+                            }
+
+                            // Drop 'System.ValueType' constraint type if the 'valuetype' constraint was also specified.
+                            if (((_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0))
+                            {
+                                continue;
+                            }
                         }
 
                         // Drop 'System.Object' constraint type.
                         if (typeSymbol.SpecialType == SpecialType.System_Object)
-                        {
-                            continue;
-                        }
-
-                        // Drop 'System.ValueType' constraint type if the 'valuetype' constraint was also specified.
-                        if (((_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0) &&
-                            (typeSymbol.SpecialType == SpecialType.System_ValueType))
                         {
                             continue;
                         }
@@ -228,6 +224,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     declaredConstraintTypes = ImmutableArray<TypeSymbol>.Empty;
                 }
 
+                // - presence of unmanaged pattern has to be matched with `valuetype`
+                // - IsUnmanagedAttribute is alloweed iif there is an unmanaged pattern
+                if (hasUnmanagedModreqPattern && (_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0 ||
+                    hasUnmanagedModreqPattern != moduleSymbol.Module.HasIsUnmanagedAttribute(_handle))
+                {
+                    // we do not recognize thse combinations as "unmanaged"
+                    hasUnmanagedModreqPattern = false;
+                    Interlocked.CompareExchange(ref _lazyConstraintsUseSiteErrorInfo, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
+                }
+
+                _lazyHasIsUnmanagedConstraint = hasUnmanagedModreqPattern.ToThreeState();
                 ImmutableInterlocked.InterlockedInitialize(ref _lazyDeclaredConstraintTypes, declaredConstraintTypes);
             }
 
@@ -254,7 +261,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                GetDeclaredConstraintTypes();
                 return (_lazyFlags & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
             }
         }
@@ -263,7 +269,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                GetDeclaredConstraintTypes();
                 return (_lazyFlags & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
             }
         }
@@ -272,8 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                GetDeclaredConstraintTypes();
-                return (_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0 || HasUnmanagedTypeConstraint;
+                return (_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
             }
         }
 
@@ -282,7 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get
             {
                 GetDeclaredConstraintTypes();
-                return this._lazyHasIsUnmanagedAttribute.Value();
+                return this._lazyHasIsUnmanagedConstraint.Value();
             }
         }
 
@@ -290,7 +294,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                GetDeclaredConstraintTypes();
                 return (VarianceKind)(_lazyFlags & GenericParameterAttributes.VarianceMask);
             }
         }
@@ -334,18 +337,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             if (_lazyCustomAttributes.IsDefault)
             {
-                var loadedCustomAttributes = ((PEModuleSymbol)this.ContainingModule).GetCustomAttributesForToken(
-                    this.Handle,
-                    out CustomAttributeHandle isUnmanagedAttribute,
-                    AttributeDescription.IsUnmanagedAttribute,
-                    out _, 
-                    default,
-                    out _, 
-                    default, 
-                    out _, 
-                    default);
+                var containingPEModuleSymbol = (PEModuleSymbol)this.ContainingModule;
 
-                this._lazyHasIsUnmanagedAttribute = (!isUnmanagedAttribute.IsNil).ToThreeState();
+                var loadedCustomAttributes = containingPEModuleSymbol.GetCustomAttributesForToken(
+                    Handle,
+                    out _,
+                    // Filter out [IsUnmanagedAttribute]
+                    HasUnmanagedTypeConstraint ? AttributeDescription.IsUnmanagedAttribute : default);
 
                 ImmutableInterlocked.InterlockedInitialize(ref _lazyCustomAttributes, loadedCustomAttributes);
             }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8635,11 +8635,6 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8635,11 +8635,6 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8635,11 +8635,6 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8635,11 +8635,6 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8635,11 +8635,6 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8635,11 +8635,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8635,11 +8635,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8635,11 +8635,6 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8635,11 +8635,6 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8635,11 +8635,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8635,11 +8635,6 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8635,11 +8635,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8635,11 +8635,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
-        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
-        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
         <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
@@ -8653,6 +8648,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_ConWithUnmanagedCon">
         <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
         <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedBoundWithClass">
+        <source>'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</source>
+        <target state="new">'{0}': cannot specify both a constraint class and the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeFirst">
+        <source>The 'unmanaged' constraint must come before any other constraints</source>
+        <target state="new">The 'unmanaged' constraint must come before any other constraints</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Test/Emit/Emit/UnmanagedTypeModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/UnmanagedTypeModifierTests.cs
@@ -860,7 +860,7 @@ public class TestRef
                 var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("D`1").TypeParameters.Single();
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
-                Assert.True(typeParameter.HasConstructorConstraint);
+                Assert.False(typeParameter.HasConstructorConstraint);   // .ctor  is an artifact of emit, we will ignore it on importing.
 
                 AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
@@ -887,7 +887,7 @@ public class Program
                     var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Program").GetTypeMember("<>c__DisplayClass0_0").TypeParameters.Single();
                     Assert.True(typeParameter.HasValueTypeConstraint);
                     Assert.True(typeParameter.HasUnmanagedTypeConstraint);
-                    Assert.True(typeParameter.HasConstructorConstraint);
+                    Assert.False(typeParameter.HasConstructorConstraint);  // .ctor  is an artifact of emit, we will ignore it on importing.
 
                     AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
                 });

--- a/src/Compilers/CSharp/Test/Emit/Emit/UnmanagedTypeModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/UnmanagedTypeModifierTests.cs
@@ -66,9 +66,15 @@ public class Test
 }";
 
             CreateCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (9,13): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'TestRef.M2<T>()'. There is no boxing conversion from 'int' to '?'.
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "M2<int>").WithArguments("TestRef.M2<T>()", "?", "T", "int").WithLocation(9, 13),
                 // (9,13): error CS0570: 'T' is not supported by the language
                 //         obj.M2<int>();      // invalid
-                Diagnostic(ErrorCode.ERR_BindToBogus, "M2<int>").WithArguments("T").WithLocation(9, 13)
+                Diagnostic(ErrorCode.ERR_BindToBogus, "M2<int>").WithArguments("T").WithLocation(9, 13),
+                // (9,13): error CS0648: '' is a type not supported by the language
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_BogusType, "M2<int>").WithArguments("").WithLocation(9, 13)
                 );
         }
 
@@ -129,9 +135,15 @@ public class Test
 }";
 
             CreateCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (9,13): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'TestRef.M2<T>()'. There is no boxing conversion from 'int' to '?'.
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "M2<int>").WithArguments("TestRef.M2<T>()", "?", "T", "int").WithLocation(9, 13),
                 // (9,13): error CS0570: 'T' is not supported by the language
                 //         obj.M2<int>();      // invalid
-                Diagnostic(ErrorCode.ERR_BindToBogus, "M2<int>").WithArguments("T").WithLocation(9, 13)
+                Diagnostic(ErrorCode.ERR_BindToBogus, "M2<int>").WithArguments("T").WithLocation(9, 13),
+                // (9,13): error CS0648: '' is a type not supported by the language
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_BogusType, "M2<int>").WithArguments("").WithLocation(9, 13)
                 );
         }
 
@@ -941,13 +953,20 @@ public class Test
     public static void Main()
     {
         new TestRef().M<int>();
+        new TestRef().M<string>();
     }
 }";
 
             CreateCompilation(code, references: new[] { reference }).VerifyDiagnostics(
-                // (6,23): error CS0570: 'T' is not supported by the language
+                // (6,23): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T' in the generic type or method 'TestRef.M<T>()'
                 //         new TestRef().M<int>();
-                Diagnostic(ErrorCode.ERR_BindToBogus, "M<int>").WithArguments("T").WithLocation(6, 23)
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "M<int>").WithArguments("TestRef.M<T>()", "T", "int").WithLocation(6, 23),
+                // (7,23): error CS0311: The type 'string' cannot be used as type parameter 'T' in the generic type or method 'TestRef.M<T>()'. There is no implicit reference conversion from 'string' to 'System.ValueType'.
+                //         new TestRef().M<string>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<string>").WithArguments("TestRef.M<T>()", "System.ValueType", "T", "string").WithLocation(7, 23),
+                // (7,23): error CS0570: 'T' is not supported by the language
+                //         new TestRef().M<string>();
+                Diagnostic(ErrorCode.ERR_BindToBogus, "M<string>").WithArguments("T").WithLocation(7, 23)
                 );
         }
 
@@ -1038,14 +1057,20 @@ public class Test
 {
     public static void Main()
     {
+        // OK
         new TestRef().M<int>();
+
+        // Not IComparable
+        new TestRef().M<S1>();
     }
+
+    struct S1{}
 }";
 
             CreateCompilation(code, references: new[] { reference }).VerifyDiagnostics(
-                // (6,23): error CS0570: 'T' is not supported by the language
-                //         new TestRef().M<int>();
-                Diagnostic(ErrorCode.ERR_BindToBogus, "M<int>").WithArguments("T").WithLocation(6, 23)
+                // (10,23): error CS0315: The type 'Test.S1' cannot be used as type parameter 'T' in the generic type or method 'TestRef.M<T>()'. There is no boxing conversion from 'Test.S1' to 'System.IComparable'.
+                //         new TestRef().M<S1>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "M<S1>").WithArguments("TestRef.M<T>()", "System.IComparable", "T", "Test.S1").WithLocation(10, 23)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -6488,11 +6488,11 @@ End Structure";
             TestSymbolDescription(@"
 class X
 {
-    void M<T>() where T : unmanaged { }
+    void M<T>() where T : unmanaged, System.IDisposable { }
 }",
                 global => global.GetTypeMember("X").GetMethod("M"),
                 SymbolDisplayFormat.TestFormat.AddGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeConstraints),
-                "void X.M<T>() where T : unmanaged",
+                "void X.M<T>() where T : unmanaged, System.IDisposable",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ClassName,
@@ -6510,7 +6510,12 @@ class X
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.Keyword);
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NamespaceName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.InterfaceName);
         }
 
         [Fact]


### PR DESCRIPTION
fixes to feature/constraints as discussed on feature review:
- `.ctor` constraint is now emitted for "unmanaged"
- `.ctor` constraint is now optionally accepted as a part of "unmanaged" metadata pattern
- metadata import accepts additional constraints.
- additional constraints are supported in source and subject to same requirements as with "struct" 
- additional constraints must come after "unmanaged"
- additional constraints must be interfaces or "System.Enum"
- some minor fixes and refactoring along the way.