### PR TITLE
Use-auto-prop should not be offered if accessors differ in accessibility

### DIFF
--- a/src/EditorFeatures/CSharp/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -14,8 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
 {
-    [Export]
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Export, DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class CSharpUseAutoPropertyAnalyzer : AbstractUseAutoPropertyAnalyzer<PropertyDeclarationSyntax, FieldDeclarationSyntax, VariableDeclaratorSyntax, ExpressionSyntax>
     {
         protected override bool SupportsReadOnlyProperties(Compilation compilation)

--- a/src/EditorFeatures/CSharp/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
@@ -12,13 +12,11 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.UseAutoProperty;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
 {
-    [Shared]
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CSharpUseAutoPropertyCodeFixProvider))]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CSharpUseAutoPropertyCodeFixProvider)), Shared]
     internal class CSharpUseAutoPropertyCodeFixProvider : AbstractUseAutoPropertyCodeFixProvider<PropertyDeclarationSyntax, FieldDeclarationSyntax, VariableDeclaratorSyntax, ConstructorDeclarationSyntax, ExpressionSyntax>
     {
         protected override SyntaxNode GetNodeToRemove(VariableDeclaratorSyntax declarator)

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -3,7 +3,6 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty;
 using Roslyn.Test.Utilities;
@@ -1217,6 +1216,64 @@ namespace RoslynSandbox
 @"class Class
 {
     int P { get; set; } = 1;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        [WorkItem(25401, "https://github.com/dotnet/roslyn/issues/25401")]
+        public async Task TestGetterAccessibilityDiffers()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    [|int i|];
+
+    public int P
+    {
+        protected get
+        {
+            return i;
+        }
+
+        set
+        {
+            i = value;
+        }
+    }
+}",
+@"class Class
+{
+
+    public int P { protected get; set; }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        [WorkItem(25401, "https://github.com/dotnet/roslyn/issues/25401")]
+        public async Task TestSetterAccessibilityDiffers()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    [|int i|];
+
+    public int P
+    {
+        get
+        {
+            return i;
+        }
+
+        protected set
+        {
+            i = value;
+        }
+    }
+}",
+@"class Class
+{
+
+    public int P { get; protected set; }
 }");
         }
     }

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
@@ -10,8 +10,7 @@ Imports Microsoft.CodeAnalysis.UseAutoProperty
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
-    <[Shared]>
-    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(VisualBasicUseAutoPropertyCodeFixProvider))>
+    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(VisualBasicUseAutoPropertyCodeFixProvider)), [Shared]>
     Friend Class VisualBasicUseAutoPropertyCodeFixProvider
         Inherits AbstractUseAutoPropertyCodeFixProvider(Of PropertyBlockSyntax, FieldDeclarationSyntax, ModifiedIdentifierSyntax, ConstructorBlockSyntax, ExpressionSyntax)
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -598,5 +598,39 @@ Namespace RoslynSandbox
 End Namespace
 ")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
+        <WorkItem(25401, "https://github.com/dotnet/roslyn/issues/25401")>
+        Public Async Function TestGetterAccessibilityDiffers() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"class Class1
+    [|dim i as integer|]
+    property P as Integer
+        protected get
+            return i
+        end get
+        set
+            i = value
+        end set
+    end property
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
+        <WorkItem(25401, "https://github.com/dotnet/roslyn/issues/25401")>
+        Public Async Function TestSetterAccessibilityDiffers() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"class Class1
+    [|dim i as integer|]
+    property P as Integer
+        get
+            return i
+        end get
+        protected set
+            i = value
+        end set
+    end property
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -218,10 +216,18 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 return;
             }
 
+            if (!CanConvert(property))
+            {
+                return;
+            }
+
             // Looks like a viable property/field to convert into an auto property.
             analysisResults.Add(new AnalysisResult(property, getterField, propertyDeclaration, fieldDeclaration, variableDeclarator,
                 property.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
         }
+
+        protected virtual bool CanConvert(IPropertySymbol property)
+            => true;
 
         private IFieldSymbol GetSetterField(
             SemanticModel semanticModel, ISymbol containingType, IMethodSymbol setMethod, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/25401