### PR TITLE
ChangeSignature: enable on local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -564,7 +564,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeModifiers) &&
                 (containingType == null ||
-                 (containingType.TypeKind != TypeKind.Interface && !IsEnumMember(symbol))))
+                 (containingType.TypeKind != TypeKind.Interface && !IsEnumMember(symbol) && !IsLocalFunction(symbol))))
             {
                 var isConst = symbol is IFieldSymbol && ((IFieldSymbol)symbol).IsConst;
                 if (symbol.IsStatic && !isConst)

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool IsLocalFunction(ISymbol symbol)
+        private static bool IsLocalFunction(ISymbol symbol)
         {
             if (symbol.Kind != SymbolKind.Method)
             {

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -287,10 +288,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeAccessibility) &&
                 (containingType == null ||
-                 (containingType.TypeKind != TypeKind.Interface && !IsEnumMember(symbol))))
+                 (containingType.TypeKind != TypeKind.Interface && !IsEnumMember(symbol) & !IsLocalFunction(symbol))))
             {
                 AddAccessibility(symbol);
             }
+        }
+
+        private bool IsLocalFunction(ISymbol symbol)
+        {
+            if (symbol.Kind != SymbolKind.Method)
+            {
+                return false;
+            }
+
+            return ((IMethodSymbol)symbol).MethodKind == MethodKind.LocalFunction;
         }
 
         private void AddAccessibility(ISymbol symbol)

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5880,7 +5880,7 @@ class C
             var root = srcTree.GetRoot();
             var comp = CreateCompilation(srcTree);
 
-            var semanticModel = comp.GetSemanticModel(comp.SyntaxTrees.Single());
+            var semanticModel = comp.GetSemanticModel(srcTree);
             var local = root.DescendantNodes()
                 .Where(n => n.Kind() == SyntaxKind.LocalFunctionStatement)
                 .Single();

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5856,6 +5856,47 @@ class C
 
         [Fact]
         [CompilerTrait(CompilerFeature.LocalFunctions)]
+        public void LocalFunctionForChangeSignature()
+        {
+            SymbolDisplayFormat changeSignatureFormat = new SymbolDisplayFormat(
+                    genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                    miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes,
+                    extensionMethodStyle: SymbolDisplayExtensionMethodStyle.StaticMethod,
+                    memberOptions:
+                        SymbolDisplayMemberOptions.IncludeType |
+                        SymbolDisplayMemberOptions.IncludeExplicitInterface |
+                        SymbolDisplayMemberOptions.IncludeAccessibility |
+                        SymbolDisplayMemberOptions.IncludeModifiers |
+                        SymbolDisplayMemberOptions.IncludeRef);
+
+            var srcTree = SyntaxFactory.ParseSyntaxTree(@"
+class C
+{
+    void M()
+    {
+        void Local() {}
+    }
+}");
+            var root = srcTree.GetRoot();
+            var comp = CreateCompilation(srcTree);
+
+            var semanticModel = comp.GetSemanticModel(comp.SyntaxTrees.Single());
+            var local = root.DescendantNodes()
+                .Where(n => n.Kind() == SyntaxKind.LocalFunctionStatement)
+                .Single();
+            var localSymbol = Assert.IsType<LocalFunctionSymbol>(
+                semanticModel.GetDeclaredSymbol(local));
+
+            Verify(localSymbol.ToDisplayParts(changeSignatureFormat),
+                "void Local",
+                SymbolDisplayPartKind.Keyword, // void
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.MethodName // Local
+                );
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.LocalFunctions)]
         public void LocalFunction2()
         {
             var srcTree = SyntaxFactory.ParseSyntaxTree(@"

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
@@ -34,6 +34,70 @@ class MyClass
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        public async Task ReorderLocalFunctionParameters()
+        {
+            var markup = @"
+using System;
+class MyClass
+{
+    public void M()
+    {
+        Goo(1, 2);
+        void $$Goo(int x, string y)
+        {
+        }
+    }
+}";
+            var permutation = new[] { 1, 0 };
+            var updatedCode = @"
+using System;
+class MyClass
+{
+    public void M()
+    {
+        Goo(2, 1);
+        void Goo(string y, int x)
+        {
+        }
+    }
+}";
+
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        public async Task ReorderLocalFunctionParameters2()
+        {
+            var markup = @"
+using System;
+class MyClass
+{
+    public void M()
+    {
+        $$Goo(1, null);
+        void Goo(int x, string y)
+        {
+        }
+    }
+}";
+            var permutation = new[] { 1, 0 };
+            var updatedCode = @"
+using System;
+class MyClass
+{
+    public void M()
+    {
+        Goo(null, 1);
+        void Goo(string y, int x)
+        {
+        }
+    }
+}";
+
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public async Task ReorderMethodParametersAndArguments()
         {
             var markup = @"

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
@@ -10,31 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ChangeSignature
     public partial class ChangeSignatureTests : AbstractChangeSignatureTests
     {
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
-        public async Task ReorderMethodParameters()
-        {
-            var markup = @"
-using System;
-class MyClass
-{
-    public void $$Goo(int x, string y)
-    {
-    }
-}";
-            var permutation = new[] { 1, 0 };
-            var updatedCode = @"
-using System;
-class MyClass
-{
-    public void Goo(string y, int x)
-    {
-    }
-}";
-
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
-        }
-
-        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
-        public async Task ReorderLocalFunctionParameters()
+        public async Task ReorderLocalFunctionParametersAndArguments_OnDeclaration()
         {
             var markup = @"
 using System;
@@ -66,7 +42,7 @@ class MyClass
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
-        public async Task ReorderLocalFunctionParameters2()
+        public async Task ReorderLocalFunctionParametersAndArguments_OnInvocation()
         {
             var markup = @"
 using System;
@@ -91,6 +67,30 @@ class MyClass
         void Goo(string y, int x)
         {
         }
+    }
+}";
+
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        public async Task ReorderMethodParameters()
+        {
+            var markup = @"
+using System;
+class MyClass
+{
+    public void $$Goo(int x, string y)
+    {
+    }
+}";
+            var permutation = new[] { 1, 0 };
+            var updatedCode = @"
+using System;
+class MyClass
+{
+    public void Goo(string y, int x)
+    {
     }
 }";
 

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -28,7 +28,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             SyntaxKind.IndexerDeclaration,
             SyntaxKind.DelegateDeclaration,
             SyntaxKind.SimpleLambdaExpression,
-            SyntaxKind.ParenthesizedLambdaExpression);
+            SyntaxKind.ParenthesizedLambdaExpression,
+            SyntaxKind.LocalFunctionStatement);
 
         private static readonly ImmutableArray<SyntaxKind> _declarationAndInvocableKinds =
             _declarationKinds.Concat(ImmutableArray.Create(
@@ -56,6 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
         private static readonly ImmutableArray<SyntaxKind> _updatableNodeKinds = ImmutableArray.Create(
             SyntaxKind.MethodDeclaration,
+            SyntaxKind.LocalFunctionStatement,
             SyntaxKind.ConstructorDeclaration,
             SyntaxKind.IndexerDeclaration,
             SyntaxKind.InvocationExpression,
@@ -256,6 +258,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
                 var method = updatedNode as MethodDeclarationSyntax;
                 var updatedParameters = PermuteDeclaration(method.ParameterList.Parameters, signaturePermutation);
                 return method.WithParameterList(method.ParameterList.WithParameters(updatedParameters).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
+            }
+
+            if (updatedNode.IsKind(SyntaxKind.LocalFunctionStatement))
+            {
+                var localFunction = updatedNode as LocalFunctionStatementSyntax;
+                var updatedParameters = PermuteDeclaration(localFunction.ParameterList.Parameters, signaturePermutation);
+                return localFunction.WithParameterList(localFunction.ParameterList.WithParameters(updatedParameters).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
 
             if (updatedNode.IsKind(SyntaxKind.ConstructorDeclaration))

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -255,42 +255,42 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
             if (updatedNode.IsKind(SyntaxKind.MethodDeclaration))
             {
-                var method = updatedNode as MethodDeclarationSyntax;
+                var method = (MethodDeclarationSyntax)updatedNode;
                 var updatedParameters = PermuteDeclaration(method.ParameterList.Parameters, signaturePermutation);
                 return method.WithParameterList(method.ParameterList.WithParameters(updatedParameters).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
 
             if (updatedNode.IsKind(SyntaxKind.LocalFunctionStatement))
             {
-                var localFunction = updatedNode as LocalFunctionStatementSyntax;
+                var localFunction = (LocalFunctionStatementSyntax)updatedNode;
                 var updatedParameters = PermuteDeclaration(localFunction.ParameterList.Parameters, signaturePermutation);
                 return localFunction.WithParameterList(localFunction.ParameterList.WithParameters(updatedParameters).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
 
             if (updatedNode.IsKind(SyntaxKind.ConstructorDeclaration))
             {
-                var constructor = updatedNode as ConstructorDeclarationSyntax;
+                var constructor = (ConstructorDeclarationSyntax)updatedNode;
                 var updatedParameters = PermuteDeclaration(constructor.ParameterList.Parameters, signaturePermutation);
                 return constructor.WithParameterList(constructor.ParameterList.WithParameters(updatedParameters).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
 
             if (updatedNode.IsKind(SyntaxKind.IndexerDeclaration))
             {
-                var indexer = updatedNode as IndexerDeclarationSyntax;
+                var indexer = (IndexerDeclarationSyntax)updatedNode;
                 var updatedParameters = PermuteDeclaration(indexer.ParameterList.Parameters, signaturePermutation);
                 return indexer.WithParameterList(indexer.ParameterList.WithParameters(updatedParameters).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
 
             if (updatedNode.IsKind(SyntaxKind.DelegateDeclaration))
             {
-                var delegateDeclaration = updatedNode as DelegateDeclarationSyntax;
+                var delegateDeclaration = (DelegateDeclarationSyntax)updatedNode;
                 var updatedParameters = PermuteDeclaration(delegateDeclaration.ParameterList.Parameters, signaturePermutation);
                 return delegateDeclaration.WithParameterList(delegateDeclaration.ParameterList.WithParameters(updatedParameters).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
 
             if (updatedNode.IsKind(SyntaxKind.AnonymousMethodExpression))
             {
-                var anonymousMethod = updatedNode as AnonymousMethodExpressionSyntax;
+                var anonymousMethod = (AnonymousMethodExpressionSyntax)updatedNode;
 
                 // Delegates may omit parameters in C#
                 if (anonymousMethod.ParameterList == null)
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
             if (updatedNode.IsKind(SyntaxKind.SimpleLambdaExpression))
             {
-                var lambda = updatedNode as SimpleLambdaExpressionSyntax;
+                var lambda = (SimpleLambdaExpressionSyntax)updatedNode;
 
                 if (signaturePermutation.UpdatedConfiguration.ToListOfParameters().Any())
                 {
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
             if (updatedNode.IsKind(SyntaxKind.ParenthesizedLambdaExpression))
             {
-                var lambda = updatedNode as ParenthesizedLambdaExpressionSyntax;
+                var lambda = (ParenthesizedLambdaExpressionSyntax)updatedNode;
                 var updatedParameters = PermuteDeclaration(lambda.ParameterList.Parameters, signaturePermutation);
                 return lambda.WithParameterList(lambda.ParameterList.WithParameters(updatedParameters));
             }
@@ -333,10 +333,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
             if (updatedNode.IsKind(SyntaxKind.InvocationExpression))
             {
-                var invocation = updatedNode as InvocationExpressionSyntax;
+                var invocation = (InvocationExpressionSyntax)updatedNode;
                 var semanticModel = document.GetSemanticModelAsync(cancellationToken).WaitAndGetResult(cancellationToken);
 
-                var symbolInfo = semanticModel.GetSymbolInfo(originalNode as InvocationExpressionSyntax, cancellationToken);
+                var symbolInfo = semanticModel.GetSymbolInfo((InvocationExpressionSyntax)originalNode, cancellationToken);
                 var methodSymbol = symbolInfo.Symbol as IMethodSymbol;
                 var isReducedExtensionMethod = false;
 
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
             if (updatedNode.IsKind(SyntaxKind.ObjectCreationExpression))
             {
-                var objCreation = updatedNode as ObjectCreationExpressionSyntax;
+                var objCreation = (ObjectCreationExpressionSyntax)updatedNode;
                 var newArguments = PermuteArgumentList(document, declarationSymbol, objCreation.ArgumentList.Arguments, signaturePermutation);
                 return objCreation.WithArgumentList(objCreation.ArgumentList.WithArguments(newArguments).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
@@ -359,21 +359,21 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             if (updatedNode.IsKind(SyntaxKind.ThisConstructorInitializer) ||
                 updatedNode.IsKind(SyntaxKind.BaseConstructorInitializer))
             {
-                var objCreation = updatedNode as ConstructorInitializerSyntax;
+                var objCreation = (ConstructorInitializerSyntax)updatedNode;
                 var newArguments = PermuteArgumentList(document, declarationSymbol, objCreation.ArgumentList.Arguments, signaturePermutation);
                 return objCreation.WithArgumentList(objCreation.ArgumentList.WithArguments(newArguments).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
 
             if (updatedNode.IsKind(SyntaxKind.ElementAccessExpression))
             {
-                var elementAccess = updatedNode as ElementAccessExpressionSyntax;
+                var elementAccess = (ElementAccessExpressionSyntax)updatedNode;
                 var newArguments = PermuteArgumentList(document, declarationSymbol, elementAccess.ArgumentList.Arguments, signaturePermutation);
                 return elementAccess.WithArgumentList(elementAccess.ArgumentList.WithArguments(newArguments).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
 
             if (updatedNode.IsKind(SyntaxKind.Attribute))
             {
-                var attribute = updatedNode as AttributeSyntax;
+                var attribute = (AttributeSyntax)updatedNode;
                 var newArguments = PermuteAttributeArgumentList(document, declarationSymbol, attribute.ArgumentList.Arguments, signaturePermutation);
                 return attribute.WithArgumentList(attribute.ArgumentList.WithArguments(newArguments).WithAdditionalAnnotations(changeSignatureFormattingAnnotation));
             }
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
             if (updatedNode.IsKind(SyntaxKind.NameMemberCref))
             {
-                var nameMemberCref = updatedNode as NameMemberCrefSyntax;
+                var nameMemberCref = (NameMemberCrefSyntax)updatedNode;
 
                 if (nameMemberCref.Parameters == null ||
                     !nameMemberCref.Parameters.Parameters.Any())


### PR DESCRIPTION
### Customer scenario

1. Write a local function
2. Invoke the light bulb (Ctrl+.) while the cursor is on one its parameters
3. Expect ChangeSignature to come up

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/14122
Fixes https://github.com/dotnet/roslyn/issues/8359

### Risk & Performance impact
Low. The ChangeSignature service can already handle many kinds of signatures (methods, delegates, constructors, invocations, etc) and this is just adding one more. The new logic tells the ChangeSignature service to recognize local function statements and directs it to the local function's parameter list.

### Is this a regression from a previous update?
No

### Root cause analysis
Local functions where introduced in C# 7.0, but with minimal IDE support.

### How was the bug found?
Reported internally.

![image](https://user-images.githubusercontent.com/12466233/37251583-b210f4c2-24c7-11e8-8b11-cf9345d3000b.png)

![image](https://user-images.githubusercontent.com/12466233/37251585-b7089a20-24c7-11e8-9bbf-9a301029b229.png)

Note: as shown in the second screenshot, there is a minor wart with the ChangeSignature popup: it should probably omit "private static" when operating on local functions. But I couldn't figure out whether that code is in Roslyn.