### PR TITLE
Merge ref reassignment into 15.7

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Expression capabilities and requirements.
         /// </summary>
         [Flags]
-        internal enum BindValueKind : byte
+        internal enum BindValueKind : ushort
         {
             ///////////////////
             // All expressions can be classified according to the following 4 capabilities:
@@ -69,6 +69,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             ///  local variable, parameter, field
             /// </summary>
             RefersToLocation = 4 << ValueKindInsignificantBits,
+
+            /// <summary>
+            /// Expression can be the LHS of a ref-assign operation.
+            /// Example:
+            ///  ref local, ref parameter, out parameter
+            /// </summary>
+            RefAssignable = 8 << ValueKindInsignificantBits,
 
             ///////////////////
             // The rest are just combinations of the above.
@@ -145,6 +152,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static bool RequiresAssignableVariable(BindValueKind kind)
         {
             return (kind & BindValueKind.Assignable) != 0;
+        }
+
+        private static bool RequiresRefAssignableVariable(BindValueKind kind)
+        {
+            return (kind & BindValueKind.RefAssignable) != 0;
         }
 
         private static bool RequiresRefOrOut(BindValueKind kind)
@@ -386,6 +398,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.ThisReference:
                     var thisref = (BoundThisReference)expr;
 
+                    // `this` is never ref assignable
+                    if (RequiresRefAssignableVariable(valueKind))
+                    {
+                        Error(diagnostics, ErrorCode.ERR_RefLocalOrParamExpected, node);
+                        return false;
+                    }
+
                     // We will already have given an error for "this" used outside of a constructor, 
                     // instance method, or instance accessor. Assume that "this" is a variable if it is in a struct.
 
@@ -430,6 +449,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.FieldAccess:
                     var fieldAccess = (BoundFieldAccess)expr;
                     return CheckFieldValueKind(node, fieldAccess, valueKind, checkingReceiver, diagnostics);
+
+                case BoundKind.AssignmentOperator:
+                    var assignment = (BoundAssignmentOperator)expr;
+                    return CheckSimpleAssignmentValueKind(node, assignment, valueKind, diagnostics);
             }
 
             // At this point we should have covered all the possible cases for anything that is not a strict RValue.
@@ -466,7 +489,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics.Add(ErrorCode.WRN_AssignmentToLockOrDispose, local.Syntax.Location, localSymbol);
                 }
 
-                if (!localSymbol.IsWritable)
+                // IsWritable means the variable is writable. If this is a ref variable, IsWritable
+                // does not imply anything about the storage location
+                if (localSymbol.RefKind == RefKind.RefReadOnly ||
+                    (localSymbol.RefKind == RefKind.None && !localSymbol.IsWritableVariable))
+                {
+                    ReportReadonlyLocalError(node, localSymbol, valueKind, checkingReceiver, diagnostics);
+                    return false;
+                }
+            }
+            else if (RequiresRefAssignableVariable(valueKind))
+            {
+                if (localSymbol.RefKind == RefKind.None)
+                {
+                    diagnostics.Add(ErrorCode.ERR_RefLocalOrParamExpected, node.Location, localSymbol);
+                    return false;
+                }
+                else if (!localSymbol.IsWritableVariable)
                 {
                     ReportReadonlyLocalError(node, localSymbol, valueKind, checkingReceiver, diagnostics);
                     return false;
@@ -617,6 +656,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            if (RequiresRefAssignableVariable(valueKind))
+            {
+                Error(diagnostics, ErrorCode.ERR_RefLocalOrParamExpected, node);
+                return false;
+            }
+
             // r/w fields that are static or belong to reference types are writeable and returnable
             if (fieldIsStatic || fieldSymbol.ContainingType.IsReferenceType)
             {
@@ -625,6 +670,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // for other fields defer to the receiver.
             return CheckIsValidReceiverForVariable(node, fieldAccess.ReceiverOpt, valueKind, diagnostics);
+        }
+
+        private bool CheckSimpleAssignmentValueKind(SyntaxNode node, BoundAssignmentOperator assignment, BindValueKind valueKind, DiagnosticBag diagnostics)
+        {
+            // Only ref-assigns produce LValues
+            if (assignment.IsRef)
+            {
+                return CheckValueKind(node, assignment.Left, valueKind, checkingReceiver: false, diagnostics);
+            }
+
+            Error(diagnostics, GetStandardLvalueError(valueKind), node);
+            return false;
         }
 
         private static bool CheckFieldRefEscape(SyntaxNode node, BoundFieldAccess fieldAccess, uint escapeFrom, uint escapeTo, DiagnosticBag diagnostics)
@@ -750,21 +807,28 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private bool CheckCallValueKind(BoundCall call, SyntaxNode node, BindValueKind valueKind, bool checkingReceiver, DiagnosticBag diagnostics)
+            => CheckMethodReturnValueKind(call.Method, call.Syntax, node, valueKind, checkingReceiver, diagnostics);
+
+        protected bool CheckMethodReturnValueKind(
+            MethodSymbol methodSymbol,
+            SyntaxNode callSyntaxOpt,
+            SyntaxNode node,
+            BindValueKind valueKind,
+            bool checkingReceiver,
+            DiagnosticBag diagnostics)
         {
             // A call can only be a variable if it returns by reference. If this is the case,
             // whether or not it is a valid variable depends on whether or not the call is the
             // RHS of a return or an assign by reference:
             // - If call is used in a context demanding ref-returnable reference all of its ref
             //   inputs must be ref-returnable
-            var methodSymbol = call.Method;
-            var callSyntax = call.Syntax;
 
             if (RequiresVariable(valueKind) && methodSymbol.RefKind == RefKind.None)
             {
                 if (checkingReceiver)
                 {
                     // Error is associated with expression, not node which may be distinct.
-                    Error(diagnostics, ErrorCode.ERR_ReturnNotLValue, callSyntax, methodSymbol);
+                    Error(diagnostics, ErrorCode.ERR_ReturnNotLValue, callSyntaxOpt, methodSymbol);
                 }
                 else
                 {
@@ -780,7 +844,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
+            if (RequiresRefAssignableVariable(valueKind))
+            {
+                Error(diagnostics, ErrorCode.ERR_RefLocalOrParamExpected, node);
+                return false;
+            }
+
             return true;
+
         }
 
         private bool CheckPropertyValueKind(SyntaxNode node, BoundExpression expr, BindValueKind valueKind, bool checkingReceiver, DiagnosticBag diagnostics)
@@ -919,6 +990,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     ReportDiagnosticsIfObsolete(diagnostics, getMethod, node, receiver?.Kind == BoundKind.BaseReference);
                 }
+            }
+
+            if (RequiresRefAssignableVariable(valueKind))
+            {
+                Error(diagnostics, ErrorCode.ERR_RefLocalOrParamExpected, node);
+                return false;
             }
 
             return true;
@@ -1409,6 +1486,9 @@ moreArguments:
                 case BindValueKind.RefReturn:
                 case BindValueKind.ReadonlyRef:
                     return ErrorCode.ERR_RefReturnThis;
+
+                case BindValueKind.RefAssignable:
+                    return ErrorCode.ERR_RefLocalOrParamExpected;
             }
 
             throw ExceptionUtilities.UnexpectedValue(kind);
@@ -1429,6 +1509,9 @@ moreArguments:
                 case BindValueKind.RefReturn:
                 case BindValueKind.ReadonlyRef:
                     return ErrorCode.ERR_RefReturnRangeVariable;
+
+                case BindValueKind.RefAssignable:
+                    return ErrorCode.ERR_RefLocalOrParamExpected;
             }
 
             if (RequiresReferenceToLocation(kind))
@@ -1475,6 +1558,9 @@ moreArguments:
                 case BindValueKind.RefReturn:
                 case BindValueKind.ReadonlyRef:
                     return ErrorCode.ERR_RefReturnLvalueExpected;
+
+                case BindValueKind.RefAssignable:
+                    return ErrorCode.ERR_RefLocalOrParamExpected;
             }
 
             if (RequiresReferenceToLocation(kind))
@@ -1759,6 +1845,17 @@ moreArguments:
                         default,
                         scopeOfTheContainingExpression,
                         isRefEscape: true);
+
+                case BoundKind.AssignmentOperator:
+                    var assignment = (BoundAssignmentOperator)expr;
+
+                    if (!assignment.IsRef)
+                    {
+                        // non-ref assignments are RValues
+                        break;
+                    }
+
+                    return GetRefEscape(assignment.Left, scopeOfTheContainingExpression);
             }
 
             // At this point we should have covered all the possible cases for anything that is not a strict RValue.
@@ -1951,6 +2048,23 @@ moreArguments:
                         escapeTo,
                         diagnostics,
                         isRefEscape: true);
+
+                case BoundKind.AssignmentOperator:
+                    var assignment = (BoundAssignmentOperator)expr;
+
+                    // Only ref-assignments can be LValues
+                    if (!assignment.IsRef)
+                    {
+                        break;
+                    }
+
+                    return CheckRefEscape(
+                        node,
+                        assignment.Left,
+                        escapeFrom,
+                        escapeTo,
+                        checkingReceiver: false,
+                        diagnostics);
             }
 
             // At this point we should have covered all the possible cases for anything that is not a strict RValue.
@@ -2461,7 +2575,7 @@ moreArguments:
 
                 case BoundKind.AssignmentOperator:
                     var assignment = (BoundAssignmentOperator)expr;
-                    return CheckValEscape(node, assignment.Right, escapeFrom, escapeTo, checkingReceiver: false, diagnostics: diagnostics);
+                    return CheckValEscape(node, assignment.Left, escapeFrom, escapeTo, checkingReceiver: false, diagnostics: diagnostics);
 
                 case BoundKind.IncrementOperator:
                     var increment = (BoundIncrementOperator)expr;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3821,7 +3821,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         diagnostics: diagnostics);
 
                     // Bind member initializer assignment expression
-                    return BindAssignment(initializer, boundLeft, boundRight, diagnostics);
+                    return BindAssignment(initializer, boundLeft, boundRight, isRef: false, diagnostics);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -592,7 +592,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindDeclarationStatementParts(LocalDeclarationStatementSyntax node, DiagnosticBag diagnostics)
         {
-            var typeSyntax = node.Declaration.Type.SkipRef(out RefKind _);
+            var typeSyntax = node.Declaration.Type.SkipRef(out _);
             bool isConst = node.IsConst;
 
             bool isVar;
@@ -640,8 +640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // or it might not; if it is not then we do not want to report an error. If it is, then
             // we want to treat the declaration as an explicitly typed declaration.
 
-            RefKind refKind;
-            TypeSymbol declType = BindType(typeSyntax.SkipRef(out refKind), diagnostics, out isVar, out alias);
+            TypeSymbol declType = BindType(typeSyntax.SkipRef(out _), diagnostics, out isVar, out alias);
             Debug.Assert((object)declType != null || isVar);
 
             if (isVar)
@@ -740,7 +739,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (expression is BoundStackAllocArrayCreation boundStackAlloc)
             {
                 var type = new PointerTypeSymbol(boundStackAlloc.ElementType);
-                expression = GenerateConversionForAssignment(type, boundStackAlloc, diagnostics, refKind: refKind);
+                expression = GenerateConversionForAssignment(type, boundStackAlloc, diagnostics, isRefAssignment: refKind != RefKind.None);
             }
 
             // Certain expressions (null literals, method groups and anonymous functions) have no type of 
@@ -754,7 +753,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return expression;
         }
 
-        protected static bool IsInitializerRefKindValid(
+        private static bool IsInitializerRefKindValid(
             EqualsValueClauseSyntax initializer,
             CSharpSyntaxNode node,
             RefKind variableRefKind,
@@ -903,7 +902,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (kind != LocalDeclarationKind.FixedVariable)
                     {
                         // If this is for a fixed statement, we'll do our own conversion since there are some special cases.		
-                        initializerOpt = GenerateConversionForAssignment(declTypeOpt, initializerOpt, localDiagnostics, refKind: localSymbol.RefKind);
+                        initializerOpt = GenerateConversionForAssignment(
+                            declTypeOpt,
+                            initializerOpt,
+                            localDiagnostics,
+                            isRefAssignment: localSymbol.RefKind != RefKind.None);
                     }
                 }
             }
@@ -1175,15 +1178,48 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BindDeconstruction(node, diagnostics);
             }
 
-            var op1 = BindValue(node.Left, diagnostics, BindValueKind.Assignable); // , BIND_MEMBERSET);
-            var op2 = BindValue(node.Right, diagnostics, BindValueKind.RValue); // , BIND_RVALUEREQUIRED);
+            BindValueKind lhsKind;
+            BindValueKind rhsKind;
+            ExpressionSyntax rhsExpr;
+            bool isRef = false;
+
+            if (node.Right.Kind() == SyntaxKind.RefExpression)
+            {
+                isRef = true;
+                lhsKind = BindValueKind.RefAssignable;
+                rhsKind = BindValueKind.RefersToLocation;
+                rhsExpr = ((RefExpressionSyntax)node.Right).Expression;
+            }
+            else
+            {
+                lhsKind = BindValueKind.Assignable;
+                rhsKind = BindValueKind.RValue;
+                rhsExpr = node.Right;
+            }
+
+            var op1 = BindValue(node.Left, diagnostics, lhsKind);
+
+            var lhsRefKind = RefKind.None;
+            // If the LHS is a ref (not ref-readonly), the rhs
+            // must also be value-assignable
+            if (lhsKind == BindValueKind.RefAssignable && !op1.HasErrors)
+            {
+                // We should now know that op1 is a valid lvalue
+                lhsRefKind = op1.GetRefKind();
+                if (lhsRefKind == RefKind.Ref || lhsRefKind == RefKind.Out)
+                {
+                    rhsKind |= BindValueKind.Assignable;
+                }
+            }
+
+            var op2 = BindValue(rhsExpr, diagnostics, rhsKind);
 
             if (op1.Kind == BoundKind.DiscardExpression)
             {
                 op1 = InferTypeForDiscardAssignment((BoundDiscardExpression)op1, op2, diagnostics);
             }
 
-            return BindAssignment(node, op1, op2, diagnostics);
+            return BindAssignment(node, op1, op2, isRef, diagnostics);
         }
 
         private BoundExpression InferTypeForDiscardAssignment(BoundDiscardExpression op1, BoundExpression op2, DiagnosticBag diagnostics)
@@ -1202,7 +1238,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return op1.SetInferredType(inferredType);
         }
 
-        private BoundAssignmentOperator BindAssignment(SyntaxNode node, BoundExpression op1, BoundExpression op2, DiagnosticBag diagnostics)
+        private BoundAssignmentOperator BindAssignment(
+            SyntaxNode node,
+            BoundExpression op1,
+            BoundExpression op2,
+            bool isRef,
+            DiagnosticBag diagnostics)
         {                      
             Debug.Assert(op1 != null);
             Debug.Assert(op2 != null);
@@ -1213,7 +1254,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Build bound conversion. The node might not be used if this is a dynamic conversion 
                 // but diagnostics should be reported anyways.
-                var conversion = GenerateConversionForAssignment(op1.Type, op2, diagnostics);
+                var conversion = GenerateConversionForAssignment(op1.Type, op2, diagnostics, isRefAssignment: isRef);
 
                 // If the result is a dynamic assignment operation (SetMember or SetIndex), 
                 // don't generate the boxing conversion to the dynamic type.
@@ -1225,10 +1266,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     op2 = conversion;
                 }
 
+                if (isRef)
+                {
+                    var leftEscape = GetRefEscape(op1, LocalScopeDepth);
+                    var rightEscape = GetRefEscape(op2, LocalScopeDepth);
+                    if (leftEscape < rightEscape)
+                    {
+                        Error(diagnostics, ErrorCode.ERR_RefAssignNarrower, node, op1.ExpressionSymbol.Name, op2.Syntax);
+                        op2 = ToBadExpression(op2);
+                    }
+                }
+
                 if (op1.Type.IsByRefLikeType)
                 {
-                    var leftEscape = GetValEscape(op1, this.LocalScopeDepth);
-                    op2 = ValidateEscape(op2, leftEscape, isByRef: false, diagnostics: diagnostics);
+                    var leftEscape = GetValEscape(op1, LocalScopeDepth);
+                    op2 = ValidateEscape(op2, leftEscape, isByRef: false, diagnostics);
                 }
             }
 
@@ -1244,7 +1296,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 type = op1.Type;
             }
 
-            return new BoundAssignmentOperator(node, op1, op2, type, hasErrors: hasErrors);
+            return new BoundAssignmentOperator(node, op1, op2, isRef, type, hasErrors);
         }
 
         private static PropertySymbol GetPropertySymbol(BoundExpression expr, out BoundExpression receiver, out SyntaxNode propertySyntax)
@@ -1473,7 +1525,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 boundStatements.ToImmutableAndFree());
         }
 
-        internal BoundExpression GenerateConversionForAssignment(TypeSymbol targetType, BoundExpression expression, DiagnosticBag diagnostics, bool isDefaultParameter = false, RefKind refKind = RefKind.None)
+        internal BoundExpression GenerateConversionForAssignment(TypeSymbol targetType, BoundExpression expression, DiagnosticBag diagnostics, bool isDefaultParameter = false, bool isRefAssignment = false)
         {
             Debug.Assert((object)targetType != null);
             Debug.Assert(expression != null);
@@ -1495,8 +1547,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var conversion = this.Conversions.ClassifyConversionFromExpression(expression, targetType, ref useSiteDiagnostics);
             diagnostics.Add(expression.Syntax, useSiteDiagnostics);
 
-            // UNDONE: cast in code
-            if (refKind != RefKind.None)
+            if (isRefAssignment)
             {
                 if (conversion.Kind != ConversionKind.Identity)
                 {
@@ -2150,6 +2201,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var typeSyntax = nodeOpt.Type;
+            // Fixed and using variables are not allowed to be ref-like, but regular variables are
+            if (localKind == LocalDeclarationKind.RegularVariable)
+            {
+                typeSyntax = typeSyntax.SkipRef(out _);
+            }
 
             AliasSymbol alias;
             bool isVar;

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         // If the type in syntax is "var", then the type should be set explicitly so that the
                         // Type property doesn't fail.
-                        TypeSyntax typeSyntax = node.Type;
+                        TypeSyntax typeSyntax = node.Type.SkipRef(out _);
 
                         bool isVar;
                         AliasSymbol alias;
@@ -238,6 +238,33 @@ namespace Microsoft.CodeAnalysis.CSharp
                         SourceLocalSymbol local = this.IterationVariable;
                         local.SetType(iterationVariableType);
                         local.SetValEscape(collectionEscape);
+
+                        if (!hasErrors)
+                        {
+                            BindValueKind requiredCurrentKind;
+                            switch (local.RefKind)
+                            {
+                                case RefKind.None:
+                                    requiredCurrentKind = BindValueKind.RValue;
+                                    break;
+                                case RefKind.Ref:
+                                    requiredCurrentKind = BindValueKind.Assignable | BindValueKind.RefersToLocation;
+                                    break;
+                                case RefKind.RefReadOnly:
+                                    requiredCurrentKind = BindValueKind.RefersToLocation;
+                                    break;
+                                default:
+                                    throw ExceptionUtilities.UnexpectedValue(local.RefKind);
+                            }
+
+                            hasErrors |= !CheckMethodReturnValueKind(
+                                builder.CurrentPropertyGetter,
+                                callSyntaxOpt: null,
+                                collectionExpr.Syntax,
+                                requiredCurrentKind,
+                                checkingReceiver: false,
+                                diagnostics);
+                        }
 
                         break;
                     }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.CSharp.Binder;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return ((BoundFieldAccess)receiver).IsByValue;
 
                 case BoundKind.Local:
-                    return !((BoundLocal)receiver).LocalSymbol.IsWritable;
+                    return !((BoundLocal)receiver).LocalSymbol.IsWritableVariable;
 
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -38,6 +38,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="BoundTree\BoundNodes.xml" />
     <Content Include="Syntax\Syntax.xml" />
     <Content Include="UseSiteDiagnosticsCheckEnforcer\BaseLine.txt" />
     <Content Include="UseSiteDiagnosticsCheckEnforcer\Run.bat" />
@@ -50,9 +51,6 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-    <BoundTreeDefinition Include="BoundTree\BoundNodes.xml">
-      <SubType>Designer</SubType>
-    </BoundTreeDefinition>
     <EmbeddedResource Update="CSharpResources.resx">
       <SubType>Designer</SubType>
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8324,6 +8324,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot ref-assign &apos;{1}&apos; to &apos;{0}&apos; because &apos;{1}&apos; has a narrower escape scope than &apos;{0}&apos;..
+        /// </summary>
+        internal static string ERR_RefAssignNarrower {
+            get {
+                return ResourceManager.GetString("ERR_RefAssignNarrower", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;await&apos; cannot be used in an expression containing a ref conditional operator.
         /// </summary>
         internal static string ERR_RefConditionalAndAwait {
@@ -8374,6 +8383,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_RefExtensionMustBeValueTypeOrConstrainedToOne {
             get {
                 return ResourceManager.GetString("ERR_RefExtensionMustBeValueTypeOrConstrainedToOne", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The left-hand side of a ref assignment must be a ref local or parameter..
+        /// </summary>
+        internal static string ERR_RefLocalOrParamExpected {
+            get {
+                return ResourceManager.GetString("ERR_RefLocalOrParamExpected", resourceCulture);
             }
         }
         
@@ -10746,11 +10764,38 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ref for-loop variables.
+        /// </summary>
+        internal static string IDS_FeatureRefFor {
+            get {
+                return ResourceManager.GetString("IDS_FeatureRefFor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ref foreach iteration variables.
+        /// </summary>
+        internal static string IDS_FeatureRefForEach {
+            get {
+                return ResourceManager.GetString("IDS_FeatureRefForEach", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to byref locals and returns.
         /// </summary>
         internal static string IDS_FeatureRefLocalsReturns {
             get {
                 return ResourceManager.GetString("IDS_FeatureRefLocalsReturns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ref reassignment.
+        /// </summary>
+        internal static string IDS_FeatureRefReassignment {
+            get {
+                return ResourceManager.GetString("IDS_FeatureRefReassignment", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4270,6 +4270,15 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureRefConditional" xml:space="preserve">
     <value>ref conditional expression</value>
   </data>
+  <data name="IDS_FeatureRefReassignment" xml:space="preserve">
+    <value>ref reassignment</value>
+  </data>
+  <data name="IDS_FeatureRefFor" xml:space="preserve">
+    <value>ref for-loop variables</value>
+  </data>
+  <data name="IDS_FeatureRefForEach" xml:space="preserve">
+    <value>ref foreach iteration variables</value>
+  </data>
   <data name="CompilationC" xml:space="preserve">
     <value>Compilation (C#): </value>
   </data>
@@ -5255,5 +5264,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_InDynamicMethodArg" xml:space="preserve">
     <value>Arguments with 'in' modifier cannot be used in dynamically dispatched expessions.</value>
+  </data>
+  <data name="ERR_RefLocalOrParamExpected" xml:space="preserve">
+    <value>The left-hand side of a ref assignment must be a ref local or parameter.</value>
+  </data>
+  <data name="ERR_RefAssignNarrower" xml:space="preserve">
+    <value>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2245,7 +2245,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 case BoundKind.Parameter:
                     {
                         var left = (BoundParameter)assignmentTarget;
-                        if (left.ParameterSymbol.RefKind != RefKind.None)
+                        if (left.ParameterSymbol.RefKind != RefKind.None &&
+                            !assignmentOperator.IsRef)
                         {
                             _builder.EmitLoadArgumentOpcode(ParameterSlot(left));
                             lhsUsesStack = true;
@@ -2398,6 +2399,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 case BoundKind.InstrumentationPayloadRoot:
                     break;
 
+                case BoundKind.AssignmentOperator:
+                    var assignment = (BoundAssignmentOperator)assignmentTarget;
+                    if (!assignment.IsRef)
+                    {
+                        goto default;
+                    }
+                    EmitAssignmentExpression(assignment, UseKind.UsedAsAddress);
+                    break;
+
                 default:
                     throw ExceptionUtilities.UnexpectedValue(assignmentTarget.Kind);
             }
@@ -2414,22 +2424,24 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             else
             {
                 int exprTempsBefore = _expressionTemps?.Count ?? 0;
-                var local = ((BoundLocal)assignmentOperator.Left).LocalSymbol;
+                BoundExpression lhs = assignmentOperator.Left;
 
                 // NOTE: passing "ReadOnlyStrict" here. 
                 //       we should not get an address of a copy if at all possible
-                LocalDefinition temp = EmitAddress(assignmentOperator.Right, local.RefKind == RefKind.RefReadOnly ? AddressKind.ReadOnlyStrict : AddressKind.Writeable);
+                LocalDefinition temp = EmitAddress(assignmentOperator.Right, lhs.GetRefKind() == RefKind.RefReadOnly ? AddressKind.ReadOnlyStrict : AddressKind.Writeable);
 
                 // Generally taking a ref for the purpose of ref assignment should not be done on homeless values
                 // however, there are very rare cases when we need to get a ref off a temp in synthetic code.
                 // Retain those temps for the extent of the encompassing expression.
                 AddExpressionTemp(temp);
 
-                // are we, by the way, ref-assigning to something that lives longer than encompassing expression?
-                if (local.SynthesizedKind.IsLongLived())
-                {
-                    var exprTempsAfter = _expressionTemps?.Count ?? 0;
+                var exprTempsAfter = _expressionTemps?.Count ?? 0;
 
+                // are we, by the way, ref-assigning to something that lives longer than encompassing expression?
+                Debug.Assert(lhs.Kind != BoundKind.Parameter || exprTempsAfter <= exprTempsBefore);
+
+                if (lhs.Kind == BoundKind.Local && ((BoundLocal)lhs).LocalSymbol.SynthesizedKind.IsLongLived())
+                {
                     // This situation is extremely rare. We are assigning a ref to a local with unknown lifetime
                     // while computing that ref required expression temps.
                     //
@@ -2459,9 +2471,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     // int sum = addr + 10;
                     // addr = sum;
                     //
-                    // In "Redhawk" we can write this sort of code directly as well. However, we should
-                    // never have a case where the value of the assignment is "used", either in our own
-                    // lowering passes or in Redhawk. We never have something like:
+                    // If we have something like:
                     //
                     // ref int t1 = (ref int t2 = ref M().s); 
                     //
@@ -2469,17 +2479,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     //
                     // int t1 = (ref int t2 = ref M().s);
                     //
-                    // Therefore we don't have to worry about what if the temporary value we are stashing
-                    // away is of ref type.
-                    //
-                    // If we ever do implement this sort of feature then we will need to figure out which
-                    // of the situations above we are in, and ensure that the correct kind of temporary
-                    // is created here. And also that either its value or its indirected value is read out
-                    // after the store, in EmitAssignmentPostfix, below.
+                    // We need to figure out which of the situations above we are in, and ensure that the
+                    // correct kind of temporary is created here. And also that either its value or its
+                    // indirected value is read out after the store, in EmitAssignmentPostfix, below.
 
-                    Debug.Assert(!assignmentOperator.IsRef);
-
-                    temp = AllocateTemp(assignmentOperator.Left.Type, assignmentOperator.Left.Syntax);
+                    temp = AllocateTemp(
+                        assignmentOperator.Left.Type,
+                        assignmentOperator.Left.Syntax,
+                        assignmentOperator.IsRef ? LocalSlotConstraints.ByRef : LocalSlotConstraints.None);
                     _builder.EmitLocalStore(temp);
                 }
             }
@@ -2533,7 +2540,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     break;
 
                 case BoundKind.Parameter:
-                    EmitParameterStore((BoundParameter)expression);
+                    EmitParameterStore((BoundParameter)expression, assignment.IsRef);
                     break;
 
                 case BoundKind.Dup:
@@ -2572,6 +2579,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     EmitInstrumentationPayloadRootStore((BoundInstrumentationPayloadRoot)expression);
                     break;
 
+                case BoundKind.AssignmentOperator:
+                    var nested = (BoundAssignmentOperator)expression;
+                    if (!nested.IsRef)
+                    {
+                        goto default;
+                    }
+                    EmitIndirectStore(nested.Type, expression.Syntax);
+                    break;
+
                 case BoundKind.PreviousSubmissionReference:
                 // Script references are lowered to a this reference and a field access.
                 default:
@@ -2583,7 +2599,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             if (temp != null)
             {
-                _builder.EmitLocalLoad(temp);
+                if (useKind == UseKind.UsedAsAddress)
+                {
+                    _builder.EmitLocalAddress(temp);
+                }
+                else
+                {
+                    _builder.EmitLocalLoad(temp);
+                }
                 FreeTemp(temp);
             }
 
@@ -2691,19 +2714,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             EmitSymbolToken(field, fieldAccess.Syntax);
         }
 
-        private void EmitParameterStore(BoundParameter parameter)
+        private void EmitParameterStore(BoundParameter parameter, bool refAssign)
         {
             int slot = ParameterSlot(parameter);
 
-            if (parameter.ParameterSymbol.RefKind == RefKind.None)
-            {
-                _builder.EmitStoreArgumentOpcode(slot);
-            }
-            else
+            if (parameter.ParameterSymbol.RefKind != RefKind.None && !refAssign)
             {
                 //NOTE: we should have the actual parameter already loaded, 
                 //now need to do a store to where it points to
                 EmitIndirectStore(parameter.ParameterSymbol.Type, parameter.Syntax);
+            }
+            else
+            {
+                _builder.EmitStoreArgumentOpcode(slot);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -972,6 +972,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 LocalSymbol localSymbol = assignmentLocal.LocalSymbol;
 
+                // If the LHS is a readonly ref and the result is used later we cannot stack
+                // schedule since we may be converting a writeable value on the RHS to a readonly
+                // one on the LHS.
+                if (localSymbol.RefKind == RefKind.RefReadOnly &&
+                    (_context == ExprContext.Address || _context == ExprContext.Value))
+                {
+                    ShouldNotSchedule(localSymbol);
+                }
+
                 // Special Case: If the RHS is a pointer conversion, then the assignment functions as
                 // a conversion (because the RHS will actually be typed as a native u/int in IL), so
                 // we should not optimize away the local (i.e. schedule it on the stack).
@@ -997,9 +1006,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             var lhs = node.Left;
 
-            Debug.Assert(!node.IsRef || lhs is BoundLocal local &&
-                         local.LocalSymbol.RefKind != RefKind.None,
-                                "only ref locals can be a target of a ref assignment");
+            Debug.Assert(!node.IsRef || 
+              (lhs is BoundLocal local && local.LocalSymbol.RefKind != RefKind.None) ||
+              (lhs is BoundParameter param && param.ParameterSymbol.RefKind != RefKind.None),
+                                "only ref symbols can be a target of a ref assignment");
             
             switch (lhs.Kind)
             {

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1558,6 +1558,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_FeatureNotAvailableInVersion7_3 = 8370,
         WRN_AttributesOnBackingFieldsNotAvailable = 8371,
         ERR_DoNotUseFixedBufferAttrOnProperty = 8372,
+        ERR_RefLocalOrParamExpected = 8373,
+        ERR_RefAssignNarrower = 8374,
 
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -149,6 +149,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureRefConditional = MessageBase + 12731,
         IDS_FeatureAttributesOnBackingFields = MessageBase + 12732,
         IDS_FeatureImprovedOverloadCandidates = MessageBase + 12733,
+        IDS_FeatureRefReassignment = MessageBase + 12734,
+        IDS_FeatureRefFor = MessageBase + 12735,
+        IDS_FeatureRefForEach = MessageBase + 12736
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -191,6 +194,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // C# 7.3 features.
                 case MessageID.IDS_FeatureAttributesOnBackingFields: // semantic check
                 case MessageID.IDS_FeatureImprovedOverloadCandidates: // semantic check
+                case MessageID.IDS_FeatureRefReassignment:
+                case MessageID.IDS_FeatureRefFor:
+                case MessageID.IDS_FeatureRefForEach:
                     return LanguageVersion.CSharp7_3;
 
                 // C# 7.2 features.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1239,6 +1239,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                 case BoundKind.Parameter:
+                    {
+                        var paramExpr = (BoundParameter)node;
+                        var param = paramExpr.ParameterSymbol;
+                        // If we're ref-reassigning an out parameter we're effectively
+                        // leaving the original
+                        if (isRef && param.RefKind == RefKind.Out)
+                        {
+                            LeaveParameter(param, node.Syntax, paramExpr.Syntax.Location);
+                        }
+
+                        int slot = MakeSlot(paramExpr);
+                        SetSlotState(slot, written);
+                        if (written) NoteWrite(paramExpr, value, read);
+                        break;
+                    }
+
                 case BoundKind.ThisReference:
                 case BoundKind.FieldAccess:
                 case BoundKind.EventAccess:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1680,7 +1680,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // byref assignment is also a potential write
             if (node.IsRef)
             {
-                WriteArgument(node.Right, node.Left.GetRefKind(), method: null);
+                // Assume that BadExpression is a ref location to avoid
+                // cascading diagnostics
+                var refKind = node.Left.Kind == BoundKind.BadExpression
+                    ? RefKind.Ref
+                    : node.Left.GetRefKind();
+                WriteArgument(node.Right, refKind, method: null);
             }
 
             return null;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -222,6 +222,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                             isRef: isRef);
                     }
 
+                case BoundKind.Parameter:
+                    {
+                        Debug.Assert(!isRef || rewrittenLeft.GetRefKind() != RefKind.None);
+                        return new BoundAssignmentOperator(
+                            syntax,
+                            rewrittenLeft,
+                            rewrittenRight,
+                            isRef,
+                            type);
+                    }
+
                 case BoundKind.DiscardExpression:
                     {
                         return rewrittenRight;

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -38,10 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get;
         }
 
-        internal virtual bool CanScheduleToStack
-        {
-            get { return !IsConst && !IsPinned; }
-        }
+        internal virtual bool CanScheduleToStack => !IsConst && !IsPinned;
 
         internal abstract SyntaxToken IdentifierToken
         {
@@ -256,7 +253,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </remarks>
         internal abstract SyntaxNode GetDeclaratorSyntax();
 
-        internal virtual bool IsWritable
+        /// <summary>
+        /// Describes whether this represents a modifiable variable. Note that
+        /// this refers to the variable, not the underlying value, so if this
+        /// variable is a ref-local, the writability refers to ref-assignment,
+        /// not assignment to the underlying storage.
+        /// </summary>
+        internal virtual bool IsWritableVariable
         {
             get
             {
@@ -268,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case LocalDeclarationKind.UsingVariable:
                         return false;
                     default:
-                        return RefKind != RefKind.RefReadOnly;
+                        return true;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -602,7 +602,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SyntaxToken identifierToken,
                 ExpressionSyntax collection,
                 LocalDeclarationKind declarationKind) :
-                    base(containingSymbol, scopeBinder, false, typeSyntax, identifierToken, declarationKind)
+                    base(containingSymbol, scopeBinder, allowRefKind: true, typeSyntax, identifierToken, declarationKind)
             {
                 Debug.Assert(declarationKind == LocalDeclarationKind.ForEachIterationVariable);
                 _collection = collection;

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -652,8 +652,8 @@
       <FactoryComment>
         <summary>Creates an AssignmentExpressionSyntax node.</summary>
       </FactoryComment>
-    </Node>
-    <Node Name="ConditionalExpressionSyntax" Base="ExpressionSyntax">
+  </Node>
+  <Node Name="ConditionalExpressionSyntax" Base="ExpressionSyntax">
     <Kind Name="ConditionalExpression"/>
     <Field Name="Condition" Type="ExpressionSyntax">
       <PropertyComment>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8615,6 +8615,31 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8615,6 +8615,31 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8615,6 +8615,31 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8615,6 +8615,31 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8615,6 +8615,31 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8615,6 +8615,31 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8615,6 +8615,31 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8615,6 +8615,31 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8615,6 +8615,31 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8615,6 +8615,31 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8615,6 +8615,31 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8615,6 +8615,31 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8615,6 +8615,31 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">Invalid hash algorithm name: '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefReassignment">
+        <source>ref reassignment</source>
+        <target state="new">ref reassignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefLocalOrParamExpected">
+        <source>The left-hand side of a ref assignment must be a ref local or parameter.</source>
+        <target state="new">The left-hand side of a ref assignment must be a ref local or parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefAssignNarrower">
+        <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
+        <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefFor">
+        <source>ref for-loop variables</source>
+        <target state="new">ref for-loop variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefForEach">
+        <source>ref foreach iteration variables</source>
+        <target state="new">ref foreach iteration variables</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -10,8 +10,1388 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     [CompilerTrait(CompilerFeature.RefLocalsReturns)]
-    public class RefLocalTests : CompilingTestBase
+    public class CodeGenRefLocalTests : CompilingTestBase
     {
+        [Fact]
+        public void RefExprNullPropagation()
+        {
+            var verifier = CompileAndVerify(@"
+using System;
+struct S : IDisposable
+{
+    public int F;
+    public S(int f) => F = f;
+    public void Dispose()
+    {
+        this.F++;
+        Console.WriteLine(""Dispose"");
+    }
+}
+
+class C
+{
+    public static void Main()
+    {
+        S s1 = new S(10);
+        S s2 = new S(5);
+        ref S rs = ref s1;
+        (rs = ref s2).Dispose();
+        Console.WriteLine(s1.F);
+        Console.WriteLine(s2.F);
+        M(ref s1, ref s2);
+        Console.WriteLine(s1.F);
+        Console.WriteLine(s2.F);
+    }
+
+    private static void M<T>(ref T t1, ref T t2) where T : IDisposable
+    {
+        (t2 = ref t1)?.Dispose();
+    }
+}", expectedOutput: @"
+Dispose
+10
+6
+Dispose
+11
+6");
+            verifier.VerifyIL("C.Main", @"
+{
+  // Code size       78 (0x4e)
+  .maxstack  2
+  .locals init (S V_0, //s1
+                S V_1) //s2
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.s   10
+  IL_0004:  call       ""S..ctor(int)""
+  IL_0009:  ldloca.s   V_1
+  IL_000b:  ldc.i4.5
+  IL_000c:  call       ""S..ctor(int)""
+  IL_0011:  ldloca.s   V_1
+  IL_0013:  call       ""void S.Dispose()""
+  IL_0018:  ldloc.0
+  IL_0019:  ldfld      ""int S.F""
+  IL_001e:  call       ""void System.Console.WriteLine(int)""
+  IL_0023:  ldloc.1
+  IL_0024:  ldfld      ""int S.F""
+  IL_0029:  call       ""void System.Console.WriteLine(int)""
+  IL_002e:  ldloca.s   V_0
+  IL_0030:  ldloca.s   V_1
+  IL_0032:  call       ""void C.M<S>(ref S, ref S)""
+  IL_0037:  ldloc.0
+  IL_0038:  ldfld      ""int S.F""
+  IL_003d:  call       ""void System.Console.WriteLine(int)""
+  IL_0042:  ldloc.1
+  IL_0043:  ldfld      ""int S.F""
+  IL_0048:  call       ""void System.Console.WriteLine(int)""
+  IL_004d:  ret
+}");
+            verifier.VerifyIL("C.M<T>", @"
+{
+  // Code size       50 (0x32)
+  .maxstack  2
+  .locals init (T V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  dup
+  IL_0002:  starg.s    V_1
+  IL_0004:  ldloca.s   V_0
+  IL_0006:  initobj    ""T""
+  IL_000c:  ldloc.0
+  IL_000d:  box        ""T""
+  IL_0012:  brtrue.s   IL_0026
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.0
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  ldloc.0
+  IL_001d:  box        ""T""
+  IL_0022:  brtrue.s   IL_0026
+  IL_0024:  pop
+  IL_0025:  ret
+  IL_0026:  constrained. ""T""
+  IL_002c:  callvirt   ""void System.IDisposable.Dispose()""
+  IL_0031:  ret
+}");
+        }
+
+        [Fact]
+        public void RefExprUnaryPlus()
+        {
+            var verifier = CompileAndVerify(@"
+using System;
+class C
+{
+    public static void Main()
+    {
+        int x = 10;
+        int y = 5;
+        ref int rx = ref x;
+        Console.WriteLine((rx = ref y)++);
+        Console.WriteLine(rx);
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+    }
+}", expectedOutput: @"5
+6
+10
+6");
+            verifier.VerifyIL("C.Main", @"
+{
+  // Code size       40 (0x28)
+  .maxstack  4
+  .locals init (int V_0, //x
+                int V_1, //y
+                int V_2)
+  IL_0000:  ldc.i4.s   10
+  IL_0002:  stloc.0
+  IL_0003:  ldc.i4.5
+  IL_0004:  stloc.1
+  IL_0005:  ldloca.s   V_1
+  IL_0007:  dup
+  IL_0008:  dup
+  IL_0009:  ldind.i4
+  IL_000a:  stloc.2
+  IL_000b:  ldloc.2
+  IL_000c:  ldc.i4.1
+  IL_000d:  add
+  IL_000e:  stind.i4
+  IL_000f:  ldloc.2
+  IL_0010:  call       ""void System.Console.WriteLine(int)""
+  IL_0015:  ldind.i4
+  IL_0016:  call       ""void System.Console.WriteLine(int)""
+  IL_001b:  ldloc.0
+  IL_001c:  call       ""void System.Console.WriteLine(int)""
+  IL_0021:  ldloc.1
+  IL_0022:  call       ""void System.Console.WriteLine(int)""
+  IL_0027:  ret
+}");
+        }
+
+        [Fact]
+        public void RefLocalFor()
+        {
+            CompileAndVerify(@"
+using System;
+class C
+{
+    class LinkedList
+    {
+        public int Value;
+        public LinkedList Next;
+    }
+    public static void Main()
+    {
+        var list = new LinkedList() { Value = 0,
+            Next = new LinkedList() { Value = 0,
+                Next = new LinkedList() { Value = 0, Next = null } } };
+
+        for (ref var cur = ref list; cur != null; cur = ref cur.Next)
+        {
+            Console.WriteLine(cur.Value);
+        }
+        for (ref var cur = ref list; cur != null; cur = ref cur.Next)
+        {
+            cur.Value++;
+        }
+        for (ref readonly var cur = ref list; cur != null; cur = ref cur.Next)
+        {
+            Console.WriteLine(cur.Value);
+        }
+    }
+}", expectedOutput: @"0
+0
+0
+1
+1
+1");
+        }
+
+        [Fact]
+        public void RefLocalForeach()
+        {
+            CompileAndVerify(@"
+using System;
+class C
+{
+    public static void Main()
+    {
+        var re = new RefEnumerable();
+        foreach (ref var x in re)
+        {
+            Console.WriteLine(x);
+        }
+        foreach (ref var x in re)
+        {
+            x++;
+        }
+        foreach (ref readonly var x in re)
+        {
+            Console.WriteLine(x);
+        }
+    }
+}
+
+class RefEnumerable
+{
+    private readonly int[] _arr = new int[5];
+    public StructEnum GetEnumerator() => new StructEnum(_arr);
+
+    public struct StructEnum
+    {
+        private readonly int[] _arr;
+        private int _current;
+        public StructEnum(int[] arr)
+        {
+            _arr = arr;
+            _current = -1;
+        }
+        public ref int Current => ref _arr[_current];
+        public bool MoveNext() => ++_current != _arr.Length;
+    }
+}", expectedOutput: @"0
+0
+0
+0
+0
+1
+1
+1
+1
+1");
+        }
+
+        [Fact]
+        public void RefReassignDifferentTupleNames()
+        {
+            var comp = CreateCompilation(@"
+using System;
+class C
+{
+    public static void Main()
+    {
+        var t = (x: 0, y: 0);
+        ref (int x, int y) rt = ref t;
+
+        var t2 = (a: 2, b: 2);
+        rt = ref t2;
+
+        Console.Write(rt.x);
+        Console.Write(rt.y);
+    }
+}", options: TestOptions.ReleaseExe);
+
+            CompileAndVerify(comp, expectedOutput: "22");
+        }
+
+        [Fact]
+        public void RefReassignRefExpressions()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static readonly int _ro = 42;
+    static int _rw = 42;
+
+    static void Main()
+    {
+        ref readonly var rro = ref _ro;
+        ref var rrw = ref _rw;
+
+        Console.WriteLine(rro);
+        Console.WriteLine(rrw);
+
+        rrw++;
+        rro = ref (rro = ref rrw);
+        rrw = ref (rrw = ref rrw);
+
+        Console.WriteLine(rro);
+        Console.WriteLine(rrw);
+        Console.WriteLine(_ro);
+    }
+}", verify: Verification.Fails, expectedOutput: @"42
+42
+43
+43
+42");
+        }
+
+        [Fact]
+        public void RefReassignParamByVal()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        int x = 0;
+        ref int rx = ref x;
+        int y = 5;
+        Console.WriteLine(rx);
+        M(rx = ref y);
+        Console.WriteLine(rx);
+    }
+
+    static void M(int p)
+    {
+        Console.WriteLine(p);
+        p++;
+        Console.WriteLine(p);
+    }
+}", expectedOutput: @"0
+5
+6
+5
+");
+        }
+
+        [Fact]
+        public void RefReassignParamIn()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        int x = 0;
+        ref int rx = ref x;
+        int y = 5;
+        Console.WriteLine(rx);
+        M(rx = ref y);
+        Console.WriteLine(rx);
+    }
+    static void M(in int p)
+    {
+        Console.WriteLine(p);
+    }
+}", expectedOutput: @"0
+5
+5");
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       27 (0x1b)
+  .maxstack  2
+  .locals init (int V_0, //x
+                int V_1) //y
+  IL_0000:  ldc.i4.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  ldc.i4.5
+  IL_0005:  stloc.1
+  IL_0006:  ldind.i4
+  IL_0007:  call       ""void System.Console.WriteLine(int)""
+  IL_000c:  ldloca.s   V_1
+  IL_000e:  dup
+  IL_000f:  call       ""void C.M(in int)""
+  IL_0014:  ldind.i4
+  IL_0015:  call       ""void System.Console.WriteLine(int)""
+  IL_001a:  ret
+}");
+        }
+
+        [Fact]
+        public void RefReassignParamInConversion()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        int x = 0;
+        ref int rx = ref x;
+        int y = 5;
+        Console.WriteLine(rx);
+        M(rx = ref y);
+        Console.WriteLine(rx);
+    }
+    static void M(in long p)
+    {
+        Console.WriteLine(p);
+    }
+}", expectedOutput: @"0
+5
+5");
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       32 (0x20)
+  .maxstack  2
+  .locals init (int V_0, //x
+                int V_1, //y
+                long V_2)
+  IL_0000:  ldc.i4.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  ldc.i4.5
+  IL_0005:  stloc.1
+  IL_0006:  ldind.i4
+  IL_0007:  call       ""void System.Console.WriteLine(int)""
+  IL_000c:  ldloca.s   V_1
+  IL_000e:  dup
+  IL_000f:  ldind.i4
+  IL_0010:  conv.i8
+  IL_0011:  stloc.2
+  IL_0012:  ldloca.s   V_2
+  IL_0014:  call       ""void C.M(in long)""
+  IL_0019:  ldind.i4
+  IL_001a:  call       ""void System.Console.WriteLine(int)""
+  IL_001f:  ret
+}");
+        }
+
+        [Fact]
+        public void RefReassignField()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+struct S
+{
+    public int X;
+    public S(int x) => X = x;
+}
+class C
+{
+    static void Main()
+    {
+        S s1 = new S(0);
+        S s2 = new S(5);
+        ref S rs = ref s1;
+        Console.WriteLine(rs.X);
+        rs.X++;
+        Console.WriteLine(rs.X);
+        Console.WriteLine((rs = ref s2).X++);
+        rs.X++;
+        Console.WriteLine(rs.X);
+        Console.WriteLine(s1.X);
+        Console.WriteLine(s2.X);
+    }
+}", expectedOutput: @"0
+1
+5
+7
+1
+7");
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size      115 (0x73)
+  .maxstack  4
+  .locals init (S V_0, //s1
+                S V_1, //s2
+                int V_2)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.0
+  IL_0003:  call       ""S..ctor(int)""
+  IL_0008:  ldloca.s   V_1
+  IL_000a:  ldc.i4.5
+  IL_000b:  call       ""S..ctor(int)""
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  dup
+  IL_0013:  ldfld      ""int S.X""
+  IL_0018:  call       ""void System.Console.WriteLine(int)""
+  IL_001d:  dup
+  IL_001e:  ldflda     ""int S.X""
+  IL_0023:  dup
+  IL_0024:  ldind.i4
+  IL_0025:  ldc.i4.1
+  IL_0026:  add
+  IL_0027:  stind.i4
+  IL_0028:  ldfld      ""int S.X""
+  IL_002d:  call       ""void System.Console.WriteLine(int)""
+  IL_0032:  ldloca.s   V_1
+  IL_0034:  dup
+  IL_0035:  ldflda     ""int S.X""
+  IL_003a:  dup
+  IL_003b:  ldind.i4
+  IL_003c:  stloc.2
+  IL_003d:  ldloc.2
+  IL_003e:  ldc.i4.1
+  IL_003f:  add
+  IL_0040:  stind.i4
+  IL_0041:  ldloc.2
+  IL_0042:  call       ""void System.Console.WriteLine(int)""
+  IL_0047:  dup
+  IL_0048:  ldflda     ""int S.X""
+  IL_004d:  dup
+  IL_004e:  ldind.i4
+  IL_004f:  ldc.i4.1
+  IL_0050:  add
+  IL_0051:  stind.i4
+  IL_0052:  ldfld      ""int S.X""
+  IL_0057:  call       ""void System.Console.WriteLine(int)""
+  IL_005c:  ldloc.0
+  IL_005d:  ldfld      ""int S.X""
+  IL_0062:  call       ""void System.Console.WriteLine(int)""
+  IL_0067:  ldloc.1
+  IL_0068:  ldfld      ""int S.X""
+  IL_006d:  call       ""void System.Console.WriteLine(int)""
+  IL_0072:  ret
+}");
+        }
+
+        [Fact]
+        public void RefReassignFieldReadonly()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+struct S
+{
+    public readonly int X;
+    public S(int x) => X = x;
+}
+class C
+{
+    static void Main()
+    {
+        S s1 = new S(0);
+        S s2 = new S(5);
+        ref S rs = ref s1;
+        Console.WriteLine(rs.X);
+        rs = new S(rs.X + 1);
+        Console.WriteLine(rs.X);
+        Console.WriteLine((rs = ref s2).X);
+        rs = new S(rs.X + 1);
+        Console.WriteLine(rs.X);
+        Console.WriteLine(s1.X);
+        Console.WriteLine(s2.X);
+    }
+}", expectedOutput: @"0
+1
+5
+6
+1
+6");
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size      127 (0x7f)
+  .maxstack  3
+  .locals init (S V_0, //s1
+                S V_1, //s2
+                S& V_2) //rs
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.0
+  IL_0003:  call       ""S..ctor(int)""
+  IL_0008:  ldloca.s   V_1
+  IL_000a:  ldc.i4.5
+  IL_000b:  call       ""S..ctor(int)""
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  stloc.2
+  IL_0013:  ldloc.2
+  IL_0014:  ldfld      ""int S.X""
+  IL_0019:  call       ""void System.Console.WriteLine(int)""
+  IL_001e:  ldloc.2
+  IL_001f:  ldloc.2
+  IL_0020:  ldfld      ""int S.X""
+  IL_0025:  ldc.i4.1
+  IL_0026:  add
+  IL_0027:  newobj     ""S..ctor(int)""
+  IL_002c:  stobj      ""S""
+  IL_0031:  ldloc.2
+  IL_0032:  ldfld      ""int S.X""
+  IL_0037:  call       ""void System.Console.WriteLine(int)""
+  IL_003c:  ldloca.s   V_1
+  IL_003e:  dup
+  IL_003f:  stloc.2
+  IL_0040:  ldfld      ""int S.X""
+  IL_0045:  call       ""void System.Console.WriteLine(int)""
+  IL_004a:  ldloc.2
+  IL_004b:  ldloc.2
+  IL_004c:  ldfld      ""int S.X""
+  IL_0051:  ldc.i4.1
+  IL_0052:  add
+  IL_0053:  newobj     ""S..ctor(int)""
+  IL_0058:  stobj      ""S""
+  IL_005d:  ldloc.2
+  IL_005e:  ldfld      ""int S.X""
+  IL_0063:  call       ""void System.Console.WriteLine(int)""
+  IL_0068:  ldloc.0
+  IL_0069:  ldfld      ""int S.X""
+  IL_006e:  call       ""void System.Console.WriteLine(int)""
+  IL_0073:  ldloc.1
+  IL_0074:  ldfld      ""int S.X""
+  IL_0079:  call       ""void System.Console.WriteLine(int)""
+  IL_007e:  ret
+}");
+        }
+
+        [Fact]
+        public void RefReassignFieldRefReadonly()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+struct S
+{
+    public int X;
+    public S(int x) => X = x;
+}
+class C
+{
+    static void Main()
+    {
+        S s1 = new S(0);
+        S s2 = new S(5);
+        ref readonly S rs = ref s1;
+        Console.WriteLine(rs.X);
+        Console.WriteLine((rs = ref s2).X);
+        Console.WriteLine(rs.X);
+    }
+}", expectedOutput: @"0
+5
+5");
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       56 (0x38)
+  .maxstack  2
+  .locals init (S V_0, //s1
+                S V_1, //s2
+                S& V_2) //rs
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.0
+  IL_0003:  call       ""S..ctor(int)""
+  IL_0008:  ldloca.s   V_1
+  IL_000a:  ldc.i4.5
+  IL_000b:  call       ""S..ctor(int)""
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  stloc.2
+  IL_0013:  ldloc.2
+  IL_0014:  ldfld      ""int S.X""
+  IL_0019:  call       ""void System.Console.WriteLine(int)""
+  IL_001e:  ldloca.s   V_1
+  IL_0020:  dup
+  IL_0021:  stloc.2
+  IL_0022:  ldfld      ""int S.X""
+  IL_0027:  call       ""void System.Console.WriteLine(int)""
+  IL_002c:  ldloc.2
+  IL_002d:  ldfld      ""int S.X""
+  IL_0032:  call       ""void System.Console.WriteLine(int)""
+  IL_0037:  ret
+}");
+        }
+
+        [Fact]
+        public void RefReadonlyStackSchedule()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+struct S
+{
+    public int X;
+    public S(int x) => X = x;
+    public void AddOne() => X++;
+}
+class C
+{
+    static void Main()
+    {
+        S s1 = new S(5);
+        ref readonly S rs = ref s1;
+        rs.AddOne();
+        Console.WriteLine(s1.X);
+    }
+}", expectedOutput: "5");
+        }
+
+        [Fact]
+        public void RefReassignCall()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+struct S
+{
+    public int X;
+    public S(int x) => X = x;
+    public void AddOne() => X++;
+}
+class C
+{
+    static void Main()
+    {
+        S s1 = new S(0);
+        S s2 = new S(5);
+        ref S rs = ref s1;
+        (rs = ref s2).AddOne();
+        Console.WriteLine(rs.X);
+        Console.WriteLine(s1.X);
+        Console.WriteLine(s2.X);
+
+        ref readonly S rs2 = ref s1;
+        (rs2 = ref s2).AddOne();
+        Console.WriteLine(rs.X);
+        Console.WriteLine(s1.X);
+        Console.WriteLine(s2.X);
+    }
+}"
+, expectedOutput: @"6
+0
+6
+6
+0
+6"
+);
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size      110 (0x6e)
+  .maxstack  3
+  .locals init (S V_0, //s1
+                S V_1, //s2
+                S& V_2, //rs2
+                S V_3)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.0
+  IL_0003:  call       ""S..ctor(int)""
+  IL_0008:  ldloca.s   V_1
+  IL_000a:  ldc.i4.5
+  IL_000b:  call       ""S..ctor(int)""
+  IL_0010:  ldloca.s   V_1
+  IL_0012:  dup
+  IL_0013:  call       ""void S.AddOne()""
+  IL_0018:  dup
+  IL_0019:  ldfld      ""int S.X""
+  IL_001e:  call       ""void System.Console.WriteLine(int)""
+  IL_0023:  ldloc.0
+  IL_0024:  ldfld      ""int S.X""
+  IL_0029:  call       ""void System.Console.WriteLine(int)""
+  IL_002e:  ldloc.1
+  IL_002f:  ldfld      ""int S.X""
+  IL_0034:  call       ""void System.Console.WriteLine(int)""
+  IL_0039:  ldloca.s   V_0
+  IL_003b:  stloc.2
+  IL_003c:  ldloca.s   V_1
+  IL_003e:  dup
+  IL_003f:  stloc.2
+  IL_0040:  ldobj      ""S""
+  IL_0045:  stloc.3
+  IL_0046:  ldloca.s   V_3
+  IL_0048:  call       ""void S.AddOne()""
+  IL_004d:  ldfld      ""int S.X""
+  IL_0052:  call       ""void System.Console.WriteLine(int)""
+  IL_0057:  ldloc.0
+  IL_0058:  ldfld      ""int S.X""
+  IL_005d:  call       ""void System.Console.WriteLine(int)""
+  IL_0062:  ldloc.1
+  IL_0063:  ldfld      ""int S.X""
+  IL_0068:  call       ""void System.Console.WriteLine(int)""
+  IL_006d:  ret
+}");
+        }
+
+        [Fact]
+        public void RefReassignTernary()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        int x = 0;
+        ref int r1 = ref x;
+        Console.WriteLine(r1);
+        int y = 2;
+        int z = 3;
+        (r1 = ref string.Empty.Length == 0
+            ? ref y
+            : ref z) = 4;
+        Console.WriteLine(x);
+        Console.WriteLine(r1);
+        Console.WriteLine(y);
+        Console.WriteLine(z);
+    }
+}", expectedOutput: @"0
+0
+4
+4
+3");
+        }
+
+        [Fact]
+        public void RefReassignTernaryParam()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        int x = 1, y = 2;
+        ref int rx = ref x;
+        M(ref (rx = ref (x == 0 ? ref x : ref y)));
+        Console.WriteLine(rx);
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+    }
+
+    static void M(ref int p)
+    {
+        Console.WriteLine(p++);
+    }
+}", expectedOutput: @"2
+3
+1
+3");
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       38 (0x26)
+  .maxstack  2
+  .locals init (int V_0, //x
+                int V_1) //y
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldc.i4.2
+  IL_0003:  stloc.1
+  IL_0004:  ldloc.0
+  IL_0005:  brfalse.s  IL_000b
+  IL_0007:  ldloca.s   V_1
+  IL_0009:  br.s       IL_000d
+  IL_000b:  ldloca.s   V_0
+  IL_000d:  dup
+  IL_000e:  call       ""void C.M(ref int)""
+  IL_0013:  ldind.i4
+  IL_0014:  call       ""void System.Console.WriteLine(int)""
+  IL_0019:  ldloc.0
+  IL_001a:  call       ""void System.Console.WriteLine(int)""
+  IL_001f:  ldloc.1
+  IL_0020:  call       ""void System.Console.WriteLine(int)""
+  IL_0025:  ret
+}");
+        }
+
+        [Fact]
+        public void RefReassignFor()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        int[] arr = new int[] { 1, 2, 3, 4, 5 };
+        int i = 0;
+        ref int r = ref arr[i]; 
+        for (;i < 4; r = ref arr[++i])
+        {
+            Console.WriteLine(i);
+            Console.WriteLine(r);
+        }
+    }
+}", expectedOutput: @"0
+1
+1
+2
+2
+3
+3
+4");
+        }
+
+        [Fact]
+        public void AssignInMethodCall()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        int a = 0;
+        int b = 2;
+
+        ref int r1 = ref a;
+        ref int r2 = ref a;
+        ref int r3 = ref a;
+
+        M(ref r1 = ref r2 = ref r3 = ref b);
+        Console.WriteLine(b);
+        Console.WriteLine(r1);
+        Console.WriteLine(r2);
+        Console.WriteLine(r3);
+    }
+
+    static void M(ref int p)
+    {
+        Console.WriteLine(p);
+        p++;
+        Console.WriteLine(p);
+    }
+}", expectedOutput: @"2
+3
+3
+3
+3
+3");
+        }
+
+        [Fact]
+        public void CompoundRefAssignIsLValue()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        int a = 0;
+        ref int r1 = ref a;
+        ref int r2 = ref a;
+        ref int r3 = ref a;
+        Console.WriteLine(r1);
+        Console.WriteLine(r2);
+        Console.WriteLine(r3);
+
+        int b = 2;
+        (r1 = ref r2 = ref r3 = ref b) = 3;
+        Console.WriteLine(r1);
+        Console.WriteLine(r2);
+        Console.WriteLine(r3);
+    }
+}", expectedOutput: @"0
+0
+0
+3
+3
+3");
+            comp.VerifyIL(@"C.Main", @"
+{
+  // Code size       62 (0x3e)
+  .maxstack  3
+  .locals init (int V_0, //a
+                int& V_1, //r2
+                int& V_2, //r3
+                int V_3) //b
+  IL_0000:  ldc.i4.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  ldloca.s   V_0
+  IL_0006:  stloc.1
+  IL_0007:  ldloca.s   V_0
+  IL_0009:  stloc.2
+  IL_000a:  ldind.i4
+  IL_000b:  call       ""void System.Console.WriteLine(int)""
+  IL_0010:  ldloc.1
+  IL_0011:  ldind.i4
+  IL_0012:  call       ""void System.Console.WriteLine(int)""
+  IL_0017:  ldloc.2
+  IL_0018:  ldind.i4
+  IL_0019:  call       ""void System.Console.WriteLine(int)""
+  IL_001e:  ldc.i4.2
+  IL_001f:  stloc.3
+  IL_0020:  ldloca.s   V_3
+  IL_0022:  dup
+  IL_0023:  stloc.2
+  IL_0024:  dup
+  IL_0025:  stloc.1
+  IL_0026:  dup
+  IL_0027:  ldc.i4.3
+  IL_0028:  stind.i4
+  IL_0029:  ldind.i4
+  IL_002a:  call       ""void System.Console.WriteLine(int)""
+  IL_002f:  ldloc.1
+  IL_0030:  ldind.i4
+  IL_0031:  call       ""void System.Console.WriteLine(int)""
+  IL_0036:  ldloc.2
+  IL_0037:  ldind.i4
+  IL_0038:  call       ""void System.Console.WriteLine(int)""
+  IL_003d:  ret
+}");
+        }
+
+        [Fact]
+        public void CompoundRefAssign()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        int a = 0;
+        ref int r1 = ref a;
+        ref int r2 = ref a;
+        ref int r3 = ref a;
+        Console.WriteLine(r1);
+        Console.WriteLine(r2);
+        Console.WriteLine(r3);
+
+        int b = 2;
+        r1 = ref r2 = ref r3 = ref b;
+        Console.WriteLine(r1);
+        Console.WriteLine(r2);
+        Console.WriteLine(r3);
+    }
+}", expectedOutput: @"0
+0
+0
+2
+2
+2");
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       59 (0x3b)
+  .maxstack  2
+  .locals init (int V_0, //a
+                int& V_1, //r2
+                int& V_2, //r3
+                int V_3) //b
+  IL_0000:  ldc.i4.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  ldloca.s   V_0
+  IL_0006:  stloc.1
+  IL_0007:  ldloca.s   V_0
+  IL_0009:  stloc.2
+  IL_000a:  ldind.i4
+  IL_000b:  call       ""void System.Console.WriteLine(int)""
+  IL_0010:  ldloc.1
+  IL_0011:  ldind.i4
+  IL_0012:  call       ""void System.Console.WriteLine(int)""
+  IL_0017:  ldloc.2
+  IL_0018:  ldind.i4
+  IL_0019:  call       ""void System.Console.WriteLine(int)""
+  IL_001e:  ldc.i4.2
+  IL_001f:  stloc.3
+  IL_0020:  ldloca.s   V_3
+  IL_0022:  dup
+  IL_0023:  stloc.2
+  IL_0024:  dup
+  IL_0025:  stloc.1
+  IL_0026:  ldind.i4
+  IL_0027:  call       ""void System.Console.WriteLine(int)""
+  IL_002c:  ldloc.1
+  IL_002d:  ldind.i4
+  IL_002e:  call       ""void System.Console.WriteLine(int)""
+  IL_0033:  ldloc.2
+  IL_0034:  ldind.i4
+  IL_0035:  call       ""void System.Console.WriteLine(int)""
+  IL_003a:  ret
+}");
+        }
+
+        [Fact]
+        public void RefReassignIn()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+
+class C
+{
+    static int x = 0;
+    static int y = 0;
+
+    static void Main()
+    {
+        M(in x);
+    }
+
+    static void M(in int rx)
+    {
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+        x++;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+
+        rx = ref y;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+        y++;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+    }
+}", expectedOutput: @"0
+0
+1
+1
+1
+0
+0
+1
+1
+1");
+        }
+
+        [Fact]
+        public void RefReassignOut()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+
+class C
+{
+    static int x = 0;
+    static int y = 0;
+
+    static void Main()
+    {
+        int z;
+        M(out z);
+        Console.WriteLine(z);
+    }
+
+    static void M(out int rx)
+    {
+        rx = 0;
+        rx = ref x;
+        Console.WriteLine(x);
+        rx++;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+        x++;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+
+        rx = ref y;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+        y++;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+    }
+}", expectedOutput: @"0
+1
+1
+2
+2
+2
+0
+0
+2
+1
+1
+0");
+        }
+
+        [Fact]
+        public void RefReassignRefParam()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+
+class C
+{
+    static int x = 0;
+    static int y = 0;
+
+    static void Main()
+    {
+        M(ref x);
+    }
+
+    static void M(ref int rx)
+    {
+        Console.WriteLine(x);
+        rx++;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+        x++;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+
+        rx = ref y;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+        y++;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+    }
+}", expectedOutput: @"0
+1
+1
+2
+2
+2
+0
+0
+2
+1
+1");
+
+        }
+
+        [Fact]
+        public void RefReassignRefReadonlyLocal()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        int x = 0;
+        ref readonly int rx = ref x;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+        x++;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+
+        int y = 0;
+        rx = ref y;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+        y++;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+    }
+}", expectedOutput: @"0
+0
+1
+1
+1
+0
+0
+1
+1
+1
+");
+        }
+
+        [Fact]
+        public void RefReassignLocal()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        int x = 0;
+        ref int rx = ref x;
+        Console.WriteLine(x);
+        rx++;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+        x++;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+
+        int y = 0;
+        rx = ref y;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+        y++;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+    }
+}", expectedOutput: @"0
+1
+1
+2
+2
+2
+0
+0
+2
+1
+1");
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       91 (0x5b)
+  .maxstack  4
+  .locals init (int V_0, //x
+                int V_1) //y
+  IL_0000:  ldc.i4.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  ldloc.0
+  IL_0005:  call       ""void System.Console.WriteLine(int)""
+  IL_000a:  dup
+  IL_000b:  dup
+  IL_000c:  ldind.i4
+  IL_000d:  ldc.i4.1
+  IL_000e:  add
+  IL_000f:  stind.i4
+  IL_0010:  ldloc.0
+  IL_0011:  call       ""void System.Console.WriteLine(int)""
+  IL_0016:  dup
+  IL_0017:  ldind.i4
+  IL_0018:  call       ""void System.Console.WriteLine(int)""
+  IL_001d:  ldloc.0
+  IL_001e:  ldc.i4.1
+  IL_001f:  add
+  IL_0020:  stloc.0
+  IL_0021:  ldloc.0
+  IL_0022:  call       ""void System.Console.WriteLine(int)""
+  IL_0027:  ldind.i4
+  IL_0028:  call       ""void System.Console.WriteLine(int)""
+  IL_002d:  ldc.i4.0
+  IL_002e:  stloc.1
+  IL_002f:  ldloca.s   V_1
+  IL_0031:  ldloc.0
+  IL_0032:  call       ""void System.Console.WriteLine(int)""
+  IL_0037:  ldloc.1
+  IL_0038:  call       ""void System.Console.WriteLine(int)""
+  IL_003d:  dup
+  IL_003e:  ldind.i4
+  IL_003f:  call       ""void System.Console.WriteLine(int)""
+  IL_0044:  ldloc.1
+  IL_0045:  ldc.i4.1
+  IL_0046:  add
+  IL_0047:  stloc.1
+  IL_0048:  ldloc.0
+  IL_0049:  call       ""void System.Console.WriteLine(int)""
+  IL_004e:  ldloc.1
+  IL_004f:  call       ""void System.Console.WriteLine(int)""
+  IL_0054:  ldind.i4
+  IL_0055:  call       ""void System.Console.WriteLine(int)""
+  IL_005a:  ret
+}");
+        }
+
+        [Fact]
+        public void RefReadonlyReassign()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        int x = 0;
+        ref int rx = ref x;
+        ref readonly int rrx = ref x;
+        Console.WriteLine(x);
+        Console.WriteLine(rx);
+        Console.WriteLine(rrx);
+
+        int y = 1;
+        rx = ref y;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+        Console.WriteLine(rrx);
+
+        rrx = ref rx;
+        y++;
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+        Console.WriteLine(rx);
+        Console.WriteLine(rrx);
+    }
+}", expectedOutput: @"0
+0
+0
+0
+1
+1
+0
+0
+2
+2
+2");
+        }
+
         [Fact]
         public void RefAssignArrayAccess()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -28,6 +28,42 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void RefReturnRefAssignment()
+        {
+            CompileAndVerify(@"
+using System;
+class C
+{
+    static readonly int _ro = 42;
+    static int _rw = 42;
+
+    static void Main()
+    {
+        Console.WriteLine(M1(ref _rw));
+        Console.WriteLine(M2(in _ro));
+        Console.WriteLine(M3(in _ro));;
+
+        M1(ref _rw)++;
+
+        Console.WriteLine(M1(ref _rw));
+        Console.WriteLine(M2(in _ro));
+        Console.WriteLine(M3(in _ro));;
+    }
+
+    static ref int M1(ref int rrw) => ref (rrw = ref _rw);
+
+    static ref readonly int M2(in int rro) => ref (rro = ref _ro);
+
+    static ref readonly int M3(in int rro) => ref (rro = ref _rw);
+}", verify: Verification.Fails, expectedOutput: @"42
+42
+42
+43
+42
+43");
+        }
+
+        [Fact]
         public void RefReturnArrayAccess()
         {
             var text = @"
@@ -2362,6 +2398,9 @@ class Program
 
             var comp = CreateCompilation(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
             comp.VerifyDiagnostics(
+                // (6,14): error CS8059: Feature 'ref for-loop variables' is not available in C# 6. Please use language version 7.3 or greater.
+                //         for (ref int a = ref d; ;) { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref int").WithArguments("ref for-loop variables", "7.3").WithLocation(6, 14),
                 // (6,14): error CS8059: Feature 'byref locals and returns' is not available in C# 6. Please use language version 7.0 or greater.
                 //         for (ref int a = ref d; ;) { }
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7.0").WithLocation(6, 14),

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests.cs
@@ -13,6 +13,227 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     [CompilerTrait(CompilerFeature.IOperation)]
     public partial class IOperationTests : SemanticModelTestBase
     {
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.RefLocalsReturns)]
+        [Fact]
+        public void RefReassignmentExpressions()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    ref readonly int M(ref int rx)
+    {
+        ref int ry = ref rx;
+        rx = ref ry;
+        ry = ref """".Length == 0
+            ? ref (rx = ref ry)
+            : ref (ry = ref rx);
+        return ref (ry = ref rx);
+    }
+}");
+            comp.VerifyDiagnostics();
+
+            var m = comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<BlockSyntax>().Single();
+            comp.VerifyOperationTree(m, expectedOperationTree: @"
+IBlockOperation (4 statements, 1 locals) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+  Locals: Local_1: System.Int32 ry
+  IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDeclarationGroup, Type: null) (Syntax: 'ref int ry = ref rx;')
+    IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null) (Syntax: 'ref int ry = ref rx')
+      Declarators:
+          IVariableDeclaratorOperation (Symbol: System.Int32 ry) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'ry = ref rx')
+            Initializer: 
+              IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= ref rx')
+                IParameterReferenceOperation: rx (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'rx')
+      Initializer: 
+        null
+  IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'rx = ref ry;')
+    Expression: 
+      ISimpleAssignmentOperation (IsRef) (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: 'rx = ref ry')
+        Left: 
+          IParameterReferenceOperation: rx (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'rx')
+        Right: 
+          ILocalReferenceOperation: ry (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'ry')
+  IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'ry = ref """" ...  = ref rx);')
+    Expression: 
+      ISimpleAssignmentOperation (IsRef) (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: 'ry = ref """" ... y = ref rx)')
+        Left: 
+          ILocalReferenceOperation: ry (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'ry')
+        Right: 
+          IConditionalOperation (IsRef) (OperationKind.Conditional, Type: System.Int32) (Syntax: '"""".Length = ... y = ref rx)')
+            Condition: 
+              IBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: '"""".Length == 0')
+                Left: 
+                  IPropertyReferenceOperation: System.Int32 System.String.Length { get; } (OperationKind.PropertyReference, Type: System.Int32) (Syntax: '"""".Length')
+                    Instance Receiver: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: """") (Syntax: '""""')
+                Right: 
+                  ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+            WhenTrue: 
+              ISimpleAssignmentOperation (IsRef) (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: 'rx = ref ry')
+                Left: 
+                  IParameterReferenceOperation: rx (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'rx')
+                Right: 
+                  ILocalReferenceOperation: ry (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'ry')
+            WhenFalse: 
+              ISimpleAssignmentOperation (IsRef) (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: 'ry = ref rx')
+                Left: 
+                  ILocalReferenceOperation: ry (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'ry')
+                Right: 
+                  IParameterReferenceOperation: rx (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'rx')
+  IReturnOperation (OperationKind.Return, Type: null) (Syntax: 'return ref  ...  = ref rx);')
+    ReturnedValue: 
+      ISimpleAssignmentOperation (IsRef) (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: 'ry = ref rx')
+        Left: 
+          ILocalReferenceOperation: ry (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'ry')
+        Right: 
+          IParameterReferenceOperation: rx (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'rx')");
+        }
+
+        [CompilerTrait(CompilerFeature.RefLocalsReturns)]
+        [Fact]
+        public void IOperationRefFor()
+        {
+            var tree = CSharpSyntaxTree.ParseText(@"
+using System;
+class C
+{
+    public class LinkedList
+    {
+        public int Value;
+        public LinkedList Next;
+    }
+    public void M(LinkedList list)
+    {
+        for (ref readonly var cur = ref list; cur != null; cur = ref cur.Next)
+        {
+            Console.WriteLine(cur.Value);
+        }
+    }
+}", options: TestOptions.Regular);
+            var comp = CreateCompilation(tree);
+            comp.VerifyDiagnostics();
+            var m = tree.GetRoot().DescendantNodes().OfType<BlockSyntax>().First();
+            comp.VerifyOperationTree(m, @"
+IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+  IForLoopOperation (LoopKind.For) (OperationKind.Loop, Type: null) (Syntax: 'for (ref re ... }')
+    Locals: Local_1: C.LinkedList cur
+    Condition: 
+      IBinaryOperation (BinaryOperatorKind.NotEquals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: 'cur != null')
+        Left: 
+          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'cur')
+            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+            Operand: 
+              ILocalReferenceOperation: cur (OperationKind.LocalReference, Type: C.LinkedList) (Syntax: 'cur')
+        Right: 
+          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, Constant: null, IsImplicit) (Syntax: 'null')
+            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+            Operand: 
+              ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
+    Before:
+        IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDeclarationGroup, Type: null, IsImplicit) (Syntax: 'ref readonl ...  = ref list')
+          IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null) (Syntax: 'ref readonl ...  = ref list')
+            Declarators:
+                IVariableDeclaratorOperation (Symbol: C.LinkedList cur) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'cur = ref list')
+                  Initializer: 
+                    IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= ref list')
+                      IParameterReferenceOperation: list (OperationKind.ParameterReference, Type: C.LinkedList) (Syntax: 'list')
+            Initializer: 
+              null
+    AtLoopBottom:
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: 'cur = ref cur.Next')
+          Expression: 
+            ISimpleAssignmentOperation (IsRef) (OperationKind.SimpleAssignment, Type: C.LinkedList) (Syntax: 'cur = ref cur.Next')
+              Left: 
+                ILocalReferenceOperation: cur (OperationKind.LocalReference, Type: C.LinkedList) (Syntax: 'cur')
+              Right: 
+                IFieldReferenceOperation: C.LinkedList C.LinkedList.Next (OperationKind.FieldReference, Type: C.LinkedList) (Syntax: 'cur.Next')
+                  Instance Receiver: 
+                    ILocalReferenceOperation: cur (OperationKind.LocalReference, Type: C.LinkedList) (Syntax: 'cur')
+    Body: 
+      IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'Console.Wri ... cur.Value);')
+          Expression: 
+            IInvocationOperation (void System.Console.WriteLine(System.Int32 value)) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Console.Wri ... (cur.Value)')
+              Instance Receiver: 
+                null
+              Arguments(1):
+                  IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value) (OperationKind.Argument, Type: null) (Syntax: 'cur.Value')
+                    IFieldReferenceOperation: System.Int32 C.LinkedList.Value (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'cur.Value')
+                      Instance Receiver: 
+                        ILocalReferenceOperation: cur (OperationKind.LocalReference, Type: C.LinkedList) (Syntax: 'cur')
+                    InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)");
+            var op = (IForLoopOperation)comp.GetSemanticModel(tree).GetOperation(tree.GetRoot().DescendantNodes().OfType<ForStatementSyntax>().Single());
+            Assert.Equal(RefKind.RefReadOnly, op.Locals.Single().RefKind);
+        }
+
+        [CompilerTrait(CompilerFeature.RefLocalsReturns)]
+        [Fact]
+        public void IOperationRefForeach()
+        {
+            var tree = CSharpSyntaxTree.ParseText(@"
+using System;
+class C
+{
+    public void M(RefEnumerable re)
+    {
+        foreach (ref readonly var x in re)
+        {
+            Console.WriteLine(x);
+        }
+    }
+}
+
+class RefEnumerable
+{
+    private readonly int[] _arr = new int[5];
+    public StructEnum GetEnumerator() => new StructEnum(_arr);
+
+    public struct StructEnum
+    {
+        private readonly int[] _arr;
+        private int _current;
+        public StructEnum(int[] arr)
+        {
+            _arr = arr;
+            _current = -1;
+        }
+        public ref int Current => ref _arr[_current];
+        public bool MoveNext() => ++_current != _arr.Length;
+    }
+}", options: TestOptions.Regular);
+            var comp = CreateCompilation(tree);
+            comp.VerifyDiagnostics();
+            var m = tree.GetRoot().DescendantNodes().OfType<BlockSyntax>().First();
+            comp.VerifyOperationTree(m, @"
+IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+  IForEachLoopOperation (LoopKind.ForEach) (OperationKind.Loop, Type: null) (Syntax: 'foreach (re ... }')
+    Locals: Local_1: System.Int32 x
+    LoopControlVariable: 
+      IVariableDeclaratorOperation (Symbol: System.Int32 x) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'var')
+        Initializer: 
+          null
+    Collection: 
+      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: RefEnumerable, IsImplicit) (Syntax: 're')
+        Conversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        Operand: 
+          IParameterReferenceOperation: re (OperationKind.ParameterReference, Type: RefEnumerable) (Syntax: 're')
+    Body: 
+      IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'Console.WriteLine(x);')
+          Expression: 
+            IInvocationOperation (void System.Console.WriteLine(System.Int32 value)) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Console.WriteLine(x)')
+              Instance Receiver: 
+                null
+              Arguments(1):
+                  IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value) (OperationKind.Argument, Type: null) (Syntax: 'x')
+                    ILocalReferenceOperation: x (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'x')
+                    InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+    NextVariables(0)");
+            var op = (IForEachLoopOperation)comp.GetSemanticModel(tree).GetOperation(tree.GetRoot().DescendantNodes().OfType<ForEachStatementSyntax>().Single());
+            Assert.Equal(RefKind.RefReadOnly, op.Locals.Single().RefKind);
+        }
+
         [CompilerTrait(CompilerFeature.IOperation)]
         [Fact]
         [WorkItem(382240, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=382240")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -12,14 +12,703 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
     [CompilerTrait(CompilerFeature.RefLocalsReturns)]
     public class RefLocalsAndReturnsTests : CompilingTestBase
     {
-        private static CSharpCompilation CreateCompilationRef(
-            string text,
-            IEnumerable<MetadataReference> references = null,
-            CSharpCompilationOptions options = null,
-            string assemblyName = "",
-            string sourceFileName = "")
+        [Fact]
+        public void RefFor72()
         {
-            return CreateCompilationWithMscorlib45(text);
+            var comp = CreateCompilation(@"
+class C
+{
+    void M(int x)
+    {
+        for (ref int rx = ref x; x < 0; x++) { }
+    }
+}", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_2));
+            comp.VerifyDiagnostics(
+                // (6,14): error CS8320: Feature 'ref for-loop variables' is not available in C# 7.2. Please use language version 7.3 or greater.
+                //         for (ref int rx = ref x; x < 0; x++) { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_2, "ref int").WithArguments("ref for-loop variables", "7.3").WithLocation(6, 14));
+        }
+
+        [Fact]
+        public void RefForEach72()
+        {
+            var comp = CreateCompilationWithMscorlibAndSpan(@"
+using System;
+class C
+{
+    void M(Span<int> span)
+    {
+        foreach (ref int x in span) { }
+    }
+}", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_2));
+            comp.VerifyDiagnostics(
+                // (7,18): error CS8320: Feature 'ref foreach iteration variables' is not available in C# 7.2. Please use language version 7.3 or greater.
+                //         foreach (ref int x in span) { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_2, "ref int").WithArguments("ref foreach iteration variables", "7.3").WithLocation(7, 18));
+        }
+
+        [Fact]
+        public void RefReturnRefExpression()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    readonly int _ro = 42;
+    int _rw = 42;
+
+    ref int M1(ref int rrw) => ref (rrw = ref _rw);
+
+    ref readonly int M2(in int rro) => ref (rro = ref _ro);
+
+    ref readonly int M3(in int rro) => ref (rro = ref _rw);
+
+    ref int M4(in int rro) => ref (rro = ref _rw);
+
+    ref int M5(ref int rrw) => ref (rrw = ref _ro);
+}");
+            comp.VerifyDiagnostics(
+                // (13,36): error CS8333: Cannot return variable 'in int' by writable reference because it is a readonly variable
+                //     ref int M4(in int rro) => ref (rro = ref _rw);
+                Diagnostic(ErrorCode.ERR_RefReturnReadonlyNotField, "rro = ref _rw").WithArguments("variable", "in int").WithLocation(13, 36),
+                // (15,47): error CS0191: A readonly field cannot be assigned to (except in a constructor or a variable initializer)
+                //     ref int M5(ref int rrw) => ref (rrw = ref _ro);
+                Diagnostic(ErrorCode.ERR_AssgReadonly, "_ro").WithLocation(15, 47));
+        }
+
+        [Fact]
+        public void ReadonlyFieldRefReassign()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    readonly int _ro = 42;
+    int _rw = 42;
+
+    void M()
+    {
+        ref readonly var rro = ref _ro;
+        ref var rrw = ref _rw;
+
+        rrw = ref (rro = ref _ro);
+        rrw = ref (rro = ref rrw);
+
+        rrw = ref (true
+                    ? ref (rro = ref _rw)
+                    : ref (rrw = ref _rw));
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (12,20): error CS1510: A ref or out value must be an assignable variable
+                //         rrw = ref (rro = ref _ro);
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "rro = ref _ro").WithLocation(12, 20),
+                // (13,20): error CS1510: A ref or out value must be an assignable variable
+                //         rrw = ref (rro = ref rrw);
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "rro = ref rrw").WithLocation(13, 20),
+                // (16,28): error CS1510: A ref or out value must be an assignable variable
+                //                     ? ref (rro = ref _rw)
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "rro = ref _rw").WithLocation(16, 28),
+                // (15,20): error CS1510: A ref or out value must be an assignable variable
+                //         rrw = ref (true
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, @"true
+                    ? ref (rro = ref _rw)
+                    : ref (rrw = ref _rw)").WithLocation(15, 20));
+        }
+
+        [Fact]
+        public void RefForeachErrorRecovery()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        foreach (ref var x in )
+        {
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (6,31): error CS1525: Invalid expression term ')'
+                //         foreach (ref var x in )
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(6, 31));
+        }
+
+        [Fact]
+        public void RefForToReadonly()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M(in int x)
+    {
+        for (ref int i = ref x; i < 0; i++) {}
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (6,30): error CS8329: Cannot use variable 'in int' as a ref or out value because it is a readonly variable
+                //         for (ref int i = ref x; i < 0; i++) {}
+                Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "x").WithArguments("variable", "in int").WithLocation(6, 30));
+        }
+
+        [Fact]
+        public void RefForOutOfScope()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    ref int M()
+    {
+        int x = 0;
+        for (ref int i = ref x; i < 0; i++)
+        {
+            if (i == 0)
+            {
+                return ref i;
+            }
+        }
+        return ref (new int[1])[0];
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (11,28): error CS8157: Cannot return 'i' by reference because it was initialized to a value that cannot be returned by reference
+                //                 return ref i;
+                Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "i").WithArguments("i").WithLocation(11, 28));
+        }
+
+        [Fact]
+        public void RefForeachReadonly()
+        {
+            var comp = CreateCompilation(@"
+using System;
+class C
+{
+    void M()
+    {
+        foreach (ref var v in new int[0])
+        {
+        }
+        foreach (ref readonly var v in new int[0])
+        {
+        }
+        foreach (ref var v in new RefEnumerable())
+        {
+            Console.WriteLine(v);
+        }
+    }
+}
+
+class RefEnumerable
+{
+    private readonly int[] _arr = new int[5];
+    public StructEnum GetEnumerator() => new StructEnum(_arr);
+
+    public struct StructEnum
+    {
+        private readonly int[] _arr;
+        private int _current;
+        public StructEnum(int[] arr)
+        {
+            _arr = arr;
+            _current = -1;
+        }
+        public ref readonly int Current => ref _arr[_current];
+        public bool MoveNext() => ++_current != _arr.Length;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (7,31): error CS1510: A ref or out value must be an assignable variable
+                //         foreach (ref var v in new int[0])
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "new int[0]").WithLocation(7, 31),
+                // (10,40): error CS1510: A ref or out value must be an assignable variable
+                //         foreach (ref readonly var v in new int[0])
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "new int[0]").WithLocation(10, 40),
+                // (13,31): error CS8331: Cannot assign to method 'RefEnumerable.StructEnum.Current.get' because it is a readonly variable
+                //         foreach (ref var v in new RefEnumerable())
+                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "new RefEnumerable()").WithArguments("method", "RefEnumerable.StructEnum.Current.get").WithLocation(13, 31));
+        }
+
+        [Fact]
+        public void RefReassignIdentityConversion()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        string s = ""s"";
+        object o = s;
+        ref string rs = ref s;
+        ref object ro = ref o;
+
+        rs = ref (string)o;
+        ro = ref s;
+        ro = s;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (11,18): error CS1510: A ref or out value must be an assignable variable
+                //         rs = ref (string)o;
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "(string)o").WithLocation(11, 18),
+                // (12,18): error CS8173: The expression must be of type 'object' because it is being assigned by reference
+                //         ro = ref s;
+                Diagnostic(ErrorCode.ERR_RefAssignmentMustHaveIdentityConversion, "s").WithArguments("object").WithLocation(12, 18));
+        }
+
+        [Fact]
+        public void RefReassign71()
+        {
+            var tree = SyntaxFactory.ParseSyntaxTree(@"
+class C
+{
+    static int _f = 0;
+    void M(ref int x, out int o)
+    {
+        x = ref _f;
+
+        ref int z = ref x;
+        z = ref _f;
+        o = 0;
+        o = ref _f;
+    }
+}", CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_2));
+            CreateCompilation(tree).VerifyDiagnostics(
+                // (7,13): error CS8320: Feature 'ref reassignment' is not available in C# 7.2. Please use language version 7.3 or greater.
+                //         x = ref _f;
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_2, "ref _f").WithArguments("ref reassignment", "7.3").WithLocation(7, 13),
+                // (10,13): error CS8320: Feature 'ref reassignment' is not available in C# 7.2. Please use language version 7.3 or greater.
+                //         z = ref _f;
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_2, "ref _f").WithArguments("ref reassignment", "7.3").WithLocation(10, 13),
+                // (12,13): error CS8320: Feature 'ref reassignment' is not available in C# 7.2. Please use language version 7.3 or greater.
+                //         o = ref _f;
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_2, "ref _f").WithArguments("ref reassignment", "7.3").WithLocation(12, 13));
+        }
+
+        [Fact]
+        public void RefReassignSpanLifetime()
+        {
+            var comp = CreateCompilationWithMscorlibAndSpan(@"
+using System;
+class C
+{
+    void M(ref Span<int> s)
+    {
+        Span<int> s2 = new Span<int>(new int[10]);
+        s = ref s2; // OK
+
+        s2 = stackalloc int[10]; // Illegal, narrower lifetime
+
+        Span<int> s3 = stackalloc int[10];
+        s = ref s3; // Illegal, narrower lifetime
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (10,14): error CS8353: A result of a stackalloc expression of type 'Span<int>' cannot be used in this context because it may be exposed outside of the containing method
+                //         s2 = stackalloc int[10]; // Illegal, narrower lifetime
+                Diagnostic(ErrorCode.ERR_EscapeStackAlloc, "stackalloc int[10]").WithArguments("System.Span<int>").WithLocation(10, 14),
+                // (13,17): error CS8352: Cannot use local 's3' in this context because it may expose referenced variables outside of their declaration scope
+                //         s = ref s3; // Illegal, narrower lifetime
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "s3").WithArguments("s3").WithLocation(13, 17));
+        }
+
+        [Fact]
+        public void RefReassignReferenceLocalToParam()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M(ref string s)
+    {
+        var s2 = string.Empty;
+        s = ref s2;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (7,9): error CS8356: Cannot ref-assign 's2' to 's' because 's2' has a narrower escape scope than 's'.
+                //         s = ref s2;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "s = ref s2").WithArguments("s", "s2").WithLocation(7, 9));
+        }
+
+        [Fact]
+        public void RefAssignReferencePropertyToParam()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    string s2 => string.Empty;
+
+    void M(ref string s)
+    {
+        s = ref s2;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (8,17): error CS1510: A ref or out value must be an assignable variable
+                //         s = ref s2;
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "s2").WithArguments("C.s2").WithLocation(8, 17));
+        }
+
+        [Fact]
+        public void RefAssignReferenceFileToParam()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    string _s2 = string.Empty;
+
+    void M(ref string s)
+    {
+        s = ref _s2;
+    }
+}");
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefAssignStaticField()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M(ref string s)
+    {
+        s = ref string.Empty;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (6,17): error CS0198: A static readonly field cannot be assigned to (except in a static constructor or a variable initializer)
+                //         s = ref string.Empty;
+                Diagnostic(ErrorCode.ERR_AssgReadonlyStatic, "string.Empty").WithLocation(6, 17));
+        }
+
+        [Fact]
+        public void RefReassignForEach()
+        {
+            var comp = CreateCompilation(@"
+using System;
+class E
+{
+    public class Enumerator
+    {
+        public ref int Current => throw new NotImplementedException();
+        public bool MoveNext() => throw new NotImplementedException();
+    }
+
+    public Enumerator GetEnumerator() => new Enumerator();
+}
+
+class C
+{
+    void M()
+    {
+        foreach (ref int x in new E())
+        {
+            int y = 0;
+            x = ref y;
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (21,13): error CS1656: Cannot assign to 'x' because it is a 'foreach iteration variable'
+                //             x = ref y;
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocalCause, "x").WithArguments("x", "foreach iteration variable").WithLocation(21, 13));
+        }
+
+        [Fact]
+        public void RefReassignNarrowLifetime()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    int _x = 0;
+    void M()
+    {
+        int y = 0;
+        ref int rx = ref _x;
+        rx = ref y;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (9,9): error CS8356: Cannot ref-assign 'y' to 'rx' because 'y' has a narrower escape scope than 'rx'.
+                //         rx = ref y;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "rx = ref y").WithArguments("rx", "y").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void RefReassignRangeVar()
+        {
+            var comp = CreateCompilation(@"
+using System;
+using System.Linq;
+class C
+{
+    void M()
+    {
+        _ = from c in ""test"" select (Action)(() =>
+        {
+            int x = 0;
+            ref int rx = ref x;
+            rx = ref c;
+            c = ref x;
+        });
+    }
+}", references: new[] { LinqAssemblyRef });
+            comp.VerifyDiagnostics(
+                // (12,22): error CS1939: Cannot pass the range variable 'c' as an out or ref parameter
+                //             rx = ref c;
+                Diagnostic(ErrorCode.ERR_QueryOutRefRangeVariable, "c").WithArguments("c").WithLocation(12, 22),
+                // (13,13): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //             c = ref x;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "c").WithArguments("c").WithLocation(13, 13));
+        }
+
+        [Fact]
+        public void RefReassignOutDefiniteAssignment()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    static int y = 0;
+    void M(out int x)
+    {
+        x = ref y;
+        x = 0;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (7,9): error CS0177: The out parameter 'x' must be assigned to before control leaves the current method
+                //         x = ref y;
+                Diagnostic(ErrorCode.ERR_ParamUnassigned, "x").WithArguments("x").WithLocation(7, 9));
+        }
+
+        [Fact]
+        public void RefReassignOutDefiniteAssignment2()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M(out int x)
+    {
+        x = 0;
+        int y;
+        x = ref y;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (8,9): error CS8356: Cannot ref-assign 'y' to 'x' because 'y' has a narrower escape scope than 'x'.
+                //         x = ref y;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "x = ref y").WithArguments("x", "y").WithLocation(8, 9),
+                // (8,17): error CS0165: Use of unassigned local variable 'y'
+                //         x = ref y;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(8, 17));
+        }
+
+        [Fact]
+        public void RefReassignParamEscape()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M(ref int x)
+    {
+        int y = 0;
+        x = ref y;
+
+        ref int z = ref y;
+        x = ref z;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (7,9): error CS8356: Cannot ref-assign 'y' to 'x' because 'y' has a narrower escape scope than 'x'.
+                //         x = ref y;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "x = ref y").WithArguments("x", "y").WithLocation(7, 9),
+                // (10,9): error CS8356: Cannot ref-assign 'z' to 'x' because 'z' has a narrower escape scope than 'x'.
+                //         x = ref z;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "x = ref z").WithArguments("x", "z").WithLocation(10, 9));
+        }
+
+        [Fact]
+        public void RefReassignThisStruct()
+        {
+            var comp = CreateCompilation(@"
+struct S
+{
+    int _f;
+    public S(int x) { _f = x; }
+
+    void M()
+    {
+        var s = new S(0);
+        this = ref s;
+
+        ref var s2 = ref s;
+        this = ref s2;
+
+        ref readonly var s3 = ref s;
+        this = ref s3;
+
+        this = ref (new S[1])[0];
+
+        ref var s4 = ref (new S[1])[0];
+        this = ref s4;
+
+        ref readonly var s5 = ref (new S[1])[0];
+        this = ref s5;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (10,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         this = ref s;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(10, 9),
+                // (13,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         this = ref s2;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(13, 9),
+                // (16,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         this = ref s3;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(16, 9),
+                // (18,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         this = ref (new S[1])[0];
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(18, 9),
+                // (21,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         this = ref s4;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(21, 9),
+                // (24,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         this = ref s5;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(24, 9));
+        }
+
+        [Fact]
+        public void RefReassignThisClass()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        this = ref (new int[1])[0];
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (6,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         this = ref (new int[1])[0];
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(6, 9));
+        }
+
+        [Fact]
+        public void RefReassignField()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    int _f = 0;
+    void M()
+    {
+        _f = ref (new int[1])[0];
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (7,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         _f = ref (new int[1])[0];
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "_f").WithLocation(7, 9));
+        }
+
+        [Fact]
+        public void RefReassignOperatorResult()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        int x = 0;
+        (2 + 3) = ref x;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (7,10): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         (2 + 3) = ref x;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "2 + 3").WithLocation(7, 10));
+        }
+
+        [Fact]
+        public void RefReassignToValue()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        int x = 0;
+        int y = 0;
+        x = ref y;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (8,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         x = ref y;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "x").WithArguments("x").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void RefReassignWithReadonly()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        int x = 0;
+        ref int rx = ref x;
+        ref readonly int rrx = ref x;
+        rx = ref rrx;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (9,18): error CS1510: A ref or out value must be an assignable variable
+                //         rx = ref rrx;
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "rrx").WithLocation(9, 18));
+        }
+
+        [Fact]
+        public void RefReassignToRefReturn()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        int x = 0;
+        ref int rx = ref M2();
+        M2() = ref x;
+    }
+    ref int M2() => ref (new int[1])[0];
+}");
+            comp.VerifyDiagnostics(
+                // (8,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         M2() = ref x;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "M2()").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void RefReassignToProperty()
+        {
+            var comp = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        int x = 0;
+        ref int rx = ref P;
+        P = ref x;
+    }
+    ref int P
+    {
+        get => ref (new int[1])[0];
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (8,9): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                //         P = ref x;
+                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "P").WithLocation(8, 9));
         }
 
         [Fact]
@@ -308,7 +997,7 @@ class C
         [Fact]
         public void AssignRefReadonlyToRefParam()
         {
-            var comp = CreateCompilationRef(@"
+            var comp = CreateCompilation(@"
 class C
 {
     void M()
@@ -348,7 +1037,7 @@ class C
         [Fact]
         public void AssignRefReadonlyLocalToRefLocal()
         {
-            var comp = CreateCompilationRef(@"
+            var comp = CreateCompilation(@"
 class C
 {
     void M()
@@ -388,7 +1077,7 @@ class Test
         ref int x;
     }
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
     // (6,17): error CS8174: A declaration of a by-reference variable must have an initializer
     //         ref int x;
@@ -412,7 +1101,7 @@ class Test
         var y = x;
     }
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
     // (7,17): error CS8172: Cannot initialize a by-reference variable with a value
     //         ref int x = a;
@@ -433,7 +1122,7 @@ class Test
         var y = ref x;
     }
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
     // (8,13): error CS8171: Cannot initialize a by-value variable with a reference
     //         var y = ref x;
@@ -477,7 +1166,7 @@ class Test
     }
 
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
     // (6,20): error CS8156: An expression cannot be used in this context because it may not be returned by reference
     //         return ref 2 + 2;
@@ -518,7 +1207,7 @@ class Test
     void VoidMethod(){}
     int P1 {get{return 1;} set{}}
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
     // (9,27): error CS8156: An expression cannot be used in this context because it may not be returned by reference
     //         D1 d1 = () => ref 2 + 2;
@@ -591,7 +1280,7 @@ public class Test
         throw null;
     }
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
     // (18,24): error CS8168: Cannot return local 'l' by reference because it is not a ref local
     //             return ref l;
@@ -645,7 +1334,7 @@ public class Test
         throw null;
     }
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
                 // (13,30): error CS1657: Cannot use 'ro' as a ref or out value because it is a 'foreach iteration variable'
                 //             ref char r = ref ro;
@@ -687,20 +1376,14 @@ public class Test
     }
 
 }";
-            var comp = CreateCompilationRef(text, references: new[] { MscorlibRef, SystemCoreRef });
+            var comp = CreateCompilation(text, references: new[] { MscorlibRef, SystemCoreRef, LinqAssemblyRef });
             comp.VerifyDiagnostics(
-                // (2,14): error CS0234: The type or namespace name 'Linq' does not exist in the namespace 'System' (are you missing an assembly reference?)
-                // using System.Linq;
-                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "Linq").WithArguments("Linq", "System").WithLocation(2, 14),
-                // (15,28): error CS1935: Could not find an implementation of the query pattern for source type 'string'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?
-                //         var x = from ch in "qqq"
-                Diagnostic(ErrorCode.ERR_QueryNoProviderStandard, @"""qqq""").WithArguments("string", "Select").WithLocation(15, 28),
-                // (18,27): error CS1935: Could not find an implementation of the query pattern for source type 'Test.S1[]'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?
-                //         var y = from s in new S1[10]
-                Diagnostic(ErrorCode.ERR_QueryNoProviderStandard, "new S1[10]").WithArguments("Test.S1[]", "Select").WithLocation(18, 27),
-                // (2,1): hidden CS8019: Unnecessary using directive.
-                // using System.Linq;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Linq;").WithLocation(2, 1)
+                // (16,34): error CS8159: Cannot return the range variable 'ch' by reference
+                //             select(D1)(() => ref ch);
+                Diagnostic(ErrorCode.ERR_RefReturnRangeVariable, "ch").WithArguments("ch").WithLocation(16, 34),
+                // (19,34): error CS8159: Cannot return the range variable 's' by reference
+                //             select(D1)(() => ref s.x);
+                Diagnostic(ErrorCode.ERR_RefReturnRangeVariable, "s.x").WithArguments("s").WithLocation(19, 34)
             );
         }
         
@@ -744,7 +1427,7 @@ public class Test
     }
 
 }";
-            var comp = CreateCompilationRef(text, references: new[] { MscorlibRef, SystemCoreRef });
+            var comp = CreateCompilation(text, references: new[] { MscorlibRef, SystemCoreRef });
             comp.VerifyDiagnostics(
     // (14,26): error CS1657: Cannot use 'M' as a ref or out value because it is a 'method group'
     //         ref char r = ref M;
@@ -861,7 +1544,7 @@ public class Test
     }
 
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
                 // (33,33): error CS0199: A static readonly field cannot be used as a ref or out value (except in a static constructor)
                 //             ref char temp = ref s1;
@@ -960,7 +1643,7 @@ public class Test
         }
     }
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
                 // (10,24): error CS8170: Struct members cannot return 'this' or other instance members by reference
                 //             return ref this;
@@ -1068,7 +1751,7 @@ public class Test
         throw null;
     }
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
     // (18,24): error CS8157: Cannot return 'r' by reference because it was initialized to a value that cannot be returned by reference
     //             return ref r;
@@ -1152,7 +1835,7 @@ public class Test
         throw null;
     }
 }";
-            var comp = CreateCompilationRef(text);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
                 // (19,24): error CS8157: Cannot return 'r' by reference because it was initialized to a value that cannot be returned by reference
                 //             return ref r;   //1

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -1660,45 +1660,62 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "for(ref T a = ref b, c = ref d;;) { }";
             var statement = this.ParseStatement(text);
 
-            Assert.NotNull(statement);
-            Assert.Equal(SyntaxKind.ForStatement, statement.Kind());
-            Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.Errors().Length);
-
-            var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
-            Assert.False(fs.ForKeyword.IsMissing);
-            Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
-
-            Assert.NotNull(fs.Declaration);
-            Assert.NotNull(fs.Declaration.Type);
-            Assert.Equal("ref T", fs.Declaration.Type.ToString());
-            Assert.Equal(2, fs.Declaration.Variables.Count);
-
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
-            Assert.Equal("a", fs.Declaration.Variables[0].Identifier.ToString());
-            var initializer = fs.Declaration.Variables[0].Initializer as EqualsValueClauseSyntax;
-            Assert.NotNull(initializer);
-            Assert.NotNull(initializer.EqualsToken);
-            Assert.Equal(SyntaxKind.RefExpression, initializer.Value.Kind());
-            Assert.Equal("ref b", initializer.Value.ToString());
-
-            Assert.NotNull(fs.Declaration.Variables[1].Identifier);
-            Assert.Equal("c", fs.Declaration.Variables[1].Identifier.ToString());
-            initializer = fs.Declaration.Variables[1].Initializer as EqualsValueClauseSyntax;
-            Assert.NotNull(initializer);
-            Assert.NotNull(initializer.EqualsToken);
-            Assert.Equal(SyntaxKind.RefExpression, initializer.Value.Kind());
-            Assert.Equal("ref d", initializer.Value.ToString());
-
-            Assert.Equal(0, fs.Initializers.Count);
-            Assert.NotNull(fs.FirstSemicolonToken);
-            Assert.Null(fs.Condition);
-            Assert.NotNull(fs.SecondSemicolonToken);
-            Assert.Equal(0, fs.Incrementors.Count);
-            Assert.NotNull(fs.CloseParenToken);
-            Assert.NotNull(fs.Statement);
+            UsingNode(statement);
+            N(SyntaxKind.ForStatement);
+            {
+                N(SyntaxKind.ForKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.VariableDeclaration);
+                {
+                    N(SyntaxKind.RefType);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "T");
+                        }
+                    }
+                    N(SyntaxKind.VariableDeclarator);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.RefExpression);
+                            {
+                                N(SyntaxKind.RefKeyword);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "b");
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.VariableDeclarator);
+                    {
+                        N(SyntaxKind.IdentifierToken, "c");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.RefExpression);
+                            {
+                                N(SyntaxKind.RefKeyword);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "d");
+                                }
+                            }
+                        }
+                    }
+                }
+                N(SyntaxKind.SemicolonToken);
+                N(SyntaxKind.SemicolonToken);
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.Block);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
+            }
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -4614,5 +4614,48 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestIntroduceLocalInCallRefExpression()
+        {
+            // This test indicates that ref-expressions are l-values and
+            // introduce local still introduces a local, not a ref-local.
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    void M(int x)
+    {
+        ref int y = ref x;
+        M2([|(y = ref x)|]);
+    }
+    void M2(int p) { }
+}", @"
+class C
+{
+    void M(int x)
+    {
+        ref int y = ref x;
+        int {|Rename:p|} = (y = ref x);
+        M2(p);
+    }
+    void M2(int p) { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestIntroduceLocalInRefCallRefExpression()
+        {
+            // Cannot extract expressions passed by ref
+            await TestMissingInRegularAndScriptAsync(@"
+class C
+{
+    void M(int x)
+    {
+        ref int y = ref x;
+        M2(ref [|(y = ref x)|]);
+    }
+    void M2(ref int p) { }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -2316,5 +2316,36 @@ public class Test
     }
 }", new TestParameters(options: ImplicitTypeEverywhere()));
         }
+
+        [Fact]
+        public async Task DoNoSuggestVarForRefForeachVar()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+using System;
+namespace System
+{
+    public readonly ref struct Span<T>
+    {
+        unsafe public Span(void* pointer, int length) { }
+
+        public ref SpanEnum GetEnumerator() => throw new Exception();
+
+        public struct SpanEnum
+        {
+            public ref int Current => 0;
+            public bool MoveNext() => false;
+        }
+    }
+}
+class C
+{
+    public void M(Span<int> span)
+    {
+        foreach ([|ref|] var rx in span)
+        {
+        }
+    }
+}", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
@@ -501,13 +501,6 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotInForEach()
-        {
-            await VerifyAbsenceWithRefsAsync(AddInsideMethod(
-@"foreach ($$"));
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotInUsing()
         {
             await VerifyAbsenceWithRefsAsync(AddInsideMethod(
@@ -831,6 +824,37 @@ ref int y = ref true ? ref x : $$"));
             await VerifyKeywordWithRefsAsync(AddInsideMethod(
 @" void Goo(int test, $$) "));
 
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestRefInFor()
+        {
+            await VerifyKeywordWithRefsAsync(AddInsideMethod(@"
+for ($$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestRefForeachVariable()
+        {
+            await VerifyKeywordWithRefsAsync(AddInsideMethod(@"
+foreach ($$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestRefExpressionInAssignment()
+        {
+            await VerifyKeywordWithRefsAsync(AddInsideMethod(@"
+int x = 0;
+ref int y = ref x;
+y = $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestRefExpressionAfterReturn()
+        {
+            await VerifyKeywordWithRefsAsync(AddInsideMethod(@"
+ref int x = ref (new int[1])[0];
+return ref (x = $$"));
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                                         properties = default(ResultProperties);
                                         return new BoundReturnStatement(syntax, RefKind.None, expression) { WasCompilerGenerated = true };
                                     });
-                                var flags = local.IsWritable ? DkmClrCompilationResultFlags.None : DkmClrCompilationResultFlags.ReadOnlyResult;
+                                var flags = local.IsWritableVariable ? DkmClrCompilationResultFlags.None : DkmClrCompilationResultFlags.ReadOnlyResult;
                                 localBuilder.Add(MakeLocalAndMethod(local, aliasMethod, flags));
                                 methodBuilder.Add(aliasMethod);
                             }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ExceptionLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ExceptionLocalSymbol.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             _getExceptionMethodName = getExceptionMethodName;
         }
 
-        internal override bool IsWritable
+        internal override bool IsWritableVariable
         {
             get { return false; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectAddressLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectAddressLocalSymbol.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             _address = address;
         }
 
-        internal override bool IsWritable
+        internal override bool IsWritableVariable
         {
             // Return true?
             get { return false; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             _isWritable = isWritable;
         }
 
-        internal override bool IsWritable
+        internal override bool IsWritableVariable
         {
             get { return _isWritable; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
 
-        internal abstract override bool IsWritable { get; }
+        internal abstract override bool IsWritableVariable { get; }
 
         internal override EELocalSymbolBase ToOtherMethod(MethodSymbol method, TypeMap typeMap)
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ReturnValueLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ReturnValueLocalSymbol.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             _index = index;
         }
 
-        internal override bool IsWritable
+        internal override bool IsWritableVariable
         {
             get { return false; }
         }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RefKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RefKeywordRecommender.cs
@@ -114,17 +114,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     return true;
 
                 // {
-                //     for(ref var x ...
-                // 
+                //     for (ref var x ...
+                //
+                //     foreach (ref var x ...
+                //
                 case SyntaxKind.OpenParenToken:
                     var previous = token.GetPreviousToken(includeSkipped: true);
-                    return previous.IsKind(SyntaxKind.ForKeyword);
+                    return previous.IsKind(SyntaxKind.ForKeyword)
+                        || previous.IsKind(SyntaxKind.ForEachKeyword);
 
                 // {
                 //     ref var x = ref
                 // 
                 case SyntaxKind.EqualsToken:
-                    return token.Parent?.Parent?.Kind() == SyntaxKind.VariableDeclarator;
+                    var parent = token.Parent;
+                    return parent?.Kind() == SyntaxKind.SimpleAssignmentExpression
+                        || parent?.Parent?.Kind() == SyntaxKind.VariableDeclarator;
 
                 // {
                 //     var x = true ?

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -46,7 +46,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
         protected override bool ShouldAnalyzeForEachStatement(ForEachStatementSyntax forEachStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
-            if (forEachStatement.Type.IsVar)
+            var type = forEachStatement.Type;
+            if (type.IsVar || (type.Kind() == SyntaxKind.RefType && ((RefTypeSyntax)type).Type.IsVar))
             {
                 // If the type is already 'var', this analyze has no work to do
                 return false;


### PR DESCRIPTION
The test plan for ref-reassignment is at https://github.com/dotnet/roslyn/issues/22466 and has already been reviewed. The blocking issues were

- Language version checks for ref in for & foreach
- Additional tests around ++ and ref assignment expressions
- Tests for ?., IDisposable, and ref assignment expressions
- Additional semantic model tests
- Additional IOperation tests

as well as the IDE checklist. These have all been completed, therefore this should be ready to merge.