### PR TITLE
API suggestion for fix all using DocumentEditor.

### DIFF
--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/DocumentEditorAction.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/DocumentEditorAction.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Microsoft.CodeAnalysis.CodeFixes
+{
+    public class DocumentEditorAction : CodeAction
+    {
+        private readonly Document document;
+
+        public DocumentEditorAction(string title, Document document, Action<DocumentEditor, CancellationToken> action, string equivalenceKey)
+        {
+            this.document = document;
+            this.Title = title;
+            this.Action = action;
+            this.EquivalenceKey = equivalenceKey;
+        }
+
+        public Action<DocumentEditor, CancellationToken> Action { get; }
+
+        public sealed override string Title { get; }
+
+        public sealed override string EquivalenceKey { get; }
+
+        protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+        {
+            var editor = await DocumentEditor.CreateAsync(this.document, cancellationToken)
+                                             .ConfigureAwait(false);
+            this.Action(editor, cancellationToken);
+            return editor.GetChangedDocument();
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/DocumentEditorCodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/DocumentEditorCodeFixContext.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CodeFixes
+{
+    public struct DocumentEditorCodeFixContext
+    {
+        private readonly CodeFixContext context;
+
+        public DocumentEditorCodeFixContext(CodeFixContext context)
+        {
+            this.context = context;
+        }
+
+        /// <summary>
+        /// Document corresponding to the <see cref="P:Microsoft.CodeAnalysis.CodeFixes.CodeFixContext.Span" /> to fix.
+        /// </summary>
+        public Document Document => this.context.Document;
+
+        public CancellationToken CancellationToken => this.context.CancellationToken;
+
+        /// <summary>
+        /// Text span within the <see cref="P:Microsoft.CodeAnalysis.CodeFixes.CodeFixContext.Document" /> to fix.
+        /// </summary>
+        public TextSpan Span => this.context.Span;
+
+        /// <summary>
+        /// Diagnostics to fix.
+        /// NOTE: All the diagnostics in this collection have the same <see cref="P:Microsoft.CodeAnalysis.CodeFixes.CodeFixContext.Span" />.
+        /// </summary>
+        public ImmutableArray<Diagnostic> Diagnostics => this.context.Diagnostics;
+
+        public void RegisterCodeFix(
+            string title,
+            Action<DocumentEditor, CancellationToken> action,
+            string equivalenceKey,
+            Diagnostic diagnostic)
+        {
+            this.context.RegisterCodeFix(
+                new DocumentEditorAction(title, this.context.Document, action, equivalenceKey),
+                diagnostic);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/DocumentEditorCodeFixProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/DocumentEditorCodeFixProvider.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.CodeFixes
+{
+    public abstract class DocumentEditorCodeFixProvider : CodeFixProvider
+    {
+        public sealed override FixAllProvider GetFixAllProvider() => this.FixAllProvider();
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context) => this.RegisterCodeFixesAsync(new DocumentEditorCodeFixContext(context));
+
+        protected virtual DocumentEditorFixAllProvider FixAllProvider() => DocumentEditorFixAllProvider.CurrentDocument;
+
+        protected abstract Task RegisterCodeFixesAsync(DocumentEditorCodeFixContext context);
+    }
+}

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/DocumentEditorFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/DocumentEditorFixAllProvider.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Microsoft.CodeAnalysis.CodeFixes
+{
+    public sealed class DocumentEditorFixAllProvider : FixAllProvider
+    {
+        public static readonly DocumentEditorFixAllProvider CurrentDocument = new DocumentEditorFixAllProvider(ImmutableArray.Create(FixAllScope.Document));
+
+        private readonly ImmutableArray<FixAllScope> supportedFixAllScopes;
+
+        private DocumentEditorFixAllProvider(ImmutableArray<FixAllScope> supportedFixAllScopes)
+        {
+            this.supportedFixAllScopes = supportedFixAllScopes;
+        }
+
+        public override IEnumerable<FixAllScope> GetSupportedFixAllScopes() => this.supportedFixAllScopes;
+
+        public override async Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+        {
+            var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(fixAllContext.Document)
+                                                 .ConfigureAwait(false);
+            var actions = new List<DocumentEditorAction>();
+            foreach (var diagnostic in diagnostics)
+            {
+                var codeFixContext = new CodeFixContext(
+                    fixAllContext.Document,
+                    diagnostic,
+                    (a, _) =>
+                    {
+                        if (a.EquivalenceKey == fixAllContext.CodeActionEquivalenceKey)
+                        {
+                            actions.Add((DocumentEditorAction)a);
+                        }
+                    },
+                    fixAllContext.CancellationToken);
+                await fixAllContext.CodeFixProvider.RegisterCodeFixesAsync(codeFixContext)
+                                   .ConfigureAwait(false);
+            }
+
+            if (actions.Count == 0)
+            {
+                return null;
+            }
+
+            return CodeAction.Create(actions[0].Title, c => FixDocumentAsync(fixAllContext.Document, actions, c));
+        }
+
+        private static async Task<Document> FixDocumentAsync(Document document, IReadOnlyList<DocumentEditorAction> actions, CancellationToken cancellationToken)
+        {
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken)
+                                             .ConfigureAwait(false);
+            foreach (var action in actions)
+            {
+                action.Action(editor, cancellationToken);
+            }
+
+            return editor.GetChangedDocument();
+        }
+    }
+}


### PR DESCRIPTION
The `WellKnownFixAllProviders.BatchFixer` does not handle nontrivial fixes well with the apply all then merge strategy.

This PR contains a draft implementation of a fixallprovider that uses `DocumentEditor`
Usage Looks like:

```cs
internal class FooCodeFixProvider : DocumentEditorCodeFixProvider
{
    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(FooAnalyzer.DiagnosticId);

    protected override async Task RegisterCodeFixesAsync(DocumentEditorCodeFixContext context)
    {
        foreach (var diagnostic in context.Diagnostics)
        {
            ...
            context.RegisterCodeFix(
                "Apply Foo",
                (editor, cancellationToken) => editor.ReplaceNode(...),
                "Apply Foo",
                diagnostic);
        }
    }
}
```