### PR TITLE
Improvements in decompiler output

### DIFF
--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
 
             // Add header to match output of metadata-only view.
             // (This also makes debugging easier, because you can see which assembly was decompiled inside VS.)
-            var header = $"#region Assembly {assemblyDefinition.FullName}" + Environment.NewLine
+            var header = $"#region {FeaturesResources.Assembly} {assemblyDefinition.FullName}" + Environment.NewLine
                 + $"// {assemblyDefinition.MainModule.FileName}" + Environment.NewLine
                 + $"// Decompiled with ICSharpCode.Decompiler {decompilerVersion.FileVersion}" + Environment.NewLine
                 + "#endregion" + Environment.NewLine;

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -3,17 +3,17 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.CSharp.Transforms;
 using ICSharpCode.Decompiler.TypeSystem;
-using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -230,11 +230,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
             var decompiler = new CSharpDecompiler(assemblyDefinition.MainModule, new DecompilerSettings());
             // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
             // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
-            decompiler.AstTransforms.Add(new ICSharpCode.Decompiler.CSharp.Transforms.EscapeInvalidIdentifiers());
+            decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers());
 
             var fullTypeName = new FullTypeName(fullName);
 
-            var decompilerVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(CSharpDecompiler).Assembly.Location);
+            var decompilerVersion = FileVersionInfo.GetVersionInfo(typeof(CSharpDecompiler).Assembly.Location);
 
             // Add header to match output of metadata-only view.
             // (This also makes debugging easier, because you can see which assembly was decompiled inside VS.)


### PR DESCRIPTION
* Add header region to decompiled code (useful for debugging).
* Add EscapeInvalidIdentifiers transform to make sure generated code is always parsable.

Note that this would make diagnosing things like #25302 a lot easier.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

* It is useful to see where the decompiled code comes from.
* Also adding the EscapeInvalidIdentifiers transform allows the parser to work with code that contains compiler-generated or invalid identifiers.

### Bugs this fixes

* change mentioned in https://github.com/dotnet/roslyn/issues/25246#issuecomment-372064351

### Workarounds, if any

Unknown.

### Risk

This is low risk, because the only change that is complex is the `EscapeInvalidIdentifiers` transform, which has already been tested well during the development and testing of ILSpy.

### Performance impact

Low performance impact, because the EscapeInvalidIdentifiers transform is very simple.

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
