### PR TITLE
Fix #25211.

### DIFF
--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
@@ -19,10 +19,6 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, 
-        Name = PredefinedCodeRefactoringProviderNames.GenerateEqualsAndGetHashCodeFromMembers), Shared]
-    [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.GenerateConstructorFromMembers,
-                    Before = PredefinedCodeRefactoringProviderNames.AddConstructorParametersFromMembers)]
     internal abstract partial class AbstractGenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider : AbstractGenerateFromMembersCodeRefactoringProvider
     {
         public const string GenerateOperatorsId = nameof(GenerateOperatorsId);


### PR DESCRIPTION
Don't place MEF Export attribute on an abstract class since that causes MEF composition errors (importing constructor on abstract class not found).

<details><summary>Ask Mode template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

VSMac can't compose due to VSMEF composition errors. VS for Windows seems to be able to survive these, but for us it's fatal, and hence, blocking. VSMac needs to be able to update to 15.7 Roslyn bits.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/25211

### Workarounds, if any

Turn off crashing on composition errors in VSMac (we'd really like to not do this, as in our world we need to be acutely aware of all composition problems).

### Risk

Low. Fix is easy to verify and should have no repercussions.

### Performance impact

None

### Is this a regression from a previous update?

Yes, regressed about a month ago.

### Root cause analysis

Roslyn needs to have a test that composes and verifies VSMEF had no composition errors. Highly recommended.

### How was the bug found?

VSMac adoption

### Test documentation updated?

Not needed.

</details>
