### PR TITLE
Move bootstrap phase to use NuPkg files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -126,7 +126,7 @@ then
     dotnet restore "${root_path}/Compilers.sln" /bl:${logs_path}/Restore-Compilers.binlog
 fi
 
-build_args="--no-restore -c ${build_configuration} /nologo /maxcpucount:1"
+build_args="--no-restore -c ${build_configuration} /nologo"
 
 if [[ "$build_bootstrap" == true ]]
 then
@@ -139,15 +139,14 @@ then
         dotnet publish "${bootstrap_file}" --framework netcoreapp2.0 ${bootstrap_build_args} "/bl:${binaries_path}/${bootstrap_name}.binlog"
     done
 
+    rm -rf ${bootstrap_path}
     mkdir -p ${bootstrap_path} 
     dotnet pack src/NuGet/Bootstrap.csproj /p:NuspecBasePath=${binaries_path}/Debug -o ${bootstrap_path}
+    mkdir -p ${bootstrap_path}/Microsoft.NETCore.Compilers
     unzip ${bootstrap_path}/Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg -d ${bootstrap_path}/Microsoft.NETCore.Compilers/1.0.0
     chmod -R 755 ${bootstrap_path}/Microsoft.NETCore.Compilers
 
-    for bootstrap_file in "${bootstrap_files[@]}"
-    do
-        dotnet clean "${bootstrap_file}"
-    done
+    dotnet clean Compilers.sln 
 fi
 
 if [[ "${use_bootstrap}" == true ]]

--- a/build.sh
+++ b/build.sh
@@ -142,9 +142,9 @@ then
     rm -rf ${bootstrap_path}
     mkdir -p ${bootstrap_path} 
     dotnet pack src/NuGet/Bootstrap.csproj /p:NuspecBasePath=${binaries_path}/Debug -o ${bootstrap_path}
-    mkdir -p ${bootstrap_path}/Microsoft.NETCore.Compilers
-    unzip ${bootstrap_path}/Microsoft.NETCore.Compilers.42.42.42.42-bootstrap.nupkg -d ${bootstrap_path}/Microsoft.NETCore.Compilers/42.42.42.42
-    chmod -R 755 ${bootstrap_path}/Microsoft.NETCore.Compilers
+    mkdir -p ${bootstrap_path}/microsoft.netcore.compilers
+    unzip ${bootstrap_path}/Microsoft.NETCore.Compilers.42.42.42.42-bootstrap.nupkg -d ${bootstrap_path}/microsoft.netcore.compilers/42.42.42.42
+    chmod -R 755 ${bootstrap_path}/microsoft.netcore.compilers
 
     dotnet clean Compilers.sln 
 fi
@@ -172,7 +172,7 @@ then
     if [[ "${use_bootstrap}" == true ]]
     then
         echo "Stopping VBCSCompiler"
-        dotnet "${bootstrap_path}"/Microsoft.NETCore.Compilers/42.42.42.42/tools/bincore/VBCSCompiler.dll -shutdown
+        dotnet "${bootstrap_path}"/microsoft.netcore.compilers/42.42.42.42/tools/bincore/VBCSCompiler.dll -shutdown
     else
         echo "--stop-vbcscompiler requires --use-bootstrap. Aborting."
         exit 1

--- a/build.sh
+++ b/build.sh
@@ -143,13 +143,10 @@ then
     dotnet pack src/NuGet/Bootstrap.csproj /p:NuspecBasePath=${binaries_path}/Debug -o ${bootstrap_path}
     unzip ${bootstrap_path}/Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg -d ${bootstrap_path}/Microsoft.NETCore.Compilers
 
-    # exit 1
-    # for bootstrap_file in "${bootstrap_files[@]}"
-    # do
-        # bootstrap_name=$(basename $bootstrap_file)
-        # dotnet clean "${bootstrap_file}"
-    # done
-    # exit 1
+    for bootstrap_file in "${bootstrap_files[@]}"
+    do
+        dotnet clean "${bootstrap_file}"
+    done
 fi
 
 if [[ "${use_bootstrap}" == true ]]

--- a/build.sh
+++ b/build.sh
@@ -142,6 +142,7 @@ then
     mkdir -p ${bootstrap_path} 
     dotnet pack src/NuGet/Bootstrap.csproj /p:NuspecBasePath=${binaries_path}/Debug -o ${bootstrap_path}
     unzip ${bootstrap_path}/Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg -d ${bootstrap_path}/Microsoft.NETCore.Compilers
+    chmod -R 755 ${bootstrap_path}/Microsoft.NETCore.Compilers
 
     for bootstrap_file in "${bootstrap_files[@]}"
     do

--- a/build.sh
+++ b/build.sh
@@ -143,7 +143,7 @@ then
     mkdir -p ${bootstrap_path} 
     dotnet pack src/NuGet/Bootstrap.csproj /p:NuspecBasePath=${binaries_path}/Debug -o ${bootstrap_path}
     mkdir -p ${bootstrap_path}/Microsoft.NETCore.Compilers
-    unzip ${bootstrap_path}/Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg -d ${bootstrap_path}/Microsoft.NETCore.Compilers/1.0.0
+    unzip ${bootstrap_path}/Microsoft.NETCore.Compilers.42.42.42.42-bootstrap.nupkg -d ${bootstrap_path}/Microsoft.NETCore.Compilers/42.42.42.42
     chmod -R 755 ${bootstrap_path}/Microsoft.NETCore.Compilers
 
     dotnet clean Compilers.sln 
@@ -172,7 +172,7 @@ then
     if [[ "${use_bootstrap}" == true ]]
     then
         echo "Stopping VBCSCompiler"
-        dotnet "${bootstrap_path}"/Microsoft.NETCore.Compilers/1.0.0/tools/bincore/VBCSCompiler.dll -shutdown
+        dotnet "${bootstrap_path}"/Microsoft.NETCore.Compilers/42.42.42.42/tools/bincore/VBCSCompiler.dll -shutdown
     else
         echo "--stop-vbcscompiler requires --use-bootstrap. Aborting."
         exit 1

--- a/build.sh
+++ b/build.sh
@@ -141,7 +141,7 @@ then
 
     mkdir -p ${bootstrap_path} 
     dotnet pack src/NuGet/Bootstrap.csproj /p:NuspecBasePath=${binaries_path}/Debug -o ${bootstrap_path}
-    unzip ${bootstrap_path}/Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg -d ${bootstrap_path}/Microsoft.NETCore.Compilers
+    unzip ${bootstrap_path}/Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg -d ${bootstrap_path}/Microsoft.NETCore.Compilers/1.0.0
     chmod -R 755 ${bootstrap_path}/Microsoft.NETCore.Compilers
 
     for bootstrap_file in "${bootstrap_files[@]}"
@@ -152,7 +152,7 @@ fi
 
 if [[ "${use_bootstrap}" == true ]]
 then
-    build_args+=" /p:BootstrapBuildPath=${bootstrap_path}/Microsoft.NETCore.Compilers/build"
+    build_args+=" /p:BootstrapBuildPath=${bootstrap_path}"
 fi
 
 # https://github.com/dotnet/roslyn/issues/23736
@@ -173,7 +173,7 @@ then
     if [[ "${use_bootstrap}" == true ]]
     then
         echo "Stopping VBCSCompiler"
-        dotnet "${bootstrap_path}"/Microsoft.NETCore.Compilers/tools/bincore/VBCSCompiler.dll -shutdown
+        dotnet "${bootstrap_path}"/Microsoft.NETCore.Compilers/1.0.0/tools/bincore/VBCSCompiler.dll -shutdown
     else
         echo "--stop-vbcscompiler requires --use-bootstrap. Aborting."
         exit 1

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -309,7 +309,7 @@
   <Target Name="CheckBootstrapState"
           Condition="'$(BootstrapBuildPath)' != ''"
           AfterTargets="CoreCompile">
-    <ValidateBootstrap BootstrapPath="$(RoslynToolsetPropsDirectory)" />
+    <ValidateBootstrap BootstrapPath="$(RoslynToolsetDirectory)" />
   </Target>
 
   <!--

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -300,8 +300,8 @@
   </PropertyGroup>
 
   <Target Name="RestoreToolsetCheck" Condition="'$(BuildingProject)' == 'true'">
-      <Error Text="Toolset packages have not been restored, run Restore.cmd before building"
-             Condition="!Exists('$(ToolsetCompilerPropsFilePath)')" />
+      <Error Text="Toolset packages have not been restored, run Restore.cmd before building. Expected '$(RoslynToolsetPropsFilePath)' to exist."
+             Condition="!Exists('$(RoslynToolsetPropsFilePath)')" />
       <Error Text="Analyzer packages have not been restored, run Restore.cmd before building. File not found: '$(RoslynDiagnosticsPropsFilePath)'"
              Condition="!Exists('$(RoslynDiagnosticsPropsFilePath)')" />
   </Target>
@@ -309,7 +309,7 @@
   <Target Name="CheckBootstrapState"
           Condition="'$(BootstrapBuildPath)' != ''"
           AfterTargets="CoreCompile">
-    <ValidateBootstrap BootstrapPath="$(BootstrapBuildPath)" />
+    <ValidateBootstrap BootstrapPath="$(RoslynToolsetPropsDirectory)" />
   </Target>
 
   <!--

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -165,15 +165,15 @@
 
   <!-- Determine compiler toolset props file to use for this build -->
   <PropertyGroup>
-    <_PackageName Condition="'$(MSBuildRuntimeType)' != 'Core'">Microsoft.Net.Compilers</_PackageName>
-    <_PackageName Condition="'$(MSBuildRuntimeType)' == 'Core'">Microsoft.NETCore.Compilers</_PackageName>
+    <_PackageName Condition="'$(MSBuildRuntimeType)' != 'Core'">microsoft.net.compilers</_PackageName>
+    <_PackageName Condition="'$(MSBuildRuntimeType)' == 'Core'">microsoft.netcore.compilers</_PackageName>
     <_PackageVersion Condition="'$(MSBuildRuntimeType)' != 'Core' AND '$(BootstrapBuildPath)' == ''">$(MicrosoftNetCompilersVersion)</_PackageVersion>
     <_PackageVersion Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(BootstrapBuildPath)' == ''">$(MicrosoftNETCoreCompilersVersion)</_PackageVersion>
-    <_PackageVersion Condition="'$(BootstrapBuildPath)' != ''">1.0.0</_PackageVersion>
+    <_PackageVersion Condition="'$(BootstrapBuildPath)' != ''">42.42.42.42</_PackageVersion>
     <_PackageRoot>$(NuGetPackageRoot)</_PackageRoot>
     <_PackageRoot Condition="'$(BootstrapBuildPath)' != ''">$(BootstrapBuildPath)</_PackageRoot>
-    <RoslynToolsetPropsDirectory>$(_PackageRoot)/$(_PackageName.ToLower())/$(_PackageVersion)/build</RoslynToolsetPropsDirectory>
-    <RoslynToolsetPropsFilePath>$(RoslynToolsetPropsDirectory)/$(_PackageName).props</RoslynToolsetPropsFilePath>
+    <RoslynToolsetDirectory>$(_PackageRoot)\$(_PackageName)\$(_PackageVersion)</RoslynToolsetDirectory>
+    <RoslynToolsetPropsFilePath>$(RoslynToolsetDirectory)\build\$(_PackageName).props</RoslynToolsetPropsFilePath>
   </PropertyGroup>
 
   <!-- Windows specific settings -->
@@ -199,7 +199,7 @@
   <Import Project="$(RoslynToolsetPropsFilePath)" Condition="Exists('$(RoslynToolsetPropsFilePath)')" />
 
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.ValidateBootstrap"
-             AssemblyFile="$(RoslynToolsetPropsDirectory)\..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll"
+             AssemblyFile="$(RoslynToolsetDirectory)\tools\Microsoft.Build.Tasks.CodeAnalysis.dll"
              Condition="'$(BootstrapBuildPath)' != ''" />
   <UsingTask TaskName="Roslyn.MSBuild.Util.FindNuGetAssetsForVsix"
              AssemblyFile="$(NuGetPackageRoot)\Roslyn.Build.Util\$(RoslynBuildUtilVersion)\lib\net46\Roslyn.MSBuild.Util.dll"

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -189,12 +189,8 @@
     <DevEnvDir>$([System.IO.Path]::GetFullPath('$(DevEnvDir)'))</DevEnvDir>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(BootstrapBuildPath)' != ''">
-    <CSharpCoreTargetsPath>$(BootstrapBuildPath)\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
-    <VisualBasicCoreTargetsPath>$(BootstrapBuildPath)\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
-  </PropertyGroup>
-
-  <Import Project="$(BootstrapBuildPath)\Microsoft.Net.Compilers.props" Condition="'$(BootstrapBuildPath)' != ''" />
+  <Import Project="$(BootstrapBuildPath)\Microsoft.Net.Compilers.props" Condition="'$(BootstrapBuildPath)' != '' AND '$(MSBuildRuntimeType)' != 'Core'" />
+  <Import Project="$(BootstrapBuildPath)\Microsoft.NETCore.Compilers.props" Condition="'$(BootstrapBuildPath)' != '' AND '$(MSBuildRuntimeType)' == 'Core'" />
 
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.ValidateBootstrap"
              AssemblyFile="$(BootstrapBuildPath)\..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll"

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -165,14 +165,14 @@
 
   <!-- Determine compiler toolset props file to use for this build -->
   <PropertyGroup>
-    <_PackageName Condition="'$(MSBuildRuntimeType)' != 'Core'">microsoft.net.compilers</_PackageName>
-    <_PackageName Condition="'$(MSBuildRuntimeType)' == 'Core'">microsoft.netcore.compilers</_PackageName>
+    <_PackageName Condition="'$(MSBuildRuntimeType)' != 'Core'">Microsoft.Net.Compilers</_PackageName>
+    <_PackageName Condition="'$(MSBuildRuntimeType)' == 'Core'">Microsoft.NETCore.Compilers</_PackageName>
     <_PackageVersion Condition="'$(MSBuildRuntimeType)' != 'Core' AND '$(BootstrapBuildPath)' == ''">$(MicrosoftNetCompilersVersion)</_PackageVersion>
     <_PackageVersion Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(BootstrapBuildPath)' == ''">$(MicrosoftNETCoreCompilersVersion)</_PackageVersion>
     <_PackageVersion Condition="'$(BootstrapBuildPath)' != ''">42.42.42.42</_PackageVersion>
     <_PackageRoot>$(NuGetPackageRoot)</_PackageRoot>
     <_PackageRoot Condition="'$(BootstrapBuildPath)' != ''">$(BootstrapBuildPath)</_PackageRoot>
-    <RoslynToolsetDirectory>$(_PackageRoot)\$(_PackageName)\$(_PackageVersion)</RoslynToolsetDirectory>
+    <RoslynToolsetDirectory>$(_PackageRoot)\$(_PackageName.ToLower())\$(_PackageVersion)</RoslynToolsetDirectory>
     <RoslynToolsetPropsFilePath>$(RoslynToolsetDirectory)\build\$(_PackageName).props</RoslynToolsetPropsFilePath>
   </PropertyGroup>
 

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -194,19 +194,10 @@
     <VisualBasicCoreTargetsPath>$(BootstrapBuildPath)\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
   </PropertyGroup>
 
-  <!-- During bootstrap builds it's important to load our bootstrap tasks before doing any
-       other imports (which could load a same named DLL) -->
-  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"
-             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
-             Condition="'$(BootstrapBuildPath)' != ''" />
-  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"
-             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
-             Condition="'$(BootstrapBuildPath)' != ''" />
+  <Import Project="$(BootstrapBuildPath)\Microsoft.Net.Compilers.props" Condition="'$(BootstrapBuildPath)' != ''" />
+
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.ValidateBootstrap"
-             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
-             Condition="'$(BootstrapBuildPath)' != ''" />
-  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly"
-             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
+             AssemblyFile="$(BootstrapBuildPath)\..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll"
              Condition="'$(BootstrapBuildPath)' != ''" />
   <UsingTask TaskName="Roslyn.MSBuild.Util.FindNuGetAssetsForVsix"
              AssemblyFile="$(NuGetPackageRoot)\Roslyn.Build.Util\$(RoslynBuildUtilVersion)\lib\net46\Roslyn.MSBuild.Util.dll"

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -62,12 +62,6 @@
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</IntermediateOutputPath>
     <ArtifactsSymStoreDirectory Condition="'$(DeveloperBuild)' != 'true' and '$(OS)' == 'Windows_NT'">$(BaseOutputPath)$(Configuration)\SymStore\</ArtifactsSymStoreDirectory>
 
-    <ToolsetPackagesSemaphore>$(ToolsetPackagesDir)toolsetpackages.semaphore</ToolsetPackagesSemaphore>
-    <ToolsetCompilerPackageName Condition="'$(MSBuildRuntimeType)' != 'Core'">Microsoft.Net.Compilers</ToolsetCompilerPackageName>
-    <ToolsetCompilerPackageName Condition="'$(MSBuildRuntimeType)' == 'Core'">Microsoft.NETCore.Compilers</ToolsetCompilerPackageName>
-    <ToolsetCompilerPackageVersion Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MicrosoftNetCompilersVersion)</ToolsetCompilerPackageVersion>
-    <ToolsetCompilerPackageVersion Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MicrosoftNETCoreCompilersVersion)</ToolsetCompilerPackageVersion>
-    <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)/$(ToolsetCompilerPackageName.ToLower())/$(ToolsetCompilerPackageVersion)/build/$(ToolsetCompilerPackageName).props</ToolsetCompilerPropsFilePath>
     <TargetFrameworkRootPath>$(NuGetPackageRoot)\roslyntools.referenceassemblies\$(RoslynToolsReferenceAssembliesVersion)\tools\framework</TargetFrameworkRootPath>
 
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -169,6 +163,19 @@
     <CustomAfterMicrosoftCommonTargets>$(MSBuildThisFileDirectory)\AfterCommonTargets.targets</CustomAfterMicrosoftCommonTargets>
   </PropertyGroup>
 
+  <!-- Determine compiler toolset props file to use for this build -->
+  <PropertyGroup>
+    <_PackageName Condition="'$(MSBuildRuntimeType)' != 'Core'">Microsoft.Net.Compilers</_PackageName>
+    <_PackageName Condition="'$(MSBuildRuntimeType)' == 'Core'">Microsoft.NETCore.Compilers</_PackageName>
+    <_PackageVersion Condition="'$(MSBuildRuntimeType)' != 'Core' AND '$(BootstrapBuildPath)' == ''">$(MicrosoftNetCompilersVersion)</_PackageVersion>
+    <_PackageVersion Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(BootstrapBuildPath)' == ''">$(MicrosoftNETCoreCompilersVersion)</_PackageVersion>
+    <_PackageVersion Condition="'$(BootstrapBuildPath)' != ''">1.0.0</_PackageVersion>
+    <_PackageRoot>$(NuGetPackageRoot)</_PackageRoot>
+    <_PackageRoot Condition="'$(BootstrapBuildPath)' != ''">$(BootstrapBuildPath)</_PackageRoot>
+    <RoslynToolsetPropsDirectory>$(_PackageRoot)/$(_PackageName.ToLower())/$(_PackageVersion)/build</RoslynToolsetPropsDirectory>
+    <RoslynToolsetPropsFilePath>$(RoslynToolsetPropsDirectory)/$(_PackageName).props</RoslynToolsetPropsFilePath>
+  </PropertyGroup>
+
   <!-- Windows specific settings -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
 
@@ -189,11 +196,10 @@
     <DevEnvDir>$([System.IO.Path]::GetFullPath('$(DevEnvDir)'))</DevEnvDir>
   </PropertyGroup>
 
-  <Import Project="$(BootstrapBuildPath)\Microsoft.Net.Compilers.props" Condition="'$(BootstrapBuildPath)' != '' AND '$(MSBuildRuntimeType)' != 'Core'" />
-  <Import Project="$(BootstrapBuildPath)\Microsoft.NETCore.Compilers.props" Condition="'$(BootstrapBuildPath)' != '' AND '$(MSBuildRuntimeType)' == 'Core'" />
+  <Import Project="$(RoslynToolsetPropsFilePath)" Condition="Exists('$(RoslynToolsetPropsFilePath)')" />
 
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.ValidateBootstrap"
-             AssemblyFile="$(BootstrapBuildPath)\..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll"
+             AssemblyFile="$(RoslynToolsetPropsDirectory)\..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll"
              Condition="'$(BootstrapBuildPath)' != ''" />
   <UsingTask TaskName="Roslyn.MSBuild.Util.FindNuGetAssetsForVsix"
              AssemblyFile="$(NuGetPackageRoot)\Roslyn.Build.Util\$(RoslynBuildUtilVersion)\lib\net46\Roslyn.MSBuild.Util.dll"
@@ -209,8 +215,6 @@
       Project="$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\$(VisualStudioBuildToolsVersion)\build\Microsoft.VsSDK.BuildTools.props"
       Condition="Exists('$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\$(VisualStudioBuildToolsVersion)\build\Microsoft.VsSDK.BuildTools.props')" />
   </ImportGroup>
-
-  <Import Project="$(ToolsetCompilerPropsFilePath)" Condition="Exists('$(ToolsetCompilerPropsFilePath)') AND '$(BootstrapBuildPath)' == ''"  />
 
   <!--
       When building WPF projects MSBuild will create a temporary project with an extension of

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -430,3 +430,8 @@ function Restore-Project([string]$dotnetExe, [string]$projectFileName, [string]$
     Exec-Console $dotnet "restore --verbosity quiet --configfile $nugetConfig $projectFilePath $logArg"
 }
 
+function Unzip-File([string]$zipFilePath, [string]$outputDir) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem | Out-Null
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFilePath, $outputDir)
+}
+

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -213,7 +213,7 @@ function Make-BootstrapBuild() {
             Exec-Console "dotnet" "publish --no-restore $projectFilePath --framework netcoreapp2.0 $bootstrapArgs -v:m -m -bl:$logsDir/$logFileName"
         }
 
-        Exec-Console "dotnet" "build --no-restore src/Interactive/csi/csi.csproj -v:m -m -bl:$logsDir/BootstrapCsi.binlog"
+        Exec-Console "dotnet" "build --no-restore src/Interactive/csi/csi.csproj -v:m -m $bootstrapArgs -bl:$logsDir/BootstrapCsi.binlog"
 
         Ensure-NuGet | Out-Null
         Exec-Console "$configDir\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.NETCore.Compilers.nuspec"

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -216,7 +216,7 @@ function Make-BootstrapBuild() {
         Exec-Console "dotnet" "build --no-restore src/Interactive/csi/csi.csproj -v:m -m -bl:$logsDir/BootstrapCsi.binlog"
 
         Ensure-NuGet | Out-Null
-        Exec-Console "$binariesDir\Debug\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.NETCore.Compilers.nuspec"
+        Exec-Console "$configDir\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.NETCore.Compilers.nuspec"
         Move-Item "$dir\Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg" $bootstrapPackageFilePath
 
         foreach ($projectFilePath in $projectFiles) { 
@@ -230,7 +230,7 @@ function Make-BootstrapBuild() {
         Create-Directory $dir
 
         Ensure-NuGet | Out-Null
-        Exec-Console "$binariesDir\Debug\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.Net.Compilers.nuspec"
+        Exec-Console "$configDir\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.Net.Compilers.nuspec"
         Move-Item "$dir\Microsoft.Net.Compilers.1.0.0-bootstrap.nupkg" $bootstrapPackageFilePath
 
         Write-Host "Cleaning Bootstrap compiler artifacts"

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -151,8 +151,7 @@ function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]
         $args += " /p:BootstrapBuildPath=$bootstrapDir"
     }
 
-    if ($testIOperation)
-    {
+    if ($testIOperation) {
         $args += " /p:TestIOperationInterface=true"
     }
 
@@ -210,7 +209,13 @@ function Make-BootstrapBuild() {
         Run-MSBuild "build\Toolset\Toolset.csproj" $bootstrapArgs -logFileName "Bootstrap"
         Remove-Item -re $dir -ErrorAction SilentlyContinue
         Create-Directory $dir
-        Move-Item "$configDir\Exes\Toolset\*" $dir
+
+        Ensure-NuGet | Out-Null
+        Exec-Console "$binariesDir\Debug\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.Net.Compilers.nuspec"
+        $packageFilePath = Join-Path $dir "Microsoft.Net.Compilers.1.0.0-bootstrap.nupkg"
+        $dir = Join-Path $dir "Microsoft.Net.Compilers"
+        Unzip-File $packageFilePath $dir
+        $dir = Join-Path $dir "build"
 
         Write-Host "Cleaning Bootstrap compiler artifacts"
         Run-MSBuild "build\Toolset\Toolset.csproj" "/t:Clean" -logFileName "BootstrapClean"

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -185,7 +185,7 @@ function Restore-Packages() {
     }
 }
 
-# Create a bootstrap build of the compiler.  Returns the directory where the bootstrap buil 
+# Create a bootstrap build of the compiler.  Returns the directory where the bootstrap build 
 # is located. 
 #
 # Important to not set $script:bootstrapDir here yet as we're actually in the process of 
@@ -211,11 +211,14 @@ function Make-BootstrapBuild() {
             Run-MSBuild $projectFilePath "/t:Publish /p:TargetFramework=netcoreapp2.0 $bootstrapArgs" -logFileName $logFileName -useDotnetBuild
         }
 
+        # The csi executable is only supported on desktop (even though we do multi-target it to 
+        # netcoreapp2.). Need to build the desktop version here in order to build our NuGet 
+        # packages below. 
         Run-MSBuild "src/Interactive/csi/csi.csproj" -logFileName "BootstrapCsi" -useDotnetBuild
 
         Ensure-NuGet | Out-Null
-        Exec-Console "$configDir\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.NETCore.Compilers.nuspec"
-        Unzip-File "$dir\Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg" "$dir\Microsoft.NETCore.Compilers\1.0.0"
+        Exec-Console "$configDir\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 42.42.42.42-bootstrap $dir `"<developer build>`" Microsoft.NETCore.Compilers.nuspec"
+        Unzip-File "$dir\Microsoft.NETCore.Compilers.42.42.42.42-bootstrap.nupkg" "$dir\Microsoft.NETCore.Compilers\42.42.42.42"
 
         Write-Host "Cleaning Bootstrap compiler artifacts"
         Run-MSBuild "Compilers.sln" "/t:Clean"
@@ -227,8 +230,8 @@ function Make-BootstrapBuild() {
         Create-Directory $dir
 
         Ensure-NuGet | Out-Null
-        Exec-Console "$configDir\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.Net.Compilers.nuspec"
-        Unzip-File "$dir\Microsoft.Net.Compilers.1.0.0-bootstrap.nupkg" "$dir\Microsoft.Net.Compilers\1.0.0"
+        Exec-Console "$configDir\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 42.42.42.42-bootstrap $dir `"<developer build>`" Microsoft.Net.Compilers.nuspec"
+        Unzip-File "$dir\Microsoft.Net.Compilers.42.42.42.42-bootstrap.nupkg" "$dir\Microsoft.Net.Compilers\42.42.42.42"
 
         Write-Host "Cleaning Bootstrap compiler artifacts"
         Run-MSBuild "build\Toolset\Toolset.csproj" "/t:Clean" -logFileName "BootstrapClean"

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -192,7 +192,6 @@ function Restore-Packages() {
 # building the bootstrap.
 function Make-BootstrapBuild() {
     $dir = Join-Path $binariesDir "Bootstrap"
-    $bootstrapPackageFilePath = Join-Path $dir "BootstrapCompiler.nupkg"
     Write-Host "Building Bootstrap compiler"
     $bootstrapArgs = "/p:UseShippingAssemblyVersion=true /p:InitialDefineConstants=BOOTSTRAP"
     Remove-Item -re $dir -ErrorAction SilentlyContinue
@@ -216,8 +215,9 @@ function Make-BootstrapBuild() {
 
         Ensure-NuGet | Out-Null
         Exec-Console "$configDir\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.NETCore.Compilers.nuspec"
-        Move-Item "$dir\Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg" $bootstrapPackageFilePath
+        Unzip-File "$dir\Microsoft.NETCore.Compilers.1.0.0-bootstrap.nupkg" "$dir\Microsoft.NETCore.Compilers\1.0.0"
 
+        Write-Host "Cleaning Bootstrap compiler artifacts"
         Run-MSBuild "Compilers.sln" "/t:Clean"
         Stop-BuildProcesses
     }
@@ -228,16 +228,14 @@ function Make-BootstrapBuild() {
 
         Ensure-NuGet | Out-Null
         Exec-Console "$configDir\Exes\csi\net46\csi.exe" "$repoDir\src\NuGet\BuildNuGets.csx $configDir 1.0.0-bootstrap $dir `"<developer build>`" Microsoft.Net.Compilers.nuspec"
-        Move-Item "$dir\Microsoft.Net.Compilers.1.0.0-bootstrap.nupkg" $bootstrapPackageFilePath
+        Unzip-File "$dir\Microsoft.Net.Compilers.1.0.0-bootstrap.nupkg" "$dir\Microsoft.Net.Compilers\1.0.0"
 
         Write-Host "Cleaning Bootstrap compiler artifacts"
         Run-MSBuild "build\Toolset\Toolset.csproj" "/t:Clean" -logFileName "BootstrapClean"
         Stop-BuildProcesses
     }
 
-    $dir = Join-Path $dir "Microsoft.Net.Compilers"
-    Unzip-File $bootstrapPackageFilePath $dir
-    return (Join-Path $dir "build")
+    return $dir
 }
 
 function Build-Artifacts() { 

--- a/build/scripts/docker/Dockerfile
+++ b/build/scripts/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN rm -rf rm -rf /var/lib/apt/lists/* && \
             git \
             curl \
             tar \
+            unzip \
             sudo && \
     apt-get clean
 

--- a/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
+++ b/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         public ValidateBootstrap()
         {
 
-
         }
 
         public override bool Execute()
@@ -43,6 +42,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 return false;
             }
 
+            var toolsPath = Path.Combine(Path.GetDirectoryName(_bootstrapPath), "tools");
             var dependencies = new[]
             {
                 typeof(ValidateBootstrap).GetTypeInfo().Assembly,
@@ -54,9 +54,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 var path = GetDirectory(dependency);
                 path = NormalizePath(path);
-                if (!comparer.Equals(path, _bootstrapPath))
+                if (!comparer.Equals(path, toolsPath))
                 {
-                    Log.LogError($"Bootstrap assembly {dependency.GetName().Name} incorrectly loaded from {path} instead of {_bootstrapPath}");
+                    Log.LogError($"Bootstrap assembly {dependency.GetName().Name} incorrectly loaded from {path} instead of {toolsPath}");
                     allGood = false;
                 }
             }

--- a/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
+++ b/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 return false;
             }
 
-            var toolsPath = Path.Combine(Path.GetDirectoryName(_bootstrapPath), "tools");
+            var toolsPath = Path.Combine(_bootstrapPath, "tools");
             var dependencies = new[]
             {
                 typeof(ValidateBootstrap).GetTypeInfo().Assembly,

--- a/src/NuGet/Bootstrap.csproj
+++ b/src/NuGet/Bootstrap.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- 
+
+    This project file is used to create the Microsoft.NetCore.Compilers NuPkg on 
+    Unix platforms during our bootstrap phase. This is a very temporary solution. Longer
+    term we are moving all of our packaging code to use `dotnet pack` at which point 
+    this will simply be folded into that work.
+
+    https://github.com/dotnet/roslyn/issues/25439 -->
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <NuspecFile>Microsoft.NETCore.Compilers.nuspec</NuspecFile>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+    <NuspecProperties>$(NuspecProperties);version=1.0.0-bootstrap</NuspecProperties>
+    <NuspecProperties>$(NuspecProperties);authors=Microsoft</NuspecProperties>
+    <NuspecProperties>$(NuspecProperties);licenseUrl=http://go.microsoft.com/fwlink/?LinkId=529443</NuspecProperties>
+    <NuspecProperties>$(NuspecProperties);projectUrl=https://github.com/dotnet/roslyn</NuspecProperties>
+    <NuspecProperties>$(NuspecProperties);additionalFilesPath=$(RepoRoot)build/NuGetAdditionalFiles</NuspecProperties>
+  </PropertyGroup>
+</Project>

--- a/src/NuGet/Bootstrap.csproj
+++ b/src/NuGet/Bootstrap.csproj
@@ -11,7 +11,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <NuspecFile>Microsoft.NETCore.Compilers.nuspec</NuspecFile>
     <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
-    <NuspecProperties>$(NuspecProperties);version=1.0.0-bootstrap</NuspecProperties>
+    <NuspecProperties>$(NuspecProperties);version=42.42.42.42-bootstrap</NuspecProperties>
     <NuspecProperties>$(NuspecProperties);authors=Microsoft</NuspecProperties>
     <NuspecProperties>$(NuspecProperties);licenseUrl=http://go.microsoft.com/fwlink/?LinkId=529443</NuspecProperties>
     <NuspecProperties>$(NuspecProperties);projectUrl=https://github.com/dotnet/roslyn</NuspecProperties>

--- a/src/NuGet/Microsoft.NETCore.Compilers.nuspec
+++ b/src/NuGet/Microsoft.NETCore.Compilers.nuspec
@@ -27,9 +27,9 @@
 
     <!-- Targets and task files -->
     <file src="Dlls/MSBuildTask/netcoreapp2.0/Microsoft.Build.Tasks.CodeAnalysis.dll" target="tools" />
-    <file src="Dlls/MSbuildTask/netcoreapp2.0/Microsoft.Managed.Core.targets" target="tools" />
-    <file src="Dlls/MSbuildTask/netcoreapp2.0/Microsoft.CSharp.Core.targets" target="tools" />
-    <file src="Dlls/MSbuildTask/netcoreapp2.0/Microsoft.VisualBasic.Core.targets" target="tools" />
+    <file src="Dlls/MSBuildTask/netcoreapp2.0/Microsoft.Managed.Core.targets" target="tools" />
+    <file src="Dlls/MSBuildTask/netcoreapp2.0/Microsoft.CSharp.Core.targets" target="tools" />
+    <file src="Dlls/MSBuildTask/netcoreapp2.0/Microsoft.VisualBasic.Core.targets" target="tools" />
     <!-- N.B.: The backslashes below cannot be replaced with forward slashes. 
          https://github.com/NuGet/Home/issues/3584 -->
     <file src="Dlls\MSBuildTask\netcoreapp2.0\publish\runtimes\**" target="tools\runtimes" />


### PR DESCRIPTION
When creating the compiler binary layout for bootstrapping our build scripts were doing a completely adhoc layout. It was meant to mimic the layout we have on disk when installed into MSBuild, dotnet, etc ... but was simply not the same. The adhoc layout functions by copying around build output while the NuSpecs tend to explicitly list dependencies. 

The differences are small but over time have allowed a number of product bugs to creep in:

- Compiler took dependencies on DLLs that never got added to NuSpec.
- Targets files had relative path issues.
- Props files had syntax errors but were simply not excercised in the adhoc layout. 
- Dependencies deployed into different locations for adhoc and NuSpec

This change address that by redefining our bootstrap layout in terms of our NuSpec file. The bootstrap phase will now construct the nupkg file, unzip it and plug the unzipped contents into our build through the props file only (exactly as our customers do). This will prevent us from having similar errors in the future. 