### PR TITLE
Resetting IsInAsync when parsing a lambda

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -10762,6 +10762,7 @@ tryAgain:
         private LambdaExpressionSyntax ParseLambdaExpression()
         {
             bool parentScopeIsInAsync = IsInAsync;
+            IsInAsync = false;
             SyntaxToken asyncToken = null;
             if (this.CurrentToken.ContextualKind == SyntaxKind.AsyncKeyword &&
                 PeekToken(1).Kind != SyntaxKind.EqualsGreaterThanToken)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
@@ -1339,7 +1339,7 @@ class C
             // DEVNOTE: Although we parse async user defined conversions, operators, etc. here,
             // anything other than async methods are detected as erroneous later, during the define phase
 
-            Action<SyntaxKind> Check = memberKind =>
+            void Check(SyntaxKind memberKind)
             {
                 N(SyntaxKind.CompilationUnit);
                 N(SyntaxKind.ClassDeclaration);
@@ -1348,7 +1348,7 @@ class C
                 N(SyntaxKind.OpenBraceToken);
                 N(memberKind);
                 N(SyntaxKind.AsyncKeyword);
-            };
+            }
 
             // ... 'async' <typedecl> ...
             UsingTree(@"

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -1911,6 +1912,87 @@ async () => {
                 }
             }
             EOF();
+        }
+
+        [WorkItem(25410, "https://github.com/dotnet/roslyn/issues/25410")]
+        [Fact]
+        public void AwaitIdentifierExpressionStatementInSyncContextWithinAsyncMethod()
+        {
+            UsingTree(@"
+class C
+{
+    async void M()
+    {
+        () => {
+            await goo;
+        };
+    }
+}
+");
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.ParenthesizedLambdaExpression);
+                                {
+                                    N(SyntaxKind.ParameterList);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                    N(SyntaxKind.EqualsGreaterThanToken);
+                                    N(SyntaxKind.Block);
+                                    {
+                                        N(SyntaxKind.OpenBraceToken);
+                                        N(SyntaxKind.LocalDeclarationStatement);
+                                        {
+                                            N(SyntaxKind.VariableDeclaration);
+                                            {
+                                                N(SyntaxKind.IdentifierName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken);
+                                                }
+                                                N(SyntaxKind.VariableDeclarator);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken);
+                                                }
+                                            }
+                                            N(SyntaxKind.SemicolonToken);
+                                        }
+                                        N(SyntaxKind.CloseBraceToken);
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
         }
 
         #endregion AwaitExpressionStatementInSyncContext

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
@@ -1916,7 +1916,7 @@ async () => {
 
         [WorkItem(25410, "https://github.com/dotnet/roslyn/issues/25410")]
         [Fact]
-        public void AwaitIdentifierExpressionStatementInSyncContextWithinAsyncMethod()
+        public void AwaitIdentifierExpressionStatementInSyncLambdaWithinAsyncMethod()
         {
             UsingTree(@"
 class C
@@ -1985,6 +1985,161 @@ class C
                                     }
                                 }
                                 N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+        }
+
+        [Fact]
+        public void AwaitIdentifierExpressionStatementInSyncAnonymousMethodWithinAsyncMethod()
+        {
+            UsingTree(@"
+class C
+{
+    async void M()
+    {
+        delegate {
+            await goo;
+        };
+    }
+}
+");
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.AnonymousMethodExpression);
+                                {
+                                    N(SyntaxKind.DelegateKeyword);
+                                    N(SyntaxKind.Block);
+                                    {
+                                        N(SyntaxKind.OpenBraceToken);
+                                        N(SyntaxKind.LocalDeclarationStatement);
+                                        {
+                                            N(SyntaxKind.VariableDeclaration);
+                                            {
+                                                N(SyntaxKind.IdentifierName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken);
+                                                }
+                                                N(SyntaxKind.VariableDeclarator);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken);
+                                                }
+                                            }
+                                            N(SyntaxKind.SemicolonToken);
+                                        }
+                                        N(SyntaxKind.CloseBraceToken);
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+        }
+
+        [Fact]
+        public void AwaitIdentifierExpressionStatementInSyncLocalFunctionWithinAsyncMethod()
+        {
+            UsingTree(@"
+class C
+{
+    async void M()
+    {
+        void F() {
+            await goo;
+        }
+    }
+}
+");
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalFunctionStatement);
+                            {
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.VoidKeyword);
+                                }
+                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.ParameterList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.Block);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.LocalDeclarationStatement);
+                                    {
+                                        N(SyntaxKind.VariableDeclaration);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken);
+                                            }
+                                            N(SyntaxKind.VariableDeclarator);
+                                            {
+                                                N(SyntaxKind.IdentifierToken);
+                                            }
+                                        }
+                                        N(SyntaxKind.SemicolonToken);
+                                    }
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
                             }
                             N(SyntaxKind.CloseBraceToken);
                         }


### PR DESCRIPTION
fixes #25410

### Risk

Low. When using an await expression in a non-async lambda, the code is invalid and won't compile anyway. I don't see how people could have depended on this. This will allow await to be parsed as an identifier.