### PR TITLE
[VSMac] Add Xamarin.Ide to InternalsVisibleTo, to expose ILogger

### DIFF
--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -264,6 +264,7 @@
     <InternalsVisibleToMonodevelop Include="MonoDevelop.Refactoring.Tests" />
     <InternalsVisibleToMonodevelop Include="MonoDevelop.CSharpBinding.Tests" />
     <InternalsVisibleToMonodevelop Include="MonoDevelop.VBNetBinding.Tests" />
+    <InternalsVisibleToMonodevelop Include="Xamarin.Ide" />
     <InternalsVisibleToTest Include="Microsoft.CodeAnalysis.Editor.UI.Wpf" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.CSharp.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests" />


### PR DESCRIPTION
Current telemetry infrastructure is all inside `Xamarin.Ide`, with nothing exposed to `MonoDevelop.*`

Thus, we need to add a new IVT so we have both access to ILogger and the TelemetryService to be able to log roslyn telemetry events
