### PR TITLE
Fix race condition in DebugDirectoryExtensions

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/DebugDirectoryExtensions.cs
+++ b/src/Compilers/Core/Portable/PEWriter/DebugDirectoryExtensions.cs
@@ -14,28 +14,24 @@ namespace Roslyn.Reflection.PortableExecutable
     // TODO: move to SRM: https://github.com/dotnet/roslyn/issues/24712
     internal static class DebugDirectoryExtensions
     {
-        private static FieldInfo s_dataBuilderField;
-        private static Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int> s_addEntry;
+        private static Lazy<(FieldInfo, Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>)> s_debugDirectoryBuilderMembers 
+            = new Lazy<(FieldInfo, Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>)>(() =>
+            {
+                var type = typeof(DebugDirectoryBuilder).GetTypeInfo();
+                return (
+                    type.GetDeclaredField("_dataBuilder"),
+                    (Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>)
+                        type.GetDeclaredMethod("AddEntry", typeof(DebugDirectoryEntryType), typeof(uint), typeof(uint), typeof(int)).
+                        CreateDelegate(typeof(Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>)));
+            });
 
         internal const DebugDirectoryEntryType PdbChecksumEntryType = (DebugDirectoryEntryType)19;
 
-        private static void InitializeReflection()
-        {
-            if (s_dataBuilderField == null)
-            {
-                var type = typeof(DebugDirectoryBuilder).GetTypeInfo();
-                s_dataBuilderField = type.GetDeclaredField("_dataBuilder");
-                s_addEntry = (Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>)
-                    type.GetDeclaredMethod("AddEntry", typeof(DebugDirectoryEntryType), typeof(uint), typeof(uint), typeof(int)).
-                    CreateDelegate(typeof(Action<DebugDirectoryBuilder, DebugDirectoryEntryType, uint, uint, int>));
-            }
-        }
-
         public static void AddPdbChecksumEntry(this DebugDirectoryBuilder builder, string algorithmName, ImmutableArray<byte> checksum)
         {
-            InitializeReflection();
-            int dataSize = WritePdbChecksumData((BlobBuilder)s_dataBuilderField.GetValue(builder), algorithmName, checksum);
-            s_addEntry(builder, PdbChecksumEntryType, 0x00000001, 0x00000000, dataSize);
+            var (dataBuilder, addEntry) = s_debugDirectoryBuilderMembers.Value;
+            int dataSize = WritePdbChecksumData((BlobBuilder)dataBuilder.GetValue(builder), algorithmName, checksum);
+            addEntry(builder, PdbChecksumEntryType, 0x00000001, 0x00000000, dataSize);
         }
 
         private static int WritePdbChecksumData(BlobBuilder builder, string algorithmName, ImmutableArray<byte> checksum)


### PR DESCRIPTION
### Customer scenario

Intermittent NullReferenceException may be thrown when emitting multiple compilations in parallel.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/25502

### Workarounds, if any

None

### Risk

Small

### Performance impact

Small

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

### Test documentation updated?
