### PR TITLE
W warnings

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -226,6 +226,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     conversion,
                     @checked: false, // There are no checked user-defined conversions, but the conversions on either side might be checked.
                     explicitCastInCode: isCast,
+                    // PROTOTYPE(NullableReferenceTypes): Should use `isExplicitlyNullable` from
+                    // the caller at the point in the conversion chain where nullable is introduced.
                     isExplicitlyNullable: false,
                     constantValueOpt: ConstantValue.NotAvailable,
                     type: conversionReturnType)
@@ -263,6 +265,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     conversion,
                     @checked: false,
                     explicitCastInCode: isCast,
+                    // PROTOTYPE(NullableReferenceTypes): Should use `isExplicitlyNullable` from
+                    // the caller at the point in the conversion chain where nullable is introduced.
                     isExplicitlyNullable: isExplicitlyNullable,
                     constantValueOpt: ConstantValue.NotAvailable,
                     type: conversionToType)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -53,7 +53,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isCast,
             bool wasCompilerGenerated,
             TypeSymbol destination,
-            DiagnosticBag diagnostics)
+            DiagnosticBag diagnostics,
+            bool isNullable = false)
         {
             Debug.Assert(source != null);
             Debug.Assert((object)destination != null);
@@ -108,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (conversion.IsUserDefined)
             {
-                return CreateUserDefinedConversion(syntax, source, conversion, isCast, destination, diagnostics);
+                return CreateUserDefinedConversion(syntax, source, conversion, isCast: isCast, isNullable: isNullable, destination, diagnostics);
             }
 
             ConstantValue constantValue = this.FoldConstantConversion(syntax, source, conversion, destination, diagnostics);
@@ -124,11 +125,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 @checked: CheckOverflowAtRuntime,
                 explicitCastInCode: isCast && !wasCompilerGenerated,
                 constantValueOpt: constantValue,
-                type: destination)
+                type: destination,
+                isNullable: isNullable)
             { WasCompilerGenerated = wasCompilerGenerated };
         }
 
-        protected BoundExpression CreateUserDefinedConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, bool isCast, TypeSymbol destination, DiagnosticBag diagnostics)
+        private BoundExpression CreateUserDefinedConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, bool isCast, bool isNullable, TypeSymbol destination, DiagnosticBag diagnostics)
         {
             if (!conversion.IsValid)
             {
@@ -142,7 +144,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     explicitCastInCode: isCast,
                     constantValueOpt: ConstantValue.NotAvailable,
                     type: destination,
-                    hasErrors: true)
+                    hasErrors: true,
+                    isNullable: isNullable)
                 { WasCompilerGenerated = source.WasCompilerGenerated };
             }
 
@@ -218,7 +221,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: false, // There are no checked user-defined conversions, but the conversions on either side might be checked.
                     explicitCastInCode: isCast,
                     constantValueOpt: ConstantValue.NotAvailable,
-                    type: conversionReturnType)
+                    type: conversionReturnType,
+                    isNullable: isNullable)
                 { WasCompilerGenerated = true };
 
                 if (conversionToType.IsNullableType() && conversionToType.GetNullableUnderlyingType() == conversionReturnType)
@@ -253,7 +257,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: false,
                     explicitCastInCode: isCast,
                     constantValueOpt: ConstantValue.NotAvailable,
-                    type: conversionToType)
+                    type: conversionToType,
+                    isNullable: isNullable)
                 { WasCompilerGenerated = true };
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool wasCompilerGenerated,
             TypeSymbol destination,
             DiagnosticBag diagnostics,
-            bool isNullable = false)
+            bool? isNullable = null)
         {
             Debug.Assert(source != null);
             Debug.Assert((object)destination != null);
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             { WasCompilerGenerated = wasCompilerGenerated };
         }
 
-        private BoundExpression CreateUserDefinedConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, bool isCast, bool isNullable, TypeSymbol destination, DiagnosticBag diagnostics)
+        private BoundExpression CreateUserDefinedConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, bool isCast, bool? isNullable, TypeSymbol destination, DiagnosticBag diagnostics)
         {
             if (!conversion.IsValid)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundDeconstructionAssignmentOperator(
                             node,
                             DeconstructionVariablesAsTuple(left, checkedVariables, diagnostics, ignoreDiagnosticsFromTuple: true),
-                            new BoundConversion(boundRHS.Syntax, boundRHS, Conversion.Deconstruction, @checked: false, explicitCastInCode: false,
+                            new BoundConversion(boundRHS.Syntax, boundRHS, Conversion.Deconstruction, @checked: false, explicitCastInCode: false, isExplicitlyNullable: false,
                                 constantValueOpt: null, type: type, hasErrors: true),
                             resultIsUsed,
                             voidType,
@@ -156,6 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 conversion,
                 @checked: false,
                 explicitCastInCode: false,
+                isExplicitlyNullable: false,
                 constantValueOpt: null,
                 type: returnType,
                 hasErrors: hasErrors)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2080,7 +2080,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (underlyingExpr.ConstantValue != null)
                 {
                     underlyingExpr.WasCompilerGenerated = true;
-                    return BindCastCore(node, underlyingExpr, targetType, wasCompilerGenerated: operand.WasCompilerGenerated,  isExplicitlyNullable: true, diagnostics: diagnostics);
+                    return BindCastCore(node, underlyingExpr, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, isExplicitlyNullable: true, diagnostics: diagnostics);
                 }
 
                 return BindCastCore(node, operand, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, isExplicitlyNullable: true, diagnostics: diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1877,10 +1877,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BindExplicitNullableCastFromNonNullable(node, operand, targetType, diagnostics);
             }
 
-            return BindCastCore(node, operand, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, diagnostics: diagnostics, isNullable: targetTypeWithNullability.IsNullable == true);
+            return BindCastCore(node, operand, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, diagnostics: diagnostics, isNullable: targetTypeWithNullability.IsNullable);
         }
 
-        private BoundExpression BindCastCore(ExpressionSyntax node, BoundExpression operand, TypeSymbol targetType, bool wasCompilerGenerated, DiagnosticBag diagnostics, bool isNullable = false)
+        private BoundExpression BindCastCore(ExpressionSyntax node, BoundExpression operand, TypeSymbol targetType, bool wasCompilerGenerated, DiagnosticBag diagnostics, bool? isNullable = null)
         {
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             Conversion conversion = this.Conversions.ClassifyConversionFromExpression(operand, targetType, ref useSiteDiagnostics, forCast: true);
@@ -1893,13 +1893,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     node,
                     operand,
                     conversion,
-                    isBaseConversion: false,
                     @checked: CheckOverflowAtRuntime,
                     explicitCastInCode: true,
                     constantValueOpt: ConstantValue.NotAvailable,
-                    isNullable: isNullable,
                     type: targetType,
-                    hasErrors: true);
+                    hasErrors: true,
+                    isNullable: isNullable);
             }
 
             return CreateConversion(node, operand, conversion, isCast: true, wasCompilerGenerated: wasCompilerGenerated, destination: targetType, diagnostics: diagnostics, isNullable: isNullable);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1877,11 +1877,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BindExplicitNullableCastFromNonNullable(node, operand, targetType, diagnostics);
             }
 
-            return BindCastCore(node, operand, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, diagnostics: diagnostics, isNullable: targetTypeWithNullability.IsNullable);
+            return BindCastCore(node, operand, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, isExplicitlyNullable: targetTypeWithNullability.IsNullable.GetValueOrDefault(), diagnostics: diagnostics);
         }
 
-        private BoundExpression BindCastCore(ExpressionSyntax node, BoundExpression operand, TypeSymbol targetType, bool wasCompilerGenerated, DiagnosticBag diagnostics, bool? isNullable = null)
+        private BoundExpression BindCastCore(ExpressionSyntax node, BoundExpression operand, TypeSymbol targetType, bool wasCompilerGenerated, bool isExplicitlyNullable, DiagnosticBag diagnostics)
         {
+            Debug.Assert(!targetType.IsNullableType() || isExplicitlyNullable);
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             Conversion conversion = this.Conversions.ClassifyConversionFromExpression(operand, targetType, ref useSiteDiagnostics, forCast: true);
             diagnostics.Add(node, useSiteDiagnostics);
@@ -1895,13 +1896,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     conversion,
                     @checked: CheckOverflowAtRuntime,
                     explicitCastInCode: true,
+                    isExplicitlyNullable: isExplicitlyNullable,
                     constantValueOpt: ConstantValue.NotAvailable,
                     type: targetType,
-                    hasErrors: true,
-                    isNullable: isNullable);
+                    hasErrors: true);
             }
 
-            return CreateConversion(node, operand, conversion, isCast: true, wasCompilerGenerated: wasCompilerGenerated, destination: targetType, diagnostics: diagnostics, isNullable: isNullable);
+            return CreateConversion(node, operand, conversion, isCast: true, isExplicitlyNullable: isExplicitlyNullable, wasCompilerGenerated: wasCompilerGenerated, destination: targetType, diagnostics: diagnostics);
         }
 
         private void GenerateExplicitConversionErrors(
@@ -2050,13 +2051,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             var underlyingConversion = Conversions.ClassifyBuiltInConversion(operand.Type, underlyingTargetType, ref unused);
             if (!underlyingConversion.Exists)
             {
-                return BindCastCore(node, operand, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, diagnostics: diagnostics);
+                return BindCastCore(node, operand, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, isExplicitlyNullable: true, diagnostics: diagnostics);
             }
 
             var bag = DiagnosticBag.GetInstance();
             try
             {
-                var underlyingExpr = BindCastCore(node, operand, targetType.GetNullableUnderlyingType(), wasCompilerGenerated: false, diagnostics: bag);
+                var underlyingExpr = BindCastCore(node, operand, targetType.GetNullableUnderlyingType(), wasCompilerGenerated: false, isExplicitlyNullable: false, diagnostics: bag);
                 if (underlyingExpr.HasErrors || bag.HasAnyErrors())
                 {
                     Error(diagnostics, ErrorCode.ERR_NoExplicitConv, node, operand.Type, targetType);
@@ -2067,6 +2068,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Conversion.NoConversion,
                         @checked: CheckOverflowAtRuntime,
                         explicitCastInCode: true,
+                        isExplicitlyNullable: true,
                         constantValueOpt: ConstantValue.NotAvailable,
                         type: targetType,
                         hasErrors: true);
@@ -2078,10 +2080,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (underlyingExpr.ConstantValue != null)
                 {
                     underlyingExpr.WasCompilerGenerated = true;
-                    return BindCastCore(node, underlyingExpr, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, diagnostics: diagnostics);
+                    return BindCastCore(node, underlyingExpr, targetType, wasCompilerGenerated: operand.WasCompilerGenerated,  isExplicitlyNullable: true, diagnostics: diagnostics);
                 }
 
-                return BindCastCore(node, operand, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, diagnostics: diagnostics);
+                return BindCastCore(node, operand, targetType, wasCompilerGenerated: operand.WasCompilerGenerated, isExplicitlyNullable: true, diagnostics: diagnostics);
             }
             finally
             {
@@ -2549,7 +2551,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         //CONSIDER: Return a bad expression so that HasErrors is true?
                     }
 
-                    arguments[arg] = CreateConversion(argument.Syntax, argument, kind, false, type, diagnostics);
+                    arguments[arg] = CreateConversion(argument.Syntax, argument, kind, isCast: false, isExplicitlyNullable: false, type, diagnostics);
                 }
                 else if (argument.Kind == BoundKind.OutVariablePendingInference)
                 {
@@ -6070,6 +6072,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Conversion.ImplicitNumeric,
                         @checked: true,
                         explicitCastInCode: false,
+                        isExplicitlyNullable: false,
                         constantValueOpt: expr.ConstantValue,
                         type: underlyingType);
                 }
@@ -6510,7 +6513,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 GenerateImplicitConversionError(diagnostics, node, failedConversion, index, int32);
 
                 // Suppress any additional diagnostics
-                return CreateConversion(index.Syntax, index, failedConversion, isCast: false, destination: int32, diagnostics: new DiagnosticBag());
+                return CreateConversion(index.Syntax, index, failedConversion, isCast: false, isExplicitlyNullable: false, destination: int32, diagnostics: new DiagnosticBag());
             }
 
             return result;
@@ -6539,7 +6542,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 conversion = conversion.SetArrayIndexConversionForDynamic();
             }
 
-            BoundExpression result = CreateConversion(expr.Syntax, expr, conversion, isCast: false, destination: type, diagnostics: attemptDiagnostics); // UNDONE: was cast?
+            BoundExpression result = CreateConversion(expr.Syntax, expr, conversion, isCast: false, isExplicitlyNullable: false, destination: type, diagnostics: attemptDiagnostics); // UNDONE: was cast?
             Debug.Assert(result != null); // If this ever fails (it shouldn't), then put a null-check around the diagnostics update.
 
             diagnostics.AddRange(attemptDiagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2293,7 +2293,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var signature = best.Signature;
 
-            var resultOperand = CreateConversion(operand.Syntax, operand, best.Conversion, false, signature.OperandType, diagnostics);
+            var resultOperand = CreateConversion(operand.Syntax, operand, best.Conversion, isCast: false, isExplicitlyNullable: false, signature.OperandType, diagnostics);
             var resultType = signature.ReturnType;
             UnaryOperatorKind resultOperatorKind = signature.Kind;
             var resultMethod = signature.Method;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1528,7 +1528,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics = new DiagnosticBag();
             }
 
-            return CreateConversion(expression.Syntax, expression, conversion, false, targetType, diagnostics);
+            return CreateConversion(expression.Syntax, expression, conversion, isCast: false, isExplicitlyNullable: false, targetType, diagnostics);
         }
 
         internal void GenerateAnonymousFunctionConversionError(DiagnosticBag diagnostics, SyntaxNode syntax,
@@ -1999,7 +1999,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // The expression could not be bound. Insert a fake conversion
                 // around it to bool and keep on going.
                 // NOTE: no user-defined conversion candidates.
-                return BoundConversion.Synthesized(node, expr, Conversion.NoConversion, false, false, ConstantValue.NotAvailable, boolean, hasErrors: true);
+                return BoundConversion.Synthesized(node, expr, Conversion.NoConversion, false, explicitCastInCode: false, isExplicitlyNullable: false, ConstantValue.NotAvailable, boolean, hasErrors: true);
             }
 
             // Oddly enough, "if(dyn)" is bound not as a dynamic conversion to bool, but as a dynamic
@@ -2052,6 +2052,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         source: expr,
                         conversion: conversion,
                         isCast: false,
+                        isExplicitlyNullable: false,
                         wasCompilerGenerated: true,
                         destination: boolean,
                         diagnostics: diagnostics);
@@ -2069,7 +2070,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(resultKind == LookupResultKind.Empty, "How could overload resolution fail if a user-defined true operator was found?");
                 Debug.Assert(originalUserDefinedOperators.IsEmpty, "How could overload resolution fail if a user-defined true operator was found?");
                 GenerateImplicitConversionError(diagnostics, node, conversion, expr, boolean);
-                return BoundConversion.Synthesized(node, expr, Conversion.NoConversion, false, false, ConstantValue.NotAvailable, boolean, hasErrors: true);
+                return BoundConversion.Synthesized(node, expr, Conversion.NoConversion, false, explicitCastInCode: false, isExplicitlyNullable: false, ConstantValue.NotAvailable, boolean, hasErrors: true);
             }
 
             UnaryOperatorSignature signature = best.Signature;
@@ -2079,6 +2080,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 expr,
                 best.Conversion,
                 isCast: false,
+                isExplicitlyNullable: false,
                 destination: best.Signature.OperandType,
                 diagnostics: diagnostics);
 
@@ -2507,7 +2509,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return CreateConversion(argument.Syntax, argument, conversion, false, returnType, diagnostics);
+            return CreateConversion(argument.Syntax, argument, conversion, isCast: false, isExplicitlyNullable: false, returnType, diagnostics);
         }
 
         private BoundTryStatement BindTryStatement(TryStatementSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -397,8 +397,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionExpr.Syntax,
                 collectionExpr,
                 builder.CollectionConversion,
-                CheckOverflowAtRuntime,
-                false,
+                @checked: CheckOverflowAtRuntime,
+                explicitCastInCode: false,
+                isExplicitlyNullable: false,
                 ConstantValue.NotAvailable,
                 builder.CollectionType);
 

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -471,7 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(conversion.Method.IsUserDefinedConversion());
                         Debug.Assert(conversion.UserDefinedToConversion.IsIdentity);
                         Debug.Assert(resultantGoverningType.IsValidV6SwitchGoverningType(isTargetTypeOfUserDefinedOp: true));
-                        return binder.CreateConversion(node, switchExpression, conversion, false, resultantGoverningType, diagnostics);
+                        return binder.CreateConversion(node, switchExpression, conversion, isCast: false, isExplicitlyNullable: false, resultantGoverningType, diagnostics);
                     }
                     else if (switchGoverningType.SpecialType != SpecialType.System_Void)
                     {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -242,7 +242,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.Call:
                     return ((BoundCall)expr).Method.ReturnType.IsNullable;
                 case BoundKind.Conversion:
-                    return ((BoundConversion)expr).IsNullable;
+                    {
+                        var conversion = (BoundConversion)expr;
+                        if (conversion.ExplicitCastInCode)
+                        {
+                            return conversion.IsExplicitlyNullable;
+                        }
+                        Debug.Assert(!conversion.IsExplicitlyNullable);
+                        return null;
+                    }
                 case BoundKind.BinaryOperator:
                     return ((BoundBinaryOperator)expr).MethodOpt?.ReturnType.IsNullable;
                 case BoundKind.NullCoalescingOperator:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -241,6 +241,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return ((BoundPropertyAccess)expr).PropertySymbol.Type.IsNullable;
                 case BoundKind.Call:
                     return ((BoundCall)expr).Method.ReturnType.IsNullable;
+                case BoundKind.Conversion:
+                    return ((BoundConversion)expr).IsNullable;
                 case BoundKind.BinaryOperator:
                     return ((BoundBinaryOperator)expr).MethodOpt?.ReturnType.IsNullable;
                 case BoundKind.NullCoalescingOperator:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -558,9 +558,10 @@
     <Field Name="IsBaseConversion" Type="Boolean"/>
     <Field Name="Checked" Type="Boolean"/>
     <Field Name="ExplicitCastInCode" Type="Boolean"/>
-    
+    <!-- True for explicit casts with top-level `?`. Used by NullableWalker. -->
+    <Field Name="IsExplicitlyNullable" Type="bool" Null="allow"/>
+
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>
-    <Field Name="IsNullable" Type="bool?" Null="allow"/>
   </Node>
 
   <!--

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -560,7 +560,7 @@
     <Field Name="ExplicitCastInCode" Type="Boolean"/>
     
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>
-    <Field Name="IsNullable" Type="Boolean"/>
+    <Field Name="IsNullable" Type="bool?" Null="allow"/>
   </Node>
 
   <!--

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -560,6 +560,7 @@
     <Field Name="ExplicitCastInCode" Type="Boolean"/>
     
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>
+    <Field Name="IsNullable" Type="Boolean"/>
   </Node>
 
   <!--

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -548,6 +548,10 @@
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>
   </Node>
 
+  <!--
+    PROTOTYPE(NullableReferenceTypes): Add HasValidate="true" and check
+    ExplicitCastInCode || !IsExplicitlyNullable in the Validate() method.
+    -->
   <Node Name="BoundConversion" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -203,6 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 @checked: false,
                 explicitCastInCode: false,
                 constantValueOpt: constantValueOpt,
+                isNullable: false,
                 type: type)
             { WasCompilerGenerated = true };
         }
@@ -244,7 +245,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool explicitCastInCode,
             ConstantValue constantValueOpt,
             TypeSymbol type,
-            bool hasErrors = false)
+            bool hasErrors = false,
+            bool isNullable = false)
             : this(
                 syntax,
                 operand,
@@ -253,6 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 @checked: @checked,
                 explicitCastInCode: explicitCastInCode,
                 constantValueOpt: constantValueOpt,
+                isNullable: isNullable,
                 type: type,
                 hasErrors: hasErrors || !conversion.IsValid)
         {

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -202,8 +202,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 isBaseConversion: false,
                 @checked: false,
                 explicitCastInCode: false,
+                isExplicitlyNullable: false,
                 constantValueOpt: constantValueOpt,
-                isNullable: null,
                 type: type)
             { WasCompilerGenerated = true };
         }
@@ -219,6 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Conversion conversion,
             bool @checked,
             bool explicitCastInCode,
+            bool isExplicitlyNullable,
             ConstantValue constantValueOpt,
             TypeSymbol type,
             bool hasErrors = false)
@@ -228,7 +229,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 operand,
                 conversion,
                 @checked,
-                explicitCastInCode,
+                explicitCastInCode: explicitCastInCode,
+                isExplicitlyNullable: isExplicitlyNullable,
                 constantValueOpt,
                 type,
                 hasErrors || !conversion.IsValid)
@@ -243,10 +245,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Conversion conversion,
             bool @checked,
             bool explicitCastInCode,
+            bool isExplicitlyNullable,
             ConstantValue constantValueOpt,
             TypeSymbol type,
-            bool hasErrors = false,
-            bool? isNullable = null)
+            bool hasErrors = false)
             : this(
                 syntax,
                 operand,
@@ -254,11 +256,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 isBaseConversion: false,
                 @checked: @checked,
                 explicitCastInCode: explicitCastInCode,
+                isExplicitlyNullable: isExplicitlyNullable,
                 constantValueOpt: constantValueOpt,
-                isNullable: isNullable,
                 type: type,
                 hasErrors: hasErrors || !conversion.IsValid)
         {
+            Debug.Assert(explicitCastInCode || !isExplicitlyNullable);
             OriginalUserDefinedConversionsOpt = conversion.OriginalUserDefinedConversions;
         }
     }

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -261,6 +261,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 type: type,
                 hasErrors: hasErrors || !conversion.IsValid)
         {
+            // PROTOTYPE(NullableReferenceTypes): Move assert to Validate method
+            // (add HasValidate="true" in BoundNodes.xml).
             Debug.Assert(explicitCastInCode || !isExplicitlyNullable);
             OriginalUserDefinedConversionsOpt = conversion.OriginalUserDefinedConversions;
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 @checked: false,
                 explicitCastInCode: false,
                 constantValueOpt: constantValueOpt,
-                isNullable: false,
+                isNullable: null,
                 type: type)
             { WasCompilerGenerated = true };
         }
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ConstantValue constantValueOpt,
             TypeSymbol type,
             bool hasErrors = false,
-            bool isNullable = false)
+            bool? isNullable = null)
             : this(
                 syntax,
                 operand,

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -12744,6 +12744,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Converting null literal or possible null value to non-nullable type..
+        /// </summary>
+        internal static string WRN_ConvertingNullableToNonNullable {
+            get {
+                return ResourceManager.GetString("WRN_ConvertingNullableToNonNullable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Converting null literal or possible null value to non-nullable type..
+        /// </summary>
+        internal static string WRN_ConvertingNullableToNonNullable_Title {
+            get {
+                return ResourceManager.GetString("WRN_ConvertingNullableToNonNullable_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The fully qualified name for &apos;{0}&apos; is too long for debug information. Compile without &apos;/debug&apos; option..
         /// </summary>
         internal static string WRN_DebugFullNameTooLong {
@@ -14307,7 +14325,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot convert null to non-nullable reference..
+        ///   Looks up a localized string similar to Cannot convert null literal to non-nullable reference..
         /// </summary>
         internal static string WRN_NullAsNonNullable {
             get {
@@ -14316,7 +14334,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot convert null to non-nullable reference..
+        ///   Looks up a localized string similar to Cannot convert null literal to non-nullable reference..
         /// </summary>
         internal static string WRN_NullAsNonNullable_Title {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5166,11 +5166,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureStaticNullChecking" xml:space="preserve">
     <value>static null checking</value>
   </data>
-  <data name="WRN_NullAsNonNullable" xml:space="preserve">
-    <value>Cannot convert null to non-nullable reference.</value>
+  <data name="WRN_ConvertingNullableToNonNullable" xml:space="preserve">
+    <value>Converting null literal or possible null value to non-nullable type.</value>
   </data>
-  <data name="WRN_NullAsNonNullable_Title" xml:space="preserve">
-    <value>Cannot convert null to non-nullable reference.</value>
+  <data name="WRN_ConvertingNullableToNonNullable_Title" xml:space="preserve">
+    <value>Converting null literal or possible null value to non-nullable type.</value>
   </data>
   <data name="WRN_NullReferenceAssignment" xml:space="preserve">
     <value>Possible null reference assignment.</value>
@@ -5303,6 +5303,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="WRN_NullabilityMismatchInParameterTypeOfTargetDelegate_Title" xml:space="preserve">
     <value>Nullability of reference types in type of parameter doesn't match the target delegate.</value>
+  </data>
+  <data name="WRN_NullAsNonNullable" xml:space="preserve">
+    <value>Cannot convert null literal to non-nullable reference.</value>
+  </data>
+  <data name="WRN_NullAsNonNullable_Title" xml:space="preserve">
+    <value>Cannot convert null literal to non-nullable reference.</value>
   </data>
   <data name="WRN_NoBestNullabilityConditionalExpression" xml:space="preserve">
     <value>No best nullability for operands of conditional expression '{0}' and '{1}'.</value>

--- a/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
@@ -122,7 +122,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     objectType),
                                 Conversion.ExplicitReference,
                                 false,
-                                true,
+                                explicitCastInCode: true,
+                                isExplicitlyNullable: true,
                                 ConstantValue.NotAvailable,
                                 hostObjectField.Type.TypeSymbol 
                             ),
@@ -150,7 +151,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 { WasCompilerGenerated = true },
                                 Conversion.ExplicitReference,
                                 false,
-                                true,
+                                explicitCastInCode: true,
+                                isExplicitlyNullable: true,
                                 ConstantValue.NotAvailable,
                                 targetScriptType
                             ),

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1558,7 +1558,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_FeatureNotAvailableInVersion8 = 8400,
 
-        WRN_NullAsNonNullable = 8600,
+        WRN_ConvertingNullableToNonNullable = 8600,
         WRN_NullReferenceAssignment = 8601,
         WRN_NullReferenceReceiver = 8602,
         WRN_NullReferenceReturn = 8603,
@@ -1583,6 +1583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_NullabilityMismatchInParameterTypeOfTargetDelegate = 8622,
         ERR_ExplicitNullableAttribute = 8623,
         ERR_NotNullableOperatorNotReferenceType = 8624,
-        WRN_NoBestNullabilityConditionalExpression = 8625,
+        WRN_NullAsNonNullable = 8625,
+        WRN_NoBestNullabilityConditionalExpression = 8626,
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -320,8 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_AlignmentMagnitude:
                 case ErrorCode.WRN_AttributeIgnoredWhenPublicSigning:
                 case ErrorCode.WRN_TupleLiteralNameMismatch:
-                case ErrorCode.WRN_Experimental:
-                case ErrorCode.WRN_NullAsNonNullable:
+                case ErrorCode.WRN_ConvertingNullableToNonNullable:
                 case ErrorCode.WRN_NullReferenceAssignment:
                 case ErrorCode.WRN_NullReferenceReceiver:
                 case ErrorCode.WRN_NullReferenceReturn:
@@ -341,7 +340,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_NullabilityMismatchInArgument:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate:
+                case ErrorCode.WRN_NullAsNonNullable:
                 case ErrorCode.WRN_NoBestNullabilityConditionalExpression:
+                case ErrorCode.WRN_Experimental:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1856,7 +1856,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 if (node.ExplicitCastInCode &&
-                    !node.IsNullable &&
+                    node.IsNullable == false &&
                     targetType.IsReferenceType &&
                     (operandType?.IsNullable == true || (operandType is null && operand.IsLiteralNullOrDefault())))
                 {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -364,12 +364,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_ConvertingNullableToNonNullable, value.Syntax);
                     }
-                    else
+                    else if (!CheckNullAsNonNullableReference(value))
                     {
-                        if (!CheckNullAsNonNullableReference(value))
-                        {
-                            ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullReferenceAssignment, value.Syntax);
-                        }
+                        ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullReferenceAssignment, value.Syntax);
                     }
                 }
 
@@ -1860,6 +1857,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     targetType.IsReferenceType &&
                     (operandType?.IsNullable == true || (operandType is null && operand.IsLiteralNullOrDefault())))
                 {
+                    // PROTOTYPE(NullableReferenceTypes): Should not report warning for explicit
+                    // user -defined conversion if the operator is defined from nullable to
+                    // non-nullable. See StaticNullChecking.ExplicitCast_UserDefined.
                     ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_ConvertingNullableToNonNullable, node.Syntax);
                 }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -350,7 +350,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void ReportAssignmentWarnings(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings)
         {
+            Debug.Assert(value != null);
             Debug.Assert(!IsConditionalState);
+
             if (this.State.Reachable)
             {
                 if (targetType is null || valueType is null)
@@ -379,7 +381,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private void TrackNullableStateForAssignment(BoundExpression value, TypeSymbolWithAnnotations targetType, int targetSlot, TypeSymbolWithAnnotations valueType, int valueSlot)
         {
+            Debug.Assert(value != null);
             Debug.Assert(!IsConditionalState);
+
             if (this.State.Reachable)
             {
                 if ((object)targetType == null)
@@ -1853,12 +1857,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 if (node.ExplicitCastInCode &&
-                    node.IsNullable == false &&
+                    !node.IsExplicitlyNullable &&
                     targetType.IsReferenceType &&
                     (operandType?.IsNullable == true || (operandType is null && operand.IsLiteralNullOrDefault())))
                 {
                     // PROTOTYPE(NullableReferenceTypes): Should not report warning for explicit
-                    // user -defined conversion if the operator is defined from nullable to
+                    // user-defined conversion if the operator is defined from nullable to
                     // non-nullable. See StaticNullChecking.ExplicitCast_UserDefined.
                     ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_ConvertingNullableToNonNullable, node.Syntax);
                 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -147,7 +147,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             int oldNext = state.Capacity;
             state.EnsureCapacity(nextVariableSlot);
-            for (int slot = oldNext; slot < nextVariableSlot; slot++)
+            Populate(ref state, oldNext);
+        }
+
+        private void Populate(ref LocalState state, int start)
+        {
+            int capacity = state.Capacity;
+            for (int slot = start; slot < capacity; slot++)
             {
                 var value = GetDefaultState(ref state, slot);
                 state[slot] = value;
@@ -355,10 +361,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return;
                 }
 
+                bool isByRefTarget = IsByRefTarget(targetSlot);
+                if (targetSlot > 0)
+                {
+                    if (targetSlot >= this.State.Capacity) Normalize(ref this.State);
+
+                    this.State[targetSlot] = isByRefTarget ?
+                        // Since reference can point to the heap, we cannot assume the value is not null after this assignment,
+                        // regardless of what value is being assigned. 
+                        (targetType.IsNullable == true) ? (bool?)false : null :
+                        !valueType?.IsNullable;
+
+                    // PROTOTYPE(NullableReferenceTypes): Might this clear state that
+                    // should be copied in InheritNullableStateOfTrackableType?
+                    InheritDefaultState(targetSlot);
+                }
+
                 if (targetType.IsReferenceType)
                 {
-                    bool isByRefTarget = IsByRefTarget(targetSlot);
-
                     if (targetType.IsNullable == false)
                     {
                         if (valueType?.IsNullable == true && (value == null || !CheckNullAsNonNullableReference(value)))
@@ -366,23 +386,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullReferenceAssignment, (value ?? node).Syntax);
                         }
                     }
-                    else if (targetSlot > 0)
-                    {
-                        if (targetSlot >= this.State.Capacity) Normalize(ref this.State);
-
-                        this.State[targetSlot] = isByRefTarget ?
-                            // Since reference can point to the heap, we cannot assume the value is not null after this assignment,
-                            // regardless of what value is being assigned. 
-                            (targetType.IsNullable == true) ? (bool?)false : null :
-                            !valueType?.IsNullable;
-                    }
 
                     if (targetSlot > 0)
                     {
-                        // PROTOTYPE(NullableReferenceTypes): Might this clear state that
-                        // should be copied in InheritNullableStateOfTrackableType?
-                        InheritDefaultState(targetSlot);
-
                         // PROTOTYPE(NullableReferenceTypes): We should copy all tracked state from `value`,
                         // regardless of BoundNode type, but we'll need to handle cycles. (For instance, the
                         // assignment to C.F below. See also StaticNullChecking_Members.FieldCycle_01.)
@@ -416,7 +422,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private int GetSlotWatermark() => this.State.Capacity;
+        private int GetSlotWatermark() => this.nextVariableSlot;
 
         private bool IsByRefTarget(int slot)
         {
@@ -554,7 +560,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override LocalState ReachableState()
         {
-            return new LocalState(BitVector.Create(nextVariableSlot), BitVector.Create(nextVariableSlot));
+            var state = new LocalState(BitVector.Create(nextVariableSlot), BitVector.Create(nextVariableSlot));
+            Populate(ref state, start: 0);
+            return state;
         }
 
         protected override LocalState UnreachableState()
@@ -579,24 +587,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void EnterParameter(ParameterSymbol parameter)
         {
             int slot = GetOrCreateSlot(parameter);
-            if (parameter.RefKind == RefKind.Out && !this._currentMethodOrLambda.IsAsync) // out parameters not allowed in async
+            Debug.Assert(!IsConditionalState);
+            if (slot > 0 && parameter.RefKind != RefKind.Out)
             {
-            }
-            else
-            {
-                Debug.Assert(!IsConditionalState);
-                if (slot > 0 && parameter.RefKind != RefKind.Out)
+                var paramType = parameter.Type.TypeSymbol;
+                if (EmptyStructTypeCache.IsTrackableStructType(paramType))
                 {
-                    var paramType = parameter.Type.TypeSymbol;
-                    if (EmptyStructTypeCache.IsTrackableStructType(paramType))
-                    {
-                        InheritNullableStateOfTrackableStruct(paramType, slot, valueSlot: -1, isByRefTarget: parameter.RefKind != RefKind.None, slotWatermark: GetSlotWatermark());
-                    }
+                    InheritNullableStateOfTrackableStruct(paramType, slot, valueSlot: -1, isByRefTarget: parameter.RefKind != RefKind.None, slotWatermark: GetSlotWatermark());
                 }
             }
         }
 
-#region Visitors
+        #region Visitors
 
         public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
         {
@@ -786,6 +788,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     slot = GetOrCreateSlot(receiver);
                     if (slot > 0 && isTrackableStructType)
                     {
+                        this.State[slot] = true;
                         InheritNullableStateOfTrackableStruct(type, slot, valueSlot: -1, isByRefTarget: false, slotWatermark: GetSlotWatermark());
                     }
                 }
@@ -1155,6 +1158,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (operandComparedToNull != null)
                     {
+                        // PROTOTYPE(NullableReferenceTypes): This check is incorrect since it compares declared
+                        // nullability rather than tracked nullability. Moreover, we should only report such
+                        // diagnostics for locals that are set or checked explicitly within this method.
                         if (operandComparedToNullType?.IsNullable == false)
                         {
                             ReportStaticNullCheckingDiagnostics(op == BinaryOperatorKind.Equal ?
@@ -1724,7 +1730,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var type = pair.Type;
             var slot = pair.Slot;
-            if (type.IsNullable != false && slot > 0 && slot < this.State.Capacity)
+            if (slot > 0 && slot < this.State.Capacity)
             {
                 bool? isNullable = !this.State[slot];
                 if (isNullable != type.IsNullable)
@@ -2413,19 +2419,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!asLvalue)
                 {
-                    // If the symbol is statically declared as not-nullable
-                    // or null-oblivious, ignore flow state.
-                    if (resultType.IsNullable == true && resultType.IsReferenceType)
+                    // We are supposed to track information for the node. Use whatever we managed to
+                    // accumulate so far.
+                    if (resultType.IsReferenceType && slot > 0 && slot < this.State.Capacity)
                     {
-                        // We are supposed to track information for the node. Use whatever we managed to
-                        // accumulate so far.
-                        if (slot > 0 && slot < this.State.Capacity)
+                        var isNullable = !this.State[slot];
+                        if (isNullable != resultType.IsNullable)
                         {
-                            var isNullable = !this.State[slot];
-                            if (isNullable != resultType.IsNullable)
-                            {
-                                resultType = TypeSymbolWithAnnotations.Create(resultType.TypeSymbol, isNullable);
-                            }
+                            resultType = TypeSymbolWithAnnotations.Create(resultType.TypeSymbol, isNullable);
                         }
                     }
                 }
@@ -3153,7 +3154,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (!self.Reachable)
             {
-                self.Clone(other);
+                self = other.Clone();
                 return true;
             }
             else
@@ -3206,11 +3207,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             private BitVector _knownNullState; // No diagnostics should be derived from a variable with a bit set to 0.
             private BitVector _notNull;
 
-            internal LocalState(BitVector unknownNullState, BitVector notNull)
+            internal LocalState(BitVector knownNullState, BitVector notNull)
             {
-                Debug.Assert(!unknownNullState.IsNull);
+                Debug.Assert(!knownNullState.IsNull);
                 Debug.Assert(!notNull.IsNull);
-                this._knownNullState = unknownNullState;
+                this._knownNullState = knownNullState;
                 this._notNull = notNull;
             }
 
@@ -3233,12 +3234,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _knownNullState[slot] = value.HasValue;
                     _notNull[slot] = value.GetValueOrDefault();
                 }
-            }
-
-            internal void Clone(LocalState other)
-            {
-                _knownNullState = other._knownNullState.Clone();
-                _notNull = other._notNull.Clone();
             }
 
             /// <summary>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -348,10 +348,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             return typeOpt ?? (object)"<null>";
         }
 
+        private void ReportAssignmentWarnings(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings)
+        {
+            Debug.Assert(!IsConditionalState);
+            if (this.State.Reachable)
+            {
+                if (targetType is null || valueType is null)
+                {
+                    return;
+                }
+
+                if (targetType.IsReferenceType && targetType.IsNullable == false && valueType.IsNullable == true)
+                {
+                    if (useLegacyWarnings)
+                    {
+                        ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_ConvertingNullableToNonNullable, value.Syntax);
+                    }
+                    else
+                    {
+                        if (!CheckNullAsNonNullableReference(value))
+                        {
+                            ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullReferenceAssignment, value.Syntax);
+                        }
+                    }
+                }
+
+                ReportNullabilityMismatchInAssignmentIfNecessary(value, valueType.TypeSymbol, targetType.TypeSymbol);
+            }
+        }
+
         /// <summary>
-        /// Report nullable mismatch warnings and optionally update tracked value on assignment.
+        /// Update tracked value on assignment.
         /// </summary>
-        private void TrackNullableStateForAssignment(BoundNode node, int targetSlot, TypeSymbolWithAnnotations targetType, BoundExpression value, TypeSymbolWithAnnotations valueType, int valueSlot)
+        private void TrackNullableStateForAssignment(BoundExpression value, TypeSymbolWithAnnotations targetType, int targetSlot, TypeSymbolWithAnnotations valueType, int valueSlot)
         {
             Debug.Assert(!IsConditionalState);
             if (this.State.Reachable)
@@ -361,63 +390,48 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return;
                 }
 
-                bool isByRefTarget = IsByRefTarget(targetSlot);
-                if (targetSlot > 0)
+                if (targetSlot <= 0)
                 {
-                    if (targetSlot >= this.State.Capacity) Normalize(ref this.State);
-
-                    this.State[targetSlot] = isByRefTarget ?
-                        // Since reference can point to the heap, we cannot assume the value is not null after this assignment,
-                        // regardless of what value is being assigned. 
-                        (targetType.IsNullable == true) ? (bool?)false : null :
-                        !valueType?.IsNullable;
-
-                    // PROTOTYPE(NullableReferenceTypes): Might this clear state that
-                    // should be copied in InheritNullableStateOfTrackableType?
-                    InheritDefaultState(targetSlot);
+                    return;
                 }
+
+                bool isByRefTarget = IsByRefTarget(targetSlot);
+                if (targetSlot >= this.State.Capacity) Normalize(ref this.State);
+
+                this.State[targetSlot] = isByRefTarget ?
+                    // Since reference can point to the heap, we cannot assume the value is not null after this assignment,
+                    // regardless of what value is being assigned. 
+                    (targetType.IsNullable == true) ? (bool?)false : null :
+                    !valueType?.IsNullable;
+
+                // PROTOTYPE(NullableReferenceTypes): Might this clear state that
+                // should be copied in InheritNullableStateOfTrackableType?
+                InheritDefaultState(targetSlot);
 
                 if (targetType.IsReferenceType)
                 {
-                    if (targetType.IsNullable == false)
+                    // PROTOTYPE(NullableReferenceTypes): We should copy all tracked state from `value`,
+                    // regardless of BoundNode type, but we'll need to handle cycles. (For instance, the
+                    // assignment to C.F below. See also StaticNullChecking_Members.FieldCycle_01.)
+                    // class C
+                    // {
+                    //     C? F;
+                    //     C() { F = this; }
+                    // }
+                    // For now, we copy a limited set of BoundNode types that shouldn't contain cycles.
+                    if ((value.Kind == BoundKind.ObjectCreationExpression || value.Kind == BoundKind.AnonymousObjectCreationExpression || value.Kind == BoundKind.DynamicObjectCreationExpression || targetType.TypeSymbol.IsAnonymousType) &&
+                        targetType.TypeSymbol.Equals(valueType?.TypeSymbol, TypeCompareKind.ConsiderEverything)) // PROTOTYPE(NullableReferenceTypes): Allow assignment to base type.
                     {
-                        if (valueType?.IsNullable == true && (value == null || !CheckNullAsNonNullableReference(value)))
+                        if (valueSlot > 0)
                         {
-                            ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullReferenceAssignment, (value ?? node).Syntax);
-                        }
-                    }
-
-                    if (targetSlot > 0)
-                    {
-                        // PROTOTYPE(NullableReferenceTypes): We should copy all tracked state from `value`,
-                        // regardless of BoundNode type, but we'll need to handle cycles. (For instance, the
-                        // assignment to C.F below. See also StaticNullChecking_Members.FieldCycle_01.)
-                        // class C
-                        // {
-                        //     C? F;
-                        //     C() { F = this; }
-                        // }
-                        // For now, we copy a limited set of BoundNode types that shouldn't contain cycles.
-                        if (value != null &&
-                            (value.Kind == BoundKind.ObjectCreationExpression || value.Kind == BoundKind.AnonymousObjectCreationExpression || value.Kind == BoundKind.DynamicObjectCreationExpression || targetType.TypeSymbol.IsAnonymousType) &&
-                            targetType.TypeSymbol.Equals(valueType?.TypeSymbol, TypeCompareKind.ConsiderEverything)) // PROTOTYPE(NullableReferenceTypes): Allow assignment to base type.
-                        {
-                            if (valueSlot > 0)
-                            {
-                                InheritNullableStateOfTrackableType(targetSlot, valueSlot, isByRefTarget, slotWatermark: GetSlotWatermark());
-                            }
+                            InheritNullableStateOfTrackableType(targetSlot, valueSlot, isByRefTarget, slotWatermark: GetSlotWatermark());
                         }
                     }
                 }
-                else if (targetSlot > 0 && EmptyStructTypeCache.IsTrackableStructType(targetType.TypeSymbol) &&
-                        (value == null || targetType.TypeSymbol.Equals(valueType?.TypeSymbol, TypeCompareKind.ConsiderEverything)))
+                else if (EmptyStructTypeCache.IsTrackableStructType(targetType.TypeSymbol) &&
+                        targetType.TypeSymbol.Equals(valueType?.TypeSymbol, TypeCompareKind.ConsiderEverything))
                 {
                     InheritNullableStateOfTrackableStruct(targetType.TypeSymbol, targetSlot, valueSlot, IsByRefTarget(targetSlot), slotWatermark: GetSlotWatermark());
-                }
-
-                if ((object)valueType?.TypeSymbol != null && IsNullabilityMismatch(targetType.TypeSymbol, valueType.TypeSymbol))
-                {
-                    ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInAssignment, (value ?? node).Syntax, valueType.TypeSymbol, targetType.TypeSymbol);
                 }
             }
         }
@@ -685,13 +699,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                if ((object)node.ExpressionOpt.Type != null && IsNullabilityMismatch(returnType.TypeSymbol, node.ExpressionOpt.Type))
-                {
-                    ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInAssignment, node.ExpressionOpt.Syntax, node.ExpressionOpt.Type, returnType.TypeSymbol);
-                }
+                ReportNullabilityMismatchInAssignmentIfNecessary(node.ExpressionOpt, node.ExpressionOpt.Type, returnType.TypeSymbol);
             }
 
             return result;
+        }
+
+        private void ReportNullabilityMismatchInAssignmentIfNecessary(BoundExpression node, TypeSymbol sourceType, TypeSymbol destinationType)
+        {
+            if ((object)sourceType != null && IsNullabilityMismatch(destinationType, sourceType))
+            {
+                ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInAssignment, node.Syntax, sourceType, destinationType);
+            }
         }
 
         public override BoundNode VisitLocal(BoundLocal node)
@@ -719,7 +738,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     type = valueType;
                 }
 
-                TrackNullableStateForAssignment(node, slot, type, initializer, valueType, value.Slot);
+                ReportAssignmentWarnings(initializer, type, valueType, useLegacyWarnings: true);
+                TrackNullableStateForAssignment(initializer, type, slot, valueType, value.Slot);
             }
 
             return null;
@@ -839,7 +859,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if ((object)containingSymbol != null)
                     {
                         var type = GetTypeOrReturnTypeWithAdjustedNullableAnnotations(containingSymbol);
-                        TrackNullableStateForAssignment(node, containingSlot, type, node, result.Type, result.Slot);
+                        ReportAssignmentWarnings(node, type, result.Type, useLegacyWarnings: false);
+                        TrackNullableStateForAssignment(node, type, containingSlot, result.Type, result.Slot);
                     }
                     break;
             }
@@ -940,7 +961,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     receiverSlot = GetOrCreateSlot(implicitReceiver);
                 }
 
-                TrackNullableStateForAssignment(argument, GetOrCreateSlot(property, receiverSlot), property.Type, argument, argumentResult.Type, argumentResult.Slot);
+                ReportAssignmentWarnings(argument, property.Type, argumentResult.Type, useLegacyWarnings: false);
+                TrackNullableStateForAssignment(argument, property.Type, GetOrCreateSlot(property, receiverSlot), argumentResult.Type, argumentResult.Slot);
             }
 
             // PROTOTYPE(NullableReferenceType): Result.Type may need to be a new anonymous
@@ -1010,7 +1032,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var result = GenerateConversionForAssignment(element, elementTypeSymbol, resultBuilder[i]);
                 if (elementTypeIsReferenceType)
                 {
-                    TrackNullableStateForAssignment(element, -1, elementType, element, result.Type, result.Slot);
+                    ReportAssignmentWarnings(element, elementType, result.Type, useLegacyWarnings: false);
                 }
             }
             resultBuilder.Free();
@@ -1566,7 +1588,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var result = results[i];
                 if (refKind != RefKind.None)
                 {
-                    TrackNullableStateForAssignment(argument, result.Slot, result.Type, null, parameter?.Type, -1);
+                    var parameterType = parameter?.Type;
+                    ReportAssignmentWarnings(argument, result.Type, parameterType, useLegacyWarnings: false);
+                    TrackNullableStateForAssignment(argument, result.Type, result.Slot, parameterType, -1);
                 }
                 if (refKind != RefKind.Out && (object)parameter != null)
                 {
@@ -1800,6 +1824,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var operand = node.Operand;
             Visit(operand);
+            var operandType = _result.Type;
+            var targetType = node.Type;
 
             //if (this.State.Reachable) // PROTOTYPE(NullableReferenceTypes): Consider reachability?
             {
@@ -1809,7 +1835,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case ConversionKind.ImplicitUserDefined:
                         if ((object)node.SymbolOpt != null && node.SymbolOpt.ParameterCount == 1)
                         {
-                            WarnOnNullReferenceArgument(operand, _result.Type, node.SymbolOpt.Parameters[0], expanded: false);
+                            WarnOnNullReferenceArgument(operand, operandType, node.SymbolOpt.Parameters[0], expanded: false);
                         }
                         break;
 
@@ -1817,23 +1843,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (!node.ExplicitCastInCode && operand.Kind == BoundKind.Lambda)
                         {
                             var lambda = (BoundLambda)operand;
-                            ReportNullabilityMismatchWithTargetDelegate(operand.Syntax, node.Type.GetDelegateType(), lambda.Symbol);
+                            ReportNullabilityMismatchWithTargetDelegate(operand.Syntax, targetType.GetDelegateType(), lambda.Symbol);
                         }
                         break;
 
                     case ConversionKind.MethodGroup:
                         if (!node.ExplicitCastInCode)
                         {
-                            ReportNullabilityMismatchWithTargetDelegate(operand.Syntax, node.Type.GetDelegateType(), node.SymbolOpt);
+                            ReportNullabilityMismatchWithTargetDelegate(operand.Syntax, targetType.GetDelegateType(), node.SymbolOpt);
                         }
                         break;
                 }
 
-                var operandType = _result.Type;
+                if (node.ExplicitCastInCode &&
+                    !node.IsNullable &&
+                    targetType.IsReferenceType &&
+                    (operandType?.IsNullable == true || (operandType is null && operand.IsLiteralNullOrDefault())))
+                {
+                    ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_ConvertingNullableToNonNullable, node.Syntax);
+                }
+
                 TypeSymbolWithAnnotations resultType;
                 if (operand.Kind == BoundKind.Literal && (object)operand.Type == null && operand.ConstantValue.IsNull)
                 {
-                    resultType = TypeSymbolWithAnnotations.Create(node.Type, true);
+                    resultType = TypeSymbolWithAnnotations.Create(targetType, true);
                 }
                 else if (node.ConversionKind == ConversionKind.Identity && !node.ExplicitCastInCode)
                 {
@@ -1841,7 +1874,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    resultType = InferResultNullability(operand, node.Conversion, node.Type, operandType, fromConversionNode: true);
+                    resultType = InferResultNullability(operand, node.Conversion, targetType, operandType, fromConversionNode: true);
                 }
                 _result = resultType;
             }
@@ -2121,7 +2154,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                TrackNullableStateForAssignment(node.Left, left.Slot, left.Type, node.Right, right.Type, right.Slot);
+                var leftKind = node.Left.Kind;
+                ReportAssignmentWarnings(node.Right, left.Type, right.Type, useLegacyWarnings: leftKind == BoundKind.Local || leftKind == BoundKind.Parameter);
+                TrackNullableStateForAssignment(node.Right, left.Type, left.Slot, right.Type, right.Slot);
                 // PROTOTYPE(NullableReferenceTypes): Check node.Type.IsErrorType() instead?
                 _result = node.HasErrors ? Result.Create(TypeSymbolWithAnnotations.Create(node.Type)) : left;
             }
@@ -2205,7 +2240,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _result = (op == UnaryOperatorKind.PrefixIncrement || op == UnaryOperatorKind.PrefixDecrement) ? resultOfIncrementType : operandResult;
                     setResult = true;
 
-                    TrackNullableStateForAssignment(node.Operand, operandResult.Slot, operandResult.Type, value: node, valueType: resultOfIncrementType, valueSlot: -1);
+                    ReportAssignmentWarnings(node, operandResult.Type, valueType: resultOfIncrementType, useLegacyWarnings: false);
+                    TrackNullableStateForAssignment(node, operandResult.Type, operandResult.Slot, valueType: resultOfIncrementType, valueSlot: -1);
                 }
             }
 
@@ -2273,7 +2309,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultType = null;
                 }
 
-                TrackNullableStateForAssignment(node, left.Slot, left.Type, node, resultType, -1);
+                ReportAssignmentWarnings(node, left.Type, resultType, useLegacyWarnings: false);
+                TrackNullableStateForAssignment(node, left.Type, left.Slot, resultType, -1);
                 _result = resultType;
             }
             //else

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -1954,7 +1954,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundConversion : BoundExpression
     {
-        public BoundConversion(SyntaxNode syntax, BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors = false)
+        public BoundConversion(SyntaxNode syntax, BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, Boolean isNullable, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.Conversion, syntax, type, hasErrors || operand.HasErrors())
         {
 
@@ -1967,6 +1967,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Checked = @checked;
             this.ExplicitCastInCode = explicitCastInCode;
             this.ConstantValueOpt = constantValueOpt;
+            this.IsNullable = isNullable;
         }
 
 
@@ -1982,16 +1983,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public ConstantValue ConstantValueOpt { get; }
 
+        public Boolean IsNullable { get; }
+
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitConversion(this);
         }
 
-        public BoundConversion Update(BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, TypeSymbol type)
+        public BoundConversion Update(BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, Boolean isNullable, TypeSymbol type)
         {
-            if (operand != this.Operand || conversion != this.Conversion || isBaseConversion != this.IsBaseConversion || @checked != this.Checked || explicitCastInCode != this.ExplicitCastInCode || constantValueOpt != this.ConstantValueOpt || type != this.Type)
+            if (operand != this.Operand || conversion != this.Conversion || isBaseConversion != this.IsBaseConversion || @checked != this.Checked || explicitCastInCode != this.ExplicitCastInCode || constantValueOpt != this.ConstantValueOpt || isNullable != this.IsNullable || type != this.Type)
             {
-                var result = new BoundConversion(this.Syntax, operand, conversion, isBaseConversion, @checked, explicitCastInCode, constantValueOpt, type, this.HasErrors);
+                var result = new BoundConversion(this.Syntax, operand, conversion, isBaseConversion, @checked, explicitCastInCode, constantValueOpt, isNullable, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -8816,7 +8819,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, type);
+            return node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.IsNullable, type);
         }
         public override BoundNode VisitArgList(BoundArgList node)
         {
@@ -9914,6 +9917,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new TreeDumperNode("@checked", node.Checked, null),
                 new TreeDumperNode("explicitCastInCode", node.ExplicitCastInCode, null),
                 new TreeDumperNode("constantValueOpt", node.ConstantValueOpt, null),
+                new TreeDumperNode("isNullable", node.IsNullable, null),
                 new TreeDumperNode("type", node.Type, null)
             }
             );

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -1954,7 +1954,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundConversion : BoundExpression
     {
-        public BoundConversion(SyntaxNode syntax, BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, Boolean isNullable, TypeSymbol type, bool hasErrors = false)
+        public BoundConversion(SyntaxNode syntax, BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, bool? isNullable, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.Conversion, syntax, type, hasErrors || operand.HasErrors())
         {
 
@@ -1983,14 +1983,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public ConstantValue ConstantValueOpt { get; }
 
-        public Boolean IsNullable { get; }
+        public bool? IsNullable { get; }
 
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitConversion(this);
         }
 
-        public BoundConversion Update(BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, Boolean isNullable, TypeSymbol type)
+        public BoundConversion Update(BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, bool? isNullable, TypeSymbol type)
         {
             if (operand != this.Operand || conversion != this.Conversion || isBaseConversion != this.IsBaseConversion || @checked != this.Checked || explicitCastInCode != this.ExplicitCastInCode || constantValueOpt != this.ConstantValueOpt || isNullable != this.IsNullable || type != this.Type)
             {

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -1954,7 +1954,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundConversion : BoundExpression
     {
-        public BoundConversion(SyntaxNode syntax, BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, bool? isNullable, TypeSymbol type, bool hasErrors = false)
+        public BoundConversion(SyntaxNode syntax, BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, bool isExplicitlyNullable, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.Conversion, syntax, type, hasErrors || operand.HasErrors())
         {
 
@@ -1966,8 +1966,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.IsBaseConversion = isBaseConversion;
             this.Checked = @checked;
             this.ExplicitCastInCode = explicitCastInCode;
+            this.IsExplicitlyNullable = isExplicitlyNullable;
             this.ConstantValueOpt = constantValueOpt;
-            this.IsNullable = isNullable;
         }
 
 
@@ -1981,20 +1981,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public Boolean ExplicitCastInCode { get; }
 
-        public ConstantValue ConstantValueOpt { get; }
+        public bool IsExplicitlyNullable { get; }
 
-        public bool? IsNullable { get; }
+        public ConstantValue ConstantValueOpt { get; }
 
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitConversion(this);
         }
 
-        public BoundConversion Update(BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, ConstantValue constantValueOpt, bool? isNullable, TypeSymbol type)
+        public BoundConversion Update(BoundExpression operand, Conversion conversion, Boolean isBaseConversion, Boolean @checked, Boolean explicitCastInCode, bool isExplicitlyNullable, ConstantValue constantValueOpt, TypeSymbol type)
         {
-            if (operand != this.Operand || conversion != this.Conversion || isBaseConversion != this.IsBaseConversion || @checked != this.Checked || explicitCastInCode != this.ExplicitCastInCode || constantValueOpt != this.ConstantValueOpt || isNullable != this.IsNullable || type != this.Type)
+            if (operand != this.Operand || conversion != this.Conversion || isBaseConversion != this.IsBaseConversion || @checked != this.Checked || explicitCastInCode != this.ExplicitCastInCode || isExplicitlyNullable != this.IsExplicitlyNullable || constantValueOpt != this.ConstantValueOpt || type != this.Type)
             {
-                var result = new BoundConversion(this.Syntax, operand, conversion, isBaseConversion, @checked, explicitCastInCode, constantValueOpt, isNullable, type, this.HasErrors);
+                var result = new BoundConversion(this.Syntax, operand, conversion, isBaseConversion, @checked, explicitCastInCode, isExplicitlyNullable, constantValueOpt, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -8819,7 +8819,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.IsNullable, type);
+            return node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.IsExplicitlyNullable, node.ConstantValueOpt, type);
         }
         public override BoundNode VisitArgList(BoundArgList node)
         {
@@ -9916,8 +9916,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new TreeDumperNode("isBaseConversion", node.IsBaseConversion, null),
                 new TreeDumperNode("@checked", node.Checked, null),
                 new TreeDumperNode("explicitCastInCode", node.ExplicitCastInCode, null),
+                new TreeDumperNode("isExplicitlyNullable", node.IsExplicitlyNullable, null),
                 new TreeDumperNode("constantValueOpt", node.ConstantValueOpt, null),
-                new TreeDumperNode("isNullable", node.IsNullable, null),
                 new TreeDumperNode("type", node.Type, null)
             }
             );

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -177,7 +177,7 @@
                 case ErrorCode.WRN_UnreferencedLocalFunction:
                 case ErrorCode.WRN_FilterIsConstantFalse:
                 case ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch:
-                case ErrorCode.WRN_NullAsNonNullable:
+                case ErrorCode.WRN_ConvertingNullableToNonNullable:
                 case ErrorCode.WRN_NullReferenceAssignment:
                 case ErrorCode.WRN_NullReferenceReceiver:
                 case ErrorCode.WRN_NullReferenceReturn:
@@ -197,6 +197,7 @@
                 case ErrorCode.WRN_NullabilityMismatchInArgument:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate:
+                case ErrorCode.WRN_NullAsNonNullable:
                 case ErrorCode.WRN_NoBestNullabilityConditionalExpression:
                     return true;
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -898,8 +898,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     isBaseConversion: node.IsBaseConversion,
                     @checked: node.Checked,
                     explicitCastInCode: node.ExplicitCastInCode,
+                    isExplicitlyNullable: node.IsExplicitlyNullable,
                     constantValueOpt: node.ConstantValueOpt,
-                    isNullable: node.IsNullable,
                     type: node.Type));
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -899,6 +899,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: node.Checked,
                     explicitCastInCode: node.ExplicitCastInCode,
                     constantValueOpt: node.ConstantValueOpt,
+                    isNullable: node.IsNullable,
                     type: node.Type));
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Need to represent the implicit conversion as a node in order to be able to produce correct diagnostics.
                 left = new BoundConversion(left.Syntax, left, node.LeftConversion, node.Operator.Kind.IsChecked(),
-                                           explicitCastInCode: false, constantValueOpt: null, type: node.Operator.LeftType);
+                                           explicitCastInCode: false, isExplicitlyNullable: false, constantValueOpt: null, type: node.Operator.LeftType);
             }
 
             CheckForBitwiseOrSignExtend(node, node.Operator.Kind, left, node.Right);

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -592,6 +592,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: conversion.Checked,
                     explicitCastInCode: true,
                     constantValueOpt: conversion.ConstantValueOpt,
+                    isNullable: conversion.IsNullable,
                     type: conversion.Type);
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -591,8 +591,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     isBaseConversion: conversion.IsBaseConversion,
                     @checked: conversion.Checked,
                     explicitCastInCode: true,
+                    isExplicitlyNullable: conversion.IsExplicitlyNullable,
                     constantValueOpt: conversion.ConstantValueOpt,
-                    isNullable: conversion.IsNullable,
                     type: conversion.Type);
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -1317,7 +1317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         @checked: false,
                         explicitCastInCode: true,
                         constantValueOpt: conversion.ConstantValueOpt,
-                        isNullable: false,
+                        isNullable: conversion.IsNullable,
                         type: conversion.Type);
                 }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -1317,6 +1317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         @checked: false,
                         explicitCastInCode: true,
                         constantValueOpt: conversion.ConstantValueOpt,
+                        isNullable: false,
                         type: conversion.Type);
                 }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -1316,8 +1316,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         isBaseConversion: false,
                         @checked: false,
                         explicitCastInCode: true,
+                        isExplicitlyNullable: conversion.IsExplicitlyNullable,
                         constantValueOpt: conversion.ConstantValueOpt,
-                        isNullable: conversion.IsNullable,
                         type: conversion.Type);
                 }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -550,6 +550,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Conversion.IdentityValue,
                 @checked: false,
                 explicitCastInCode: true,
+                isExplicitlyNullable: false,
                 constantValueOpt: null,
                 type: expr.Type)
             { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -319,8 +319,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             isBaseConversion: false,
                             @checked: false,
                             explicitCastInCode: explicitCastInCode,
+                            isExplicitlyNullable: oldNode.IsExplicitlyNullable,
                             constantValueOpt: constantValueOpt,
-                            isNullable: null,
                             type: rewrittenType);
                     }
 
@@ -366,8 +366,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     isBaseConversion: oldNode.IsBaseConversion,
                     @checked: @checked,
                     explicitCastInCode: explicitCastInCode,
+                    isExplicitlyNullable: oldNode.IsExplicitlyNullable,
                     constantValueOpt: constantValueOpt,
-                    isNullable: oldNode.IsNullable,
                     type: rewrittenType) :
                 new BoundConversion(
                     syntax,
@@ -376,8 +376,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     isBaseConversion: false,
                     @checked: @checked,
                     explicitCastInCode: explicitCastInCode,
+                    isExplicitlyNullable: false, // BoundConversion.IsExplicitlyNullable is not used in lowered tree
                     constantValueOpt: constantValueOpt,
-                    isNullable: null,
                     type: rewrittenType);
         }
 
@@ -480,6 +480,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             conversion,             
                             @checked: @checked,
                             explicitCastInCode: false,
+                            isExplicitlyNullable: false,
                             constantValueOpt: default(ConstantValue),
                             type: type,
                             hasErrors: !conversion.IsValid) { WasCompilerGenerated = true };
@@ -777,6 +778,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol rewrittenOperandType = rewrittenOperand.Type;
             Debug.Assert(rewrittenType.IsNullableType() || rewrittenOperandType.IsNullableType());
 
+            const bool isExplicitlyNullable = false; // BoundConversion.IsExplicitlyNullable is not used in lowered tree
+
             TypeSymbol typeFrom = rewrittenOperandType.StrippedType();
             TypeSymbol typeTo = rewrittenType.StrippedType();
             if (typeFrom != typeTo && (typeFrom.SpecialType == SpecialType.System_Decimal || typeTo.SpecialType == SpecialType.System_Decimal))
@@ -801,12 +804,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var method = (MethodSymbol)_compilation.Assembly.GetSpecialTypeMember(DecimalConversionMethod(typeFromUnderlying, typeToUnderlying));
                 var conversionKind = conversion.Kind.IsImplicitConversion() ? ConversionKind.ImplicitUserDefined : ConversionKind.ExplicitUserDefined;
-                var result = new BoundConversion(syntax, rewrittenOperand, new Conversion(conversionKind, method, false), @checked, explicitCastInCode, default(ConstantValue), rewrittenType);
+                var result = new BoundConversion(syntax, rewrittenOperand, new Conversion(conversionKind, method, false), @checked, explicitCastInCode: explicitCastInCode, isExplicitlyNullable: isExplicitlyNullable, default(ConstantValue), rewrittenType);
                 return result;
             }
             else
             {
-                return new BoundConversion(syntax, rewrittenOperand, conversion, @checked, explicitCastInCode, default(ConstantValue), rewrittenType);
+                return new BoundConversion(syntax, rewrittenOperand, conversion, @checked, explicitCastInCode: explicitCastInCode, isExplicitlyNullable: isExplicitlyNullable, default(ConstantValue), rewrittenType);
             }
         }
 
@@ -1019,7 +1022,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression result =
                 _inExpressionLambda
-                ? BoundConversion.Synthesized(syntax, rewrittenOperand, conversion, false, true, default(ConstantValue), rewrittenType)
+                ? BoundConversion.Synthesized(syntax, rewrittenOperand, conversion, false, explicitCastInCode: true, isExplicitlyNullable: false, default(ConstantValue), rewrittenType)
                 : (BoundExpression)BoundCall.Synthesized(syntax, null, conversion.Method, rewrittenOperand);
             Debug.Assert(result.Type == rewrittenType);
             return result;
@@ -1046,7 +1049,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (_inExpressionLambda)
             {
                 Conversion conv = TryMakeConversion(syntax, conversion, rewrittenOperand.Type, rewrittenType);
-                return BoundConversion.Synthesized(syntax, rewrittenOperand, conv, false, true, default(ConstantValue), rewrittenType);
+                return BoundConversion.Synthesized(syntax, rewrittenOperand, conv, false, explicitCastInCode: true, isExplicitlyNullable: false, default(ConstantValue), rewrittenType);
             }
 
             // DELIBERATE SPEC VIOLATION: 
@@ -1162,7 +1165,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_inExpressionLambda)
             {
-                return BoundConversion.Synthesized(syntax, rewrittenOperand, conversion, @checked, explicitCastInCode, constantValueOpt, rewrittenType);
+                return BoundConversion.Synthesized(syntax, rewrittenOperand, conversion, @checked, explicitCastInCode: explicitCastInCode, isExplicitlyNullable: false, constantValueOpt, rewrittenType);
             }
 
             var rewrittenCall = MakeCall(
@@ -1348,7 +1351,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ConversionKind conversionKind = isImplicit ? ConversionKind.ImplicitUserDefined : ConversionKind.ExplicitUserDefined;
                 var conversion = new Conversion(conversionKind, method, isExtensionMethod: false);
 
-                return new BoundConversion(syntax, operand, conversion, @checked: false, explicitCastInCode: false, constantValueOpt: constantValueOpt, type: toType);
+                return new BoundConversion(syntax, operand, conversion, @checked: false, explicitCastInCode: false, isExplicitlyNullable: false, constantValueOpt: constantValueOpt, type: toType);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             @checked: false,
                             explicitCastInCode: explicitCastInCode,
                             constantValueOpt: constantValueOpt,
-                            isNullable: false,
+                            isNullable: null,
                             type: rewrittenType);
                     }
 
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: @checked,
                     explicitCastInCode: explicitCastInCode,
                     constantValueOpt: constantValueOpt,
-                    isNullable: false,
+                    isNullable: null,
                     type: rewrittenType);
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -320,6 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             @checked: false,
                             explicitCastInCode: explicitCastInCode,
                             constantValueOpt: constantValueOpt,
+                            isNullable: false,
                             type: rewrittenType);
                     }
 
@@ -366,6 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: @checked,
                     explicitCastInCode: explicitCastInCode,
                     constantValueOpt: constantValueOpt,
+                    isNullable: oldNode.IsNullable,
                     type: rewrittenType) :
                 new BoundConversion(
                     syntax,
@@ -375,6 +377,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: @checked,
                     explicitCastInCode: explicitCastInCode,
                     constantValueOpt: constantValueOpt,
+                    isNullable: false,
                     type: rewrittenType);
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -443,7 +443,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (conversion.Kind != ConversionKind.Identity)
                 {
                     Debug.Assert(CurrentMethod.RefKind == RefKind.None);
-                    expression = BoundConversion.Synthesized(Syntax, expression, conversion, false, false, ConstantValue.NotAvailable, CurrentMethod.ReturnType.TypeSymbol);
+                    expression = BoundConversion.Synthesized(Syntax, expression, conversion, false, explicitCastInCode: false, isExplicitlyNullable: false, ConstantValue.NotAvailable, CurrentMethod.ReturnType.TypeSymbol);
                 }
             }
 
@@ -1147,7 +1147,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return this.Call(arg, this.SpecialMethod(CodeAnalysis.SpecialMember.System_Nullable_T_get_Value).AsMember((NamedTypeSymbol)arg.Type));
             }
 
-            return new BoundConversion(Syntax, arg, conversion, isChecked, true, null, type) { WasCompilerGenerated = true };
+            return new BoundConversion(Syntax, arg, conversion, @checked: isChecked, explicitCastInCode: true, isExplicitlyNullable: false, null, type) { WasCompilerGenerated = true };
         }
 
         public BoundExpression ArrayOrEmpty(TypeSymbol elementType, BoundExpression[] elements)

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -1009,7 +1009,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var underlyingType = _underlying.TypeSymbol;
                 var str = underlyingType.ToDisplayString(format);
-                return underlyingType.IsValueType ? str : str + "?";
+                return underlyingType.IsNullableType() ? str : str + "?";
             }
         }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8606,13 +8606,13 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8606,13 +8606,13 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8606,13 +8606,13 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8606,13 +8606,13 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8606,13 +8606,13 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8606,13 +8606,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8606,13 +8606,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8606,13 +8606,13 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8606,13 +8606,13 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8606,13 +8606,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8606,13 +8606,13 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8606,13 +8606,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8606,13 +8606,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullAsNonNullable_Title">
-        <source>Cannot convert null to non-nullable reference.</source>
-        <target state="new">Cannot convert null to non-nullable reference.</target>
+        <source>Cannot convert null literal to non-nullable reference.</source>
+        <target state="new">Cannot convert null literal to non-nullable reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceAssignment">
@@ -8853,6 +8853,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="WRN_NoBestNullabilityConditionalExpression_Title">
         <source>No best nullability for operands of conditional expression.</source>
         <target state="new">No best nullability for operands of conditional expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ConvertingNullableToNonNullable_Title">
+        <source>Converting null literal or possible null value to non-nullable type.</source>
+        <target state="new">Converting null literal or possible null value to non-nullable type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -3779,6 +3779,9 @@ struct S2
                 // (133,18): warning CS8600: Cannot convert null to non-nullable reference.
                 //         y15.F3 = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(133, 18),
+                // (135,15): warning CS8601: Possible null reference assignment.
+                //         u15 = y15.F3;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y15.F3").WithLocation(135, 15),
                 // (136,15): warning CS8601: Possible null reference assignment.
                 //         u15 = y15.F4;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y15.F4").WithLocation(136, 15),
@@ -3955,9 +3958,6 @@ class CL1
                 // (27,16): error CS0165: Use of unassigned local variable 'x3'
                 //         M2(ref x3);
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x3").WithArguments("x3").WithLocation(27, 16),
-                // (27,16): warning CS8601: Possible null reference assignment.
-                //         M2(ref x3);
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3").WithLocation(27, 16),
                 // (32,16): warning CS8601: Possible null reference assignment.
                 //         M2(ref x4);
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4").WithLocation(32, 16),
@@ -4479,7 +4479,13 @@ public struct S2
 }
 ", parseOptions: TestOptions.Regular8, references: new[] { c0.EmitToImageReference() });
 
-            c.VerifyDiagnostics();
+            c.VerifyDiagnostics(
+                // (63,16): warning CS8603: Possible null reference return.
+                //         return y11.F1; 
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y11.F1").WithLocation(63, 16),
+                // (70,16): hidden CS8607: Expression is probably never null.
+                //         return y12.F1 ?? new object(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y12.F1").WithLocation(70, 16));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Conversions: NullCoalescingOperator
@@ -5898,22 +5904,27 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (15,13): warning CS8602: Possible dereference of a null reference.
-                 //             x1.M1(); // 2
-                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(15, 13),
-                 // (28,13): warning CS8602: Possible dereference of a null reference.
-                 //             x2.M1(); // 2
-                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(28, 13),
-                 // (29,18): warning CS8601: Possible null reference assignment.
-                 //             y2 = x2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(29, 18),
-                 // (30,19): warning CS8604: Possible null reference argument for parameter 'x' in 'void CL1.M2(CL1 x)'.
-                 //             y2.M2(x2);
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("x", "void CL1.M2(CL1 x)").WithLocation(30, 19),
-                 // (34,24): warning CS8603: Possible null reference return.
-                 //                 return x2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "x2").WithLocation(34, 24)
-                );
+                // (15,13): warning CS8602: Possible dereference of a null reference.
+                //             x1.M1(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(15, 13),
+                // (28,13): warning CS8602: Possible dereference of a null reference.
+                //             x2.M1(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(28, 13),
+                // (29,18): warning CS8601: Possible null reference assignment.
+                //             y2 = x2;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(29, 18),
+                // (30,13): warning CS8602: Possible dereference of a null reference.
+                //             y2.M2(x2);
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(30, 13),
+                // (30,19): warning CS8604: Possible null reference argument for parameter 'x' in 'void CL1.M2(CL1 x)'.
+                //             y2.M2(x2);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("x", "void CL1.M2(CL1 x)").WithLocation(30, 19),
+                // (34,24): warning CS8603: Possible null reference return.
+                //                 return x2;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "x2").WithLocation(34, 24),
+                // (38,16): warning CS8603: Possible null reference return.
+                //         return y2;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y2").WithLocation(38, 16));
         }
 
         [Fact]
@@ -5964,6 +5975,117 @@ class CL1
                  //         if (x2 == null) {} // 1
                  Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse, "x2 == null").WithLocation(23, 13)
                 );
+        }
+
+        [Fact]
+        public void Loop_03()
+        {
+            var source0 =
+@"public class A
+{
+    public object F;
+}";
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular7);
+            comp0.VerifyDiagnostics();
+            var source1 =
+@"#pragma warning disable 8618
+class B
+{
+    object G;
+    static object F1(B b1, object? o)
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            b1.G = o;
+        }
+        return b1.G;
+    }
+    static object F2(B b2, A a)
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            b2.G = a.F;
+        }
+        return b2.G;
+    }
+    static object F3(B b3, object? o, A a)
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            if (i % 2 == 0)
+                b3.G = o;
+            else
+                b3.G = a.F;
+        }
+        return b3.G;
+    }
+}";
+            var comp1 = CreateStandardCompilation(source1, references: new[] { comp0.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics(
+                // (9,20): warning CS8601: Possible null reference assignment.
+                //             b1.G = o;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "o").WithLocation(9, 20),
+                // (11,16): warning CS8603: Possible null reference return.
+                //         return b1.G;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "b1.G").WithLocation(11, 16),
+                // (26,24): warning CS8601: Possible null reference assignment.
+                //                 b3.G = o;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "o").WithLocation(26, 24),
+                // (30,16): warning CS8603: Possible null reference return.
+                //         return b3.G;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "b3.G").WithLocation(30, 16));
+        }
+
+        [Fact]
+        public void Loop_04()
+        {
+            var source0 =
+@"public class A
+{
+    public object F;
+}";
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular7);
+            comp0.VerifyDiagnostics();
+            var source1 =
+@"#pragma warning disable 8618
+class C
+{
+    static object F1(A a1, object? o)
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            a1.F = o;
+        }
+        return a1.F;
+    }
+    static object F2(A a2, object o)
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            a2.F = o;
+        }
+        return a2.F;
+    }
+    static object F3(A a3, object? o, A a)
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            if (i % 2 == 0)
+                a3.F = o;
+            else
+                a3.F = a.F;
+        }
+        return a3.F;
+    }
+}";
+            var comp1 = CreateStandardCompilation(source1, references: new[] { comp0.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics(
+                // (10,16): warning CS8603: Possible null reference return.
+                //         return a1.F;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "a1.F").WithLocation(10, 16),
+                // (29,16): warning CS8603: Possible null reference return.
+                //         return a3.F;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "a3.F").WithLocation(29, 16));
         }
 
         [Fact]
@@ -6426,9 +6548,18 @@ class C
                 // (32,25): warning CS8600: Cannot convert null to non-nullable reference.
                 //         object? [] u5 = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(32, 25),
+                // (33,16): warning CS8603: Possible null reference return.
+                //         return u5;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "u5").WithLocation(33, 16),
                 // (38,28): warning CS8600: Cannot convert null to non-nullable reference.
                 //         object [][,]? u6 = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(38, 28),
+                // (39,9): warning CS8602: Possible dereference of a null reference.
+                //         u6[0] = null;
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6").WithLocation(39, 9),
+                // (40,9): warning CS8602: Possible dereference of a null reference.
+                //         u6[0][0,0] = null;
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6").WithLocation(40, 9),
                 // (40,9): warning CS8602: Possible dereference of a null reference.
                 //         u6[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(40, 9),
@@ -6437,13 +6568,22 @@ class C
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(40, 22),
                 // (41,9): warning CS8602: Possible dereference of a null reference.
                 //         u6[0][0,0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6").WithLocation(41, 9),
+                // (41,9): warning CS8602: Possible dereference of a null reference.
+                //         u6[0][0,0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(41, 9),
                 // (46,27): warning CS8600: Cannot convert null to non-nullable reference.
                 //         object [][,] u7 = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(46, 27),
+                // (47,9): warning CS8602: Possible dereference of a null reference.
+                //         u7[0] = null;
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u7").WithLocation(47, 9),
                 // (47,17): warning CS8600: Cannot convert null to non-nullable reference.
                 //         u7[0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(47, 17),
+                // (48,9): warning CS8602: Possible dereference of a null reference.
+                //         u7[0][0,0] = null;
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u7").WithLocation(48, 9),
                 // (48,22): warning CS8600: Cannot convert null to non-nullable reference.
                 //         u7[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(48, 22),
@@ -8007,12 +8147,18 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (21,26): warning CS8601: Possible null reference assignment.
-                 //                     y1 = M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(21, 26),
-                 // (30,26): warning CS8601: Possible null reference assignment.
-                 //                     y2 = M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(30, 26)
+                // (21,26): warning CS8601: Possible null reference assignment.
+                //                     y1 = M1();
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(21, 26),
+                // (22,28): warning CS8603: Possible null reference return.
+                //                     return y1;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y1").WithLocation(22, 28),
+                // (30,26): warning CS8601: Possible null reference assignment.
+                //                     y2 = M1();
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(30, 26),
+                // (31,28): warning CS8603: Possible null reference return.
+                //                     return y2;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y2").WithLocation(31, 28)
                 );
         }
 
@@ -10927,9 +11073,6 @@ class CL1
                  // (27,18): hidden CS8607: Expression is probably never null.
                  //         CL1 v4 = u4 ?? new CL1(); 
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
-                 // (28,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 w4 = x4 ?? new CL1();
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4").WithLocation(28, 18),
                  // (32,18): warning CS8601: Possible null reference assignment.
                  //         CL1 u5 = --x5;
                  Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5").WithLocation(32, 18),
@@ -11600,6 +11743,9 @@ class CL1
                  // (18,18): warning CS8601: Possible null reference assignment.
                  //         CL1 u2 = x2 += y2;
                  Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2 += y2").WithLocation(18, 18),
+                // (19,18): warning CS8601: Possible null reference assignment.
+                //         CL1 w2 = x2; 
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(19, 18),
                  // (24,9): warning CS8601: Possible null reference assignment.
                  //         x3 += y3;
                  Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3 += y3").WithLocation(24, 9),
@@ -16363,7 +16509,8 @@ class C
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(I<object>)y").WithArguments("I<object>", "I<object?>").WithLocation(11, 13));
         }
 
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): Conversions: Call
+        [Fact(Skip = "TODO")]
         public void SuppressNullableWarning_Ref()
         {
             var source =
@@ -17151,6 +17298,9 @@ class B
                 // (7,13): warning CS8601: Possible null reference assignment.
                 //         x = F(s);
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "F(s)").WithLocation(7, 13),
+                // (8,11): warning CS8604: Possible null reference argument for parameter 's' in 'string? C.F(string s)'.
+                //         F(x);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("s", "string? C.F(string s)").WithLocation(8, 11),
                 // (11,11): warning CS8604: Possible null reference argument for parameter 's' in 'string? C.F(string s)'.
                 //         F(y);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y").WithArguments("s", "string? C.F(string s)").WithLocation(11, 11));
@@ -18000,6 +18150,121 @@ class C
             comp.VerifyDiagnostics();
             comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TrackNonNullableLocals()
+        {
+            var source =
+@"class C
+{
+    static void F(object x)
+    {
+        object y = x;
+        x.ToString(); // 1
+        y.ToString(); // 2
+        x = null;
+        y = x;
+        x.ToString(); // 3
+        y.ToString(); // 4
+        if (x == null) return;
+        if (y == null) return;
+        x.ToString(); // 5
+        y.ToString(); // 6
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,13): warning CS8600: Cannot convert null to non-nullable reference.
+                //         x = null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 13),
+                // (9,13): warning CS8601: Possible null reference assignment.
+                //         y = x;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x").WithLocation(9, 13),
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         x.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 9),
+                // (11,9): warning CS8602: Possible dereference of a null reference.
+                //         y.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(11, 9));
+        }
+
+        [Fact]
+        public void TrackNonNullableFieldsAndProperties()
+        {
+            var source =
+@"#pragma warning disable 8618
+class C
+{
+    object F;
+    object P { get; set; }
+    static void M(C c)
+    {
+        c.F.ToString(); // 1
+        c.P.ToString(); // 2
+        c.F = null;
+        c.P = null;
+        c.F.ToString(); // 3
+        c.P.ToString(); // 4
+        if (c.F == null) return;
+        if (c.P == null) return;
+        c.F.ToString(); // 5
+        c.P.ToString(); // 6
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (10,15): warning CS8600: Cannot convert null to non-nullable reference.
+                //         c.F = null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 15),
+                // (11,15): warning CS8600: Cannot convert null to non-nullable reference.
+                //         c.P = null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 15),
+                // (12,9): warning CS8602: Possible dereference of a null reference.
+                //         c.F.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F").WithLocation(12, 9),
+                // (13,9): warning CS8602: Possible dereference of a null reference.
+                //         c.P.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.P").WithLocation(13, 9));
+        }
+
+        [Fact]
+        public void TrackUnannotatedFieldsAndProperties()
+        {
+            var source0 =
+@"public class C
+{
+    public object F;
+    public object P { get; set; }
+}";
+            var comp0 = CreateStandardCompilation(source0, parseOptions: TestOptions.Regular7);
+            comp0.VerifyDiagnostics();
+
+            var source1 =
+@"class P
+{
+    static void M(C c)
+    {
+        c.F.ToString(); // 1
+        c.P.ToString(); // 2
+        c.F = null;
+        c.P = null;
+        c.F.ToString(); // 3
+        c.P.ToString(); // 4
+        if (c.F == null) return;
+        if (c.P == null) return;
+        c.F.ToString(); // 5
+        c.P.ToString(); // 6
+    }
+}";
+            var comp1 = CreateStandardCompilation(source1, references: new[] { comp0.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
+            comp1.VerifyDiagnostics(
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         c.F.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F").WithLocation(9, 9),
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         c.P.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.P").WithLocation(10, 9));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -11093,7 +11093,10 @@ class CL1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5").WithLocation(32, 18),
                 // (37,9): warning CS8601: Possible null reference assignment.
                 //         x6--; 
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6--").WithLocation(37, 9)
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6--").WithLocation(37, 9),
+                // (43,9): error CS0165: Use of unassigned local variable 'x7'
+                //         x7--; 
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x7").WithArguments("x7").WithLocation(43, 9)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -6193,7 +6193,8 @@ class CL1
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z5").WithLocation(34, 35),
                 // (39,39): warning CS8601: Possible null reference assignment.
                 //         var x6 = new CL1 [,] { {y6}, {z6} };
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z6").WithLocation(39, 39));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z6").WithLocation(39, 39)
+                );
         }
 
         [Fact]
@@ -6251,7 +6252,8 @@ class CL1
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z4").WithLocation(37, 17),
                 // (38,19): warning CS8601: Possible null reference assignment.
                 //         v4[0,0] = z4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z4").WithLocation(38, 19));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z4").WithLocation(38, 19)
+                );
         }
 
         [Fact]
@@ -6722,7 +6724,8 @@ class C
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(44, 22),
                 // (45,9): warning CS8602: Possible dereference of a null reference.
                 //         u9[0][0,0].ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(45, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(45, 9)
+                );
         }
 
         [Fact]
@@ -6808,7 +6811,8 @@ class CL1
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(9, 35),
                 // (14,35): warning CS8601: Possible null reference assignment.
                 //         var z2 = new CL1() { P1 = x2, P2 = y2 };
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(14, 35));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(14, 35)
+                );
         }
 
         [Fact]
@@ -7572,7 +7576,8 @@ struct S1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "P3").WithLocation(33, 14),
                 // (12,14): warning CS8601: Possible null reference assignment.
                 //         P1 = x1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(12, 14));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(12, 14)
+                );
         }
 
         [Fact]
@@ -7658,7 +7663,8 @@ struct S1
                 Diagnostic(ErrorCode.ERR_UseDefViolationProperty, "P2").WithArguments("P2").WithLocation(22, 14),
                 // (56,14): hidden CS8607: Expression is probably never null.
                 //         x5 = P5.F1 ?? x5;
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "P5.F1").WithLocation(56, 14));
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "P5.F1").WithLocation(56, 14)
+                );
         }
 
         [Fact]
@@ -8487,7 +8493,8 @@ class C
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(21, 26),
                 // (22,28): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //                     return null; // 2
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(22, 28));
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(22, 28)
+                );
         }
 
         // PROTOTYPE(NullableReferenceTypes): Calculate lamba conversion.
@@ -8751,7 +8758,8 @@ class CL0
             c.VerifyDiagnostics(
                 // (9,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         dynamic y1 = x1[(dynamic)0];
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1[(dynamic)0]").WithLocation(9, 22));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1[(dynamic)0]").WithLocation(9, 22)
+                );
         }
 
         [Fact]
@@ -9043,7 +9051,8 @@ class CL1
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(14, 26),
                 // (15,17): warning CS8601: Possible null reference assignment.
                 //         z2[0] = y2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(15, 17));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(15, 17)
+                );
         }
 
         [Fact]
@@ -10292,7 +10301,8 @@ class C
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x7 + y7").WithLocation(40, 28),
                 // (45,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         System.Action u8 = x8 - y8;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x8 - y8").WithLocation(45, 28));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x8 - y8").WithLocation(45, 28)
+                );
         }
 
         [Fact]
@@ -10767,7 +10777,8 @@ class CL2
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator !(CL0 x)").WithLocation(10, 19),
                 // (15,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 u2 = !x2;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "!x2").WithLocation(15, 18));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "!x2").WithLocation(15, 18)
+                );
         }
 
         [Fact]
@@ -11074,7 +11085,8 @@ class CL1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5").WithLocation(32, 18),
                 // (37,9): warning CS8601: Possible null reference assignment.
                 //         x6--; 
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6--").WithLocation(37, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6--").WithLocation(37, 9)
+                );
         }
 
         [Fact]
@@ -11166,7 +11178,8 @@ class CL1
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5").WithLocation(32, 18),
                 // (32,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 u5 = --x5;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5").WithLocation(32, 18));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5").WithLocation(32, 18)
+                );
         }
 
         [Fact]
@@ -11278,7 +11291,8 @@ class X4
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5[0]").WithLocation(32, 18),
                 // (32,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 u5 = --x5[0];
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5[0]").WithLocation(32, 18));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5[0]").WithLocation(32, 18)
+                );
         }
 
         [Fact]
@@ -11424,7 +11438,8 @@ class B : A
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "++x1").WithLocation(10, 16),
                 // (10,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         B u1 = ++x1;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "++x1").WithLocation(10, 16));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "++x1").WithLocation(10, 16)
+                );
         }
 
         [Fact]
@@ -11752,7 +11767,8 @@ class CL1
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4").WithLocation(31, 18),
                 // (36,9): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1.implicit operator CL0(CL1 x)'.
                 //         x5 += y5;
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x5 += y5").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(36, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x5 += y5").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(36, 9)
+                );
         }
 
         [Fact]
@@ -12003,7 +12019,8 @@ class Test
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E1").WithLocation(40, 28),
                 // (45,14): warning CS8601: Possible null reference assignment.
                 //         E2 = x6;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6").WithLocation(45, 14));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6").WithLocation(45, 14)
+                );
         }
 
         // PROTOTYPE(NullableReferenceTypes): Events are not tracked for structs.
@@ -12541,28 +12558,25 @@ class C
     }
 }
 ";
+            var expected = new[]
+            {
+                // (10,17): warning CS8601: Possible null reference assignment.
+                //         x1.F1 = y1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17),
+                // (15,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         y2 = x2.P1;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2.P1").WithLocation(15, 14)
+            };
 
             CSharpCompilation c = CreateStandardCompilation(source,
                                                                 parseOptions: TestOptions.Regular8,
                                                                 references: new[] { c0.EmitToImageReference() });
-            c.VerifyDiagnostics(
-                // (10,17): warning CS8601: Possible null reference assignment.
-                //         x1.F1 = y1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17),
-                // (15,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         y2 = x2.P1;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2.P1").WithLocation(15, 14));
+            c.VerifyDiagnostics(expected);
 
             c = CreateStandardCompilation(source,
                                                                 parseOptions: TestOptions.Regular8,
                                                                 references: new[] { c0.ToMetadataReference() });
-            c.VerifyDiagnostics(
-                // (10,17): warning CS8601: Possible null reference assignment.
-                //         x1.F1 = y1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17),
-                // (15,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         y2 = x2.P1;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2.P1").WithLocation(15, 14));
+            c.VerifyDiagnostics(expected);
         }
 
         [Fact]
@@ -12588,21 +12602,22 @@ class C
     }
 }
 ";
+            var expected = new[]
+            {
+                // (10,17): warning CS8601: Possible null reference assignment.
+                //         x1.F1 = y1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17)
+            };
+
             CSharpCompilation c = CreateStandardCompilation(source,
                                                                 parseOptions: TestOptions.Regular8,
                                                                 references: new[] { c0.EmitToImageReference() });
-            c.VerifyDiagnostics(
-                // (10,17): warning CS8601: Possible null reference assignment.
-                //         x1.F1 = y1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17));
+            c.VerifyDiagnostics(expected);
 
             c = CreateStandardCompilation(source,
                                                                 parseOptions: TestOptions.Regular8,
                                                                 references: new[] { c0.ToMetadataReference() });
-            c.VerifyDiagnostics(
-                // (10,17): warning CS8601: Possible null reference assignment.
-                //         x1.F1 = y1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17));
+            c.VerifyDiagnostics(expected);
         }
 
         [Fact]
@@ -13068,7 +13083,8 @@ partial class C
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.P2").WithLocation(30, 19),
                 // (31,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.M2();
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19)
+                );
 
             CSharpCompilation c1 = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, moduleAttributes, lib },
                                                                 parseOptions: TestOptions.Regular8,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -18278,6 +18278,8 @@ class C
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "b2").WithArguments("a", "A.explicit operator C(A a)").WithLocation(20, 17));
         }
 
+        // PROTOTYPE(NullableReferenceTypes): Should report CS8600 for `(C)a1`,
+        // `(C)b1`, etc. since the user-defined conversion is defined from A? to C?.
         [Fact]
         public void MultipleConversions_Explicit_02()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -244,13 +244,13 @@ class C
             // ... used in 8.0.
             comp1 = CreateStandardCompilation(source1, references: compRefs0, parseOptions: TestOptions.Regular8);
             comp1.VerifyDiagnostics(
-                // (6,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (6,13): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         A.F(null);
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 13));
             Assert.Equal(false, getParameterType(comp1).IsNullable);
             comp1 = CreateStandardCompilation(source1, references: metadataRefs0, parseOptions: TestOptions.Regular8);
             comp1.VerifyDiagnostics(
-                // (6,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (6,13): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         A.F(null);
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 13));
             Assert.Equal(false, getParameterType(comp1).IsNullable);
@@ -441,9 +441,9 @@ public class C
             comp0.VerifyDiagnostics();
             var comp1 = CreateStandardCompilation(source1, references: new[] { comp0.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
             comp1.VerifyDiagnostics(
-                // (7,13): warning CS8601: Possible null reference assignment.
+                // (7,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         z = C.Create(y).F;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "C.Create(y).F").WithLocation(7, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "C.Create(y).F").WithLocation(7, 13));
         }
 
         [Fact]
@@ -518,30 +518,30 @@ class P
                 // (43,18): warning CS8604: Possible null reference argument for parameter 'o' in 'object? B2.F(object o)'.
                 //         y = b2.F(x);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("o", "object? B2.F(object o)").WithLocation(43, 18),
-                // (43,13): warning CS8601: Possible null reference assignment.
+                // (43,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = b2.F(x);
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b2.F(x)").WithLocation(43, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "b2.F(x)").WithLocation(43, 13),
                 // (51,18): warning CS8604: Possible null reference argument for parameter 'o' in 'object? C2.F(object o)'.
                 //         y = d2.F(x);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("o", "object? C2.F(object o)").WithLocation(51, 18),
-                // (51,13): warning CS8601: Possible null reference assignment.
+                // (51,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = d2.F(x);
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "d2.F(x)").WithLocation(51, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "d2.F(x)").WithLocation(51, 13));
 
             comp1 = CreateStandardCompilation(source1, references: new[] { comp0.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
             comp1.VerifyDiagnostics(
                 // (43,18): warning CS8604: Possible null reference argument for parameter 'o' in 'object? B2.F(object o)'.
                 //         y = b2.F(x);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("o", "object? B2.F(object o)").WithLocation(43, 18),
-                // (43,13): warning CS8601: Possible null reference assignment.
+                // (43,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = b2.F(x);
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b2.F(x)").WithLocation(43, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "b2.F(x)").WithLocation(43, 13),
                 // (51,18): warning CS8604: Possible null reference argument for parameter 'o' in 'object? C2.F(object o)'.
                 //         y = d2.F(x);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("o", "object? C2.F(object o)").WithLocation(51, 18),
-                // (51,13): warning CS8601: Possible null reference assignment.
+                // (51,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = d2.F(x);
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "d2.F(x)").WithLocation(51, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "d2.F(x)").WithLocation(51, 13));
         }
 
         [Fact]
@@ -611,19 +611,19 @@ public class D : C
                 // (5,9): warning CS8602: Possible dereference of a null reference.
                 //         ((I)a).F(o).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((I)a).F(o)").WithLocation(5, 9),
-                // (6,18): warning CS8600: Cannot convert null to non-nullable reference.
+                // (6,18): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         ((I)a).G(null).ToString();
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 18),
                 // (12,9): warning CS8602: Possible dereference of a null reference.
                 //         ((I)b).F(o).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((I)b).F(o)").WithLocation(12, 9),
-                // (13,18): warning CS8600: Cannot convert null to non-nullable reference.
+                // (13,18): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         ((I)b).G(null).ToString();
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 18),
                 // (19,9): warning CS8602: Possible dereference of a null reference.
                 //         ((I)d).F(o).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((I)d).F(o)").WithLocation(19, 9),
-                // (20,18): warning CS8600: Cannot convert null to non-nullable reference.
+                // (20,18): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         ((I)d).G(null).ToString();
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(20, 18));
         }
@@ -3719,45 +3719,45 @@ struct S2
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (12,21): warning CS8601: Possible null reference assignment.
+                // (12,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         string z1 = x1; 
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(12, 21),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1").WithLocation(12, 21),
                 // (24,21): error CS0165: Use of unassigned local variable 'x3'
                 //         string z3 = x3; 
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x3").WithArguments("x3").WithLocation(24, 21),
                 // (30,21): error CS0165: Use of unassigned local variable 'x4'
                 //         string z4 = x4; 
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x4").WithArguments("x4").WithLocation(30, 21),
-                // (40,14): warning CS8601: Possible null reference assignment.
+                // (40,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         z5 = x5; 
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x5").WithLocation(40, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x5").WithLocation(40, 14),
                 // (53,18): warning CS8602: Possible dereference of a null reference.
                 //         CL1 y7 = x7.P1; 
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x7").WithLocation(53, 18),
-                // (54,18): warning CS8601: Possible null reference assignment.
+                // (54,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z7 = x7?.P1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x7?.P1").WithLocation(54, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x7?.P1").WithLocation(54, 18),
                 // (64,18): warning CS8602: Possible dereference of a null reference.
                 //         CL1 u8 = x8.M1(); 
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x8").WithLocation(64, 18),
-                // (65,18): warning CS8601: Possible null reference assignment.
+                // (65,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z8 = x8?.M1();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x8?.M1()").WithLocation(65, 18),
-                // (71,14): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x8?.M1()").WithLocation(65, 18),
+                // (71,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u9 = x9;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x9").WithLocation(71, 14),
-                // (76,14): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x9").WithLocation(71, 14),
+                // (76,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y9 = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(76, 14),
-                // (83,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(76, 14),
+                // (83,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u10 = x10.P2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x10.P2").WithLocation(83, 15),
-                // (85,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x10.P2").WithLocation(83, 15),
+                // (85,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u10 = x10.M2();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x10.M2()").WithLocation(85, 15),
-                // (95,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x10.M2()").WithLocation(85, 15),
+                // (95,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u11 = x11.F2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11.F2").WithLocation(95, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x11.F2").WithLocation(95, 15),
                 // (101,15): warning CS8602: Possible dereference of a null reference.
                 //         v11 = y11.F1;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y11").WithLocation(101, 15),
@@ -3773,54 +3773,54 @@ struct S2
                 // (117,15): error CS0170: Use of possibly unassigned field 'F4'
                 //         u13 = y13.F4;
                 Diagnostic(ErrorCode.ERR_UseDefViolationField, "y13.F4").WithArguments("F4").WithLocation(117, 15),
-                // (123,18): warning CS8600: Cannot convert null to non-nullable reference.
+                // (123,18): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         y14.F3 = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(123, 18),
-                // (133,18): warning CS8600: Cannot convert null to non-nullable reference.
+                // (133,18): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         y15.F3 = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(133, 18),
-                // (135,15): warning CS8601: Possible null reference assignment.
+                // (135,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u15 = y15.F3;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y15.F3").WithLocation(135, 15),
-                // (136,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y15.F3").WithLocation(135, 15),
+                // (136,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u15 = y15.F4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y15.F4").WithLocation(136, 15),
-                // (150,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y15.F4").WithLocation(136, 15),
+                // (150,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u16 = y16.F4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y16.F4").WithLocation(150, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y16.F4").WithLocation(150, 15),
                 // (161,15): error CS0165: Use of unassigned local variable 'x17'
                 //         y17 = x17;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x17").WithArguments("x17").WithLocation(161, 15),
-                // (159,15): warning CS8601: Possible null reference assignment.
+                // (159,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u17 = y17.F4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y17.F4").WithLocation(159, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y17.F4").WithLocation(159, 15),
                 // (170,18): error CS0165: Use of unassigned local variable 'x18'
                 //         S1 y18 = x18;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x18").WithArguments("x18").WithLocation(170, 18),
-                // (180,15): warning CS8601: Possible null reference assignment.
+                // (180,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u19 = y19.F4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y19.F4").WithLocation(180, 15),
-                // (197,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y19.F4").WithLocation(180, 15),
+                // (197,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         v20 = y20.F4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y20.F4").WithLocation(197, 15),
-                // (213,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y20.F4").WithLocation(197, 15),
+                // (213,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         v21 = y21.F4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y21.F4").WithLocation(213, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y21.F4").WithLocation(213, 15),
                 // (220,15): error CS0170: Use of possibly unassigned field 'F4'
                 //         u22 = y22.F4;
                 Diagnostic(ErrorCode.ERR_UseDefViolationField, "y22.F4").WithArguments("F4").WithLocation(220, 15),
-                // (224,15): warning CS8601: Possible null reference assignment.
+                // (224,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         v22 = y22.F4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y22.F4").WithLocation(224, 15),
-                // (236,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y22.F4").WithLocation(224, 15),
+                // (236,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         v23 = y23.F5.F4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y23.F5.F4").WithLocation(236, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y23.F5.F4").WithLocation(236, 15),
                 // (248,15): error CS0170: Use of possibly unassigned field 'F4'
                 //         u24 = y24.F5.F4; // 1
                 Diagnostic(ErrorCode.ERR_UseDefViolationField, "y24.F5.F4").WithArguments("F4").WithLocation(248, 15),
-                // (253,15): warning CS8601: Possible null reference assignment.
+                // (253,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         v24 = y24.F5.F4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y24.F5.F4").WithLocation(253, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y24.F5.F4").WithLocation(253, 15),
                 // (268,18): warning CS8601: Possible null reference assignment.
                 //         x26.P1 = y26;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y26").WithLocation(268, 18),
@@ -3830,22 +3830,24 @@ struct S2
                 // (280,13): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1 CL1.this[CL1 x].get'.
                 //         x28[y28] = z28;
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y28").WithArguments("x", "CL1 CL1.this[CL1 x].get").WithLocation(280, 13),
-                // (286,15): warning CS8601: Possible null reference assignment.
+                // (286,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         z29 = x29[1];
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x29[1]").WithLocation(286, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x29[1]").WithLocation(286, 15),
                 // (291,15): warning CS8602: Possible dereference of a null reference.
                 //         z30 = x30[y30];
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x30").WithLocation(291, 15),
-                // (296,15): warning CS8600: Cannot convert null to non-nullable reference.
+                // (296,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x31 = default(CL1);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(CL1)").WithLocation(296, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default(CL1)").WithLocation(296, 15),
                 // (301,19): hidden CS8607: Expression is probably never null.
                 //         var y32 = new CL1() ?? x32;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "new CL1()").WithLocation(301, 19),
+                // (306,29): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         var y33 = new { p = (object)null } ?? x33;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(object)null").WithLocation(306, 29),
                 // (306,19): hidden CS8607: Expression is probably never null.
                 //         var y33 = new { p = (object)null } ?? x33;
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "new { p = (object)null }").WithLocation(306, 19)
-                );
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "new { p = (object)null }").WithLocation(306, 19));
         }
 
         [Fact]
@@ -3967,9 +3969,9 @@ class CL1
                 // (48,16): warning CS8604: Possible null reference argument for parameter 'p' in 'void C.M4(ref CL1 p)'.
                 //         M4(ref x6);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x6").WithArguments("p", "void C.M4(ref CL1 p)").WithLocation(48, 16),
-                // (56,18): warning CS8601: Possible null reference assignment.
+                // (56,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 u7 = x7;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x7").WithLocation(56, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x7").WithLocation(56, 18),
                 // (65,24): warning CS8604: Possible null reference argument for parameter 'p1' in 'void C.M6(CL1 p1, CL1? p2)'.
                 //         M6(p2: x8, p1: y8);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y8").WithArguments("p1", "void C.M6(CL1 p1, CL1? p2)").WithLocation(65, 24),
@@ -3987,8 +3989,7 @@ class CL1
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "z11").WithArguments("p2", "void C.M8(CL1 p1, params CL1[] p2)").WithLocation(84, 22),
                 // (89,16): warning CS8604: Possible null reference argument for parameter 'p2' in 'void C.M8(CL1 p1, params CL1[] p2)'.
                 //         M8(p2: x12, p1: y12);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x12").WithArguments("p2", "void C.M8(CL1 p1, params CL1[] p2)").WithLocation(89, 16)
-                );
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x12").WithArguments("p2", "void C.M8(CL1 p1, params CL1[] p2)").WithLocation(89, 16));
         }
 
         [Fact]
@@ -4018,10 +4019,9 @@ class CL0
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (10,31): warning CS8600: Cannot convert null to non-nullable reference.
+                // (10,31): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         var y1 = new CL0() { [null] = x1 };
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 31)
-                );
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 31));
         }
 
         [Fact]
@@ -4054,10 +4054,9 @@ class CL0 : System.Collections.IEnumerable
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (10,30): warning CS8600: Cannot convert null to non-nullable reference.
+                // (10,30): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         var y1 = new CL0() { null };
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 30)
-                );
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 30));
         }
 
         [Fact]
@@ -4111,21 +4110,21 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (15,14): warning CS8601: Possible null reference assignment.
+                 // (15,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         y2 = x2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(15, 14),
-                 // (21,14): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2").WithLocation(15, 14),
+                 // (21,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         y3 = x3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3").WithLocation(21, 14),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3").WithLocation(21, 14),
                  // (26,14): error CS0269: Use of unassigned out parameter 'x4'
                  //         y4 = x4;
                  Diagnostic(ErrorCode.ERR_UseDefViolationOut, "x4").WithArguments("x4").WithLocation(26, 14),
                  // (32,14): error CS0269: Use of unassigned out parameter 'x5'
                  //         y5 = x5;
                  Diagnostic(ErrorCode.ERR_UseDefViolationOut, "x5").WithArguments("x5").WithLocation(32, 14),
-                 // (39,14): warning CS8601: Possible null reference assignment.
+                 // (39,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         y6 = x6;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6").WithLocation(39, 14)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x6").WithLocation(39, 14)
                 );
         }
 
@@ -4189,21 +4188,21 @@ struct S1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (15,14): warning CS8601: Possible null reference assignment.
+                 // (15,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         y2 = x2.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2.F2").WithLocation(15, 14),
-                 // (21,14): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2.F2").WithLocation(15, 14),
+                 // (21,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         y3 = x3.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3.F2").WithLocation(21, 14),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3.F2").WithLocation(21, 14),
                  // (26,14): error CS0170: Use of possibly unassigned field 'F1'
                  //         y4 = x4.F1;
                  Diagnostic(ErrorCode.ERR_UseDefViolationField, "x4.F1").WithArguments("F1").WithLocation(26, 14),
                  // (33,14): error CS0170: Use of possibly unassigned field 'F2'
                  //         y5 = x5.F2;
                  Diagnostic(ErrorCode.ERR_UseDefViolationField, "x5.F2").WithArguments("F2").WithLocation(33, 14),
-                 // (42,14): warning CS8601: Possible null reference assignment.
+                 // (42,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         y6 = x6.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6.F2").WithLocation(42, 14)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x6.F2").WithLocation(42, 14)
                 );
         }
 
@@ -4248,12 +4247,12 @@ struct S1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (14,14): warning CS8601: Possible null reference assignment.
+                 // (14,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         y3 = x3.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3.F2").WithLocation(14, 14),
-                 // (23,14): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3.F2").WithLocation(14, 14),
+                 // (23,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         y6 = x6.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6.F2").WithLocation(23, 14)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x6.F2").WithLocation(23, 14)
                 );
         }
 
@@ -4573,9 +4572,9 @@ class C
                 // (34,21): hidden CS8607: Expression is probably never null.
                 //         object z4 = x4 ?? new object();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4").WithLocation(34, 21),
-                // (39,21): warning CS8601: Possible null reference assignment.
+                // (39,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object x5 = M2() ?? M2();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M2() ?? M2()").WithLocation(39, 21),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M2() ?? M2()").WithLocation(39, 21),
                 // (44,22): hidden CS8607: Expression is probably never null.
                 //         object? x6 = M3() ?? M3();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "M3()").WithLocation(44, 22),
@@ -4699,15 +4698,15 @@ class C
 ", parseOptions: TestOptions.Regular8, references: new[] { c0.EmitToImageReference() });
 
             c.VerifyDiagnostics(
-                // (14,21): warning CS8601: Possible null reference assignment.
+                // (14,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object x1 = M4() ? CL0.M1() : M2();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M4() ? CL0.M1() : M2()").WithLocation(14, 21),
-                // (26,22): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M4() ? CL0.M1() : M2()").WithLocation(14, 21),
+                // (26,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object x3 =  M4() ? M3() : M2();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M4() ? M3() : M2()").WithLocation(26, 22),
-                // (38,22): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M4() ? M3() : M2()").WithLocation(26, 22),
+                // (38,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object x5 =  M4() ? M2() : M2();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M4() ? M2() : M2()").WithLocation(38, 22),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M4() ? M2() : M2()").WithLocation(38, 22),
                 // (44,21): hidden CS8607: Expression is probably never null.
                 //         object z6 = x6 ?? new object();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x6").WithLocation(44, 21)
@@ -4756,12 +4755,12 @@ class C
 ", parseOptions: TestOptions.Regular8, references: new[] { c0.EmitToImageReference() });
 
             c.VerifyDiagnostics(
-                 // (14,21): warning CS8601: Possible null reference assignment.
+                 // (14,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         object x1 = M4() ? M2() : CL0.M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M4() ? M2() : CL0.M1()").WithLocation(14, 21),
-                 // (26,22): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M4() ? M2() : CL0.M1()").WithLocation(14, 21),
+                 // (26,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         object x3 =  M4() ? M2() : M3();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M4() ? M2() : M3()").WithLocation(26, 22)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M4() ? M2() : M3()").WithLocation(26, 22)
                 );
         }
 
@@ -4833,15 +4832,15 @@ class C
 ", parseOptions: TestOptions.Regular8, references: new[] { c0.EmitToImageReference() });
 
             c.VerifyDiagnostics(
-                // (16,21): warning CS8601: Possible null reference assignment.
+                // (16,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object y1 = x1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(16, 21),
-                // (31,21): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1").WithLocation(16, 21),
+                // (31,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object y3 = x3;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3").WithLocation(31, 21),
-                // (46,21): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3").WithLocation(31, 21),
+                // (46,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object y5 = x5;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x5").WithLocation(46, 21),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x5").WithLocation(46, 21),
                 // (53,21): hidden CS8607: Expression is probably never null.
                 //         object z6 = x6 ?? new object();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x6").WithLocation(53, 21)
@@ -4894,12 +4893,12 @@ class C
 ", parseOptions: TestOptions.Regular8, references: new[] { c0.EmitToImageReference() });
 
             c.VerifyDiagnostics(
-                // (16,21): warning CS8601: Possible null reference assignment.
+                // (16,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object y1 = x1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(16, 21),
-                // (31,21): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1").WithLocation(16, 21),
+                // (31,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object y3 = x3;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3").WithLocation(31, 21)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3").WithLocation(31, 21)
                 );
         }
 
@@ -5189,18 +5188,18 @@ class CL2
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (16,18): warning CS8601: Possible null reference assignment.
+                 // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             z1 = y1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(16, 18),
-                 // (24,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1").WithLocation(16, 18),
+                 // (24,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x2 = y2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(24, 18),
-                 // (40,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(24, 18),
+                 // (40,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             z3 = y3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y3").WithLocation(40, 18),
-                 // (48,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y3").WithLocation(40, 18),
+                 // (48,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x4 = y4;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y4").WithLocation(48, 18),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y4").WithLocation(48, 18),
                  // (58,13): hidden CS8605: Result of the comparison is possibly always true.
                  //         if (y5 != null)
                  Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "y5 != null").WithLocation(58, 13)
@@ -5292,18 +5291,18 @@ class CL2
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (16,18): warning CS8601: Possible null reference assignment.
+                 // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             z1 = y1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(16, 18),
-                 // (24,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1").WithLocation(16, 18),
+                 // (24,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x2 = y2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(24, 18),
-                 // (40,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(24, 18),
+                 // (40,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             z3 = y3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y3").WithLocation(40, 18),
-                 // (48,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y3").WithLocation(40, 18),
+                 // (48,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x4 = y4;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y4").WithLocation(48, 18),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y4").WithLocation(48, 18),
                  // (58,13): hidden CS8606: Result of the comparison is possibly always false.
                  //         if (null == y5)
                  Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse, "null == y5").WithLocation(58, 13)
@@ -5367,15 +5366,15 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (12,18): warning CS8601: Possible null reference assignment.
+                 // (12,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x1 = y1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(12, 18),
-                 // (16,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1").WithLocation(12, 18),
+                 // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             z1 = y1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(16, 18),
-                 // (28,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1").WithLocation(16, 18),
+                 // (28,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             z2 = y2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(28, 18),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(28, 18),
                  // (34,16): warning CS8602: Possible dereference of a null reference.
                  //         return x3.M1();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(34, 16),
@@ -5438,9 +5437,9 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (15,18): warning CS8601: Possible null reference assignment.
+                // (15,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z2 = y2 ?? x2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2 ?? x2").WithLocation(15, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2 ?? x2").WithLocation(15, 18),
                 // (20,18): hidden CS8607: Expression is probably never null.
                 //         CL1 z3 = x3 ?? y3;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x3").WithLocation(20, 18),
@@ -5492,18 +5491,18 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (10,18): warning CS8601: Possible null reference assignment.
+                 // (10,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL1 z1 = x1?.M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1?.M1()").WithLocation(10, 18),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1?.M1()").WithLocation(10, 18),
                  // (16,18): hidden CS8607: Expression is probably never null.
                  //         CL1 z2 = x2?.M1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x2").WithLocation(16, 18),
                  // (22,18): hidden CS8607: Expression is probably never null.
                  //         CL1 z3 = x3?.M2();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x3").WithLocation(22, 18),
-                 // (22,18): warning CS8601: Possible null reference assignment.
+                 // (22,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL1 z3 = x3?.M2();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3?.M2()").WithLocation(22, 18)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3?.M2()").WithLocation(22, 18)
                 );
         }
 
@@ -5566,24 +5565,24 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (15,18): warning CS8601: Possible null reference assignment.
+                // (15,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z2 = y2 != null ? y2 : x2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2 != null ? y2 : x2").WithLocation(15, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2 != null ? y2 : x2").WithLocation(15, 18),
                 // (20,18): hidden CS8605: Result of the comparison is possibly always true.
                 //         CL1 z3 = x3 != null ? x3 : y3;
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "x3 != null").WithLocation(20, 18),
-                // (20,18): warning CS8601: Possible null reference assignment.
+                // (20,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z3 = x3 != null ? x3 : y3;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3 != null ? x3 : y3").WithLocation(20, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 != null ? x3 : y3").WithLocation(20, 18),
                 // (26,18): hidden CS8605: Result of the comparison is possibly always true.
                 //         CL1 z4 = x4 != null ? x4 : x4.M1();
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "x4 != null").WithLocation(26, 18),
                 // (38,21): hidden CS8605: Result of the comparison is possibly always true.
                 //         string z6 = y6 != null ? y6 : x6.M2();
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "y6 != null").WithLocation(38, 21),
-                // (44,21): warning CS8601: Possible null reference assignment.
+                // (44,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         string z7 = y7 != null ? y7 : x7.M2();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y7 != null ? y7 : x7.M2()").WithLocation(44, 21)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y7 != null ? y7 : x7.M2()").WithLocation(44, 21)
                 );
         }
 
@@ -5646,24 +5645,24 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (15,18): warning CS8601: Possible null reference assignment.
+                // (15,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z2 = y2 == null ? x2 : y2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2 == null ? x2 : y2").WithLocation(15, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2 == null ? x2 : y2").WithLocation(15, 18),
                 // (20,18): hidden CS8606: Result of the comparison is possibly always false.
                 //         CL1 z3 = x3 == null ? y3 : x3;
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse, "x3 == null").WithLocation(20, 18),
-                // (20,18): warning CS8601: Possible null reference assignment.
+                // (20,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z3 = x3 == null ? y3 : x3;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3 == null ? y3 : x3").WithLocation(20, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 == null ? y3 : x3").WithLocation(20, 18),
                 // (26,18): hidden CS8606: Result of the comparison is possibly always false.
                 //         CL1 z4 = x4 == null ? x4.M1() : x4;
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse, "x4 == null").WithLocation(26, 18),
                 // (38,21): hidden CS8606: Result of the comparison is possibly always false.
                 //         string z6 = y6 == null ? x6.M2() : y6;
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse, "y6 == null").WithLocation(38, 21),
-                // (44,21): warning CS8601: Possible null reference assignment.
+                // (44,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         string z7 = y7 == null ? x7.M2() : y7;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y7 == null ? x7.M2() : y7").WithLocation(44, 21)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y7 == null ? x7.M2() : y7").WithLocation(44, 21)
                 );
         }
 
@@ -5910,9 +5909,9 @@ class CL1
                 // (28,13): warning CS8602: Possible dereference of a null reference.
                 //             x2.M1(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(28, 13),
-                // (29,18): warning CS8601: Possible null reference assignment.
+                // (29,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             y2 = x2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(29, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2").WithLocation(29, 18),
                 // (30,13): warning CS8602: Possible dereference of a null reference.
                 //             y2.M2(x2);
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(30, 13),
@@ -6118,10 +6117,12 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (17,14): warning CS8600: Cannot convert null to non-nullable reference.
+                // (10,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         var x1 = (CL1)null;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(CL1)null").WithLocation(10, 18),
+                // (17,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y2 = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(17, 14)
-                );
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(17, 14));
         }
 
         [Fact]
@@ -6181,19 +6182,18 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (11,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 z1 = x1[0];
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1[0]").WithLocation(11, 18),
-                 // (17,17): warning CS8601: Possible null reference assignment.
-                 //         x2[1] = z2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z2").WithLocation(17, 17),
-                 // (34,35): warning CS8601: Possible null reference assignment.
-                 //         var x5 = new CL1 [] { y5, z5 };
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z5").WithLocation(34, 35),
-                 // (39,39): warning CS8601: Possible null reference assignment.
-                 //         var x6 = new CL1 [,] { {y6}, {z6} };
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z6").WithLocation(39, 39)
-                );
+                // (11,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 z1 = x1[0];
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1[0]").WithLocation(11, 18),
+                // (17,17): warning CS8601: Possible null reference assignment.
+                //         x2[1] = z2;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z2").WithLocation(17, 17),
+                // (34,35): warning CS8601: Possible null reference assignment.
+                //         var x5 = new CL1 [] { y5, z5 };
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z5").WithLocation(34, 35),
+                // (39,39): warning CS8601: Possible null reference assignment.
+                //         var x6 = new CL1 [,] { {y6}, {z6} };
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z6").WithLocation(39, 39));
         }
 
         [Fact]
@@ -6251,8 +6251,7 @@ class CL1
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z4").WithLocation(37, 17),
                 // (38,19): warning CS8601: Possible null reference assignment.
                 //         v4[0,0] = z4;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z4").WithLocation(38, 19)
-                );
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z4").WithLocation(38, 19));
         }
 
         [Fact]
@@ -6536,24 +6535,24 @@ class C
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (11,14): warning CS8600: Cannot convert null to non-nullable reference.
+                // (11,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u1 = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(11, 14),
                 // (16,24): warning CS8619: Nullability of reference types in value of type 'object?[]' doesn't match target type 'object[]'.
                 //         object [] u2 = new [] { null, new object() };
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [] { null, new object() }").WithArguments("object?[]", "object[]").WithLocation(16, 24),
-                // (21,34): warning CS8600: Cannot convert null to non-nullable reference.
+                // (21,34): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         var u3 = new object [] { null, new object() };
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(21, 34),
-                // (32,25): warning CS8600: Cannot convert null to non-nullable reference.
+                // (32,25): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object? [] u5 = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(32, 25),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(32, 25),
                 // (33,16): warning CS8603: Possible null reference return.
                 //         return u5;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "u5").WithLocation(33, 16),
-                // (38,28): warning CS8600: Cannot convert null to non-nullable reference.
+                // (38,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object [][,]? u6 = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(38, 28),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(38, 28),
                 // (39,9): warning CS8602: Possible dereference of a null reference.
                 //         u6[0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6").WithLocation(39, 9),
@@ -6563,7 +6562,7 @@ class C
                 // (40,9): warning CS8602: Possible dereference of a null reference.
                 //         u6[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(40, 9),
-                // (40,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (40,22): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u6[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(40, 22),
                 // (41,9): warning CS8602: Possible dereference of a null reference.
@@ -6572,31 +6571,31 @@ class C
                 // (41,9): warning CS8602: Possible dereference of a null reference.
                 //         u6[0][0,0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(41, 9),
-                // (46,27): warning CS8600: Cannot convert null to non-nullable reference.
+                // (46,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object [][,] u7 = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(46, 27),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(46, 27),
                 // (47,9): warning CS8602: Possible dereference of a null reference.
                 //         u7[0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u7").WithLocation(47, 9),
-                // (47,17): warning CS8600: Cannot convert null to non-nullable reference.
+                // (47,17): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u7[0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(47, 17),
                 // (48,9): warning CS8602: Possible dereference of a null reference.
                 //         u7[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u7").WithLocation(48, 9),
-                // (48,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (48,22): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u7[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(48, 22),
                 // (54,9): warning CS8602: Possible dereference of a null reference.
                 //         u8[0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u8").WithLocation(54, 9),
-                // (54,17): warning CS8600: Cannot convert null to non-nullable reference.
+                // (54,17): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u8[0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(54, 17),
                 // (55,9): warning CS8602: Possible dereference of a null reference.
                 //         u8[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u8").WithLocation(55, 9),
-                // (55,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (55,22): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u8[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(55, 22),
                 // (56,9): warning CS8602: Possible dereference of a null reference.
@@ -6611,7 +6610,7 @@ class C
                 // (63,9): warning CS8602: Possible dereference of a null reference.
                 //         u9[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(63, 9),
-                // (63,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (63,22): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u9[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(63, 22),
                 // (64,9): warning CS8602: Possible dereference of a null reference.
@@ -6676,55 +6675,54 @@ class C
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (16,54): warning CS8600: Cannot convert null to non-nullable reference.
+                // (16,54): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //                                     new object[,]? {{null}}};
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(16, 54),
                 // (18,9): warning CS8602: Possible dereference of a null reference.
                 //         u6[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(18, 9),
-                // (18,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (18,22): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u6[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(18, 22),
                 // (19,9): warning CS8602: Possible dereference of a null reference.
                 //         u6[0][0,0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(19, 9),
-                // (24,36): warning CS8600: Cannot convert null to non-nullable reference.
-                //         var u7 = new object [][,] {null, 
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(24, 36),
-                // (25,52): warning CS8600: Cannot convert null to non-nullable reference.
+                // (25,52): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //                                    new object[,] {{null}}};
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(25, 52),
-                // (26,17): warning CS8600: Cannot convert null to non-nullable reference.
+                // (24,36): warning CS8625: Cannot convert null literal to non-nullable reference.
+                //         var u7 = new object [][,] {null, 
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(24, 36),
+                // (26,17): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u7[0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(26, 17),
-                // (27,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (27,22): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u7[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(27, 22),
-                // (32,37): warning CS8600: Cannot convert null to non-nullable reference.
-                //         var u8 = new object []?[,] {null, 
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(32, 37),
-                // (33,53): warning CS8600: Cannot convert null to non-nullable reference.
+                // (33,53): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //                                     new object[,] {{null}}};
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(33, 53),
-                // (34,17): warning CS8600: Cannot convert null to non-nullable reference.
+                // (32,37): warning CS8625: Cannot convert null literal to non-nullable reference.
+                //         var u8 = new object []?[,] {null, 
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(32, 37),
+                // (34,17): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u8[0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(34, 17),
-                // (35,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (35,22): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u8[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(35, 22),
-                // (42,55): warning CS8600: Cannot convert null to non-nullable reference.
+                // (42,55): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //                                      new object[,]? {{null}}};
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(42, 55),
                 // (44,9): warning CS8602: Possible dereference of a null reference.
                 //         u9[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(44, 9),
-                // (44,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (44,22): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         u9[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(44, 22),
                 // (45,9): warning CS8602: Possible dereference of a null reference.
                 //         u9[0][0,0].ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(45, 9)
-                );
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(45, 9));
         }
 
         [Fact]
@@ -6805,13 +6803,12 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (9,35): warning CS8601: Possible null reference assignment.
-                 //         var z1 = new CL1() { F1 = x1, F2 = y1 };
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(9, 35),
-                 // (14,35): warning CS8601: Possible null reference assignment.
-                 //         var z2 = new CL1() { P1 = x2, P2 = y2 };
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(14, 35)
-                );
+                // (9,35): warning CS8601: Possible null reference assignment.
+                //         var z1 = new CL1() { F1 = x1, F2 = y1 };
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(9, 35),
+                // (14,35): warning CS8601: Possible null reference assignment.
+                //         var z2 = new CL1() { P1 = x2, P2 = y2 };
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(14, 35));
         }
 
         [Fact]
@@ -6880,24 +6877,24 @@ struct S2
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (12,14): warning CS8601: Possible null reference assignment.
+                 // (12,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         x1 = y1.F1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1.F1").WithLocation(12, 14),
-                 // (22,14): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1.F1").WithLocation(12, 14),
+                 // (22,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         x2 = y2.F1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2.F1").WithLocation(22, 14),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2.F1").WithLocation(22, 14),
                  // (34,14): hidden CS8607: Expression is probably never null.
                  //         x4 = y4.F2.F1 ?? x4;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y4.F2.F1").WithLocation(34, 14),
-                 // (35,14): warning CS8601: Possible null reference assignment.
+                 // (35,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         x4 = y4.F2.F3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y4.F2.F3").WithLocation(35, 14),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y4.F2.F3").WithLocation(35, 14),
                  // (42,14): hidden CS8607: Expression is probably never null.
                  //         x5 = u5.F1 ?? x5;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u5.F1").WithLocation(42, 14),
-                 // (43,14): warning CS8601: Possible null reference assignment.
+                 // (43,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         x5 = u5.F3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "u5.F3").WithLocation(43, 14)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u5.F3").WithLocation(43, 14)
                 );
         }
 
@@ -7083,9 +7080,9 @@ struct S2
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (9,14): warning CS8601: Possible null reference assignment.
+                 // (9,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         x1 = new S1().F1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "new S1().F1").WithLocation(9, 14),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "new S1().F1").WithLocation(9, 14),
                  // (19,14): hidden CS8607: Expression is probably never null.
                  //         x3 = new S1() {F1 = x3}.F1 ?? x3;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "new S1() {F1 = x3}.F1").WithLocation(19, 14),
@@ -7124,9 +7121,9 @@ struct TS2
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (15,28): warning CS8601: Possible null reference assignment.
+                 // (15,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         System.Action z2 = E2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(15, 28)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E2").WithLocation(15, 28)
                 );
         }
 
@@ -7251,87 +7248,87 @@ struct S1
                 // (10,14): hidden CS8607: Expression is probably never null.
                 //         x1 = y1.p1 ?? x1;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y1.p1").WithLocation(10, 14),
-                // (11,14): warning CS8601: Possible null reference assignment.
+                // (11,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x1 = y1.p2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1.p2").WithLocation(11, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1.p2").WithLocation(11, 14),
                 // (19,14): hidden CS8607: Expression is probably never null.
                 //         x2 = u2.p2 ?? x2;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u2.p2").WithLocation(19, 14),
-                // (20,14): warning CS8601: Possible null reference assignment.
+                // (20,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x2 = u2.p1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "u2.p1").WithLocation(20, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u2.p1").WithLocation(20, 14),
                 // (21,14): hidden CS8607: Expression is probably never null.
                 //         x2 = v2.p2 ?? x2;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "v2.p2").WithLocation(21, 14),
-                // (22,14): warning CS8601: Possible null reference assignment.
+                // (22,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x2 = v2.p1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "v2.p1").WithLocation(22, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "v2.p1").WithLocation(22, 14),
                 // (29,14): hidden CS8607: Expression is probably never null.
                 //         x3 = v3.p1 ?? x3;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "v3.p1").WithLocation(29, 14),
-                // (30,14): warning CS8601: Possible null reference assignment.
+                // (30,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x3 = v3.p2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "v3.p2").WithLocation(30, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "v3.p2").WithLocation(30, 14),
                 // (38,14): hidden CS8607: Expression is probably never null.
                 //         x4 = u4.p0.p2 ?? x4;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4.p0.p2").WithLocation(38, 14),
-                // (39,14): warning CS8601: Possible null reference assignment.
+                // (39,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x4 = u4.p0.p1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "u4.p0.p1").WithLocation(39, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u4.p0.p1").WithLocation(39, 14),
                 // (40,14): hidden CS8607: Expression is probably never null.
                 //         x4 = v4.p0.p2 ?? x4;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "v4.p0.p2").WithLocation(40, 14),
-                // (41,14): warning CS8601: Possible null reference assignment.
+                // (41,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x4 = v4.p0.p1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "v4.p0.p1").WithLocation(41, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "v4.p0.p1").WithLocation(41, 14),
                 // (48,14): hidden CS8607: Expression is probably never null.
                 //         x5 = v5.p0.p1 ?? x5;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "v5.p0.p1").WithLocation(48, 14),
-                // (49,14): warning CS8601: Possible null reference assignment.
+                // (49,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x5 = v5.p0.p2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "v5.p0.p2").WithLocation(49, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "v5.p0.p2").WithLocation(49, 14),
                 // (56,14): hidden CS8607: Expression is probably never null.
                 //         x6 = v6.p1 ?? x6;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "v6.p1").WithLocation(56, 14),
-                // (57,14): warning CS8601: Possible null reference assignment.
+                // (57,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x6 = v6.p2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "v6.p2").WithLocation(57, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "v6.p2").WithLocation(57, 14),
                 // (65,14): hidden CS8607: Expression is probably never null.
                 //         x7 = u7.p0.p2 ?? x7;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u7.p0.p2").WithLocation(65, 14),
-                // (66,14): warning CS8601: Possible null reference assignment.
+                // (66,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x7 = u7.p0.p1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "u7.p0.p1").WithLocation(66, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u7.p0.p1").WithLocation(66, 14),
                 // (67,14): hidden CS8607: Expression is probably never null.
                 //         x7 = v7.p0.p2 ?? x7;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "v7.p0.p2").WithLocation(67, 14),
-                // (68,14): warning CS8601: Possible null reference assignment.
+                // (68,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x7 = v7.p0.p1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "v7.p0.p1").WithLocation(68, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "v7.p0.p1").WithLocation(68, 14),
                 // (75,14): hidden CS8607: Expression is probably never null.
                 //         x8 = v8.p0.p1 ?? x8;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "v8.p0.p1").WithLocation(75, 14),
-                // (76,14): warning CS8601: Possible null reference assignment.
+                // (76,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x8 = v8.p0.p2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "v8.p0.p2").WithLocation(76, 14),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "v8.p0.p2").WithLocation(76, 14),
                 // (83,14): hidden CS8607: Expression is probably never null.
                 //         x9 = v9.p1 ?? x9;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "v9.p1").WithLocation(83, 14),
-                // (84,14): warning CS8601: Possible null reference assignment.
+                // (84,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x9 = v9.p2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "v9.p2").WithLocation(84, 14),
-                // (98,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "v9.p2").WithLocation(84, 14),
+                // (98,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x10 = u10.a0; // 4
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "u10.a0").WithLocation(98, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u10.a0").WithLocation(98, 15),
                 // (99,15): warning CS8602: Possible dereference of a null reference.
                 //         x10 = u10.a1.p1; // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u10.a1").WithLocation(99, 15),
-                // (99,15): warning CS8601: Possible null reference assignment.
+                // (99,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x10 = u10.a1.p1; // 5
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "u10.a1.p1").WithLocation(99, 15),
-                // (100,15): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u10.a1.p1").WithLocation(99, 15),
+                // (100,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x10 = u10.a2.p2; // 6 
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "u10.a2.p2").WithLocation(100, 15)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u10.a2.p2").WithLocation(100, 15)
                 );
         }
 
@@ -7567,16 +7564,15 @@ struct S1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (12,14): warning CS8601: Possible null reference assignment.
-                 //         P1 = x1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(12, 14),
-                 // (33,14): warning CS8601: Possible null reference assignment.
-                 //         x3 = P3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P3").WithLocation(33, 14),
-                 // (22,14): warning CS8601: Possible null reference assignment.
-                 //         x2 = P2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P2").WithLocation(22, 14)
-                );
+                // (22,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x2 = P2;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "P2").WithLocation(22, 14),
+                // (33,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x3 = P3;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "P3").WithLocation(33, 14),
+                // (12,14): warning CS8601: Possible null reference assignment.
+                //         P1 = x1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(12, 14));
         }
 
         [Fact]
@@ -7651,19 +7647,18 @@ struct S1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (34,14): warning CS8601: Possible null reference assignment.
-                 //         x3 = P3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P3").WithLocation(34, 14),
-                 // (12,14): warning CS8601: Possible null reference assignment.
-                 //         P1 = x1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(12, 14),
-                 // (22,14): error CS8079: Use of possibly unassigned auto-implemented property 'P2'
-                 //         x2 = P2;
-                 Diagnostic(ErrorCode.ERR_UseDefViolationProperty, "P2").WithArguments("P2").WithLocation(22, 14),
-                 // (56,14): hidden CS8607: Expression is probably never null.
-                 //         x5 = P5.F1 ?? x5;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "P5.F1").WithLocation(56, 14)
-                );
+                // (12,14): warning CS8601: Possible null reference assignment.
+                //         P1 = x1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(12, 14),
+                // (34,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x3 = P3;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "P3").WithLocation(34, 14),
+                // (22,14): error CS8079: Use of possibly unassigned auto-implemented property 'P2'
+                //         x2 = P2;
+                Diagnostic(ErrorCode.ERR_UseDefViolationProperty, "P2").WithArguments("P2").WithLocation(22, 14),
+                // (56,14): hidden CS8607: Expression is probably never null.
+                //         x5 = P5.F1 ?? x5;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "P5.F1").WithLocation(56, 14));
         }
 
         [Fact]
@@ -7877,12 +7872,12 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (12,46): warning CS8601: Possible null reference assignment.
+                 // (12,46): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         System.Action<CL1> x1 = (p1) => p1 = M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(12, 46),
-                 // (19,30): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(12, 46),
+                 // (19,30): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         D1 x3 = (p3) => p3 = M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(19, 30)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(19, 30)
                 );
         }
 
@@ -8147,15 +8142,15 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (21,26): warning CS8601: Possible null reference assignment.
+                // (21,26): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //                     y1 = M1();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(21, 26),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(21, 26),
                 // (22,28): warning CS8603: Possible null reference return.
                 //                     return y1;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y1").WithLocation(22, 28),
-                // (30,26): warning CS8601: Possible null reference assignment.
+                // (30,26): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //                     y2 = M1();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(30, 26),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(30, 26),
                 // (31,28): warning CS8603: Possible null reference return.
                 //                     return y2;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y2").WithLocation(31, 28)
@@ -8254,18 +8249,18 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (12,50): warning CS8601: Possible null reference assignment.
+                 // (12,50): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         System.Action<CL1> x1 = (CL1 p1) => p1 = M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(12, 50),
-                 // (17,58): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(12, 50),
+                 // (17,58): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         System.Action<CL1> x2 = delegate (CL1 p2) { p2 = M1(); };
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(17, 58),
-                 // (24,34): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(17, 58),
+                 // (24,34): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         D1 x3 = (CL1 p3) => p3 = M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(24, 34),
-                 // (29,42): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(24, 34),
+                 // (29,42): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         D1 x4 = delegate (CL1 p4) { p4 = M1(); };
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(29, 42)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(29, 42)
                 );
         }
 
@@ -8310,27 +8305,27 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (12,51): warning CS8601: Possible null reference assignment.
+                 // (12,51): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         System.Action<CL1?> x1 = (CL1 p1) => p1 = M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(12, 51),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(12, 51),
                  // (12,34): warning CS8622: Nullability of reference types in type of parameter 'p1' of 'lambda expression' doesn't match the target delegate 'Action<CL1?>'.
                  //         System.Action<CL1?> x1 = (CL1 p1) => p1 = M1();
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1 p1) => p1 = M1()").WithArguments("p1", "lambda expression", "System.Action<CL1?>").WithLocation(12, 34),
-                 // (17,59): warning CS8601: Possible null reference assignment.
+                 // (17,59): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         System.Action<CL1?> x2 = delegate (CL1 p2) { p2 = M1(); };
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(17, 59),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(17, 59),
                  // (17,34): warning CS8622: Nullability of reference types in type of parameter 'p2' of 'lambda expression' doesn't match the target delegate 'Action<CL1?>'.
                  //         System.Action<CL1?> x2 = delegate (CL1 p2) { p2 = M1(); };
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1 p2) { p2 = M1(); }").WithArguments("p2", "lambda expression", "System.Action<CL1?>").WithLocation(17, 34),
-                 // (24,34): warning CS8601: Possible null reference assignment.
+                 // (24,34): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         D1 x3 = (CL1 p3) => p3 = M1();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(24, 34),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(24, 34),
                  // (24,17): warning CS8622: Nullability of reference types in type of parameter 'p3' of 'lambda expression' doesn't match the target delegate 'C.D1'.
                  //         D1 x3 = (CL1 p3) => p3 = M1();
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1 p3) => p3 = M1()").WithArguments("p3", "lambda expression", "C.D1").WithLocation(24, 17),
-                 // (29,42): warning CS8601: Possible null reference assignment.
+                 // (29,42): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         D1 x4 = delegate (CL1 p4) { p4 = M1(); };
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "M1()").WithLocation(29, 42),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(29, 42),
                  // (29,17): warning CS8622: Nullability of reference types in type of parameter 'p4' of 'lambda expression' doesn't match the target delegate 'C.D1'.
                  //         D1 x4 = delegate (CL1 p4) { p4 = M1(); };
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1 p4) { p4 = M1(); }").WithArguments("p4", "lambda expression", "C.D1").WithLocation(29, 17)
@@ -8484,16 +8479,15 @@ class C
 ", parseOptions: TestOptions.Regular8, references: new[] { notAnnotated.EmitToImageReference() });
 
             c.VerifyDiagnostics(
-                // (20,29): warning CS8600: Cannot convert null to non-nullable reference.
+                // (20,29): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //                     p2.F1 = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(20, 29),
-                // (21,26): warning CS8600: Cannot convert null to non-nullable reference.
+                // (21,26): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //                     p2 = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(21, 26),
-                // (22,28): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(21, 26),
+                // (22,28): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //                     return null; // 2
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(22, 28)
-                );
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(22, 28));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Calculate lamba conversion.
@@ -8755,10 +8749,9 @@ class CL0
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (9,22): warning CS8601: Possible null reference assignment.
-                 //         dynamic y1 = x1[(dynamic)0];
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1[(dynamic)0]").WithLocation(9, 22)
-                );
+                // (9,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         dynamic y1 = x1[(dynamic)0];
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1[(dynamic)0]").WithLocation(9, 22));
         }
 
         [Fact]
@@ -8798,9 +8791,9 @@ class CL0
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (9,22): warning CS8601: Possible null reference assignment.
+                 // (9,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         dynamic y1 = x1[(dynamic)0];
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1[(dynamic)0]").WithLocation(9, 22)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1[(dynamic)0]").WithLocation(9, 22)
                 );
         }
 
@@ -8841,9 +8834,9 @@ class CL0
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (9,22): warning CS8601: Possible null reference assignment.
+                 // (9,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         dynamic y1 = x1[(dynamic)0];
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1[(dynamic)0]").WithLocation(9, 22)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1[(dynamic)0]").WithLocation(9, 22)
                 );
         }
 
@@ -9050,8 +9043,7 @@ class CL1
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(14, 26),
                 // (15,17): warning CS8601: Possible null reference assignment.
                 //         z2[0] = y2;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(15, 17)
-                );
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(15, 17));
         }
 
         [Fact]
@@ -9176,9 +9168,9 @@ class CL0
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (9,22): warning CS8601: Possible null reference assignment.
+                 // (9,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         dynamic y1 = x1.M1((dynamic)0);
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1.M1((dynamic)0)").WithLocation(9, 22)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1.M1((dynamic)0)").WithLocation(9, 22)
                 );
         }
 
@@ -9217,9 +9209,9 @@ class CL0
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (9,22): warning CS8601: Possible null reference assignment.
+                 // (9,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         dynamic y1 = x1.M1((dynamic)0);
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1.M1((dynamic)0)").WithLocation(9, 22)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1.M1((dynamic)0)").WithLocation(9, 22)
                 );
         }
 
@@ -9258,9 +9250,9 @@ class CL0
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (9,22): warning CS8601: Possible null reference assignment.
+                 // (9,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         dynamic y1 = x1.M1((dynamic)0);
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1.M1((dynamic)0)").WithLocation(9, 22)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1.M1((dynamic)0)").WithLocation(9, 22)
                 );
         }
 
@@ -9742,9 +9734,9 @@ class C
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (10,14): warning CS8600: Cannot convert null to non-nullable reference.
+                // (10,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x1 = default(C);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(C)").WithLocation(10, 14)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default(C)").WithLocation(10, 14)
                 );
         }
 
@@ -9902,9 +9894,9 @@ class CL2
                  // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1? CL1.operator +(string x, CL1? y)'.
                  //         CL1 z2 = x2 + y2;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("x", "CL1? CL1.operator +(string x, CL1? y)").WithLocation(16, 18),
-                 // (16,18): warning CS8601: Possible null reference assignment.
+                 // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL1 z2 = x2 + y2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2 + y2").WithLocation(16, 18),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2 + y2").WithLocation(16, 18),
                  // (21,23): warning CS8604: Possible null reference argument for parameter 'y' in 'CL0 CL0.operator +(string? x, CL0 y)'.
                  //         CL2 u3 = x3 + y3 + z3;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y3").WithArguments("y", "CL0 CL0.operator +(string? x, CL0 y)").WithLocation(21, 23),
@@ -10286,22 +10278,21 @@ class C
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (15,28): hidden CS8607: Expression is probably never null.
-                 //         System.Action u2 = x2 + y2 ?? x2;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x2 + y2").WithLocation(15, 28),
-                 // (25,28): hidden CS8607: Expression is probably never null.
-                 //         System.Action u4 = x4 + y4 ?? y4;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4 + y4").WithLocation(25, 28),
-                 // (35,28): hidden CS8607: Expression is probably never null.
-                 //         System.Action u6 = x6 + y6 ?? x6;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x6 + y6").WithLocation(35, 28),
-                 // (40,28): warning CS8601: Possible null reference assignment.
-                 //         System.Action u7 = x7 + y7;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x7 + y7").WithLocation(40, 28),
-                 // (45,28): warning CS8601: Possible null reference assignment.
-                 //         System.Action u8 = x8 - y8;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x8 - y8").WithLocation(45, 28)
-                );
+                // (15,28): hidden CS8607: Expression is probably never null.
+                //         System.Action u2 = x2 + y2 ?? x2;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x2 + y2").WithLocation(15, 28),
+                // (25,28): hidden CS8607: Expression is probably never null.
+                //         System.Action u4 = x4 + y4 ?? y4;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4 + y4").WithLocation(25, 28),
+                // (35,28): hidden CS8607: Expression is probably never null.
+                //         System.Action u6 = x6 + y6 ?? x6;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x6 + y6").WithLocation(35, 28),
+                // (40,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         System.Action u7 = x7 + y7;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x7 + y7").WithLocation(40, 28),
+                // (45,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         System.Action u8 = x8 - y8;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x8 - y8").WithLocation(45, 28));
         }
 
         [Fact]
@@ -10392,9 +10383,9 @@ class CL0
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (10,18): warning CS8601: Possible null reference assignment.
+                // (10,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL0 z1 = x1 && y1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1 && y1").WithLocation(10, 18)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1 && y1").WithLocation(10, 18)
                 );
         }
 
@@ -10771,13 +10762,12 @@ class CL2
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (10,19): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator !(CL0 x)'.
-                 //         CL0 u1 = !x1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator !(CL0 x)").WithLocation(10, 19),
-                 // (15,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u2 = !x2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "!x2").WithLocation(15, 18)
-                );
+                // (10,19): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator !(CL0 x)'.
+                //         CL0 u1 = !x1;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator !(CL0 x)").WithLocation(10, 19),
+                // (15,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 u2 = !x2;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "!x2").WithLocation(15, 18));
         }
 
         [Fact]
@@ -10917,36 +10907,39 @@ class CL4 : CL3 {}
                 // (15,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0.implicit operator int(CL0 x)'.
                 //         int u2 = x2;
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("x", "CL0.implicit operator int(CL0 x)").WithLocation(15, 18),
-                // (22,18): warning CS8601: Possible null reference assignment.
+                // (22,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL2 u3 = x3;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3").WithLocation(22, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3").WithLocation(22, 18),
                 // (28,18): hidden CS8607: Expression is probably never null.
                 //         CL3 v4 = u4 ?? new CL3();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(28, 18),
-                // (44,22): warning CS8601: Possible null reference assignment.
+                // (44,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         dynamic u7 = x7;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x7").WithLocation(44, 22),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x7").WithLocation(44, 22),
                 // (50,22): hidden CS8607: Expression is probably never null.
                 //         dynamic v8 = u8 ?? x8;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u8").WithLocation(50, 22),
-                // (55,21): warning CS8601: Possible null reference assignment.
+                // (55,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object u9 = x9;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x9").WithLocation(55, 21),
-                // (60,23): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x9").WithLocation(55, 21),
+                // (60,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         dynamic u10 = x10;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x10").WithLocation(60, 23),
-                // (65,19): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x10").WithLocation(60, 23),
+                // (65,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL3 u11 = x11;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(65, 19),
-                // (70,19): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x11").WithLocation(65, 19),
+                // (70,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL4 u12 = (CL4)x12;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(CL4)x12").WithLocation(70, 19),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(CL4)x12").WithLocation(70, 19),
+                // (70,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL4 u12 = (CL4)x12;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(CL4)x12").WithLocation(70, 19),
                 // (76,22): hidden CS8607: Expression is probably never null.
                 //         object v13 = u13 ?? new object();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u13").WithLocation(76, 22),
-                // (87,22): warning CS8601: Possible null reference assignment.
+                // (87,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object u15 = x15;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x15").WithLocation(87, 22),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x15").WithLocation(87, 22),
                 // (93,22): hidden CS8607: Expression is probably never null.
                 //         object v16 = u16 ?? new object();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u16").WithLocation(93, 22)
@@ -11043,46 +11036,45 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (10,21): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
-                 //         CL0? u1 = ++x1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(10, 21),
-                 // (11,18): hidden CS8607: Expression is probably never null.
-                 //         CL0 v1 = u1 ?? new CL0(); 
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
-                 // (12,18): hidden CS8607: Expression is probably never null.
-                 //         CL0 w1 = x1 ?? new CL0(); 
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x1").WithLocation(12, 18),
-                 // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
-                 //         CL0 u2 = x2++;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(16, 18),
-                 // (16,18): warning CS8601: Possible null reference assignment.
-                 //         CL0 u2 = x2++;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2++").WithLocation(16, 18),
-                 // (17,18): hidden CS8607: Expression is probably never null.
-                 //         CL0 v2 = x2 ?? new CL0();
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x2").WithLocation(17, 18),
-                 // (21,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u3 = --x3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x3").WithLocation(21, 18),
-                 // (22,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 v3 = x3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3").WithLocation(22, 18),
-                 // (26,19): warning CS8601: Possible null reference assignment.
-                 //         CL1? u4 = x4--; // Result of increment is nullable, storing it in not nullable parameter.
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4--").WithLocation(26, 19),
-                 // (27,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 v4 = u4 ?? new CL1(); 
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
-                 // (32,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u5 = --x5;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5").WithLocation(32, 18),
-                 // (32,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u5 = --x5;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5").WithLocation(32, 18),
-                 // (37,9): warning CS8601: Possible null reference assignment.
-                 //         x6--; 
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6--").WithLocation(37, 9)
-                );
+                // (10,21): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
+                //         CL0? u1 = ++x1;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(10, 21),
+                // (11,18): hidden CS8607: Expression is probably never null.
+                //         CL0 v1 = u1 ?? new CL0(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
+                // (12,18): hidden CS8607: Expression is probably never null.
+                //         CL0 w1 = x1 ?? new CL0(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x1").WithLocation(12, 18),
+                // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
+                //         CL0 u2 = x2++;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(16, 18),
+                // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL0 u2 = x2++;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2++").WithLocation(16, 18),
+                // (17,18): hidden CS8607: Expression is probably never null.
+                //         CL0 v2 = x2 ?? new CL0();
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x2").WithLocation(17, 18),
+                // (21,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 u3 = --x3;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x3").WithLocation(21, 18),
+                // (22,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 v3 = x3;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3").WithLocation(22, 18),
+                // (26,19): warning CS8601: Possible null reference assignment.
+                //         CL1? u4 = x4--; // Result of increment is nullable, storing it in not nullable parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4--").WithLocation(26, 19),
+                // (27,18): hidden CS8607: Expression is probably never null.
+                //         CL1 v4 = u4 ?? new CL1(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
+                // (32,18): warning CS8601: Possible null reference assignment.
+                //         CL1 u5 = --x5;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5").WithLocation(32, 18),
+                // (32,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 u5 = --x5;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5").WithLocation(32, 18),
+                // (37,9): warning CS8601: Possible null reference assignment.
+                //         x6--; 
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6--").WithLocation(37, 9));
         }
 
         [Fact]
@@ -11148,34 +11140,33 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (10,21): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
-                 //         CL0? u1 = ++x1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(10, 21),
-                 // (11,18): hidden CS8607: Expression is probably never null.
-                 //         CL0 v1 = u1 ?? new CL0(); 
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
-                 // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
-                 //         CL0 u2 = x2++;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(16, 18),
-                 // (16,18): warning CS8601: Possible null reference assignment.
-                 //         CL0 u2 = x2++;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2++").WithLocation(16, 18),
-                 // (21,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u3 = --x3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x3").WithLocation(21, 18),
-                 // (26,19): warning CS8601: Possible null reference assignment.
-                 //         CL1? u4 = x4--; // Result of increment is nullable, storing it in not nullable property.
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4--").WithLocation(26, 19),
-                 // (27,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 v4 = u4 ?? new CL1(); 
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
-                 // (32,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u5 = --x5;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5").WithLocation(32, 18),
-                 // (32,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u5 = --x5;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5").WithLocation(32, 18)
-                );
+                // (10,21): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
+                //         CL0? u1 = ++x1;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(10, 21),
+                // (11,18): hidden CS8607: Expression is probably never null.
+                //         CL0 v1 = u1 ?? new CL0(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
+                // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
+                //         CL0 u2 = x2++;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(16, 18),
+                // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL0 u2 = x2++;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2++").WithLocation(16, 18),
+                // (21,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 u3 = --x3;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x3").WithLocation(21, 18),
+                // (26,19): warning CS8601: Possible null reference assignment.
+                //         CL1? u4 = x4--; // Result of increment is nullable, storing it in not nullable property.
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4--").WithLocation(26, 19),
+                // (27,18): hidden CS8607: Expression is probably never null.
+                //         CL1 v4 = u4 ?? new CL1(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
+                // (32,18): warning CS8601: Possible null reference assignment.
+                //         CL1 u5 = --x5;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5").WithLocation(32, 18),
+                // (32,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 u5 = --x5;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5").WithLocation(32, 18));
         }
 
         [Fact]
@@ -11261,34 +11252,33 @@ class X4
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (10,21): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
-                 //         CL0? u1 = ++x1[0];
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1[0]").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(10, 21),
-                 // (11,18): hidden CS8607: Expression is probably never null.
-                 //         CL0 v1 = u1 ?? new CL0(); 
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
-                 // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
-                 //         CL0 u2 = x2[0]++;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2[0]").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(16, 18),
-                 // (16,18): warning CS8601: Possible null reference assignment.
-                 //         CL0 u2 = x2[0]++;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2[0]++").WithLocation(16, 18),
-                 // (21,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u3 = --x3[0];
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x3[0]").WithLocation(21, 18),
-                 // (26,19): warning CS8601: Possible null reference assignment.
-                 //         CL1? u4 = x4[0]--; // Result of increment is nullable, storing it in not nullable parameter.
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4[0]--").WithLocation(26, 19),
-                 // (27,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 v4 = u4 ?? new CL1(); 
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
-                 // (32,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u5 = --x5[0];
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5[0]").WithLocation(32, 18),
-                 // (32,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u5 = --x5[0];
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5[0]").WithLocation(32, 18)
-                );
+                // (10,21): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
+                //         CL0? u1 = ++x1[0];
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1[0]").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(10, 21),
+                // (11,18): hidden CS8607: Expression is probably never null.
+                //         CL0 v1 = u1 ?? new CL0(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
+                // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
+                //         CL0 u2 = x2[0]++;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2[0]").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(16, 18),
+                // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL0 u2 = x2[0]++;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2[0]++").WithLocation(16, 18),
+                // (21,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 u3 = --x3[0];
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x3[0]").WithLocation(21, 18),
+                // (26,19): warning CS8601: Possible null reference assignment.
+                //         CL1? u4 = x4[0]--; // Result of increment is nullable, storing it in not nullable parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4[0]--").WithLocation(26, 19),
+                // (27,18): hidden CS8607: Expression is probably never null.
+                //         CL1 v4 = u4 ?? new CL1(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
+                // (32,18): warning CS8601: Possible null reference assignment.
+                //         CL1 u5 = --x5[0];
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "--x5[0]").WithLocation(32, 18),
+                // (32,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 u5 = --x5[0];
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5[0]").WithLocation(32, 18));
         }
 
         [Fact]
@@ -11331,9 +11321,9 @@ class C
 ", new[] { CSharpRef, SystemCoreRef }, parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (16,22): warning CS8601: Possible null reference assignment.
+                // (16,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         dynamic u2 = x2++;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2++").WithLocation(16, 22),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2++").WithLocation(16, 22),
                 // (27,22): hidden CS8607: Expression is probably never null.
                 //         dynamic v4 = u4 ?? new object(); 
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 22)
@@ -11429,13 +11419,12 @@ class B : A
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (10,16): warning CS8601: Possible null reference assignment.
-                 //         B u1 = ++x1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "++x1").WithLocation(10, 16),
-                 // (10,16): warning CS8601: Possible null reference assignment.
-                 //         B u1 = ++x1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "++x1").WithLocation(10, 16)
-                );
+                // (10,16): warning CS8601: Possible null reference assignment.
+                //         B u1 = ++x1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "++x1").WithLocation(10, 16),
+                // (10,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         B u1 = ++x1;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "++x1").WithLocation(10, 16));
         }
 
         [Fact]
@@ -11653,21 +11642,21 @@ class CL1
                  // (17,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1 CL0.operator +(CL0 x, CL0? y)'.
                  //         CL0 u2 = x2 += y2;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x2").WithArguments("x", "CL1 CL0.operator +(CL0 x, CL0? y)").WithLocation(17, 18),
-                 // (17,18): warning CS8601: Possible null reference assignment.
+                 // (17,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL0 u2 = x2 += y2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2 += y2").WithLocation(17, 18),
-                 // (18,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2 += y2").WithLocation(17, 18),
+                 // (18,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL0 w2 = x2; 
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(18, 18),
-                 // (24,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2").WithLocation(18, 18),
+                 // (24,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL0 u3 = x3 += y3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3 += y3").WithLocation(24, 18),
-                 // (25,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 += y3").WithLocation(24, 18),
+                 // (25,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL0 w3 = x3; 
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3").WithLocation(25, 18),
-                 // (32,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3").WithLocation(25, 18),
+                 // (32,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL0 w4 = x4; 
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4").WithLocation(32, 18)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x4").WithLocation(32, 18)
                 );
         }
 
@@ -11731,40 +11720,39 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (12,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 w1 = x1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(12, 18),
-                 // (13,14): warning CS8601: Possible null reference assignment.
-                 //         w1 = u1; 
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "u1").WithLocation(13, 14),
-                 // (18,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u2 = x2 += y2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2 += y2").WithLocation(18, 18),
-                 // (18,18): warning CS8601: Possible null reference assignment.
-                 //         CL1 u2 = x2 += y2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2 += y2").WithLocation(18, 18),
-                // (19,18): warning CS8601: Possible null reference assignment.
+                // (12,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 w1 = x1;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1").WithLocation(12, 18),
+                // (13,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         w1 = u1; 
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u1").WithLocation(13, 14),
+                // (18,18): warning CS8601: Possible null reference assignment.
+                //         CL1 u2 = x2 += y2;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2 += y2").WithLocation(18, 18),
+                // (18,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         CL1 u2 = x2 += y2;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2 += y2").WithLocation(18, 18),
+                // (19,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 w2 = x2; 
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(19, 18),
-                 // (24,9): warning CS8601: Possible null reference assignment.
-                 //         x3 += y3;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3 += y3").WithLocation(24, 9),
-                 // (29,19): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1? CL0.operator +(CL0 x, CL0? y)'.
-                 //         CL0? u4 = x4 += y4;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x4").WithArguments("x", "CL1? CL0.operator +(CL0 x, CL0? y)").WithLocation(29, 19),
-                 // (29,19): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1.implicit operator CL0(CL1 x)'.
-                 //         CL0? u4 = x4 += y4;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x4 += y4").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(29, 19),
-                 // (30,18): hidden CS8607: Expression is probably never null.
-                 //         CL0 v4 = u4 ?? new CL0(); 
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(30, 18),
-                 // (31,18): hidden CS8607: Expression is probably never null.
-                 //         CL0 w4 = x4 ?? new CL0(); 
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4").WithLocation(31, 18),
-                 // (36,9): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1.implicit operator CL0(CL1 x)'.
-                 //         x5 += y5;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x5 += y5").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(36, 9)
-                );
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2").WithLocation(19, 18),
+                // (24,9): warning CS8601: Possible null reference assignment.
+                //         x3 += y3;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3 += y3").WithLocation(24, 9),
+                // (29,19): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1? CL0.operator +(CL0 x, CL0? y)'.
+                //         CL0? u4 = x4 += y4;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x4").WithArguments("x", "CL1? CL0.operator +(CL0 x, CL0? y)").WithLocation(29, 19),
+                // (29,19): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1.implicit operator CL0(CL1 x)'.
+                //         CL0? u4 = x4 += y4;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x4 += y4").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(29, 19),
+                // (30,18): hidden CS8607: Expression is probably never null.
+                //         CL0 v4 = u4 ?? new CL0(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(30, 18),
+                // (31,18): hidden CS8607: Expression is probably never null.
+                //         CL0 w4 = x4 ?? new CL0(); 
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4").WithLocation(31, 18),
+                // (36,9): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1.implicit operator CL0(CL1 x)'.
+                //         x5 += y5;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x5 += y5").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(36, 9));
         }
 
         [Fact]
@@ -12004,19 +11992,18 @@ class Test
                 // (12,9): warning CS8602: Possible dereference of a null reference.
                 //         E1();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "E1").WithLocation(12, 9),
-                // (20,12): warning CS8600: Cannot convert null to non-nullable reference.
+                // (20,12): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         E2(null);
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(20, 12),
-                // (28,21): warning CS8601: Possible null reference assignment.
+                // (28,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object x3 = E3();
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E3()").WithLocation(28, 21),
-                // (40,28): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E3()").WithLocation(28, 21),
+                // (40,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         System.Action x5 = E1;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E1").WithLocation(40, 28),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E1").WithLocation(40, 28),
                 // (45,14): warning CS8601: Possible null reference assignment.
                 //         E2 = x6;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6").WithLocation(45, 14)
-                );
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6").WithLocation(45, 14));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Events are not tracked for structs.
@@ -12103,9 +12090,9 @@ struct TS2
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (16,28): warning CS8601: Possible null reference assignment.
+                 // (16,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         System.Action z2 = E2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(16, 28)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E2").WithLocation(16, 28)
                 );
         }
 
@@ -12240,21 +12227,21 @@ class CL1 {}
                  // (15,21): hidden CS8607: Expression is probably never null.
                  //         object y2 = x2 as object ?? new object();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x2 as object").WithLocation(15, 21),
-                 // (20,21): warning CS8601: Possible null reference assignment.
+                 // (20,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         object y3 = x3 as object;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3 as object").WithLocation(20, 21),
-                 // (25,21): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 as object").WithLocation(20, 21),
+                 // (25,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         object y4 = x4 as object;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4 as object").WithLocation(25, 21),
-                 // (30,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x4 as object").WithLocation(25, 21),
+                 // (30,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL1 y5 = x5 as CL1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x5 as CL1").WithLocation(30, 18),
-                 // (35,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x5 as CL1").WithLocation(30, 18),
+                 // (35,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL1 y6 = null as CL1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as CL1").WithLocation(35, 18),
-                 // (40,18): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null as CL1").WithLocation(35, 18),
+                 // (40,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL1 y7 = x7 as CL1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x7 as CL1").WithLocation(40, 18)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x7 as CL1").WithLocation(40, 18)
                 );
         }
 
@@ -12324,9 +12311,9 @@ class Awaiter : System.Runtime.CompilerServices.INotifyCompletion
     public bool IsCompleted { get { return true; } }
 }";
             CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Regular8).VerifyDiagnostics(
-                 // (10,20): warning CS8601: Possible null reference assignment.
+                 // (10,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         object x = await new D();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "await new D()").WithLocation(10, 20)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "await new D()").WithLocation(10, 20)
                 );
         }
 
@@ -12555,27 +12542,27 @@ class C
 }
 ";
 
-            var expected = new[]
-            {
-                // (10,17): warning CS8601: Possible null reference assignment.
-                //         x1.F1 = y1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17),
-                // (15,14): warning CS8601: Possible null reference assignment.
-                //         y2 = x2.P1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2.P1").WithLocation(15, 14)
-            };
-
             CSharpCompilation c = CreateStandardCompilation(source,
                                                                 parseOptions: TestOptions.Regular8,
                                                                 references: new[] { c0.EmitToImageReference() });
-
-            c.VerifyDiagnostics(expected);
+            c.VerifyDiagnostics(
+                // (10,17): warning CS8601: Possible null reference assignment.
+                //         x1.F1 = y1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17),
+                // (15,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         y2 = x2.P1;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2.P1").WithLocation(15, 14));
 
             c = CreateStandardCompilation(source,
                                                                 parseOptions: TestOptions.Regular8,
                                                                 references: new[] { c0.ToMetadataReference() });
-
-            c.VerifyDiagnostics(expected);
+            c.VerifyDiagnostics(
+                // (10,17): warning CS8601: Possible null reference assignment.
+                //         x1.F1 = y1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17),
+                // (15,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         y2 = x2.P1;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2.P1").WithLocation(15, 14));
         }
 
         [Fact]
@@ -12601,25 +12588,21 @@ class C
     }
 }
 ";
-
-            var expected = new[]
-            {
-                // (10,17): warning CS8601: Possible null reference assignment.
-                //         x1.F1 = y1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17)
-            };
-
             CSharpCompilation c = CreateStandardCompilation(source,
                                                                 parseOptions: TestOptions.Regular8,
                                                                 references: new[] { c0.EmitToImageReference() });
-
-            c.VerifyDiagnostics(expected);
+            c.VerifyDiagnostics(
+                // (10,17): warning CS8601: Possible null reference assignment.
+                //         x1.F1 = y1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17));
 
             c = CreateStandardCompilation(source,
                                                                 parseOptions: TestOptions.Regular8,
                                                                 references: new[] { c0.ToMetadataReference() });
-
-            c.VerifyDiagnostics(expected);
+            c.VerifyDiagnostics(
+                // (10,17): warning CS8601: Possible null reference assignment.
+                //         x1.F1 = y1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(10, 17));
         }
 
         [Fact]
@@ -12760,9 +12743,9 @@ class C
 
             var expected = new[]
             {
-                // (17,17): warning CS8601: Possible null reference assignment.
+                // (17,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x2.F2 = y2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(17, 17)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(17, 17)
             };
 
             CSharpCompilation c = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, source },
@@ -13050,43 +13033,42 @@ partial class C
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (18,18): warning CS8601: Possible null reference assignment.
-                 //             E1 = x11;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(18, 18),
-                 // (24,19): hidden CS8607: Expression is probably never null.
-                 //             x12 = E1 ?? x12;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(24, 19),
-                 // (30,19): warning CS8601: Possible null reference assignment.
-                 //             x13 = E2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(30, 19),
-                 // (13,20): warning CS8601: Possible null reference assignment.
-                 //             c.F1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
-                 // (14,20): warning CS8601: Possible null reference assignment.
-                 //             c.P1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
-                 // (15,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
-                 //             c.M3(x21);
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
-                 // (21,19): hidden CS8607: Expression is probably never null.
-                 //             x22 = c.F1 ?? x22;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
-                 // (22,19): hidden CS8607: Expression is probably never null.
-                 //             x22 = c.P1 ?? x22;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
-                 // (23,19): hidden CS8607: Expression is probably never null.
-                 //             x22 = c.M1() ?? x22;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
-                 // (29,19): warning CS8601: Possible null reference assignment.
-                 //             x23 = c.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
-                 // (30,19): warning CS8601: Possible null reference assignment.
-                 //             x23 = c.P2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
-                 // (31,19): warning CS8601: Possible null reference assignment.
-                 //             x23 = c.M2();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
-                );
+                // (18,18): warning CS8601: Possible null reference assignment.
+                //             E1 = x11;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(18, 18),
+                // (24,19): hidden CS8607: Expression is probably never null.
+                //             x12 = E1 ?? x12;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(24, 19),
+                // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             x13 = E2;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E2").WithLocation(30, 19),
+                // (13,20): warning CS8601: Possible null reference assignment.
+                //             c.F1 = x21;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+                // (14,20): warning CS8601: Possible null reference assignment.
+                //             c.P1 = x21;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+                // (15,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
+                //             c.M3(x21);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+                // (21,19): hidden CS8607: Expression is probably never null.
+                //             x22 = c.F1 ?? x22;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+                // (22,19): hidden CS8607: Expression is probably never null.
+                //             x22 = c.P1 ?? x22;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+                // (23,19): hidden CS8607: Expression is probably never null.
+                //             x22 = c.M1() ?? x22;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+                // (29,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             x23 = c.F2;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F2").WithLocation(29, 19),
+                // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             x23 = c.P2;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.P2").WithLocation(30, 19),
+                // (31,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             x23 = c.M2();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19));
 
             CSharpCompilation c1 = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, moduleAttributes, lib },
                                                                 parseOptions: TestOptions.Regular8,
@@ -13097,31 +13079,31 @@ partial class C
             var expected = new[] {
                 // (13,20): warning CS8601: Possible null reference assignment.
                 //             c.F1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
                 // (14,20): warning CS8601: Possible null reference assignment.
                 //             c.P1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
                 // (15,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                 //             c.M3(x21);
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
                 // (21,19): hidden CS8607: Expression is probably never null.
                 //             x22 = c.F1 ?? x22;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
                 // (22,19): hidden CS8607: Expression is probably never null.
                 //             x22 = c.P1 ?? x22;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
                 // (23,19): hidden CS8607: Expression is probably never null.
                 //             x22 = c.M1() ?? x22;
-                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
-                // (29,19): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+                // (29,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
-                // (30,19): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F2").WithLocation(29, 19),
+                // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.P2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
-                // (31,19): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.P2").WithLocation(30, 19),
+                // (31,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.M2();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19)
                 };
 
             c = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
@@ -13241,18 +13223,18 @@ partial class C
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                // (17,18): warning CS8601: Possible null reference assignment.
+                // (17,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             E1 = x11;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(17, 18),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x11").WithLocation(17, 18),
                 // (22,19): hidden CS8607: Expression is probably never null.
                 //             x12 = E1 ?? x12;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(22, 19),
-                // (10,20): warning CS8601: Possible null reference assignment.
+                // (10,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.F1 = x21;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(10, 20),
-                // (11,20): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(10, 20),
+                // (11,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.P1 = x21;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(11, 20),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(11, 20),
                 // (12,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                 //             c.M3(x21);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(12, 18),
@@ -13277,12 +13259,12 @@ partial class C
                                               options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                // (10,20): warning CS8601: Possible null reference assignment.
+                // (10,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.F1 = x21;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(10, 20),
-                // (11,20): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(10, 20),
+                // (11,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.P1 = x21;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(11, 20),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(11, 20),
                 // (12,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                 //             c.M3(x21);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(12, 18),
@@ -13301,12 +13283,12 @@ partial class C
                                               options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                // (10,20): warning CS8601: Possible null reference assignment.
+                // (10,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.F1 = x21;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(10, 20),
-                // (11,20): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(10, 20),
+                // (11,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.P1 = x21;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(11, 20),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(11, 20),
                 // (12,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                 //             c.M3(x21);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(12, 18),
@@ -14159,21 +14141,21 @@ partial class C
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (18,18): warning CS8601: Possible null reference assignment.
+                 // (18,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             E1 = x11;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(18, 18),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x11").WithLocation(18, 18),
                  // (24,19): hidden CS8607: Expression is probably never null.
                  //             x12 = E1 ?? x12;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(24, 19),
-                 // (30,19): warning CS8601: Possible null reference assignment.
+                 // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x13 = E2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(30, 19),
-                 // (13,20): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E2").WithLocation(30, 19),
+                 // (13,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             c.F1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
-                 // (14,20): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(13, 20),
+                 // (14,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             c.P1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(14, 20),
                  // (15,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                  //             c.M3(x21);
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
@@ -14186,15 +14168,15 @@ partial class C
                  // (23,19): hidden CS8607: Expression is probably never null.
                  //             x22 = c.M1() ?? x22;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
-                 // (29,19): warning CS8601: Possible null reference assignment.
+                 // (29,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x23 = c.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
-                 // (30,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F2").WithLocation(29, 19),
+                 // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x23 = c.P2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
-                 // (31,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.P2").WithLocation(30, 19),
+                 // (31,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x23 = c.M2();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19)
                 );
 
             CSharpCompilation c1 = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, moduleAttributes, lib },
@@ -14204,12 +14186,12 @@ partial class C
             c1.VerifyDiagnostics();
 
             var expected = new[] {
-                // (13,20): warning CS8601: Possible null reference assignment.
+                // (13,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.F1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
-                // (14,20): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(13, 20),
+                // (14,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.P1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(14, 20),
                 // (15,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                 //             c.M3(x21);
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
@@ -14222,15 +14204,15 @@ partial class C
                 // (23,19): hidden CS8607: Expression is probably never null.
                 //             x22 = c.M1() ?? x22;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
-                // (29,19): warning CS8601: Possible null reference assignment.
+                // (29,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
-                // (30,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F2").WithLocation(29, 19),
+                // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.P2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
-                // (31,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.P2").WithLocation(30, 19),
+                // (31,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.M2();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19)
                 };
 
             c = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
@@ -14351,21 +14333,21 @@ partial class C
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (18,18): warning CS8601: Possible null reference assignment.
+                 // (18,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             E1 = x11;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(18, 18),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x11").WithLocation(18, 18),
                  // (24,19): hidden CS8607: Expression is probably never null.
                  //             x12 = E1 ?? x12;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(24, 19),
-                 // (30,19): warning CS8601: Possible null reference assignment.
+                 // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x13 = E2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(30, 19),
-                 // (13,20): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E2").WithLocation(30, 19),
+                 // (13,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             c.F1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
-                 // (14,20): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(13, 20),
+                 // (14,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             c.P1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(14, 20),
                  // (15,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                  //             c.M3(x21);
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
@@ -14378,15 +14360,15 @@ partial class C
                  // (23,19): hidden CS8607: Expression is probably never null.
                  //             x22 = c.M1() ?? x22;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
-                 // (29,19): warning CS8601: Possible null reference assignment.
+                 // (29,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x23 = c.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
-                 // (30,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F2").WithLocation(29, 19),
+                 // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x23 = c.P2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
-                 // (31,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.P2").WithLocation(30, 19),
+                 // (31,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x23 = c.M2();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19)
                 );
 
             CSharpCompilation c1 = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, moduleAttributes, lib },
@@ -14396,12 +14378,12 @@ partial class C
             c1.VerifyDiagnostics();
 
             var expected = new[] {
-                // (13,20): warning CS8601: Possible null reference assignment.
+                // (13,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.F1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
-                // (14,20): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(13, 20),
+                // (14,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.P1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(14, 20),
                 // (15,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                 //             c.M3(x21);
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
@@ -14414,15 +14396,15 @@ partial class C
                 // (23,19): hidden CS8607: Expression is probably never null.
                 //             x22 = c.M1() ?? x22;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
-                // (29,19): warning CS8601: Possible null reference assignment.
+                // (29,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
-                // (30,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F2").WithLocation(29, 19),
+                // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.P2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
-                // (31,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.P2").WithLocation(30, 19),
+                // (31,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.M2();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19)
                 };
 
             c = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
@@ -14543,21 +14525,21 @@ partial class C
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (18,18): warning CS8601: Possible null reference assignment.
+                 // (18,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             E1 = x11;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(18, 18),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x11").WithLocation(18, 18),
                  // (24,19): hidden CS8607: Expression is probably never null.
                  //             x12 = E1 ?? x12;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(24, 19),
-                 // (30,19): warning CS8601: Possible null reference assignment.
+                 // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x13 = E2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(30, 19),
-                 // (13,20): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "E2").WithLocation(30, 19),
+                 // (13,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             c.F1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
-                 // (14,20): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(13, 20),
+                 // (14,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             c.P1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(14, 20),
                  // (15,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                  //             c.M3(x21);
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
@@ -14570,15 +14552,15 @@ partial class C
                  // (23,19): hidden CS8607: Expression is probably never null.
                  //             x22 = c.M1() ?? x22;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
-                 // (29,19): warning CS8601: Possible null reference assignment.
+                 // (29,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x23 = c.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
-                 // (30,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F2").WithLocation(29, 19),
+                 // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x23 = c.P2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
-                 // (31,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.P2").WithLocation(30, 19),
+                 // (31,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             x23 = c.M2();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19)
                 );
 
             CSharpCompilation c1 = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, moduleAttributes, lib },
@@ -14588,12 +14570,12 @@ partial class C
             c1.VerifyDiagnostics();
 
             var expected = new[] {
-                // (13,20): warning CS8601: Possible null reference assignment.
+                // (13,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.F1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
-                // (14,20): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(13, 20),
+                // (14,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             c.P1 = x21;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x21").WithLocation(14, 20),
                 // (15,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
                 //             c.M3(x21);
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
@@ -14606,15 +14588,15 @@ partial class C
                 // (23,19): hidden CS8607: Expression is probably never null.
                 //             x22 = c.M1() ?? x22;
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
-                // (29,19): warning CS8601: Possible null reference assignment.
+                // (29,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.F2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
-                // (30,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F2").WithLocation(29, 19),
+                // (30,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.P2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
-                // (31,19): warning CS8601: Possible null reference assignment.
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.P2").WithLocation(30, 19),
+                // (31,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.M2();
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.M2()").WithLocation(31, 19)
                 };
 
             c = CreateStandardCompilation(new[] { NullableOptOutAttributesDefinition, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
@@ -14744,9 +14726,9 @@ class CL1<T>
                  // (39,9): warning CS8602: Possible dereference of a null reference.
                  //         M3().P1.ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M3().P1").WithLocation(39, 9),
-                 // (50,19): warning CS8601: Possible null reference assignment.
+                 // (50,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         M4().P1 = null;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(50, 19),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(50, 19),
                  // (51,18): hidden CS8607: Expression is probably never null.
                  //         var x4 = M4().P1 ?? "";
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "M4().P1").WithLocation(51, 18)
@@ -14994,9 +14976,9 @@ class CL1<T>
                  // (30,9): warning CS8602: Possible dereference of a null reference.
                  //         M3.P1.ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M3.P1").WithLocation(30, 9),
-                 // (38,17): warning CS8601: Possible null reference assignment.
+                 // (38,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         M4.P1 = null;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(38, 17),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(38, 17),
                  // (39,18): hidden CS8607: Expression is probably never null.
                  //         var x4 = M4.P1 ?? "";
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "M4.P1").WithLocation(39, 18)
@@ -15104,9 +15086,9 @@ class CL1<T>
                  // (30,9): warning CS8602: Possible dereference of a null reference.
                  //         M3.P1.ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M3.P1").WithLocation(30, 9),
-                 // (38,17): warning CS8601: Possible null reference assignment.
+                 // (38,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         M4.P1 = null;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(38, 17),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(38, 17),
                  // (39,18): hidden CS8607: Expression is probably never null.
                  //         var x4 = M4.P1 ?? "";
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "M4.P1").WithLocation(39, 18)
@@ -15304,18 +15286,18 @@ class CL1<T>
                  // (35,18): warning CS8602: Possible dereference of a null reference.
                  //         M3(b3 => b3.P1.ToString());
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b3.P1").WithLocation(35, 18),
-                 // (44,27): warning CS8601: Possible null reference assignment.
+                 // (44,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         M4(a4 => {a4.P1 = null;});
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(44, 27),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(44, 27),
                  // (45,28): hidden CS8607: Expression is probably never null.
                  //         M4(b4 => {var x4 = b4.P1 ?? "";});
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "b4.P1").WithLocation(45, 28),
                  // (64,25): warning CS8602: Possible dereference of a null reference.
                  //         D3 v31 = b31 => b31.P1.ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b31.P1").WithLocation(64, 25),
-                 // (70,35): warning CS8601: Possible null reference assignment.
+                 // (70,35): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         D4 u41 = a41 => {a41.P1 = null;};
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(70, 35),
+                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(70, 35),
                  // (71,36): hidden CS8607: Expression is probably never null.
                  //         D4 v41 = b41 => {var x41 = b41.P1 ?? "";};
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "b41.P1").WithLocation(71, 36)
@@ -15777,7 +15759,7 @@ struct S
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (8,26): warning CS8600: Cannot convert null to non-nullable reference.
+                // (8,26): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //     public S(B b) : this(null, b)
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 26));
         }
@@ -15816,50 +15798,50 @@ class Program
                 source,
                 parseOptions: TestOptions.Regular8.WithNullCheckingFeature(NullableReferenceFlags.AllowNullAsNonNull));
             comp.VerifyDiagnostics(
-                // (15,22): warning CS8601: Possible null reference assignment.
+                // (15,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = null as string;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string").WithLocation(15, 22),
-                // (16,22): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null as string").WithLocation(15, 22),
+                // (16,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = null as string?;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string?").WithLocation(16, 22),
-                // (19,23): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null as string?").WithLocation(16, 22),
+                // (19,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.FirstName = p.MiddleName;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName").WithLocation(19, 23),
-                // (20,22): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "p.MiddleName").WithLocation(19, 23),
+                // (20,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = p.MiddleName ?? null;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName ?? null").WithLocation(20, 22));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "p.MiddleName ?? null").WithLocation(20, 22));
 
             comp = CreateStandardCompilation(
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (12,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (12,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 22),
-                // (13,22): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(12, 22),
+                // (13,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = (string)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(13, 22),
-                // (14,22): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(13, 22),
+                // (14,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = (string?)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(14, 22),
-                // (15,22): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string?)null").WithLocation(14, 22),
+                // (15,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = null as string;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string").WithLocation(15, 22),
-                // (16,22): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null as string").WithLocation(15, 22),
+                // (16,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = null as string?;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string?").WithLocation(16, 22),
-                // (17,22): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null as string?").WithLocation(16, 22),
+                // (17,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = default(string);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(17, 22),
-                // (18,22): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default(string)").WithLocation(17, 22),
+                // (18,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = default;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(18, 22),
-                // (19,23): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(18, 22),
+                // (19,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.FirstName = p.MiddleName;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName").WithLocation(19, 23),
-                // (20,22): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "p.MiddleName").WithLocation(19, 23),
+                // (20,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         p.LastName = p.MiddleName ?? null;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName ?? null").WithLocation(20, 22));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "p.MiddleName ?? null").WithLocation(20, 22));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Conversions: NullCoalescingOperator
@@ -15918,21 +15900,21 @@ static class Extensions
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (12,10): warning CS8600: Cannot convert null to non-nullable reference.
+                // (12,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         ((string)null).F();
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(12, 10),
-                // (13,10): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(12, 10),
+                // (13,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         ((string?)null).F();
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(13, 10),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string?)null").WithLocation(13, 10),
                 // (14,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         (null as string).F();
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("s", "void Extensions.F(string s)").WithLocation(14, 10),
                 // (15,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         (null as string?).F();
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("s", "void Extensions.F(string s)").WithLocation(15, 10),
-                // (16,9): warning CS8600: Cannot convert null to non-nullable reference.
+                // (16,9): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         default(string).F();
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(16, 9),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default(string)").WithLocation(16, 9),
                 // (17,11): hidden CS8605: Result of the comparison is possibly always true.
                 //         ((p != null) ? p.MiddleName : null).F();
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(17, 11),
@@ -15999,27 +15981,27 @@ class Program
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (12,11): warning CS8600: Cannot convert null to non-nullable reference.
+                // (12,11): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         G(null);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 11),
-                // (13,11): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(12, 11),
+                // (13,11): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         G((string)null);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(13, 11),
-                // (14,11): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(13, 11),
+                // (14,11): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         G((string?)null);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(14, 11),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string?)null").WithLocation(14, 11),
                 // (15,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G(null as string);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("name", "void Program.G(string name)").WithLocation(15, 11),
                 // (16,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G(null as string?);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("name", "void Program.G(string name)").WithLocation(16, 11),
-                // (17,11): warning CS8600: Cannot convert null to non-nullable reference.
+                // (17,11): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         G(default(string));
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(17, 11),
-                // (18,11): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default(string)").WithLocation(17, 11),
+                // (18,11): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         G(default);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(18, 11),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(18, 11),
                 // (19,12): hidden CS8605: Result of the comparison is possibly always true.
                 //         G((p != null) ? p.MiddleName : null);
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(19, 12),
@@ -16080,27 +16062,27 @@ class Program
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (10,27): warning CS8600: Cannot convert null to non-nullable reference.
+                // (10,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //     static string F1() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 27),
-                // (11,27): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(10, 27),
+                // (11,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //     static string F2() => (string)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(11, 27),
-                // (12,27): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(11, 27),
+                // (12,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //     static string F3() => (string?)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(12, 27),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string?)null").WithLocation(12, 27),
                 // (13,27): warning CS8603: Possible null reference return.
                 //     static string F4() => null as string;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string").WithLocation(13, 27),
                 // (14,27): warning CS8603: Possible null reference return.
                 //     static string F5() => null as string?;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string?").WithLocation(14, 27),
-                // (15,27): warning CS8600: Cannot convert null to non-nullable reference.
+                // (15,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //     static string F6() => default(string);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(15, 27),
-                // (16,27): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default(string)").WithLocation(15, 27),
+                // (16,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //     static string F7() => default;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(16, 27),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(16, 27),
                 // (17,36): hidden CS8605: Result of the comparison is possibly always true.
                 //     static string F8(Person p) => (p != null) ? p.MiddleName : null;
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(17, 36),
@@ -16317,36 +16299,36 @@ class C
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8625: No best nullability for operands of conditional expression 'C<object>' and 'C<object?>'.
+                // (7,13): warning CS8626: No best nullability for operands of conditional expression 'C<object>' and 'C<object?>'.
                 //         a = c ? x : y;
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "c ? x : y").WithArguments("C<object>", "C<object?>").WithLocation(7, 13),
-                // (7,13): warning CS8601: Possible null reference assignment.
+                // (7,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         a = c ? x : y;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c ? x : y").WithLocation(7, 13),
-                // (8,13): warning CS8625: No best nullability for operands of conditional expression 'C<object?>' and 'C<object>'.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c ? x : y").WithLocation(7, 13),
+                // (8,13): warning CS8626: No best nullability for operands of conditional expression 'C<object?>' and 'C<object>'.
                 //         a = c ? y : x;
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "c ? y : x").WithArguments("C<object?>", "C<object>").WithLocation(8, 13),
-                // (8,13): warning CS8601: Possible null reference assignment.
+                // (8,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         a = c ? y : x;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c ? y : x").WithLocation(8, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c ? y : x").WithLocation(8, 13),
                 // (8,13): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'C<object>'.
                 //         a = c ? y : x;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "c ? y : x").WithArguments("C<object?>", "C<object>").WithLocation(8, 13),
-                // (9,13): warning CS8601: Possible null reference assignment.
+                // (9,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         a = c ? x : y!;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c ? x : y!").WithLocation(9, 13),
-                // (13,13): warning CS8625: No best nullability for operands of conditional expression 'C<object>' and 'C<object?>'.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c ? x : y!").WithLocation(9, 13),
+                // (13,13): warning CS8626: No best nullability for operands of conditional expression 'C<object>' and 'C<object?>'.
                 //         b = c ? x : y;
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "c ? x : y").WithArguments("C<object>", "C<object?>").WithLocation(13, 13),
-                // (13,13): warning CS8601: Possible null reference assignment.
+                // (13,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         b = c ? x : y;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c ? x : y").WithLocation(13, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c ? x : y").WithLocation(13, 13),
                 // (13,13): warning CS8619: Nullability of reference types in value of type 'C<object>' doesn't match target type 'C<object?>'.
                 //         b = c ? x : y;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "c ? x : y").WithArguments("C<object>", "C<object?>").WithLocation(13, 13),
-                // (14,13): warning CS8601: Possible null reference assignment.
+                // (14,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         b = c ? x : y!;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c ? x : y!").WithLocation(14, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c ? x : y!").WithLocation(14, 13),
                 // (14,13): warning CS8619: Nullability of reference types in value of type 'C<object>' doesn't match target type 'C<object?>'.
                 //         b = c ? x : y!;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "c ? x : y!").WithArguments("C<object>", "C<object?>").WithLocation(14, 13));
@@ -16535,9 +16517,9 @@ class C
                 // (10,15): warning CS8604: Possible null reference argument for parameter 's' in 'void C.F(ref string s, ref string? t)'.
                 //         F(ref s, ref t);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "s").WithArguments("s", "void C.F(ref string s, ref string? t)").WithLocation(10, 15),
-                // (10,22): warning CS8601: Possible null reference assignment.
+                // (10,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         F(ref s, ref t);
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "t").WithLocation(10, 22));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "t").WithLocation(10, 22));
         }
 
         [Fact]
@@ -16620,7 +16602,10 @@ class C
             comp.VerifyDiagnostics(
                 // (12,14): warning CS8604: Possible null reference argument for parameter 'a' in 'A.implicit operator B(A a)'.
                 //         G((B)a);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("a", "A.implicit operator B(A a)").WithLocation(12, 14));
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a").WithArguments("a", "A.implicit operator B(A a)").WithLocation(12, 14),
+                // (12,11): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         G((B)a);
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(B)a").WithLocation(12, 11));
         }
 
         // PROTOTYPE(NullableReferenceTypes): PreciseAbstractFlowPass.VisitSuppressNullableWarningExpression
@@ -16886,9 +16871,9 @@ End Class";
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,17): warning CS8601: Possible null reference assignment.
+                // (9,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x = t;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "t").WithLocation(9, 17),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "t").WithLocation(9, 17),
                 // (14,15): warning CS8604: Possible null reference argument for parameter 's' in 'void C.G(string s)'.
                 //             G(y); // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y").WithArguments("s", "void C.G(string s)").WithLocation(14, 15));
@@ -17144,7 +17129,7 @@ class C
                 source,
                 parseOptions: TestOptions.Regular8.WithFeature("staticNullChecking"));
             comp.VerifyDiagnostics(
-                // (3,26): warning CS8600: Cannot convert null to non-nullable reference.
+                // (3,26): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //     static object F() => null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(3, 26),
                 // (4,35): warning CS8603: Possible null reference return.
@@ -17155,7 +17140,7 @@ class C
                 source,
                 parseOptions: TestOptions.Regular8.WithFeature("staticNullChecking", "0"));
             comp.VerifyDiagnostics(
-                // (3,26): warning CS8600: Cannot convert null to non-nullable reference.
+                // (3,26): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //     static object F() => null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(3, 26),
                 // (4,35): warning CS8603: Possible null reference return.
@@ -17174,7 +17159,7 @@ class C
                 source,
                 parseOptions: TestOptions.Regular8.WithFeature("staticNullChecking", "2"));
             comp.VerifyDiagnostics(
-                // (3,26): warning CS8600: Cannot convert null to non-nullable reference.
+                // (3,26): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //     static object F() => null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(3, 26),
                 // (4,35): warning CS8603: Possible null reference return.
@@ -17295,9 +17280,9 @@ class B
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8601: Possible null reference assignment.
+                // (7,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x = F(s);
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "F(s)").WithLocation(7, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "F(s)").WithLocation(7, 13),
                 // (8,11): warning CS8604: Possible null reference argument for parameter 's' in 'string? C.F(string s)'.
                 //         F(x);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("s", "string? C.F(string s)").WithLocation(8, 11),
@@ -17466,7 +17451,7 @@ class Program
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (12,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (12,13): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         C.F(null);
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 13));
         }
@@ -17505,7 +17490,7 @@ class Program
                 parseOptions: TestOptions.Regular8,
                 references: new[] { ref0 });
             comp1.VerifyDiagnostics(
-                // (6,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (6,13): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         C.F(null);
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 13));
         }
@@ -17634,7 +17619,7 @@ class A : System.Attribute
                 // (1,2): error CS1729: 'A' does not contain a constructor that takes 1 arguments
                 // [A(P)]
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, "A(P)").WithArguments("A", "1").WithLocation(1, 2),
-                // (4,17): warning CS8600: Cannot convert null to non-nullable reference.
+                // (4,17): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //     string P => null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(4, 17));
         }
@@ -17688,9 +17673,9 @@ class A : System.Attribute
                 // (5,17): error CS0177: The out parameter 'c' must be assigned to before control leaves the current method
                 //     static void G(out C c)
                 Diagnostic(ErrorCode.ERR_ParamUnassigned, "G").WithArguments("c").WithLocation(5, 17),
-                // (7,20): warning CS8601: Possible null reference assignment.
+                // (7,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object o = c.F;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F").WithLocation(7, 20),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F").WithLocation(7, 20),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         c.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F").WithLocation(8, 9));
@@ -17805,9 +17790,9 @@ struct S
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8601: Possible null reference assignment.
+                // (7,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         c = s.P;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "s.P").WithLocation(7, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "s.P").WithLocation(7, 13),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         s.P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.P").WithLocation(8, 9));
@@ -17828,9 +17813,9 @@ struct S
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (6,13): warning CS8601: Possible null reference assignment.
+                // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = P;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P").WithLocation(6, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "P").WithLocation(6, 13),
                 // (7,9): warning CS8602: Possible dereference of a null reference.
                 //         P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "P").WithLocation(7, 9));
@@ -17851,9 +17836,9 @@ struct S
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (6,13): warning CS8601: Possible null reference assignment.
+                // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = P;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P").WithLocation(6, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "P").WithLocation(6, 13),
                 // (7,9): warning CS8602: Possible dereference of a null reference.
                 //         P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "P").WithLocation(7, 9));
@@ -17874,9 +17859,9 @@ struct S
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (6,13): warning CS8601: Possible null reference assignment.
+                // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = P;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P").WithLocation(6, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "P").WithLocation(6, 13),
                 // (7,9): warning CS8602: Possible dereference of a null reference.
                 //         P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "P").WithLocation(7, 9));
@@ -17921,9 +17906,9 @@ struct S
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (8,20): warning CS8601: Possible null reference assignment.
+                // (8,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object z = y.F;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y.F").WithLocation(8, 20));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y.F").WithLocation(8, 20));
         }
 
         [Fact]
@@ -17942,9 +17927,9 @@ struct S
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (8,20): warning CS8601: Possible null reference assignment.
+                // (8,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object z = y.F;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y.F").WithLocation(8, 20));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y.F").WithLocation(8, 20));
         }
 
         [Fact]
@@ -18175,12 +18160,12 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (8,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 13),
-                // (9,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(8, 13),
+                // (9,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = x;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x").WithLocation(9, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x").WithLocation(9, 13),
                 // (10,9): warning CS8602: Possible dereference of a null reference.
                 //         x.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 9),
@@ -18214,10 +18199,10 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (10,15): warning CS8600: Cannot convert null to non-nullable reference.
+                // (10,15): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         c.F = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 15),
-                // (11,15): warning CS8600: Cannot convert null to non-nullable reference.
+                // (11,15): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         c.P = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 15),
                 // (12,9): warning CS8602: Possible dereference of a null reference.
@@ -18265,6 +18250,290 @@ class C
                 // (10,9): warning CS8602: Possible dereference of a null reference.
                 //         c.P.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.P").WithLocation(10, 9));
+        }
+
+        /// <summary>
+        /// Assignment warnings for local and parameters should be distinct from
+        /// fields and properties because the former may be warnings from legacy
+        /// method bodies and it should be possible to disable those warnings separately.
+        /// </summary>
+        [Fact]
+        public void AssignmentWarningsDistinctForLocalsAndParameters()
+        {
+            var source =
+@"#pragma warning disable 0649
+#pragma warning disable 8618
+class C
+{
+    internal object F;
+    internal object P { get; set; }
+}
+class P
+{
+    static void F(out object? x)
+    {
+        x = null;
+    }
+    static void Local()
+    {
+        object? y = null;
+        object x1 = null;
+        x1 = y;
+        F(out x1);
+    }
+    static void Parameter(object x2)
+    {
+        object? y = null;
+        x2 = null;
+        x2 = y;
+        F(out x2);
+    }
+    static void OutParameter(out object x3)
+    {
+        object? y = null;
+        x3 = null;
+        x3 = y;
+        F(out x3);
+    }
+    static void RefParameter(ref object x4)
+    {
+        object? y = null;
+        x4 = null;
+        x4 = y;
+        F(out x4);
+    }
+    static void Field()
+    {
+        var c = new C();
+        object? y = null;
+        c.F = null;
+        c.F = y;
+        F(out c.F);
+    }
+    static void Property()
+    {
+        var c = new C();
+        object? y = null;
+        c.P = null;
+        c.P = y;
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (17,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         object x1 = null;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(17, 21),
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x1 = y;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y").WithLocation(18, 14),
+                // (19,15): warning CS8601: Possible null reference assignment.
+                //         F(out x1);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1").WithLocation(19, 15),
+                // (24,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x2 = null;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(24, 14),
+                // (25,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x2 = y;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y").WithLocation(25, 14),
+                // (26,15): warning CS8601: Possible null reference assignment.
+                //         F(out x2);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(26, 15),
+                // (31,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x3 = null;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(31, 14),
+                // (32,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x3 = y;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y").WithLocation(32, 14),
+                // (33,15): warning CS8601: Possible null reference assignment.
+                //         F(out x3);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x3").WithLocation(33, 15),
+                // (38,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x4 = null;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(38, 14),
+                // (39,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x4 = y;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y").WithLocation(39, 14),
+                // (40,15): warning CS8601: Possible null reference assignment.
+                //         F(out x4);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4").WithLocation(40, 15),
+                // (46,15): warning CS8625: Cannot convert null literal to non-nullable reference.
+                //         c.F = null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(46, 15),
+                // (47,15): warning CS8601: Possible null reference assignment.
+                //         c.F = y;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y").WithLocation(47, 15),
+                // (48,15): warning CS8601: Possible null reference assignment.
+                //         F(out c.F);
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F").WithLocation(48, 15),
+                // (54,15): warning CS8625: Cannot convert null literal to non-nullable reference.
+                //         c.P = null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(54, 15),
+                // (55,15): warning CS8601: Possible null reference assignment.
+                //         c.P = y;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y").WithLocation(55, 15));
+        }
+
+        /// <summary>
+        /// Explicit cast does not cast away top-level nullability.
+        /// </summary>
+        [Fact]
+        public void ExplicitCast()
+        {
+            var source =
+@"#pragma warning disable 0649
+class A<T>
+{
+    internal T F;
+}
+class B1 : A<string> { }
+class B2 : A<string?> { }
+class C
+{
+    static void F0()
+    {
+        ((A<string>)null).F.ToString();
+        ((A<string>?)null).F.ToString();
+        ((A<string?>)default).F.ToString();
+        ((A<string?>?)default).F.ToString();
+    }
+    static void F1(A<string> x1, A<string>? y1)
+    {
+        ((B2?)x1).F.ToString();
+        ((B2)y1).F.ToString();
+    }
+    static void F2(B1 x2, B1? y2)
+    {
+        ((A<string?>?)x2).F.ToString();
+        ((A<string?>)y2).F.ToString();
+    }
+    static void F3(A<string?> x3, A<string?>? y3)
+    {
+        ((B2?)x3).F.ToString();
+        ((B2)y3).F.ToString();
+    }
+    static void F4(B2 x4, B2? y4)
+    {
+        ((A<string>?)x4).F.ToString();
+        ((A<string>)y4).F.ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (12,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         ((A<string>)null).F.ToString();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(A<string>)null").WithLocation(12, 10),
+                // (12,10): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string>)null).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string>)null").WithLocation(12, 10),
+                // (13,10): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string>?)null).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string>?)null").WithLocation(13, 10),
+                // (14,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         ((A<string?>)default).F.ToString();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(A<string?>)default").WithLocation(14, 10),
+                // (14,10): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string?>)default).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string?>)default").WithLocation(14, 10),
+                // (14,9): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string?>)default).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A<string?>)default).F").WithLocation(14, 9),
+                // (15,10): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string?>?)default).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string?>?)default").WithLocation(15, 10),
+                // (15,9): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string?>?)default).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A<string?>?)default).F").WithLocation(15, 9),
+                // (19,9): warning CS8602: Possible dereference of a null reference.
+                //         ((B2?)x1).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B2?)x1).F").WithLocation(19, 9),
+                // (20,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         ((B2)y1).F.ToString();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(B2)y1").WithLocation(20, 10),
+                // (20,10): warning CS8602: Possible dereference of a null reference.
+                //         ((B2)y1).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(B2)y1").WithLocation(20, 10),
+                // (20,9): warning CS8602: Possible dereference of a null reference.
+                //         ((B2)y1).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B2)y1).F").WithLocation(20, 9),
+                // (24,9): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string?>?)x2).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A<string?>?)x2).F").WithLocation(24, 9),
+                // (25,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         ((A<string?>)y2).F.ToString();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(A<string?>)y2").WithLocation(25, 10),
+                // (25,10): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string?>)y2).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string?>)y2").WithLocation(25, 10),
+                // (25,9): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string?>)y2).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A<string?>)y2).F").WithLocation(25, 9),
+                // (29,9): warning CS8602: Possible dereference of a null reference.
+                //         ((B2?)x3).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B2?)x3).F").WithLocation(29, 9),
+                // (30,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         ((B2)y3).F.ToString();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(B2)y3").WithLocation(30, 10),
+                // (30,10): warning CS8602: Possible dereference of a null reference.
+                //         ((B2)y3).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(B2)y3").WithLocation(30, 10),
+                // (30,9): warning CS8602: Possible dereference of a null reference.
+                //         ((B2)y3).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B2)y3).F").WithLocation(30, 9),
+                // (35,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         ((A<string>)y4).F.ToString();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(A<string>)y4").WithLocation(35, 10),
+                // (35,10): warning CS8602: Possible dereference of a null reference.
+                //         ((A<string>)y4).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string>)y4").WithLocation(35, 10));
+        }
+
+        [Fact]
+        public void ExplicitCast_UserDefined()
+        {
+            var source =
+@"class A
+{
+    public static implicit operator B?(A? a) => new B();
+}
+class B { }
+class C
+{
+    static B F(A? x) => (B)x;
+    static B? G(A? y) => (B?)y;
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,25): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //     static B F(A? x) => (B)x;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(B)x").WithLocation(8, 25),
+                // (8,25): warning CS8603: Possible null reference return.
+                //     static B F(A? x) => (B)x;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "(B)x").WithLocation(8, 25));
+        }
+
+        [Fact]
+        public void ExplicitCast_StaticType()
+        {
+            var source =
+@"static class C
+{
+    static object F(object? x) => (C)x;
+    static object? G(object? y) => (C?)y;
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (3,35): error CS0716: Cannot convert to static type 'C'
+                //     static object F(object? x) => (C)x;
+                Diagnostic(ErrorCode.ERR_ConvertToStaticClass, "(C)x").WithArguments("C").WithLocation(3, 35),
+                // (3,35): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //     static object F(object? x) => (C)x;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(C)x").WithLocation(3, 35),
+                // (3,35): warning CS8603: Possible null reference return.
+                //     static object F(object? x) => (C)x;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "(C)x").WithLocation(3, 35),
+                // (4,36): error CS0716: Cannot convert to static type 'C'
+                //     static object? G(object? y) => (C?)y;
+                Diagnostic(ErrorCode.ERR_ConvertToStaticClass, "(C?)y").WithArguments("C").WithLocation(4, 36));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -18236,8 +18236,8 @@ class C
                 Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "new S<object>()").WithArguments("S<object>", "bool").WithLocation(6, 18));
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Should not report CS8600 for
-        // `(C)b` since the user-defined conversion is defined from A to C and we're
+        // PROTOTYPE(NullableReferenceTypes): Should not report CS8600 for `(C)b2`
+        // since the user-defined conversion is defined from A to C and we're
         // already reporting a warning on the argument to the conversion method.
         [Fact]
         public void MultipleConversions_Explicit_01()
@@ -18252,24 +18252,30 @@ class B : A
 }
 class C
 {
-    static void F(B? b)
+    static void F1(B b1)
     {
         C? c;
-        c = (C)b; // (ExplicitUserDefined)(ImplicitReference)
-        c = (C?)b; // (ExplicitUserDefined)(ImplicitReference)
+        c = (C)b1; // (ExplicitUserDefined)(ImplicitReference)
+        c = (C?)b1; // (ExplicitUserDefined)(ImplicitReference)
+    }
+    static void F2(B? b2)
+    {
+        C? c;
+        c = (C)b2; // (ExplicitUserDefined)(ImplicitReference)
+        c = (C?)b2; // (ExplicitUserDefined)(ImplicitReference)
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (13,16): warning CS8604: Possible null reference argument for parameter 'a' in 'A.explicit operator C(A a)'.
-                //         c = (C)b; // (ExplicitUserDefined)(ImplicitReference)
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "b").WithArguments("a", "A.explicit operator C(A a)").WithLocation(13, 16),
-                // (13,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         c = (C)b; // (ExplicitUserDefined)(ImplicitReference)
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(C)b").WithLocation(13, 13),
-                // (14,17): warning CS8604: Possible null reference argument for parameter 'a' in 'A.explicit operator C(A a)'.
-                //         c = (C?)b; // (ExplicitUserDefined)(ImplicitReference)
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "b").WithArguments("a", "A.explicit operator C(A a)").WithLocation(14, 17));
+                // (19,16): warning CS8604: Possible null reference argument for parameter 'a' in 'A.explicit operator C(A a)'.
+                //         c = (C)b2; // (ExplicitUserDefined)(ImplicitReference)
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "b2").WithArguments("a", "A.explicit operator C(A a)").WithLocation(19, 16),
+                // (19,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         c = (C)b2; // (ExplicitUserDefined)(ImplicitReference)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(C)b2").WithLocation(19, 13),
+                // (20,17): warning CS8604: Possible null reference argument for parameter 'a' in 'A.explicit operator C(A a)'.
+                //         c = (C?)b2; // (ExplicitUserDefined)(ImplicitReference)
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "b2").WithArguments("a", "A.explicit operator C(A a)").WithLocation(20, 17));
         }
 
         [Fact]
@@ -18285,34 +18291,47 @@ class C { }
 class D : C { }
 class P
 {
-    static void F(A? a, B? b)
+    static void F1(A a1, B b1)
     {
         C? c;
-        c = (C)a; // (ExplicitUserDefined)
-        c = (C?)a; // (ExplicitUserDefined)
-        c = (C)b; // (ExplicitUserDefined)(ImplicitReference)
-        c = (C?)b; // (ExplicitUserDefined)(ImplicitReference)
+        c = (C)a1; // (ExplicitUserDefined)
+        c = (C?)a1; // (ExplicitUserDefined)
+        c = (C)b1; // (ExplicitUserDefined)(ImplicitReference)
+        c = (C?)b1; // (ExplicitUserDefined)(ImplicitReference)
         D? d;
-        d = (D)a; // (ExplicitReference)(ExplicitUserDefined)
-        d = (D?)a; // (ExplicitReference)(ExplicitUserDefined)
-        d = (D)b; // (ExplicitReference)(ExplicitUserDefined)(ImplicitReference)
-        d = (D?)b; // (ExplicitReference)(ExplicitUserDefined)(ImplicitReference)
+        d = (D)a1; // (ExplicitReference)(ExplicitUserDefined)
+        d = (D?)a1; // (ExplicitReference)(ExplicitUserDefined)
+        d = (D)b1; // (ExplicitReference)(ExplicitUserDefined)(ImplicitReference)
+        d = (D?)b1; // (ExplicitReference)(ExplicitUserDefined)(ImplicitReference)
+    }
+    static void F2(A? a2, B? b2)
+    {
+        C? c;
+        c = (C)a2; // (ExplicitUserDefined)
+        c = (C?)a2; // (ExplicitUserDefined)
+        c = (C)b2; // (ExplicitUserDefined)(ImplicitReference)
+        c = (C?)b2; // (ExplicitUserDefined)(ImplicitReference)
+        D? d;
+        d = (D)a2; // (ExplicitReference)(ExplicitUserDefined)
+        d = (D?)a2; // (ExplicitReference)(ExplicitUserDefined)
+        d = (D)b2; // (ExplicitReference)(ExplicitUserDefined)(ImplicitReference)
+        d = (D?)b2; // (ExplicitReference)(ExplicitUserDefined)(ImplicitReference)
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (13,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         c = (C)a; // (ExplicitUserDefined)
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(C)a").WithLocation(13, 13),
-                // (15,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         c = (C)b; // (ExplicitUserDefined)(ImplicitReference)
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(C)b").WithLocation(15, 13),
-                // (18,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         d = (D)a; // (ExplicitReference)(ExplicitUserDefined)
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(D)a").WithLocation(18, 13),
-                // (20,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         d = (D)b; // (ExplicitReference)(ExplicitUserDefined)(ImplicitReference)
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(D)b").WithLocation(20, 13));
+                // (26,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         c = (C)a2; // (ExplicitUserDefined)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(C)a2").WithLocation(26, 13),
+                // (28,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         c = (C)b2; // (ExplicitUserDefined)(ImplicitReference)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(C)b2").WithLocation(28, 13),
+                // (31,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         d = (D)a2; // (ExplicitReference)(ExplicitUserDefined)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(D)a2").WithLocation(31, 13),
+                // (33,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         d = (D)b2; // (ExplicitReference)(ExplicitUserDefined)(ImplicitReference)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(D)b2").WithLocation(33, 13));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -147,6 +147,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Nullable
         c[0].ToString();
         var d = new[] { (string)null, new object() };
         d[0].ToString();
+        var e = new[] { new object(), (string)null! };
+        e[0].ToString();
+        var f = new[] { (object)null!, s };
+        f[0].ToString();
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
@@ -1289,19 +1293,19 @@ class C
         }
         else
         {
-            Create(x).F = null;
+            Create(x).F = null; // warn
             var y = Create(x);
-            y.F = null;
+            y.F = null; // warn
         }
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (21,27): warning CS8625: Cannot convert null literal to non-nullable reference.
-                //             Create(x).F = null;
+                //             Create(x).F = null; // warn
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(21, 27),
                 // (23,19): warning CS8625: Cannot convert null literal to non-nullable reference.
-                //             y.F = null;
+                //             y.F = null; // warn
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(23, 19));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -151,15 +151,27 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Nullable
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
+                // (5,39): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         var a = new[] { new object(), (string)null };
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(5, 39),
                 // (6,9): warning CS8602: Possible dereference of a null reference.
                 //         a[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a[0]").WithLocation(6, 9),
+                // (7,25): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         var b = new[] { (object)null, s };
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(object)null").WithLocation(7, 25),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         b[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(8, 9),
+                // (9,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         var c = new[] { s, (object)null };
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(object)null").WithLocation(9, 28),
                 // (10,9): warning CS8602: Possible dereference of a null reference.
                 //         c[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0]").WithLocation(10, 9),
+                // (11,25): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         var d = new[] { (string)null, new object() };
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(11, 25),
                 // (12,9): warning CS8602: Possible dereference of a null reference.
                 //         d[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d[0]").WithLocation(12, 9));
@@ -454,19 +466,19 @@ class C
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (13,10): warning CS8625: No best nullability for operands of conditional expression 'A<object>' and 'B1'.
+                // (13,10): warning CS8626: No best nullability for operands of conditional expression 'A<object>' and 'B1'.
                 //         (b ? x : y)/*T:A<object!>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "b ? x : y").WithArguments("A<object>", "B1").WithLocation(13, 10),
-                // (14,10): warning CS8625: No best nullability for operands of conditional expression 'B1' and 'A<object>'.
+                // (14,10): warning CS8626: No best nullability for operands of conditional expression 'B1' and 'A<object>'.
                 //         (b ? y : x).P.ToString();
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "b ? y : x").WithArguments("B1", "A<object>").WithLocation(14, 10),
-                // (18,10): warning CS8625: No best nullability for operands of conditional expression 'A<object?>' and 'B2'.
+                // (18,10): warning CS8626: No best nullability for operands of conditional expression 'A<object?>' and 'B2'.
                 //         (b ? x : y)/*T:A<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "b ? x : y").WithArguments("A<object?>", "B2").WithLocation(18, 10),
                 // (18,9): warning CS8602: Possible dereference of a null reference.
                 //         (b ? x : y)/*T:A<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? x : y)/*T:A<object?>!*/.F").WithLocation(18, 9),
-                // (19,10): warning CS8625: No best nullability for operands of conditional expression 'B2' and 'A<object?>'.
+                // (19,10): warning CS8626: No best nullability for operands of conditional expression 'B2' and 'A<object?>'.
                 //         (b ? y : x).P.ToString();
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "b ? y : x").WithArguments("B2", "A<object?>").WithLocation(19, 10),
                 // (19,9): warning CS8602: Possible dereference of a null reference.
@@ -1285,10 +1297,10 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (21,27): warning CS8600: Cannot convert null to non-nullable reference.
+                // (21,27): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //             Create(x).F = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(21, 27),
-                // (23,19): warning CS8600: Cannot convert null to non-nullable reference.
+                // (23,19): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //             y.F = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(23, 19));
         }
@@ -1807,28 +1819,28 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,13): warning CS8625: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
+                // (9,13): warning CS8626: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
                 //         a = c ? x : y;
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "c ? x : y").WithArguments("I<object>", "I<object?>").WithLocation(9, 13),
-                // (10,13): warning CS8625: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
+                // (10,13): warning CS8626: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
                 //         a = false ? x : y;
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "false ? x : y").WithArguments("I<object>", "I<object?>").WithLocation(10, 13),
-                // (11,13): warning CS8625: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
+                // (11,13): warning CS8626: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
                 //         a = true ? x : y;
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "true ? x : y").WithArguments("I<object>", "I<object?>").WithLocation(11, 13),
-                // (13,13): warning CS8625: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
+                // (13,13): warning CS8626: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
                 //         b = c ? x : y;
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "c ? x : y").WithArguments("I<object>", "I<object?>").WithLocation(13, 13),
                 // (13,13): warning CS8619: Nullability of reference types in value of type 'I<object>' doesn't match target type 'I<object?>'.
                 //         b = c ? x : y;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "c ? x : y").WithArguments("I<object>", "I<object?>").WithLocation(13, 13),
-                // (14,13): warning CS8625: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
+                // (14,13): warning CS8626: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
                 //         b = false ? x : y;
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "false ? x : y").WithArguments("I<object>", "I<object?>").WithLocation(14, 13),
                 // (14,13): warning CS8619: Nullability of reference types in value of type 'I<object>' doesn't match target type 'I<object?>'.
                 //         b = false ? x : y;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "false ? x : y").WithArguments("I<object>", "I<object?>").WithLocation(14, 13),
-                // (15,13): warning CS8625: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
+                // (15,13): warning CS8626: No best nullability for operands of conditional expression 'I<object>' and 'I<object?>'.
                 //         b = true ? x : y;
                 Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "true ? x : y").WithArguments("I<object>", "I<object?>").WithLocation(15, 13),
                 // (15,13): warning CS8619: Nullability of reference types in value of type 'I<object>' doesn't match target type 'I<object?>'.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_Members.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_Members.cs
@@ -212,33 +212,33 @@ class Program
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (24,13): warning CS8601: Possible null reference assignment.
+                // (24,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.A; // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.A").WithLocation(24, 13),
-                // (26,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.A").WithLocation(24, 13),
+                // (26,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.A; // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.A").WithLocation(26, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.A").WithLocation(26, 13),
                 // (28,13): warning CS8602: Possible dereference of a null reference.
                 //         o = c.B.A; // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.B").WithLocation(28, 13),
-                // (28,13): warning CS8601: Possible null reference assignment.
+                // (28,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.A; // 4
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.A").WithLocation(28, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.A").WithLocation(28, 13),
                 // (30,13): warning CS8602: Possible dereference of a null reference.
                 //         o = c.B.A; // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.B").WithLocation(30, 13),
-                // (30,13): warning CS8601: Possible null reference assignment.
+                // (30,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.A; // 5
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.A").WithLocation(30, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.A").WithLocation(30, 13),
                 // (32,13): warning CS8602: Possible dereference of a null reference.
                 //         o = c.B.A; // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(32, 13),
                 // (32,13): warning CS8602: Possible dereference of a null reference.
                 //         o = c.B.A; // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.B").WithLocation(32, 13),
-                // (32,13): warning CS8601: Possible null reference assignment.
+                // (32,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.A; // 6
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.A").WithLocation(32, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.A").WithLocation(32, 13));
         }
 
         [Fact]
@@ -285,33 +285,33 @@ class Program
                 // (17,13): warning CS8602: Possible dereference of a null reference.
                 //         o = c.A.A; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.A").WithLocation(17, 13),
-                // (17,13): warning CS8601: Possible null reference assignment.
+                // (17,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.A.A; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.A.A").WithLocation(17, 13),
-                // (18,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.A.A").WithLocation(17, 13),
+                // (18,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.F; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.F").WithLocation(18, 13),
-                // (21,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.F").WithLocation(18, 13),
+                // (21,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.A.A; // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.A.A").WithLocation(21, 13),
-                // (22,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.A.A").WithLocation(21, 13),
+                // (22,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.F; // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.F").WithLocation(22, 13),
-                // (29,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.F").WithLocation(22, 13),
+                // (29,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.A.A; // 4
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.A.A").WithLocation(29, 13),
-                // (30,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.A.A").WithLocation(29, 13),
+                // (30,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.F; // 4
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.F").WithLocation(30, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.F").WithLocation(30, 13),
                 // (32,13): warning CS8602: Possible dereference of a null reference.
                 //         o = c.A.A; // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.A").WithLocation(32, 13),
-                // (32,13): warning CS8601: Possible null reference assignment.
+                // (32,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.A.A; // 5
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.A.A").WithLocation(32, 13),
-                // (33,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.A.A").WithLocation(32, 13),
+                // (33,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.F; // 5
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.F").WithLocation(33, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.F").WithLocation(33, 13));
         }
 
         [Fact]
@@ -358,33 +358,33 @@ class Program
                 // (17,13): warning CS8602: Possible dereference of a null reference.
                 //         o = c.A.A; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.A").WithLocation(17, 13),
-                // (17,13): warning CS8601: Possible null reference assignment.
+                // (17,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.A.A; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.A.A").WithLocation(17, 13),
-                // (18,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.A.A").WithLocation(17, 13),
+                // (18,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.P; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.P").WithLocation(18, 13),
-                // (21,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.P").WithLocation(18, 13),
+                // (21,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.A.A; // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.A.A").WithLocation(21, 13),
-                // (22,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.A.A").WithLocation(21, 13),
+                // (22,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.P; // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.P").WithLocation(22, 13),
-                // (29,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.P").WithLocation(22, 13),
+                // (29,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.A.A; // 4
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.A.A").WithLocation(29, 13),
-                // (30,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.A.A").WithLocation(29, 13),
+                // (30,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.P; // 4
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.P").WithLocation(30, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.P").WithLocation(30, 13),
                 // (32,13): warning CS8602: Possible dereference of a null reference.
                 //         o = c.A.A; // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.A").WithLocation(32, 13),
-                // (32,13): warning CS8601: Possible null reference assignment.
+                // (32,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.A.A; // 5
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.A.A").WithLocation(32, 13),
-                // (33,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.A.A").WithLocation(32, 13),
+                // (33,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.P; // 5
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.B.P").WithLocation(33, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.P").WithLocation(33, 13));
         }
 
         [Fact]
@@ -421,15 +421,15 @@ class Program
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (23,13): warning CS8601: Possible null reference assignment.
+                // (23,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = b.A.F; // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b.A.F").WithLocation(23, 13),
-                // (25,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "b.A.F").WithLocation(23, 13),
+                // (25,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = b.G; // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b.G").WithLocation(25, 13),
-                // (26,13): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "b.G").WithLocation(25, 13),
+                // (26,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = b.A.F; // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "b.A.F").WithLocation(26, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "b.A.F").WithLocation(26, 13));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Handle struct properties that are not auto-properties.
@@ -456,9 +456,9 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (13,13): warning CS8601: Possible null reference assignment.
+                // (13,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = F.P; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "F.P").WithLocation(13, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "F.P").WithLocation(13, 13));
         }
 
         [Fact]
@@ -483,9 +483,9 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (12,13): warning CS8601: Possible null reference assignment.
+                // (12,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = F.P; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "F.P").WithLocation(12, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "F.P").WithLocation(12, 13));
         }
 
         [Fact]
@@ -514,9 +514,9 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8601: Possible null reference assignment.
+                // (8,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = F.P; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "F.P").WithLocation(8, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "F.P").WithLocation(8, 13));
         }
 
         [Fact]
@@ -537,9 +537,9 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8601: Possible null reference assignment.
+                // (8,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = P; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P").WithLocation(8, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "P").WithLocation(8, 13));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Handle struct properties that are not auto-properties.
@@ -565,9 +565,9 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (12,13): warning CS8601: Possible null reference assignment.
+                // (12,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = F.P; // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "F.P").WithLocation(12, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "F.P").WithLocation(12, 13));
         }
 
         // Calling a method should reset the state for members.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -173,7 +173,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             comp.VerifyDiagnostics(
                 // (5,20): warning CS8600: Cannot convert null to non-nullable reference.
                 //         string s = default;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(5, 20));
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(5, 20),
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         s.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9));
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -277,6 +280,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 // (5,15): warning CS8600: Cannot convert null to non-nullable reference.
                 //         T s = default;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(5, 15),
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         s.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(8, 9));
@@ -314,7 +320,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             comp.VerifyDiagnostics(
                 // (7,13): warning CS8600: Cannot convert null to non-nullable reference.
                 //         s = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 13));
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 13),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         s.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9));
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -171,9 +171,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (5,20): warning CS8600: Cannot convert null to non-nullable reference.
+                // (5,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         string s = default;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(5, 20),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(5, 20),
                 // (6,9): warning CS8602: Possible dereference of a null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9));
@@ -277,9 +277,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (5,15): warning CS8600: Cannot convert null to non-nullable reference.
+                // (5,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T s = default;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(5, 15),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(5, 15),
                 // (6,9): warning CS8602: Possible dereference of a null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9),
@@ -318,9 +318,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (7,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 13),
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(7, 13),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9));
@@ -440,9 +440,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (11,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (11,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         t = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(11, 13));
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -1480,9 +1480,9 @@ static class E
                 // (6,9): warning CS8602: Possible dereference of a null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9),
-                // (9,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (9,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(9, 13));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Deconstruction declaration ignores nullability.
@@ -1510,9 +1510,9 @@ static class E
                 // (7,9): warning CS8602: Possible dereference of a null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9),
-                // (10,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (10,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(10, 13));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Deconstruction declaration ignores nullability.
@@ -1544,9 +1544,9 @@ static class E
                 // (11,9): warning CS8602: Possible dereference of a null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(11, 9),
-                // (14,13): warning CS8600: Cannot convert null to non-nullable reference.
+                // (14,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(14, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(14, 13));
         }
 
         [Fact]
@@ -1572,7 +1572,7 @@ static class E
                 references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (11,15): warning CS8600: Cannot convert null to non-nullable reference.
+                // (11,15): warning CS8625: Cannot convert null literal to non-nullable reference.
                 //         t.x = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 15));
         }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -263,7 +263,7 @@ class X
                         case ErrorCode.WRN_UnreferencedLocalFunction:
                             Assert.Equal(3, ErrorFacts.GetWarningLevel(errorCode));
                             break;
-                        case ErrorCode.WRN_NullAsNonNullable:
+                        case ErrorCode.WRN_ConvertingNullableToNonNullable:
                         case ErrorCode.WRN_NullReferenceAssignment:
                         case ErrorCode.WRN_NullReferenceReceiver:
                         case ErrorCode.WRN_NullReferenceReturn:
@@ -283,6 +283,7 @@ class X
                         case ErrorCode.WRN_NullabilityMismatchInArgument:
                         case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:
                         case ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate:
+                        case ErrorCode.WRN_NullAsNonNullable:
                         case ErrorCode.WRN_NoBestNullabilityConditionalExpression:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -103,8 +103,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 isBaseConversion: true,
                 @checked: false,
                 explicitCastInCode: false,
+                isExplicitlyNullable: false,
                 constantValueOpt: null,
-                isNullable: null,
                 type: baseType,
                 hasErrors: !conversion.IsValid)
             { WasCompilerGenerated = true };

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 @checked: false,
                 explicitCastInCode: false,
                 constantValueOpt: null,
-                isNullable: false,
+                isNullable: null,
                 type: baseType,
                 hasErrors: !conversion.IsValid)
             { WasCompilerGenerated = true };

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -104,6 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 @checked: false,
                 explicitCastInCode: false,
                 constantValueOpt: null,
+                isNullable: false,
                 type: baseType,
                 hasErrors: !conversion.IsValid)
             { WasCompilerGenerated = true };

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -187,6 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 conversion,
                 @checked: false,
                 explicitCastInCode: false,
+                isExplicitlyNullable: false,
                 constantValueOpt: null,
                 type: type,
                 hasErrors: !conversion.IsValid);


### PR DESCRIPTION
Adds a new warning `CS8600: Converting null literal or possible null value to non-nullable value`. The warning is used for assignment to non-nullable local or parameter and for explicit cast of nullable value to non-nullable.
```
object x = null; // warning
object y = MaybeNull(); // warning
F((string)MaybeNull()); // warning
```
The intention is to provide a single warning that can be disabled separately from other warnings to reduce the noise when recompiling legacy code.

Note: First commit is #25411.