### PR TITLE
Fix ForegroundThreadAffinitizedObject.InvokeBelowInputPriority on non…

### DIFF
--- a/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
@@ -150,6 +150,12 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
         /// </summary>
         protected bool IsInputPending()
         {
+            // The code below invokes into user32.dll, which is not available in non-Windows.
+            if (PlatformInformation.IsUnix)
+            {
+                return false;
+            }
+
             // The return value of GetQueueStatus is HIWORD:LOWORD.
             // A non-zero value in HIWORD indicates some input message in the queue.
             uint result = NativeMethods.GetQueueStatus(NativeMethods.QS_INPUT);


### PR DESCRIPTION
…-Windows

The code was invoking into user32.dll, thus causing an exception on non-Windows. The end result of this was that all actions using this were discarded.

Not sure which default would be better, either true or false, but this should unblock the issue.

Probably a better fix would be to have a `EditorFeatures.Wpf` layer AffinizedThreadObject implementation so it doesn't use runtime checks for the platform.

<details><summary>Ask Mode template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Trying to use Roslyn in VS for Mac is crashing.

### Bugs this fixes

#25525

### Workarounds, if any

Nope.

### Risk

Very low: simple check.

### Performance impact

None.

### Is this a regression from a previous update?

No, spotted under new bringup.

### Root cause analysis

Our "cross platform" portion still had a P/Invoke to Windows code. This avoids calling the P/Invoke on non-windows platforms.

### How was the bug found?

New feature bringup.

</details>
