### PR TITLE
Removing package dependency for Microsoft.VisualStudio.Text.UI.Wpf

### DIFF
--- a/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
+++ b/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
@@ -43,8 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />    
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="CSharpEditorResources.resx">

--- a/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
+++ b/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />    
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="CSharpEditorResources.resx">

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -29,14 +29,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
-    <!-- This package is no longer being consumed by the build, but failure to have this line means the dependency
-         on Microsoft.VisualStudio.Text.Internal will consume a really old version of Microsoft.VisualStudio.Text.UI.Wpf
-         which doesn't have the type forwards to the new Microsoft.VisualStudio.Text.UI. By including this and then
-         saying ExcludeAssets=all, we ensure the package graph is sane but doesn't pull in what we don't want.
-         This line can be deleted once we move off of Microsoft.VisualStudio.Text.Internal. -->
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)">
-      <ExcludeAssets>all</ExcludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Version="$(MicrosoftCodeAnalysisElfieVersion)" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="$(ICSharpCodeDecompilerVersion)" />
   </ItemGroup>


### PR DESCRIPTION
<details><summary>Removing package dependency for Microsoft.VisualStudio.Text.UI.Wpf in EditorFeatures and CSharpEditorFeatures projects</summary>

### Customer scenario
These non-wpf projects should not refer to the Microsoft.VisualStudio.Text.UI.Wpf package.

### Bugs this fixes
https://github.com/dotnet/roslyn/issues/24162

### Workarounds, if any
No

### Risk
Low, these projects do not use the Microsoft.VisualStudio.Text.UI.Wpf package.

### Performance impact
No

### Is this a regression from a previous update?
No

### Root cause analysis
NA

### How was the bug found?
We found it when working on a bug customer reported.

### Test documentation updated?
NA

</details>
