### PR TITLE
Fixed DDRIT failure

### DIFF
--- a/src/EditorFeatures/Text/Extensions.TextBufferContainer.cs
+++ b/src/EditorFeatures/Text/Extensions.TextBufferContainer.cs
@@ -105,6 +105,9 @@ namespace Microsoft.CodeAnalysis.Text
                     return;
                 }
 
+                // we should process all changes even though there is no text changes
+                // otherwise, Workspace.CurrentSolution won't move forward to latest ITextSnapshot
+
                 // this should convert given editor snapshots to roslyn forked snapshots
                 var oldText = (SnapshotSourceText)args.Before.AsText();
                 var newText = SnapshotSourceText.From(args.After);

--- a/src/EditorFeatures/Text/Extensions.TextBufferContainer.cs
+++ b/src/EditorFeatures/Text/Extensions.TextBufferContainer.cs
@@ -100,18 +100,21 @@ namespace Microsoft.CodeAnalysis.Text
             private void OnTextContentChanged(object sender, TextContentChangedEventArgs args)
             {
                 var changed = this.EtextChanged;
-                if (changed != null && args.Changes.Count != 0)
+                if (changed == null)
                 {
-                    // this should convert given editor snapshots to roslyn forked snapshots
-                    var oldText = (SnapshotSourceText)args.Before.AsText();
-                    var newText = SnapshotSourceText.From(args.After);
-                    _currentText = newText;
-
-                    var changes = ImmutableArray.CreateRange(args.Changes.Select(c => new TextChangeRange(new TextSpan(c.OldSpan.Start, c.OldSpan.Length), c.NewLength)));
-                    var eventArgs = new TextChangeEventArgs(oldText, newText, changes);
-                    this.LastEventArgs = eventArgs;
-                    changed(sender, eventArgs);
+                    return;
                 }
+
+                // this should convert given editor snapshots to roslyn forked snapshots
+                var oldText = (SnapshotSourceText)args.Before.AsText();
+                var newText = SnapshotSourceText.From(args.After);
+                _currentText = newText;
+
+                var changes = ImmutableArray.CreateRange(args.Changes.Select(c => new TextChangeRange(new TextSpan(c.OldSpan.Start, c.OldSpan.Length), c.NewLength)));
+                var eventArgs = new TextChangeEventArgs(oldText, newText, changes);
+
+                this.LastEventArgs = eventArgs;
+                changed(sender, eventArgs);
             }
 
             // These are the event args that were last sent from this text container when the text


### PR DESCRIPTION
fixed issue workspace not raising events if ITextBuffer change doesn't include any text change. 
- this is a problem since Workspace won't move forward to latest ITextSnapshot. this is due to this PR 
(https://github.com/dotnet/roslyn/pull/24849)
...

### Customer scenario

No user facing change.

### Bugs this fixes

N/A

### Workarounds, if any

No workaround.

### Risk

No risk

### Performance impact

it should let us to be slightly more efficient before by not forking solution from Workspace.CurrentSolution unnecessarily.

### Is this a regression from a previous update?

Yes

### Root cause analysis

We used to share same SourceText for different ITextSnapshots if contents are same. which caused some issues since we expect SourceText to ITextSnapshot is 1:1 map. not 1:n map. 

when that is fixed, I forgot to remove optimization in ETextChange event where it swallows events if contents are same.

### How was the bug found?

Testing (DDRIT)

