### PR TITLE
fixed MEF composition failure

### DIFF
--- a/src/Features/CSharp/Portable/GenerateEqualsAndGetHashCodeFromMembers/CSharpGenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/GenerateEqualsAndGetHashCodeFromMembers/CSharpGenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
@@ -10,10 +10,6 @@ using Microsoft.CodeAnalysis.PickMembers;
 
 namespace Microsoft.CodeAnalysis.CSharp.GenerateEqualsAndGetHashCodeFromMembers
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp,
-        Name = PredefinedCodeRefactoringProviderNames.GenerateEqualsAndGetHashCodeFromMembers), Shared]
-    [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.GenerateConstructorFromMembers,
-                    Before = PredefinedCodeRefactoringProviderNames.AddConstructorParametersFromMembers)]
     internal class CSharpGenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider 
         : AbstractGenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider
     {


### PR DESCRIPTION
### Customer scenario

User couldn't use Generate Equals and GetHashCode refactoring.

### Bugs this fixes

N/A

### Workarounds, if any

No

### Risk

No

### Performance impact

N/A

### Is this a regression from a previous update?

Yes

### Root cause analysis

MEF export wasn't removed when code got refactored.

### How was the bug found?

DDRIT

