### PR TITLE
Add names to code refactoring providers which don't have one

### DIFF
--- a/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerCodeRefactoringProvider.cs
@@ -6,7 +6,8 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 
 namespace Microsoft.CodeAnalysis.CSharp.AddFileBanner
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp), Shared]
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp,
+        Name = PredefinedCodeRefactoringProviderNames.AddFileBanner), Shared]
     internal class CSharpAddFileBannerCodeRefactoringProvider : AbstractAddFileBannerCodeRefactoringProvider
     {
         protected override bool IsCommentStartCharacter(char ch)

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -7,7 +7,8 @@ using Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag;
 
 namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp), Shared]
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp,
+        Name = PredefinedCodeRefactoringProviderNames.ReplaceDocCommentTextWithTag), Shared]
     internal class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider :
         AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
     {

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -15,7 +15,8 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp), Shared]
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp,
+        Name = PredefinedCodeRefactoringProviderNames.UseExpressionBody), Shared]
     internal class UseExpressionBodyCodeRefactoringProvider : CodeRefactoringProvider
     {
         private static readonly ImmutableArray<UseExpressionBodyHelper> _helpers = UseExpressionBodyHelper.Helpers;

--- a/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
@@ -4,6 +4,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 {
     internal static class PredefinedCodeRefactoringProviderNames
     {
+        public const string AddFileBanner = "Add Banner To File Code Action Provider";
         public const string AddConstructorParametersFromMembers = "Add Parameters From Members Code Action Provider";
         public const string ChangeSignature = "Change Signature Code Action Provider";
         public const string EncapsulateField = "Encapsulate Field";
@@ -20,6 +21,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         public const string SimplifyLambda = "Simplify Lambda Code Action Provider";
         public const string ConvertToInterpolatedString = "Convert To Interpolated String Code Action Provider";
         public const string MoveTypeToFile = "Move Type To File Code Action Provider";
+        public const string ReplaceDocCommentTextWithTag = "Replace Documentation Comment Text With Tag Code Action Provider";
         public const string UseExplicitType = "Use Explicit Type Code Action Provider";
+        public const string UseExpressionBody = "Use Expression Body Code Action Provider";
     }
 }

--- a/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
@@ -6,7 +6,7 @@ Imports Microsoft.CodeAnalysis.CodeRefactorings
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.AddFileBanner
     <ExportCodeRefactoringProvider(LanguageNames.VisualBasic,
-        Name := PredefinedCodeRefactoringProviderNames.AddFileBanner), [Shared]>
+        Name:=PredefinedCodeRefactoringProviderNames.AddFileBanner), [Shared]>
     Friend Class VisualBasicAddFileBannerCodeRefactoringProvider
         Inherits AbstractAddFileBannerCodeRefactoringProvider
 

--- a/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
@@ -5,7 +5,8 @@ Imports Microsoft.CodeAnalysis.AddFileBanner
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.AddFileBanner
-    <ExportCodeRefactoringProvider(LanguageNames.VisualBasic), [Shared]>
+    <ExportCodeRefactoringProvider(LanguageNames.VisualBasic,
+        Name := PredefinedCodeRefactoringProviderNames.AddFileBanner), [Shared]>
     Friend Class VisualBasicAddFileBannerCodeRefactoringProvider
         Inherits AbstractAddFileBannerCodeRefactoringProvider
 

--- a/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
@@ -6,7 +6,7 @@ Imports Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
     <ExportCodeRefactoringProvider(LanguageNames.VisualBasic,
-        Name := PredefinedCodeRefactoringProviderNames.ReplaceDocCommentWithTextTag), [Shared]>
+        Name:=PredefinedCodeRefactoringProviderNames.ReplaceDocCommentTextWithTag), [Shared]>
     Friend Class VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider
         Inherits AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
 

--- a/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
@@ -5,7 +5,8 @@ Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
-    <ExportCodeRefactoringProvider(LanguageNames.VisualBasic), [Shared]>
+    <ExportCodeRefactoringProvider(LanguageNames.VisualBasic,
+        Name := PredefinedCodeRefactoringProviderNames.ReplaceDocCommentWithTextTag), [Shared]>
     Friend Class VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider
         Inherits AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
 


### PR DESCRIPTION
We have a few code refactorings showing up in our configuration UI which don't have names. The problem is from roslyn, as these don't have names. I've also added the VB counterparts missing names.

See https://github.com/mono/monodevelop/issues/4218

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
