### PR TITLE
[wip for review] Accessor specific search

### DIFF
--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
 {
     internal abstract partial class AbstractFindUsagesService : IFindUsagesService
     {
+        public static SymbolFinderOptions DefaultSymbolFinderOptions = new SymbolFinderOptions(searchAccessorsAsContainingMember: false, includeImplicitAccessorUsages: true);
+
         public async Task FindImplementationsAsync(
             Document document, int position, IFindUsagesContext context)
         {
@@ -134,10 +136,6 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 FindUsagesHelpers.GetDisplayName(symbol))).ConfigureAwait(false);
             var progressAdapter = new FindReferencesProgressAdapter(project.Solution, context);
 
-            var options = symbol.IsAccessor()
-                    ? new SymbolFinderOptions(cascade: false, includeImplicitAccessorUsages: true)
-                    : SymbolFinderOptions.Default;
-
             // Now call into the underlying FAR engine to find reference.  The FAR
             // engine will push results into the 'progress' instance passed into it.
             // We'll take those results, massage them, and forward them along to the 
@@ -147,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 project.Solution,
                 progressAdapter,
                 documents: null,
-                options,
+                DefaultSymbolFinderOptions,
                 cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
@@ -134,6 +134,10 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 FindUsagesHelpers.GetDisplayName(symbol))).ConfigureAwait(false);
             var progressAdapter = new FindReferencesProgressAdapter(project.Solution, context);
 
+            var options = symbol.IsAccessor()
+                    ? new SymbolFinderOptions(cascade: false, includeImplicitAccessorUsages: true)
+                    : SymbolFinderOptions.Default;
+
             // Now call into the underlying FAR engine to find reference.  The FAR
             // engine will push results into the 'progress' instance passed into it.
             // We'll take those results, massage them, and forward them along to the 
@@ -143,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 project.Solution,
                 progressAdapter,
                 documents: null,
-                SymbolFinderOptions.Default,
+                options,
                 cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
@@ -143,7 +143,8 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 project.Solution,
                 progressAdapter,
                 documents: null,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                SymbolFinderOptions.Default,
+                cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<bool> TryFindLiteralReferencesAsync(

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
@@ -893,5 +893,51 @@ End Class
 </Workspace>
             Await TestAPIAndFeature(input)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_GetterReferences() As Task
+            Await TestAPIAndFeature(
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class A
+{
+    public int P { {|Definition:$$get|}; set; }
+    
+    public void M()
+    {
+        _ = nameof(P); // References neither accessor
+        _ = [|P|];     // References getter only
+        P = 0;         // References setter only
+        [|P|]++;       // References both accessors
+    }
+}
+        </Document>
+    </Project>
+</Workspace>)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_SetterReferences() As Task
+            Await TestAPIAndFeature(
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class A
+{
+    public int P { get; {|Definition:$$set|}; }
+    
+    public void M()
+    {
+        _ = nameof(P); // References neither accessor
+        _ = P;         // References getter only
+        [|P|] = 0;     // References setter only
+        [|P|]++;       // References both accessors
+    }
+}
+        </Document>
+    </Project>
+</Workspace>)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -188,7 +188,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
 
                         Dim scope = If(searchSingleFileOnly, ImmutableHashSet.Create(Of Document)(document), Nothing)
 
-                        result = result.Concat(Await SymbolFinder.FindReferencesAsync(symbol, document.Project.Solution, progress:=Nothing, documents:=scope))
+                        result = result.Concat(
+                            Await SymbolFinder.FindReferencesAsync(
+                                symbol,
+                                document.Project.Solution,
+                                progress:=Nothing,
+                                documents:=scope,
+                                options:=AbstractFindUsagesService.DefaultSymbolFinderOptions))
                     End If
 
                     Dim actualDefinitions =

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -468,6 +468,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
                 solution: invocationDocument.Project.Solution,
                 documents: null,
                 progress: progress,
+                options: SymbolFinderOptions.Default,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
             var referencedSymbols = progress.GetReferencedSymbols();
             return referencedSymbols.Select(referencedSymbol => referencedSymbol.Definition)

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -187,6 +187,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                     documents,
                     ReferenceFinders.DefaultReferenceFinders.Add(DelegateInvokeMethodReferenceFinder.DelegateInvokeMethod),
                     streamingProgress,
+                    SymbolFinderOptions.Default,
                     cancellationToken);
 
                 await engine.FindReferencesAsync(symbolAndProjectId).ConfigureAwait(false);

--- a/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
+++ b/src/Features/Core/Portable/ChangeSignature/DelegateInvokeMethodReferenceFinder.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -35,6 +34,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             SymbolAndProjectId<IMethodSymbol> symbolAndProjectId,
             Solution solution,
             IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var result = ImmutableArray.CreateBuilder<SymbolAndProjectId>();
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             IMethodSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return Task.FromResult(project.Documents.ToImmutableArray());
@@ -73,6 +74,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             IMethodSymbol methodSymbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // FAR on the Delegate type and use those results to find Invoke calls

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -111,8 +111,12 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                 var progress = new StreamingProgressCollector(
                     StreamingFindReferencesProgress.Instance);
                 await SymbolFinder.FindReferencesAsync(
-                    symbolAndProjectId, document.Project.Solution, progress,
-                    documentsToSearch, cancellationToken).ConfigureAwait(false);
+                    symbolAndProjectId,
+                    document.Project.Solution,
+                    progress,
+                    documentsToSearch,
+                    SymbolFinderOptions.Default,
+                    cancellationToken).ConfigureAwait(false);
 
                 return await FilterAndCreateSpansAsync(
                     progress.GetReferencedSymbols(), document, documentsToSearch,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             _solution = solution;
             _finders = finders;
             _progress = progress;
-            _options = options;
+            _options = options ?? SymbolFinderOptions.Default;
             _cancellationToken = cancellationToken;
             _dependencyGraph = solution.GetProjectDependencyGraph();
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private readonly ImmutableArray<IReferenceFinder> _finders;
         private readonly StreamingProgressTracker _progressTracker;
         private readonly IStreamingFindReferencesProgress _progress;
+        private readonly SymbolFinderOptions _options;
         private readonly CancellationToken _cancellationToken;
         private readonly ProjectDependencyGraph _dependencyGraph;
 
@@ -40,12 +41,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             IImmutableSet<Document> documents,
             ImmutableArray<IReferenceFinder> finders,
             IStreamingFindReferencesProgress progress,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             _documents = documents;
             _solution = solution;
             _finders = finders;
             _progress = progress;
+            _options = options;
             _cancellationToken = cancellationToken;
             _dependencyGraph = solution.GetProjectDependencyGraph();
 
@@ -88,7 +91,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 // it.
                 // For each connected component, we'll process the individual projects from bottom to
                 // top.  i.e. we'll first process the projects with no dependencies.  Then the projects
-                // that depend on those projects, and so and.  This way we always have creates the 
+                // that depend on those projects, and so and.  This way we always have creates the
                 // dependent compilations when they're needed by later projects.  If we went the other
                 // way (i.e. processed the projects with lots of project dependencies first), then we'd
                 // have to create all their depedent compilations in order to get their compilation.

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_DocumentProcessing.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_DocumentProcessing.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 try
                 {
-                    var references = await finder.FindReferencesInDocumentAsync(symbolAndProjectId, document, semanticModel, _cancellationToken).ConfigureAwait(false);
+                    var references = await finder.FindReferencesInDocumentAsync(symbolAndProjectId, document, semanticModel, _options, _cancellationToken).ConfigureAwait(false);
                     foreach (var location in references)
                     {
                         await HandleLocationAsync(symbolAndProjectId, location).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMemberScopedReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMemberScopedReferenceFinder.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             TSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var location = symbol.Locations.FirstOrDefault();
@@ -50,6 +51,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             TSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var container = GetContainer(symbol);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             SymbolAndProjectId<TSymbol> symbolAndProjectId,
             Solution solution,
             IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // Static methods can't cascade.

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorInitializerSymbolReferenceFinder.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -23,6 +21,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return FindDocumentsAsync(project, documents, async (d, c) =>
@@ -54,6 +53,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol methodSymbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var syntaxFactsService = document.GetLanguageService<ISyntaxFactsService>();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -29,6 +28,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var typeName = symbol.ContainingType.Name;
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol methodSymbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return FindAllReferencesInDocumentAsync(methodSymbol, document, semanticModel, cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +18,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             SymbolAndProjectId<IMethodSymbol> symbol,
             Solution solution,
             IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return SpecializedTasks.EmptyImmutableArray<SymbolAndProjectId>();
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return SpecializedTasks.EmptyImmutableArray<Document>();
@@ -37,6 +38,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol methodSymbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return SpecializedTasks.EmptyImmutableArray<ReferenceLocation>();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 {
@@ -20,10 +17,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<SymbolAndProjectId>> DetermineCascadedSymbolsAsync(
             SymbolAndProjectId<IEventSymbol> symbolAndProjectId,
             Solution solution, 
-            IImmutableSet<Project> projects, 
+            IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
-            var baseSymbols = await base.DetermineCascadedSymbolsAsync(symbolAndProjectId, solution, projects, cancellationToken).ConfigureAwait(false);
+            var baseSymbols = await base.DetermineCascadedSymbolsAsync(symbolAndProjectId, solution, projects, options, cancellationToken).ConfigureAwait(false);
 
             var symbol = symbolAndProjectId.Symbol;
             var backingFields = symbol.ContainingType.GetMembers()
@@ -45,6 +43,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IEventSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return FindDocumentsAsync(project, documents, cancellationToken, symbol.Name);
@@ -54,6 +53,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IEventSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return FindReferencesInDocumentUsingSymbolNameAsync(symbol, document, semanticModel, cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -20,6 +19,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             SymbolAndProjectId<IMethodSymbol> symbolAndProjectId,
             Solution solution,
             IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // An explicit interface method will cascade to all the methods that it implements.
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // An explicit method can't be referenced anywhere.
@@ -42,6 +43,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // An explicit method can't be referenced anywhere.

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +18,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             SymbolAndProjectId<IFieldSymbol> symbolAndProjectId,
             Solution solution,
             IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var symbol = symbolAndProjectId.Symbol;
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IFieldSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return FindDocumentsAsync(project, documents, cancellationToken, symbol.Name);
@@ -46,6 +47,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IFieldSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return FindReferencesInDocumentUsingSymbolNameAsync(symbol, document, semanticModel, cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// Implementations of this method must be thread-safe.
         /// </summary>
         Task<ImmutableArray<SymbolAndProjectId>> DetermineCascadedSymbolsAsync(
-            SymbolAndProjectId symbolAndProject, Solution solution, IImmutableSet<Project> projects, CancellationToken cancellationToken);
+            SymbolAndProjectId symbolAndProject, Solution solution, IImmutableSet<Project> projects, SymbolFinderOptions options, CancellationToken cancellationToken);
 
         /// <summary>
         /// Called by the find references search engine to determine which projects should be
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// Implementations of this method must be thread-safe.
         /// </summary>
         Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
-            ISymbol symbol, Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken);
+            ISymbol symbol, Project project, IImmutableSet<Document> documents, SymbolFinderOptions options, CancellationToken cancellationToken);
 
         /// <summary>
         /// Called by the find references search engine to determine the set of reference locations
@@ -65,6 +65,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// Implementations of this method must be thread-safe.
         /// </summary>
         Task<ImmutableArray<ReferenceLocation>> FindReferencesInDocumentAsync(
-            SymbolAndProjectId symbolAndProjectId, Document document, SemanticModel semanticModel, CancellationToken cancellationToken);
+            SymbolAndProjectId symbolAndProjectId, Document document, SemanticModel semanticModel, SymbolFinderOptions options, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/LinkedFileReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/LinkedFileReferenceFinder.cs
@@ -12,7 +12,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
     internal class LinkedFileReferenceFinder : IReferenceFinder
     {
         public async Task<ImmutableArray<SymbolAndProjectId>> DetermineCascadedSymbolsAsync(
-            SymbolAndProjectId symbolAndProjectId, Solution solution, IImmutableSet<Project> projects = null, CancellationToken cancellationToken = default)
+            SymbolAndProjectId symbolAndProjectId, Solution solution, IImmutableSet<Project> projects = null,
+            SymbolFinderOptions options = null, CancellationToken cancellationToken = default)
         {
             var linkedSymbols = new HashSet<SymbolAndProjectId>();
 
@@ -62,7 +63,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return linkedSymbols.ToImmutableArray();
         }
 
-        public Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(ISymbol symbol, Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken = default)
+        public Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(ISymbol symbol, Project project, IImmutableSet<Document> documents, SymbolFinderOptions options, CancellationToken cancellationToken = default)
         {
             return SpecializedTasks.EmptyImmutableArray<Document>();
         }
@@ -73,7 +74,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         }
 
         public Task<ImmutableArray<ReferenceLocation>> FindReferencesInDocumentAsync(
-            SymbolAndProjectId symbolAndProjectId, Document document, SemanticModel semanticModel, CancellationToken cancellationToken = default)
+            SymbolAndProjectId symbolAndProjectId, Document document, SemanticModel semanticModel, SymbolFinderOptions options, CancellationToken cancellationToken = default)
         {
             return SpecializedTasks.EmptyImmutableArray<ReferenceLocation>();
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +18,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             SymbolAndProjectId<ITypeParameterSymbol> symbolAndProjectId,
             Solution solution,
             IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var symbol = symbolAndProjectId.Symbol;
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             ITypeParameterSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // Type parameters are only found in documents that have both their name, and the name
@@ -76,6 +77,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             ITypeParameterSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // TODO(cyrusn): Method type parameters are like locals.  They are only in scope in

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -23,6 +22,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             SymbolAndProjectId<INamedTypeSymbol> symbolAndProjectId,
             Solution solution,
             IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var result = ArrayBuilder<SymbolAndProjectId>.GetInstance();
@@ -55,6 +55,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             INamedTypeSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var documentsWithName = await FindDocumentsAsync(project, documents, cancellationToken, symbol.Name).ConfigureAwait(false);
@@ -81,6 +82,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             INamedTypeSymbol namedType,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var namedTypereferences = await FindReferencesInDocumentWorker(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -24,6 +21,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             INamespaceSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return FindDocumentsAsync(project, documents, cancellationToken, GetNamespaceIdentifierName(symbol, project));
@@ -40,6 +38,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             INamespaceSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var identifierName = GetNamespaceIdentifierName(symbol, document.Project);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,6 +19,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var op = symbol.GetPredefinedOperator();
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             SymbolAndProjectId<IMethodSymbol> symbolAndProjectId,
             Solution solution,
             IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // If it's a delegate method, then cascade to the type as well.  These guys are
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             else
             {
                 var otherPartsOfPartial = GetOtherPartsOfPartial(symbolAndProjectId);
-                var baseCascadedSymbols = await base.DetermineCascadedSymbolsAsync(symbolAndProjectId, solution, projects, cancellationToken).ConfigureAwait(false);
+                var baseCascadedSymbols = await base.DetermineCascadedSymbolsAsync(symbolAndProjectId, solution, projects, options, cancellationToken).ConfigureAwait(false);
 
                 if (otherPartsOfPartial == null && baseCascadedSymbols == null)
                 {
@@ -71,6 +72,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol methodSymbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // TODO(cyrusn): Handle searching for IDisposable.Dispose (or an implementation
@@ -114,6 +116,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IMethodSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ParameterSymbolReferenceFinder.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 {
@@ -24,6 +23,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IParameterSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // TODO(cyrusn): We can be smarter with parameters.  They will either be found
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IParameterSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var symbolsMatch = GetParameterSymbolsMatchFunction(
@@ -98,6 +99,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             SymbolAndProjectId<IParameterSymbol> parameterAndProjectId,
             Solution solution,
             IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var parameter = parameterAndProjectId.Symbol;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 {
@@ -19,29 +19,105 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<SymbolAndProjectId>> DetermineCascadedSymbolsAsync(
             SymbolAndProjectId<IMethodSymbol> symbolAndProjectId,
             Solution solution,
-            IImmutableSet<Project> projects,
+            IImmutableSet<Project> projects, 
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var result = await base.DetermineCascadedSymbolsAsync(
-                symbolAndProjectId, solution, projects, cancellationToken).ConfigureAwait(false);
+                symbolAndProjectId, solution, projects, options, cancellationToken).ConfigureAwait(false);
 
-            var symbol = symbolAndProjectId.Symbol;
-            if (symbol.AssociatedSymbol != null)
+            if ((options ?? SymbolFinderOptions.Default).SearchAccessorsAsContainingMember)
             {
-                result = result.Add(symbolAndProjectId.WithSymbol(symbol.AssociatedSymbol));
+                var symbol = symbolAndProjectId.Symbol;
+                if (symbol.AssociatedSymbol != null)
+                {
+                    result = result.Add(symbolAndProjectId.WithSymbol(symbol.AssociatedSymbol));
+                }
             }
 
             return result;
         }
 
-        protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(IMethodSymbol symbol, Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
+        protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(IMethodSymbol symbol, Project project, IImmutableSet<Document> documents, SymbolFinderOptions options, CancellationToken cancellationToken)
         {
-            return FindDocumentsAsync(project, documents, cancellationToken, symbol.Name);
+            var namesToIncludeInSearch =
+                options.IncludeImplicitAccessorUsages && symbol.AssociatedSymbol is IPropertySymbol property
+                    ? new[] { symbol.Name, property.Name }
+                    : new[] { symbol.Name };
+
+            return FindDocumentsAsync(
+                project,
+                documents,
+                documentIndex => namesToIncludeInSearch.Any(documentIndex.ProbablyContainsIdentifier),
+                cancellationToken);
         }
 
-        protected override Task<ImmutableArray<ReferenceLocation>> FindReferencesInDocumentAsync(IMethodSymbol symbol, Document document, SemanticModel semanticModel, CancellationToken cancellationToken)
+        protected override async Task<ImmutableArray<ReferenceLocation>> FindReferencesInDocumentAsync(IMethodSymbol symbol, Document document, SemanticModel semanticModel, SymbolFinderOptions options, CancellationToken cancellationToken)
         {
-            return FindReferencesInDocumentUsingSymbolNameAsync(symbol, document, semanticModel, cancellationToken);
+            var explicitReferences = await FindReferencesInDocumentUsingSymbolNameAsync(symbol, document, semanticModel, cancellationToken).ConfigureAwait(false);
+
+            var property = symbol.AssociatedSymbol as IPropertySymbol;
+            if (property == null || !options.IncludeImplicitAccessorUsages)
+            {
+                return explicitReferences;
+            }
+
+            // Picks up whatever an IPropertySymbol search would find, e.g. foreach and element access.
+            // Each of these is a candidate implicit reference.
+            var propertyReferences = await ReferenceFinders.Property.FindReferencesInDocumentAsync(
+                SymbolAndProjectId.Create(property, document.Project.Id),
+                document,
+                semanticModel,
+                options,
+                cancellationToken).ConfigureAwait(false);
+
+            var results = ImmutableArray.CreateBuilder<ReferenceLocation>();
+            results.AddRange(explicitReferences);
+
+            var semanticFactsService = document.GetLanguageService<ISemanticFactsService>();
+            var isSetterSearch = symbol == property.SetMethod;
+
+            foreach (var propertyReference in propertyReferences)
+            {
+                if (isSetterSearch) 
+                {
+                    if (!propertyReference.IsWrittenTo)
+                    {
+                        continue;
+                    }
+                }
+                else
+                {
+                    if (!IsPropertyReadFrom(propertyReference, semanticModel, semanticFactsService, cancellationToken))
+                    {
+                        continue;
+                    }
+                }
+
+                results.Add(new ReferenceLocation(
+                    document,
+                    propertyReference.Alias,
+                    propertyReference.Location,
+                    isImplicit: true,
+                    propertyReference.IsWrittenTo,
+                    propertyReference.CandidateReason));
+            }
+
+            return results.ToImmutable();
+        }
+
+        private static bool IsPropertyReadFrom(ReferenceLocation propertyReference, SemanticModel semanticModel, ISemanticFactsService semanticFactsService, CancellationToken cancellationToken)
+        {
+            if (propertyReference.IsWrittenTo)
+            {
+                // If it’s not only written to, it’s read from.
+                return !semanticFactsService.IsOnlyWrittenTo(semanticModel, propertyReference.Location.FindNode(cancellationToken), cancellationToken);
+            }
+            else
+            {
+                // If it’s a nameof expression, neither accessor is involved.
+                return !semanticFactsService.IsNameOfContext(semanticModel, propertyReference.Location.SourceSpan.Start, cancellationToken);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
@@ -22,10 +22,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override async Task<ImmutableArray<SymbolAndProjectId>> DetermineCascadedSymbolsAsync(
             SymbolAndProjectId<IPropertySymbol> symbolAndProjectId, 
             Solution solution, 
-            IImmutableSet<Project> projects, 
+            IImmutableSet<Project> projects,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
-            var baseSymbols = await base.DetermineCascadedSymbolsAsync(symbolAndProjectId, solution, projects, cancellationToken).ConfigureAwait(false);
+            var baseSymbols = await base.DetermineCascadedSymbolsAsync(symbolAndProjectId, solution, projects, options, cancellationToken).ConfigureAwait(false);
 
             var symbol = symbolAndProjectId.Symbol;
             var backingFields = symbol.ContainingType.GetMembers()
@@ -53,6 +54,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IPropertySymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var ordinaryDocuments = await FindDocumentsAsync(project, documents, cancellationToken, symbol.Name).ConfigureAwait(false);
@@ -83,6 +85,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             IPropertySymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             var nameReferences = await FindReferencesInDocumentUsingSymbolNameAsync(symbol, document, semanticModel, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/TypeParameterSymbolReferenceFinder.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             ITypeParameterSymbol symbol,
             Project project,
             IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             // Type parameters are only found in documents that have both their name, and the
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             ITypeParameterSymbol symbol,
             Document document,
             SemanticModel semanticModel,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken)
         {
             return FindReferencesInDocumentUsingSymbolNameAsync(symbol, document, semanticModel, cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 {
     internal interface IRemoteSymbolFinder
     {
-        Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs, CancellationToken cancellationToken);
+        Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs, SymbolFinderOptions options, CancellationToken cancellationToken);
         Task FindLiteralReferencesAsync(object value, TypeCode typeCode, CancellationToken cancellationToken);
 
         Task<IList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinderOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinderOptions.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.FindSymbols
+{
+    /// <summary>
+    /// Options for <see cref="SymbolFinder"/> operations.
+    /// </summary>
+    internal sealed class SymbolFinderOptions
+    {
+        public static SymbolFinderOptions Default { get; } = new SymbolFinderOptions();
+
+        /// <summary>
+        /// <para>
+        /// Determines whether searches for an accessor are replaced with searches for its
+        /// containing member.
+        /// </para>
+        /// <para>
+        /// For example, if you search for an <see cref="IMethodSymbol"/> which happens
+        /// to be a property accessor, you will get results as if you had searched for
+        /// the containing <see cref="IPropertySymbol"/>.
+        /// </para>
+        /// </summary>
+        public bool SearchAccessorsAsContainingMember { get; }
+
+        /// <summary>
+        /// <para>
+        /// Determines whether searches for accessors (<see cref="IMethodSymbol"/>s)
+        /// include results for usages of the containing member.
+        /// </para>
+        /// <para>
+        /// For example, this would cause <c>set_SomeProperty</c> to be found in the syntax
+        /// <c>SomeProperty = 42</c> even though only the property (not the setter itself)
+        /// is syntactically referenced.
+        /// (A hypothetical accessor reference, as opposed to containing member reference,
+        /// would look something like <c>new Action&lt;int&gt;(SomeProperty.set)</c>.)
+        /// </para>
+        /// <para>
+        /// This is different than <see cref="SearchAccessorsAsContainingMember"/>. Cascading
+        /// returns no results keyed to the accessor <see cref="IMethodSymbol"/> for which
+        /// you actually searched. Cascading instead returns results keyed to the containing
+        /// member (say,<see cref="IPropertySymbol"/>) as though you had searched for the
+        /// property instead of the accessor. Those results would include implicit usages
+        /// of all the property’s accessors, not just the accessor for which you searched.
+        /// </para>
+        /// </summary>
+        public bool IncludeImplicitAccessorUsages { get; }
+
+        /// <param name="searchAccessorsAsContainingMember">See <see cref="SearchAccessorsAsContainingMember" />.</param>
+        /// <param name="includeImplicitAccessorUsages">See <see cref="IncludeImplicitAccessorUsages" />.</param>
+        public SymbolFinderOptions(bool searchAccessorsAsContainingMember = true, bool includeImplicitAccessorUsages = false)
+        {
+            SearchAccessorsAsContainingMember = searchAccessorsAsContainingMember;
+            IncludeImplicitAccessorUsages = includeImplicitAccessorUsages;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Legacy.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Legacy.cs
@@ -65,11 +65,22 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// information as the search is undertaken.</param>
         /// <param name="documents">An optional set of documents to be searched. If documents is null, then that means "all documents".</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        public static async Task<IEnumerable<ReferencedSymbol>> FindReferencesAsync(
+        public static Task<IEnumerable<ReferencedSymbol>> FindReferencesAsync(
             ISymbol symbol,
             Solution solution,
             IFindReferencesProgress progress,
             IImmutableSet<Document> documents,
+            CancellationToken cancellationToken = default)
+        {
+            return FindReferencesAsync(symbol, solution, progress, documents, SymbolFinderOptions.Default);
+        }
+        
+        internal static async Task<IEnumerable<ReferencedSymbol>> FindReferencesAsync(
+            ISymbol symbol,
+            Solution solution,
+            IFindReferencesProgress progress,
+            IImmutableSet<Document> documents,
+            SymbolFinderOptions options,
             CancellationToken cancellationToken = default)
         {
             progress = progress ?? FindReferencesProgress.Instance;
@@ -80,7 +91,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 solution,
                 streamingProgress,
                 documents,
-                SymbolFinderOptions.Default,
+                options,
                 cancellationToken).ConfigureAwait(false);
             return streamingProgress.GetReferencedSymbols();
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Legacy.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Legacy.cs
@@ -32,8 +32,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var progressCollector = new StreamingProgressCollector(StreamingFindReferencesProgress.Instance);
             await FindReferencesAsync(
                 SymbolAndProjectId.Create(symbol, projectId: null),
-                solution, progress: progressCollector,
-                documents: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+                solution,
+                progress: progressCollector,
+                documents: null,
+                SymbolFinderOptions.Default,
+                cancellationToken).ConfigureAwait(false);
             return progressCollector.GetReferencedSymbols();
         }
 
@@ -74,7 +77,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 new StreamingFindReferencesProgressAdapter(progress));
             await FindReferencesAsync(
                 SymbolAndProjectId.Create(symbol, projectId: null),
-                solution, streamingProgress, documents, cancellationToken).ConfigureAwait(false);
+                solution,
+                streamingProgress,
+                documents,
+                SymbolFinderOptions.Default,
+                cancellationToken).ConfigureAwait(false);
             return streamingProgress.GetReferencedSymbols();
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindRenamableReferences.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindRenamableReferences.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     documents,
                     ReferenceFinders.DefaultRenameReferenceFinders,
                     streamingProgress,
+                    SymbolFinderOptions.Default,
                     cancellationToken);
 
                 await engine.FindReferencesAsync(symbolAndProjectId).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Remote
     // root level service for all Roslyn services
     internal partial class CodeAnalysisService : IRemoteSymbolFinder
     {
-        public Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs, CancellationToken cancellationToken)
+        public Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs, SymbolFinderOptions options, CancellationToken cancellationToken)
         {
             return RunServiceAsync(async token =>
             {
@@ -44,8 +44,12 @@ namespace Microsoft.CodeAnalysis.Remote
                                                  .ToImmutableHashSet();
 
                     await SymbolFinder.FindReferencesInCurrentProcessAsync(
-                        symbolAndProjectId.Value, solution,
-                        progressCallback, documents, token).ConfigureAwait(false);
+                        symbolAndProjectId.Value,
+                        solution,
+                        progressCallback,
+                        documents,
+                        options,
+                        token).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }


### PR DESCRIPTION
Addresses https://github.com/dotnet/roslyn/issues/24877. When you ask to find references of an accessor, only results for that accessor will be returned.

➡ I need feedback on the direction and implementation. 

### What this does

<details>
<summary>*Images; click to expand*</summary>

This is the typical find-all-references-for-property result:

<img src="https://user-images.githubusercontent.com/8040367/36404177-418f2d46-15b7-11e8-9eb1-86eb00dffe8d.png" width="60%" />

Now, instead of also giving the above result when you click the `get` or `set` keyword and find references, references are only shown if they are relevant to the accessor you asked about:

<img src="https://user-images.githubusercontent.com/8040367/36404200-5eb8c9b8-15b7-11e8-852c-7c9963d87420.png" width="49%" /> <img src="https://user-images.githubusercontent.com/8040367/36404219-723092dc-15b7-11e8-8e38-6c2ee87f8c6a.png" width="49%" />

Don't worry though; you won't accidentally search for an accessor when you meant to search for a property. To limit to an accessor, you have to be searching from the keyword declaring the accessor. Searching from an actual usage of the property will always find all references of the property:

<img src="https://user-images.githubusercontent.com/8040367/36404383-48974fbe-15b8-11e8-8dd3-19d74dd65ac4.png" width="60%" />

</details>

### Alternatives

There's a simpler implementation which people didn't favor, https://github.com/dotnet/roslyn/compare/master...jnm2:accessor_specific_search(UI_only).

### To do

- [ ] confirm direction (PR is currently up to get reviews for this purpose)
- [ ] write tests
- [ ] repeat for event accessors

/cc @CyrusNajmabadi, @jcouv, @MaStr11 