### PR TITLE
Allow deconstruction of 'default' literal

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -10440,6 +10440,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to deconstruction on default.
+        /// </summary>
+        internal static string IDS_FeatureDeconstructDefault {
+            get {
+                return ResourceManager.GetString("IDS_FeatureDeconstructDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to default operator.
         /// </summary>
         internal static string IDS_FeatureDefault {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -219,6 +219,9 @@
   <data name="IDS_FeatureTupleEquality" xml:space="preserve">
     <value>tuple equality</value>
   </data>
+  <data name="IDS_FeatureDeconstructDefault" xml:space="preserve">
+    <value>deconstruction on default</value>
+  </data>
   <data name="IDS_FeatureNullable" xml:space="preserve">
     <value>nullable types</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -158,6 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureStackAllocInitializer = MessageBase + 12740,
         IDS_FeatureTupleEquality = MessageBase + 12741,
         IDS_FeatureExpressionVariablesInQueriesAndInitializers = MessageBase + 12742,
+        IDS_FeatureDeconstructDefault = MessageBase + 12743,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -201,6 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureAttributesOnBackingFields: // semantic check
                 case MessageID.IDS_FeatureImprovedOverloadCandidates: // semantic check
                 case MessageID.IDS_FeatureTupleEquality: // semantic check
+                case MessageID.IDS_FeatureDeconstructDefault: // semantic check
                 case MessageID.IDS_FeatureRefReassignment:
                 case MessageID.IDS_FeatureRefFor:
                 case MessageID.IDS_FeatureRefForEach:

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8715,6 +8715,11 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8715,6 +8715,11 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8715,6 +8715,11 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8715,6 +8715,11 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8715,6 +8715,11 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8715,6 +8715,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8715,6 +8715,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8715,6 +8715,11 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8715,6 +8715,11 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8715,6 +8715,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8715,6 +8715,11 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8715,6 +8715,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8715,6 +8715,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">declaration of expression variables in member initializers and queries</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDeconstructDefault">
+        <source>deconstruction on default</source>
+        <target state="new">deconstruction on default</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
This language change needs to be confirmed with LDM, but I think it would make sense to allow (and give `default` the type from the left-hand-side). This would be consistent with `default` being allowed in tuple equality (`(1, 2) == default`).

Relates to discussion: https://github.com/dotnet/csharplang/issues/1358

### Customer scenario
`(int i, string j) = default; // error CS8131: Deconstruct assignment requires an expression with a type on the right-hand-side.`
`(i, s) = default; // error CS8131: Deconstruct assignment requires an expression with a type on the right-hand-side.`
With this PR, this change becomes allowed.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/25559

### Workarounds, if any
You could write `(default, default)` instead.

### Risk
### Performance impact
Low. The only change is to extend the logic to fix the type of tuple literals in deconstructions to also fix the type of `default` literal.

### Is this a regression from a previous update?
No. This is a minor language feature.

Tagging @gafter 