### PR TITLE
Add overload of ToListAndFree, to handle SeparatedSyntaxList.

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListPool.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxListPool.cs
@@ -77,6 +77,14 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
             Array.Copy(_freeList, tmp, _freeList.Length);
             _freeList = tmp;
         }
+        
+        public SeparatedSyntaxList<TNode> ToListAndFree<TNode>(SeparatedSyntaxListBuilder<TNode> item)
+            where TNode : GreenNode
+        {
+            var list = item.ToList();
+            Free(item);
+            return list;
+        }
 
         public SyntaxList<TNode> ToListAndFree<TNode>(SyntaxListBuilder<TNode> item)
             where TNode : GreenNode


### PR DESCRIPTION
Add overload of ToListAndFree, to handle SeparatedSyntaxList, this enables similar usage to the existing SyntaxList of using it in a return statement. `Return _pool.ToListAndFree( _examples_ )`

*Note* There possible usage in the current code base, but I'll do them as a separate pull requests.