### PR TITLE
[SQLite] Fix continuous probing for sqlite

### DIFF
--- a/src/VisualStudio/CSharp/Test/PersistentStorage/SQLitePersistentStorageTests.cs
+++ b/src/VisualStudio/CSharp/Test/PersistentStorage/SQLitePersistentStorageTests.cs
@@ -17,6 +17,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
     /// </remarks>
     public class SQLitePersistentStorageTests : AbstractPersistentStorageTests
     {
+        static SQLitePersistentStorageTests()
+        {
+            Assert.True(SQLitePersistentStorageService.TryInitializeLibraries());
+        }
+
         internal override IPersistentStorageService GetStorageService(IPersistentStorageLocationService locationService, ISolutionSizeTracker solutionSizeTracker, IPersistentStorageFaultInjector faultInjector)
             => new SQLitePersistentStorageService(_persistentEnabledOptionService, locationService, solutionSizeTracker, faultInjector);
 

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
@@ -92,33 +91,6 @@ namespace Microsoft.CodeAnalysis.SQLite
 
         private const string DataIdColumnName = "DataId";
         private const string DataColumnName = "Data";
-
-        static SQLitePersistentStorage()
-        {
-            // Attempt to load the correct version of e_sqlite.dll.  That way when we call
-            // into SQLitePCL.Batteries_V2.Init it will be able to find it.
-            //
-            // Only do this on Windows when we can safely do the LoadLibrary call to this
-            // direct dll.  On other platforms, it is the responsibility of the host to ensure
-            // that the necessary sqlite library has already been loaded such that SQLitePCL.Batteries_V2
-            // will be able to call into it.
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
-                var myFolder = Path.GetDirectoryName(
-                    typeof(SQLitePersistentStorage).Assembly.Location);
-
-                var is64 = IntPtr.Size == 8;
-                var subfolder = is64 ? "x64" : "x86";
-
-                LoadLibrary(Path.Combine(myFolder, subfolder, "e_sqlite3.dll"));
-            }
-
-            // Necessary to initialize SQLitePCL.
-            SQLitePCL.Batteries_V2.Init();
-        }
-
-        [DllImport("kernel32.dll")]
-        private static extern IntPtr LoadLibrary(string dllToLoad);
 
         private readonly CancellationTokenSource _shutdownTokenSource = new CancellationTokenSource();
 

--- a/src/Workspaces/Core/Desktop/Workspace/Storage/PersistenceStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Storage/PersistenceStorageServiceFactory.cs
@@ -28,6 +28,11 @@ namespace Microsoft.CodeAnalysis.Storage
             switch (database)
             {
                 case StorageDatabase.SQLite:
+                    if (!SQLitePersistentStorageService.TryInitializeLibraries())
+                    {
+                        break;
+                    }
+
                     var locationService = workspaceServices.GetService<IPersistentStorageLocationService>();
 
                     if (locationService != null)


### PR DESCRIPTION
The static constructor of SQLitePersistentStorage would throw an
exception, which would then get logged by the exception logger.

This changes the following logic:

* Don't delete the database if e_sqlite is not found.
* Disable persistent storage if e_sqlite is not found.
* Releases the db ownership lock if e_sqlite is not found.

Fixes #24042

Extra story:
There is a architectures of e_sqlite not existing for some platforms,
i.e. ARM64. Therefore, in MonoDevelop, it would throw a
TypeInitializationException on trying to initialize the SQLitePersistentStorage.

In this case, what would happen is:
* The persistent storage service would create the lock file.
* It would throw in the static constructor, without having passed
ownership
* Thus, the lock file is created by the service, not held by anyone
specifically
* The exception wasn't accounted for, so the storage file would be
deleted
* We now have a lock file present and no storage created
* Roslyn will keep trying to create the persistent storage on every
subsequent try, ending up in a performance issue caused by continuous
IO on trying to get ownership on the lock file, but it can't take it
because nobody released the old lock

Therefore, shortcircuiting and disabling persistent storage in case the
lib is not found is better.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
