### PR TITLE
Cancel pending work on workspace dispose

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -162,6 +162,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
             public void DisconnectFromWorkspace()
             {
+                _reportChangeCancellationSource.Cancel();
+
                 if (_workspace != null)
                 {
                     _workspace.WorkspaceChanged -= this.OnWorkspaceChanged;

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.BatchChangeNotifier.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.BatchChangeNotifier.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             /// </summary>
             private readonly IAsynchronousOperationListener _listener;
             private readonly IForegroundNotificationService _notificationService;
+            private readonly CancellationToken _cancellationToken;
 
             /// <summary>
             /// We keep track of the last time we reported a span, so that if things have been idle for
@@ -63,12 +64,14 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 ITextBuffer subjectBuffer,
                 IAsynchronousOperationListener listener,
                 IForegroundNotificationService notificationService,
-                Action<NormalizedSnapshotSpanCollection> notifyEditorNow)
+                Action<NormalizedSnapshotSpanCollection> notifyEditorNow,
+                CancellationToken cancellationToken)
             {
                 Contract.ThrowIfNull(notifyEditorNow);
                 _subjectBuffer = subjectBuffer;
                 _listener = listener;
                 _notificationService = notificationService;
+                _cancellationToken = cancellationToken;
                 _notifyEditorNow = notifyEditorNow;
             }
 
@@ -140,15 +143,19 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     // RecomputeTags. We must eventually notify the editor about these changes so that the
                     // UI reaches parity with our internal model.  Also, if we cancel it, then
                     // 'reportTagsScheduled' will stay 'true' forever and we'll never notify the UI.
-                    _notificationService.RegisterNotification(() =>
-                    {
-                        AssertIsForeground();
+                    _notificationService.RegisterNotification(
+                        () =>
+                        {
+                            AssertIsForeground();
 
-                        // First, clear the flag.  That way any new changes we hear about will enqueue a task
-                        // to run at a later point.
-                        _notificationRequestEnqueued = false;
-                        this.NotifyEditor();
-                    }, (int)delay.ComputeTimeDelay(_subjectBuffer).TotalMilliseconds, _listener.BeginAsyncOperation("EnqueueNotificationRequest"));
+                            // First, clear the flag.  That way any new changes we hear about will enqueue a task
+                            // to run at a later point.
+                            _notificationRequestEnqueued = false;
+                            this.NotifyEditor();
+                        },
+                        (int)delay.ComputeTimeDelay(_subjectBuffer).TotalMilliseconds,
+                        _listener.BeginAsyncOperation("EnqueueNotificationRequest"),
+                        _cancellationToken);
                 }
             }
 


### PR DESCRIPTION
During my recent work to ensure asynchronous operations from a test complete before moving to the next test, I observed significant test delays due to the way pending work is handled when a workspace is disposed. Two items contributed to the majority of the delay:

* In two main cases, pending work was scheduled without a cancellation token or the cancellation token source was not cancelled when the workspace was disposed
* When a pending work item scheduled for execution in `ForegroundNotificationService` is cancelled, it is not immediately processed. Specifically, items scheduled for execution after a delay only registered the cancellation with `IAsyncToken` after the delay completed.

This pull request resolves the first item, and provides the ability for test code to resolve the second item through an API call after a workspace is disposed.

This change is not absolutely required for the work in #25560 to be included, but it avoids a ~1hr delay in overall test execution time.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
