### PR TITLE
Add unit test leg on ES image

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -63,21 +63,38 @@ if (branchName.startsWith("features/")) {
 commitPullList.each { isPr ->
   ['debug', 'release'].each { configuration ->
         ['unit32', 'unit64'].each { buildTarget ->
-      def jobName = Utilities.getFullJobName(projectName, "windows_${configuration}_${buildTarget}", isPr)
-            def myJob = job(jobName) {
-        description("Windows ${configuration} tests on ${buildTarget}")
+        def jobName = Utilities.getFullJobName(projectName, "windows_${configuration}_${buildTarget}", isPr)
+        def myJob = job(jobName) {
+            description("Windows ${configuration} tests on ${buildTarget}")
                   steps {
                     batchFile(""".\\build\\scripts\\cibuild.cmd ${(configuration == 'debug') ? '-debug' : '-release'} ${(buildTarget == 'unit32') ? '-test32' : '-test64'} -testDesktop""")
                   }
-                }
+        }
 
-      def triggerPhraseOnly = false
-      def triggerPhraseExtra = ""
-      Utilities.setMachineAffinity(myJob, 'Windows_NT', windowsUnitTestMachine)
-      Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
-      addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
+        def triggerPhraseOnly = false
+        def triggerPhraseExtra = ""
+        Utilities.setMachineAffinity(myJob, 'Windows_NT', windowsUnitTestMachine)
+        Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
+        addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
     }
   }
+}
+
+// Windows ES image
+commitPullList.each { isPr ->
+  def jobName = Utilities.getFullJobName(projectName, "windows_debug_es_unit32", isPr)
+  def myJob = job(jobName) {
+    description("Windows CoreCLR unit tests")
+          steps {
+            batchFile(""".\\build\\scripts\\cibuild.cmd -debug -test32 -testDesktop""")
+          }
+  }
+
+  def triggerPhraseOnly = false
+  def triggerPhraseExtra = ""
+  Utilities.setMachineAffinity(myJob, 'Windows_NT', 'Windows.10.Amd64.ClientRS3.ES.Open')
+  Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
+  addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
 }
 
 // Windows CoreCLR

--- a/netci.groovy
+++ b/netci.groovy
@@ -80,11 +80,11 @@ commitPullList.each { isPr ->
   }
 }
 
-// Windows ES image
+// Windows Spanish image
 commitPullList.each { isPr ->
   def jobName = Utilities.getFullJobName(projectName, "windows_debug_es_unit32", isPr)
   def myJob = job(jobName) {
-    description("Windows CoreCLR unit tests")
+    description("Windows debug unit tests on unit32 using Spanish language")
           steps {
             batchFile(""".\\build\\scripts\\cibuild.cmd -debug -test32 -testDesktop""")
           }
@@ -92,7 +92,7 @@ commitPullList.each { isPr ->
 
   def triggerPhraseOnly = false
   def triggerPhraseExtra = ""
-  Utilities.setMachineAffinity(myJob, 'Windows_NT', 'Windows.10.Amd64.ClientRS3.ES.Open')
+  Utilities.setMachineAffinity(myJob, 'Windows.10.Amd64.ClientRS3.ES.Open')
   Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
   addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
 }


### PR DESCRIPTION
This adds a unit test leg which runs on a Windows machine with only the
ES language installed. This should help us catch issues that make
contribution difficult for developers who don't run English as their
primary language on Windows.

