### PR TITLE
Updates the IDE to reflect code style enforced during compiler team reviews

### DIFF
--- a/src/Compilers/.editorconfig
+++ b/src/Compilers/.editorconfig
@@ -1,6 +1,6 @@
 # Project-specific settings:
 # CSharp code style settings:
 [*.cs]
-csharp_style_var_for_built_in_types = false:none
+csharp_style_var_for_built_in_types = false:warning
 csharp_style_var_when_type_is_apparent = true:none
-csharp_style_var_elsewhere = false:none
+csharp_style_var_elsewhere = false:warning


### PR DESCRIPTION
This change has no impact on command line or in-IDE builds. It is only a visual indicator and follows the practices already being enforced be members of the team.
