### PR TITLE
Add C# 7.3 features to compiler test plan

### DIFF
--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -38,7 +38,7 @@ This document provides guidance for thinking about language interactions and tes
     - events (including add/remove accessors)
 - Parameter modifiers (ref, out, in, params)
 - Attributes (including security attribute)
-- Generics (type arguments, constraints, variance)
+- Generics (type arguments, variance, constraints including `class`, `struct`, `new()`, `unmanaged`)
 - Default and constant values
 - Partial classes
 - Literals
@@ -46,7 +46,7 @@ This document provides guidance for thinking about language interactions and tes
 - Expression trees
 - Iterators
 - Initializers (object, collection, dictionary)
-- Array (single- or multi-dimensional, jagged, initializer)
+- Array (single- or multi-dimensional, jagged, initializer, fixed)
 - Expression-bodied methods/properties/...
 - Extension methods
 - Partial method
@@ -70,7 +70,8 @@ This document provides guidance for thinking about language interactions and tes
 - Overload resolution, override/hide/implement (OHI)
 - Inheritance (virtual, override, abstract, new)
 - Anonymous types
-- Tuple types and literals (elements with explicit or inferred names, long tuples)
+- Tuple types and literals (elements with explicit or inferred names, long tuples), tuple equality
+- Deconstructions
 - Local functions
 - Unsafe code
 - LINQ
@@ -82,6 +83,8 @@ This document provides guidance for thinking about language interactions and tes
     - Assignment exprs
 - Ref return, ref readonly return, ref ternary, ref readonly local
 - `this = e;` in `struct` .ctor
+- Stackalloc
+- Patterns
 
 # Misc
 - reserved keywords (sometimes contextual)


### PR DESCRIPTION
Updating the compiler test plan with notes for recent features.

@dotnet/roslyn-compiler Anything to add?