### PR TITLE
Re-enable integration tests against the newer image

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -239,7 +239,7 @@ commitPullList.each { isPr ->
       def myJob = job(jobName) {
         description("Windows ${configuration} tests on ${buildTarget}")
         steps {
-          batchFile(""".\\build\\scripts\\cibuild.cmd ${(configuration == 'debug') ? '-debug' : '-release'} -testVsi""")
+          batchFile(""".\\build\\scripts\\cibuild.cmd -${configuration} -testVsi""")
         }
       }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -231,6 +231,27 @@ commitPullList.each { isPr ->
   addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
 }
 
+// VS Integration Tests
+commitPullList.each { isPr ->
+  ['debug', 'release'].each { configuration ->
+    ['vs-integration'].each { buildTarget ->
+      def jobName = Utilities.getFullJobName(projectName, "windows_${configuration}_${buildTarget}", isPr)
+      def myJob = job(jobName) {
+        description("Windows ${configuration} tests on ${buildTarget}")
+        steps {
+          batchFile(""".\\build\\scripts\\cibuild.cmd ${(configuration == 'debug') ? '-debug' : '-release'} -testVsi""")
+        }
+      }
+
+      def triggerPhraseOnly = false
+      def triggerPhraseExtra = ""
+      Utilities.setMachineAffinity(myJob, 'Windows.10.Amd64.ClientRS3.DevEx.Open')
+      Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
+      addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
+    }
+  }
+}
+
 JobReport.Report.generateJobReport(out)
 
 // Make the call to generate the help job


### PR DESCRIPTION
We had disabled integration tests in -vs-deps since we were regularly moving to new Visual Studio APIs and we were waiting to get new imaging systems setup. Now that things have stabilized and we have new images, we can use them.