### PR TITLE
SkipLocalsInitAttribute on classes

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <summary>
     /// Information decoded from well-known custom attributes applied on a method.
     /// </summary>
-    class MethodWellKnownAttributeData : CommonMethodWellKnownAttributeData
+    internal sealed class MethodWellKnownAttributeData : CommonMethodWellKnownAttributeData
     {
         #region SkipLocalsInitAttribute
         private bool _hasSkipLocalsInitAttribute;

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// Information decoded from well-known custom attributes applied on a method.
+    /// </summary>
+    class MethodWellKnownAttributeData : CommonMethodWellKnownAttributeData
+    {
+        #region SkipLocalsInitAttribute
+        private bool _hasSkipLocalsInitAttribute;
+        public bool HasSkipLocalsInitAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasSkipLocalsInitAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasSkipLocalsInitAttribute = value;
+                SetDataStored();
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// Information decoded from well-known custom attributes applied on a property.
+    /// </summary>
+    internal sealed class PropertyWellKnownAttributeData : CommonPropertyWellKnownAttributeData
+    {
+        #region SkipLocalsInitAttribute
+        private bool _hasSkipLocalsInitAttribute;
+        public bool HasSkipLocalsInitAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasSkipLocalsInitAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasSkipLocalsInitAttribute = value;
+                SetDataStored();
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownAttributeData.cs
@@ -32,5 +32,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         #endregion
+
+        #region SkipLocalsInitAttribute
+        private bool _hasSkipLocalsInitAttribute;
+        public bool HasSkipLocalsInitAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasSkipLocalsInitAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasSkipLocalsInitAttribute = value;
+                SetDataStored();
+            }
+        }
+        #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -114,6 +114,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return GetEmptyTypeArgumentCustomModifiers(ordinal);
         }
 
+        public sealed override bool AreLocalsZeroed
+        {
+            get { return true; }
+        }
+
         internal override bool IsComImport
         {
             get { return false; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -753,14 +753,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public sealed override bool AreLocalsZeroed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
         public override Accessibility DeclaredAccessibility
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -864,7 +864,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        protected CommonMethodWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        protected MethodWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -872,7 +872,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 attributesBag = this.GetAttributesBag();
             }
 
-            return (CommonMethodWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+            return (MethodWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
         }
 
         /// <summary>
@@ -1083,11 +1083,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (attribute.IsTargetAttribute(this, AttributeDescription.PreserveSigAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().SetPreserveSignature(arguments.Index);
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().SetPreserveSignature(arguments.Index);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.MethodImplAttribute))
             {
-                AttributeData.DecodeMethodImplAttribute<CommonMethodWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>(ref arguments, MessageProvider.Instance);
+                AttributeData.DecodeMethodImplAttribute<MethodWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>(ref arguments, MessageProvider.Instance);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DllImportAttribute))
             {
@@ -1095,11 +1095,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasSpecialNameAttribute = true;
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ConditionalAttribute))
             {
@@ -1107,11 +1107,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasSuppressUnmanagedCodeSecurityAttribute = true;
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasSuppressUnmanagedCodeSecurityAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicSecurityMethodAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasDynamicSecurityMethodAttribute = true;
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasDynamicSecurityMethodAttribute = true;
             }
             else if (VerifyObsoleteAttributeAppliedToMethod(ref arguments, AttributeDescription.ObsoleteAttribute))
             {
@@ -1144,14 +1144,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasSkipLocalsInitAttribute = true;
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasSkipLocalsInitAttribute = true;
             }
             else
             {
                 var compilation = this.DeclaringCompilation;
                 if (attribute.IsSecurityAttribute(compilation))
                 {
-                    attribute.DecodeSecurityAttribute<CommonMethodWellKnownAttributeData>(this, compilation, ref arguments);
+                    attribute.DecodeSecurityAttribute<MethodWellKnownAttributeData>(this, compilation, ref arguments);
                 }
             }
         }
@@ -1368,7 +1368,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!hasErrors)
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().SetDllImport(
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().SetDllImport(
                     arguments.Index,
                     moduleName,
                     importName,
@@ -1497,7 +1497,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override IEnumerable<Cci.SecurityAttribute> GetSecurityInformation()
         {
             var attributesBag = this.GetAttributesBag();
-            var wellKnownData = (CommonMethodWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+            var wellKnownData = (MethodWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
             if (wellKnownData != null)
             {
                 SecurityWellKnownAttributeData securityData = wellKnownData.SecurityInformation;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -363,12 +363,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var data = this.GetDecodedWellKnownAttributeData();
-                if (data == null)
-                {
-                    return ContainingType.AreLocalsZeroed;
-                }
-
-                return !data.HasSkipLocalsInitAttribute && ContainingType.AreLocalsZeroed;
+                return data?.HasSkipLocalsInitAttribute != true && ContainingType.AreLocalsZeroed;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -953,13 +953,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var data = this.GetDecodedWellKnownAttributeData();
-
-                if (data != null)
-                {
-                    return !data.HasSkipLocalsInitAttribute;
-                }
-
-                return ContainingType?.AreLocalsZeroed ?? true;
+                return data?.HasSkipLocalsInitAttribute != true && ContainingType?.AreLocalsZeroed != false;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -737,6 +737,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSecurityCriticalAttributes = true;
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
+            {
+                arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSkipLocalsInitAttribute = true;
+            }
             else if (_lazyIsExplicitDefinitionOfNoPiaLocalType == ThreeState.Unknown && attribute.IsTargetAttribute(this, AttributeDescription.TypeIdentifierAttribute))
             {
                 _lazyIsExplicitDefinitionOfNoPiaLocalType = ThreeState.True;
@@ -941,6 +945,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var data = this.GetDecodedWellKnownAttributeData();
                 return data != null && data.HasSerializableAttribute;
+            }
+        }
+
+        public sealed override bool AreLocalsZeroed
+        {
+            get
+            {
+                var data = this.GetDecodedWellKnownAttributeData();
+
+                if (data != null)
+                {
+                    return !data.HasSkipLocalsInitAttribute;
+                }
+
+                return ContainingType?.AreLocalsZeroed ?? true;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1121,7 +1121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        private CommonPropertyWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        private PropertyWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -1129,7 +1129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 attributesBag = this.GetAttributesBag();
             }
 
-            return (CommonPropertyWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+            return (PropertyWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
         }
 
         /// <summary>
@@ -1261,15 +1261,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
             {
-                arguments.GetOrCreateData<CommonPropertyWellKnownAttributeData>().HasSpecialNameAttribute = true;
+                arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
-                arguments.GetOrCreateData<CommonPropertyWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
+                arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
             {
-                arguments.GetOrCreateData<CommonPropertyWellKnownAttributeData>().HasSkipLocalsInitAttribute = true;
+                arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasSkipLocalsInitAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -693,12 +693,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var data = this.GetDecodedWellKnownAttributeData();
-                if (data == null)
-                {
-                    return ContainingType.AreLocalsZeroed;
-                }
-
-                return !data.HasSkipLocalsInitAttribute && ContainingType.AreLocalsZeroed;
+                return data?.HasSkipLocalsInitAttribute != true && ContainingType.AreLocalsZeroed;
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -18,6 +18,24 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
+    public static class WellKnownAttributeTestsUtil
+    {
+        public static bool? HasLocalsInit(this CompilationVerifier verifier, string methodName, bool realIL = false)
+        {
+            var il = verifier.VisualizeIL(methodName, realIL);
+
+            if (il.Contains(".locals init ("))
+            {
+                return true;
+            }
+            if (il.Contains(".locals ("))
+            {
+                return false;
+            }
+            return null;
+        }
+    }
+
     public class AttributeTests_WellKnownAttributes : WellKnownAttributesTestBase
     {
         #region Misc
@@ -8591,69 +8609,10 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.M_init", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}", realIL: true);
-
-            comp.VerifyIL("C.M_skip", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}", realIL: true);
-
-            comp.VerifyIL("C.M_init", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}", realIL: false);
-
-            comp.VerifyIL("C.M_skip", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}", realIL: false);
+            Assert.True(comp.HasLocalsInit("C.M_init", realIL: true));
+            Assert.False(comp.HasLocalsInit("C.M_skip", realIL: true));
+            Assert.True(comp.HasLocalsInit("C.M_init", realIL: false));
+            Assert.False(comp.HasLocalsInit("C.M_skip", realIL: false));
         }
 
         [Fact]
@@ -8685,21 +8644,7 @@ partial class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.M", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.M"));
         }
 
         [Fact]
@@ -8853,21 +8798,7 @@ public class C
 
             var comp = CompileAndVerify(source);
 
-            comp.VerifyIL("C.M", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.True(comp.HasLocalsInit("C.M"));
         }
 
         [Fact]
@@ -8897,21 +8828,7 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.<M>g__F|0_0", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.<M>g__F|0_0"));
         }
 
         [Fact]
@@ -8941,21 +8858,7 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.<>c.<M>b__0_0", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.<>c.<M>b__0_0"));
         }
 
         [Fact]
@@ -9015,119 +8918,12 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            // F
-            comp.VerifyIL("C.<M>g__F|0_0", @"
-{
-  // Code size       37 (0x25)
-  .maxstack  2
-  .locals (int V_0) //y
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ldsfld     ""System.Action C.<>c.<>9__0_3""
-  IL_000d:  brtrue.s   IL_0024
-  IL_000f:  ldsfld     ""C.<>c C.<>c.<>9""
-  IL_0014:  ldftn      ""void C.<>c.<M>b__0_3()""
-  IL_001a:  newobj     ""System.Action..ctor(object, System.IntPtr)""
-  IL_001f:  stsfld     ""System.Action C.<>c.<>9__0_3""
-  IL_0024:  ret
-}");
-
-            // FF
-            comp.VerifyIL("C.<M>g__FF|0_2", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            // FL
-            comp.VerifyIL("C.<>c.<M>b__0_3", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            // L
-            comp.VerifyIL("C.<>c.<M>b__0_1", @"
-{
-  // Code size       37 (0x25)
-  .maxstack  2
-  .locals (int V_0) //y
-  IL_0000:  ldc.i4.4
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ldsfld     ""System.Action C.<>c.<>9__0_5""
-  IL_000d:  brtrue.s   IL_0024
-  IL_000f:  ldsfld     ""C.<>c C.<>c.<>9""
-  IL_0014:  ldftn      ""void C.<>c.<M>b__0_5()""
-  IL_001a:  newobj     ""System.Action..ctor(object, System.IntPtr)""
-  IL_001f:  stsfld     ""System.Action C.<>c.<>9__0_5""
-  IL_0024:  ret
-}");
-
-            // LF
-            comp.VerifyIL("C.<M>g__LF|0_4", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.5
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            // LL
-            comp.VerifyIL("C.<>c.<M>b__0_5", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.6
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.<M>g__F|0_0")); // F
+            Assert.False(comp.HasLocalsInit("C.<M>g__FF|0_2")); // FF
+            Assert.False(comp.HasLocalsInit("C.<>c.<M>b__0_3")); // FL
+            Assert.False(comp.HasLocalsInit("C.<>c.<M>b__0_1")); // L
+            Assert.False(comp.HasLocalsInit("C.<M>g__LF|0_4")); // LF
+            Assert.False(comp.HasLocalsInit("C.<>c.<M>b__0_5")); // LL
         }
 
         [Fact]
@@ -9160,265 +8956,25 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.<M_skip>d__0.System.Collections.IEnumerator.MoveNext", @"
-{
-  // Code size       92 (0x5c)
-  .maxstack  2
-  .locals (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  switch    (
-        IL_001b,
-        IL_0037,
-        IL_0053)
-  IL_0019:  ldc.i4.0
-  IL_001a:  ret
-  IL_001b:  ldarg.0
-  IL_001c:  ldc.i4.m1
-  IL_001d:  stfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.1
-  IL_0024:  box        ""int""
-  IL_0029:  stfld      ""object C.<M_skip>d__0.<>2__current""
-  IL_002e:  ldarg.0
-  IL_002f:  ldc.i4.1
-  IL_0030:  stfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_0035:  ldc.i4.1
-  IL_0036:  ret
-  IL_0037:  ldarg.0
-  IL_0038:  ldc.i4.m1
-  IL_0039:  stfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_003e:  ldarg.0
-  IL_003f:  ldc.i4.2
-  IL_0040:  box        ""int""
-  IL_0045:  stfld      ""object C.<M_skip>d__0.<>2__current""
-  IL_004a:  ldarg.0
-  IL_004b:  ldc.i4.2
-  IL_004c:  stfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_0051:  ldc.i4.1
-  IL_0052:  ret
-  IL_0053:  ldarg.0
-  IL_0054:  ldc.i4.m1
-  IL_0055:  stfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_005a:  ldc.i4.0
-  IL_005b:  ret
-}");
-
-            comp.VerifyIL("C.<M_init>d__1.System.Collections.IEnumerator.MoveNext", @"
-{
-  // Code size       92 (0x5c)
-  .maxstack  2
-  .locals init (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<M_init>d__1.<>1__state""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  switch    (
-        IL_001b,
-        IL_0037,
-        IL_0053)
-  IL_0019:  ldc.i4.0
-  IL_001a:  ret
-  IL_001b:  ldarg.0
-  IL_001c:  ldc.i4.m1
-  IL_001d:  stfld      ""int C.<M_init>d__1.<>1__state""
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.3
-  IL_0024:  box        ""int""
-  IL_0029:  stfld      ""object C.<M_init>d__1.<>2__current""
-  IL_002e:  ldarg.0
-  IL_002f:  ldc.i4.1
-  IL_0030:  stfld      ""int C.<M_init>d__1.<>1__state""
-  IL_0035:  ldc.i4.1
-  IL_0036:  ret
-  IL_0037:  ldarg.0
-  IL_0038:  ldc.i4.m1
-  IL_0039:  stfld      ""int C.<M_init>d__1.<>1__state""
-  IL_003e:  ldarg.0
-  IL_003f:  ldc.i4.4
-  IL_0040:  box        ""int""
-  IL_0045:  stfld      ""object C.<M_init>d__1.<>2__current""
-  IL_004a:  ldarg.0
-  IL_004b:  ldc.i4.2
-  IL_004c:  stfld      ""int C.<M_init>d__1.<>1__state""
-  IL_0051:  ldc.i4.1
-  IL_0052:  ret
-  IL_0053:  ldarg.0
-  IL_0054:  ldc.i4.m1
-  IL_0055:  stfld      ""int C.<M_init>d__1.<>1__state""
-  IL_005a:  ldc.i4.0
-  IL_005b:  ret
-}");
-
-            comp.VerifyIL("C.<M_skip>d__0.System.Collections.Generic.IEnumerable<object>.GetEnumerator", @"
-{
-  // Code size       43 (0x2b)
-  .maxstack  2
-  .locals (C.<M_skip>d__0 V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_0006:  ldc.i4.s   -2
-  IL_0008:  bne.un.s   IL_0022
-  IL_000a:  ldarg.0
-  IL_000b:  ldfld      ""int C.<M_skip>d__0.<>l__initialThreadId""
-  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0015:  bne.un.s   IL_0022
-  IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.0
-  IL_0019:  stfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_001e:  ldarg.0
-  IL_001f:  stloc.0
-  IL_0020:  br.s       IL_0029
-  IL_0022:  ldc.i4.0
-  IL_0023:  newobj     ""C.<M_skip>d__0..ctor(int)""
-  IL_0028:  stloc.0
-  IL_0029:  ldloc.0
-  IL_002a:  ret
-}");
-
-            comp.VerifyIL("C.<M_init>d__1.System.Collections.Generic.IEnumerable<object>.GetEnumerator", @"
-{
-  // Code size       43 (0x2b)
-  .maxstack  2
-  .locals init (C.<M_init>d__1 V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<M_init>d__1.<>1__state""
-  IL_0006:  ldc.i4.s   -2
-  IL_0008:  bne.un.s   IL_0022
-  IL_000a:  ldarg.0
-  IL_000b:  ldfld      ""int C.<M_init>d__1.<>l__initialThreadId""
-  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0015:  bne.un.s   IL_0022
-  IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.0
-  IL_0019:  stfld      ""int C.<M_init>d__1.<>1__state""
-  IL_001e:  ldarg.0
-  IL_001f:  stloc.0
-  IL_0020:  br.s       IL_0029
-  IL_0022:  ldc.i4.0
-  IL_0023:  newobj     ""C.<M_init>d__1..ctor(int)""
-  IL_0028:  stloc.0
-  IL_0029:  ldloc.0
-  IL_002a:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.<M_skip>d__0.System.Collections.IEnumerator.MoveNext"));
+            Assert.True(comp.HasLocalsInit("C.<M_init>d__1.System.Collections.IEnumerator.MoveNext"));
+            Assert.False(comp.HasLocalsInit("C.<M_skip>d__0.System.Collections.Generic.IEnumerable<object>.GetEnumerator"));
+            Assert.True(comp.HasLocalsInit("C.<M_init>d__1.System.Collections.Generic.IEnumerable<object>.GetEnumerator"));
 
             // The following methods do not contain locals, so the attribute should not alter their behavior
 
-            comp.VerifyIL("C.<M_skip>d__0.System.IDisposable.Dispose", @"
-{
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
-}");
-
-            comp.VerifyIL("C.<M_init>d__1.System.IDisposable.Dispose", @"
-{
-  // Code size        1 (0x1)
-  .maxstack  0
-  IL_0000:  ret
-}");
-
-            comp.VerifyIL("C.<M_skip>d__0.System.Collections.IEnumerable.GetEnumerator", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""System.Collections.Generic.IEnumerator<object> C.<M_skip>d__0.GetEnumerator()""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("C.<M_init>d__1.System.Collections.IEnumerable.GetEnumerator", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""System.Collections.Generic.IEnumerator<object> C.<M_init>d__1.GetEnumerator()""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("C.<M_skip>d__0.System.Collections.IEnumerator.get_Current", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""object C.<M_skip>d__0.<>2__current""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("C.<M_init>d__1.System.Collections.IEnumerator.get_Current", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""object C.<M_init>d__1.<>2__current""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("C.<M_skip>d__0.System.Collections.IEnumerator.Reset", @"
-{
-  // Code size        6 (0x6)
-  .maxstack  1
-  IL_0000:  newobj     ""System.NotSupportedException..ctor()""
-  IL_0005:  throw
-}");
-
-            comp.VerifyIL("C.<M_init>d__1.System.Collections.IEnumerator.Reset", @"
-{
-  // Code size        6 (0x6)
-  .maxstack  1
-  IL_0000:  newobj     ""System.NotSupportedException..ctor()""
-  IL_0005:  throw
-}");
-
-            comp.VerifyIL("C.<M_skip>d__0.System.Collections.Generic.IEnumerator<object>.get_Current", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""object C.<M_skip>d__0.<>2__current""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("C.<M_init>d__1.System.Collections.Generic.IEnumerator<object>.get_Current", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""object C.<M_init>d__1.<>2__current""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("C.<M_skip>d__0..ctor", @"
-{
-  // Code size       25 (0x19)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""object..ctor()""
-  IL_0006:  ldarg.0
-  IL_0007:  ldarg.1
-  IL_0008:  stfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_000d:  ldarg.0
-  IL_000e:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0013:  stfld      ""int C.<M_skip>d__0.<>l__initialThreadId""
-  IL_0018:  ret
-}");
-
-            comp.VerifyIL("C.<M_init>d__1..ctor", @"
-{
-  // Code size       25 (0x19)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""object..ctor()""
-  IL_0006:  ldarg.0
-  IL_0007:  ldarg.1
-  IL_0008:  stfld      ""int C.<M_init>d__1.<>1__state""
-  IL_000d:  ldarg.0
-  IL_000e:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0013:  stfld      ""int C.<M_init>d__1.<>l__initialThreadId""
-  IL_0018:  ret
-}");
+            Assert.Null(comp.HasLocalsInit("C.<M_skip>d__0.System.IDisposable.Dispose"));
+            Assert.Null(comp.HasLocalsInit("C.<M_init>d__1.System.IDisposable.Dispose"));
+            Assert.Null(comp.HasLocalsInit("C.<M_skip>d__0.System.Collections.IEnumerable.GetEnumerator"));
+            Assert.Null(comp.HasLocalsInit("C.<M_init>d__1.System.Collections.IEnumerable.GetEnumerator"));
+            Assert.Null(comp.HasLocalsInit("C.<M_skip>d__0.System.Collections.IEnumerator.get_Current"));
+            Assert.Null(comp.HasLocalsInit("C.<M_init>d__1.System.Collections.IEnumerator.get_Current"));
+            Assert.Null(comp.HasLocalsInit("C.<M_skip>d__0.System.Collections.IEnumerator.Reset"));
+            Assert.Null(comp.HasLocalsInit("C.<M_init>d__1.System.Collections.IEnumerator.Reset"));
+            Assert.Null(comp.HasLocalsInit("C.<M_skip>d__0.System.Collections.Generic.IEnumerator<object>.get_Current"));
+            Assert.Null(comp.HasLocalsInit("C.<M_init>d__1.System.Collections.Generic.IEnumerator<object>.get_Current"));
+            Assert.Null(comp.HasLocalsInit("C.<M_skip>d__0..ctor"));
+            Assert.Null(comp.HasLocalsInit("C.<M_init>d__1..ctor"));
         }
 
         [Fact]
@@ -9448,77 +9004,8 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.<<M>g__F|0_0>d.System.Collections.IEnumerator.MoveNext", @"
-{
-  // Code size       92 (0x5c)
-  .maxstack  2
-  .locals (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  switch    (
-        IL_001b,
-        IL_0037,
-        IL_0053)
-  IL_0019:  ldc.i4.0
-  IL_001a:  ret
-  IL_001b:  ldarg.0
-  IL_001c:  ldc.i4.m1
-  IL_001d:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.1
-  IL_0024:  box        ""int""
-  IL_0029:  stfld      ""object C.<<M>g__F|0_0>d.<>2__current""
-  IL_002e:  ldarg.0
-  IL_002f:  ldc.i4.1
-  IL_0030:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_0035:  ldc.i4.1
-  IL_0036:  ret
-  IL_0037:  ldarg.0
-  IL_0038:  ldc.i4.m1
-  IL_0039:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_003e:  ldarg.0
-  IL_003f:  ldc.i4.2
-  IL_0040:  box        ""int""
-  IL_0045:  stfld      ""object C.<<M>g__F|0_0>d.<>2__current""
-  IL_004a:  ldarg.0
-  IL_004b:  ldc.i4.2
-  IL_004c:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_0051:  ldc.i4.1
-  IL_0052:  ret
-  IL_0053:  ldarg.0
-  IL_0054:  ldc.i4.m1
-  IL_0055:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_005a:  ldc.i4.0
-  IL_005b:  ret
-}");
-
-            comp.VerifyIL("C.<<M>g__F|0_0>d.System.Collections.Generic.IEnumerable<object>.GetEnumerator()", @"
-{
-  // Code size       43 (0x2b)
-  .maxstack  2
-  .locals (C.<<M>g__F|0_0>d V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_0006:  ldc.i4.s   -2
-  IL_0008:  bne.un.s   IL_0022
-  IL_000a:  ldarg.0
-  IL_000b:  ldfld      ""int C.<<M>g__F|0_0>d.<>l__initialThreadId""
-  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0015:  bne.un.s   IL_0022
-  IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.0
-  IL_0019:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_001e:  ldarg.0
-  IL_001f:  stloc.0
-  IL_0020:  br.s       IL_0029
-  IL_0022:  ldc.i4.0
-  IL_0023:  newobj     ""C.<<M>g__F|0_0>d..ctor(int)""
-  IL_0028:  stloc.0
-  IL_0029:  ldloc.0
-  IL_002a:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.<<M>g__F|0_0>d.System.Collections.IEnumerator.MoveNext"));
+            Assert.False(comp.HasLocalsInit("C.<<M>g__F|0_0>d.System.Collections.Generic.IEnumerable<object>.GetEnumerator"));
         }
 
         [Fact]
@@ -9551,175 +9038,13 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.<M_skip>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
-{
-  // Code size      145 (0x91)
-  .maxstack  3
-  .locals (int V_0,
-           System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
-           System.Runtime.CompilerServices.YieldAwaitable V_2,
-           System.Exception V_3)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_0006:  stloc.0
-  .try
-  {
-    IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0041
-    IL_000a:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_000f:  stloc.2
-    IL_0010:  ldloca.s   V_2
-    IL_0012:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0017:  stloc.1
-    IL_0018:  ldloca.s   V_1
-    IL_001a:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_001f:  brtrue.s   IL_005d
-    IL_0021:  ldarg.0
-    IL_0022:  ldc.i4.0
-    IL_0023:  dup
-    IL_0024:  stloc.0
-    IL_0025:  stfld      ""int C.<M_skip>d__0.<>1__state""
-    IL_002a:  ldarg.0
-    IL_002b:  ldloc.1
-    IL_002c:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<M_skip>d__0.<>u__1""
-    IL_0031:  ldarg.0
-    IL_0032:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M_skip>d__0.<>t__builder""
-    IL_0037:  ldloca.s   V_1
-    IL_0039:  ldarg.0
-    IL_003a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<M_skip>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<M_skip>d__0)""
-    IL_003f:  leave.s    IL_0090
-    IL_0041:  ldarg.0
-    IL_0042:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<M_skip>d__0.<>u__1""
-    IL_0047:  stloc.1
-    IL_0048:  ldarg.0
-    IL_0049:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<M_skip>d__0.<>u__1""
-    IL_004e:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0054:  ldarg.0
-    IL_0055:  ldc.i4.m1
-    IL_0056:  dup
-    IL_0057:  stloc.0
-    IL_0058:  stfld      ""int C.<M_skip>d__0.<>1__state""
-    IL_005d:  ldloca.s   V_1
-    IL_005f:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0064:  leave.s    IL_007d
-  }
-  catch System.Exception
-  {
-    IL_0066:  stloc.3
-    IL_0067:  ldarg.0
-    IL_0068:  ldc.i4.s   -2
-    IL_006a:  stfld      ""int C.<M_skip>d__0.<>1__state""
-    IL_006f:  ldarg.0
-    IL_0070:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M_skip>d__0.<>t__builder""
-    IL_0075:  ldloc.3
-    IL_0076:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_007b:  leave.s    IL_0090
-  }
-  IL_007d:  ldarg.0
-  IL_007e:  ldc.i4.s   -2
-  IL_0080:  stfld      ""int C.<M_skip>d__0.<>1__state""
-  IL_0085:  ldarg.0
-  IL_0086:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M_skip>d__0.<>t__builder""
-  IL_008b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0090:  ret
-}");
-
-            comp.VerifyIL("C.<M_init>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
-{
-  // Code size      145 (0x91)
-  .maxstack  3
-  .locals init (int V_0,
-                System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
-                System.Runtime.CompilerServices.YieldAwaitable V_2,
-                System.Exception V_3)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<M_init>d__1.<>1__state""
-  IL_0006:  stloc.0
-  .try
-  {
-    IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0041
-    IL_000a:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_000f:  stloc.2
-    IL_0010:  ldloca.s   V_2
-    IL_0012:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0017:  stloc.1
-    IL_0018:  ldloca.s   V_1
-    IL_001a:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_001f:  brtrue.s   IL_005d
-    IL_0021:  ldarg.0
-    IL_0022:  ldc.i4.0
-    IL_0023:  dup
-    IL_0024:  stloc.0
-    IL_0025:  stfld      ""int C.<M_init>d__1.<>1__state""
-    IL_002a:  ldarg.0
-    IL_002b:  ldloc.1
-    IL_002c:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<M_init>d__1.<>u__1""
-    IL_0031:  ldarg.0
-    IL_0032:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M_init>d__1.<>t__builder""
-    IL_0037:  ldloca.s   V_1
-    IL_0039:  ldarg.0
-    IL_003a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<M_init>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<M_init>d__1)""
-    IL_003f:  leave.s    IL_0090
-    IL_0041:  ldarg.0
-    IL_0042:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<M_init>d__1.<>u__1""
-    IL_0047:  stloc.1
-    IL_0048:  ldarg.0
-    IL_0049:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<M_init>d__1.<>u__1""
-    IL_004e:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0054:  ldarg.0
-    IL_0055:  ldc.i4.m1
-    IL_0056:  dup
-    IL_0057:  stloc.0
-    IL_0058:  stfld      ""int C.<M_init>d__1.<>1__state""
-    IL_005d:  ldloca.s   V_1
-    IL_005f:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0064:  leave.s    IL_007d
-  }
-  catch System.Exception
-  {
-    IL_0066:  stloc.3
-    IL_0067:  ldarg.0
-    IL_0068:  ldc.i4.s   -2
-    IL_006a:  stfld      ""int C.<M_init>d__1.<>1__state""
-    IL_006f:  ldarg.0
-    IL_0070:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M_init>d__1.<>t__builder""
-    IL_0075:  ldloc.3
-    IL_0076:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_007b:  leave.s    IL_0090
-  }
-  IL_007d:  ldarg.0
-  IL_007e:  ldc.i4.s   -2
-  IL_0080:  stfld      ""int C.<M_init>d__1.<>1__state""
-  IL_0085:  ldarg.0
-  IL_0086:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M_init>d__1.<>t__builder""
-  IL_008b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0090:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.<M_skip>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext"));
+            Assert.True(comp.HasLocalsInit("C.<M_init>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext"));
 
             // The following method does not contain locals, so the attribute should not alter its behavior
 
-            comp.VerifyIL("C.<M_skip>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine", @"
-{
-  // Code size       13 (0xd)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M_skip>d__0.<>t__builder""
-  IL_0006:  ldarg.1
-  IL_0007:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine)""
-  IL_000c:  ret
-}");
-
-            comp.VerifyIL("C.<M_init>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine", @"
-{
-  // Code size       13 (0xd)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M_init>d__1.<>t__builder""
-  IL_0006:  ldarg.1
-  IL_0007:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine)""
-  IL_000c:  ret
-}");
+            Assert.Null(comp.HasLocalsInit("C.<M_skip>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine"));
+            Assert.Null(comp.HasLocalsInit("C.<M_init>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine"));
         }
 
         [Fact]
@@ -9750,78 +9075,7 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.<<M>g__F|0_0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
-{
-  // Code size      145 (0x91)
-  .maxstack  3
-  .locals (int V_0,
-           System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
-           System.Runtime.CompilerServices.YieldAwaitable V_2,
-           System.Exception V_3)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_0006:  stloc.0
-  .try
-  {
-    IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0041
-    IL_000a:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_000f:  stloc.2
-    IL_0010:  ldloca.s   V_2
-    IL_0012:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0017:  stloc.1
-    IL_0018:  ldloca.s   V_1
-    IL_001a:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_001f:  brtrue.s   IL_005d
-    IL_0021:  ldarg.0
-    IL_0022:  ldc.i4.0
-    IL_0023:  dup
-    IL_0024:  stloc.0
-    IL_0025:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-    IL_002a:  ldarg.0
-    IL_002b:  ldloc.1
-    IL_002c:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<<M>g__F|0_0>d.<>u__1""
-    IL_0031:  ldarg.0
-    IL_0032:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<<M>g__F|0_0>d.<>t__builder""
-    IL_0037:  ldloca.s   V_1
-    IL_0039:  ldarg.0
-    IL_003a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<<M>g__F|0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<<M>g__F|0_0>d)""
-    IL_003f:  leave.s    IL_0090
-    IL_0041:  ldarg.0
-    IL_0042:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<<M>g__F|0_0>d.<>u__1""
-    IL_0047:  stloc.1
-    IL_0048:  ldarg.0
-    IL_0049:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<<M>g__F|0_0>d.<>u__1""
-    IL_004e:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0054:  ldarg.0
-    IL_0055:  ldc.i4.m1
-    IL_0056:  dup
-    IL_0057:  stloc.0
-    IL_0058:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-    IL_005d:  ldloca.s   V_1
-    IL_005f:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0064:  leave.s    IL_007d
-  }
-  catch System.Exception
-  {
-    IL_0066:  stloc.3
-    IL_0067:  ldarg.0
-    IL_0068:  ldc.i4.s   -2
-    IL_006a:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-    IL_006f:  ldarg.0
-    IL_0070:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<<M>g__F|0_0>d.<>t__builder""
-    IL_0075:  ldloc.3
-    IL_0076:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_007b:  leave.s    IL_0090
-  }
-  IL_007d:  ldarg.0
-  IL_007e:  ldc.i4.s   -2
-  IL_0080:  stfld      ""int C.<<M>g__F|0_0>d.<>1__state""
-  IL_0085:  ldarg.0
-  IL_0086:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<<M>g__F|0_0>d.<>t__builder""
-  IL_008b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0090:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.<<M>g__F|0_0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext"));
         }
 
         [Fact]
@@ -9852,78 +9106,7 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.<>c.<<M>b__0_0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
-{
-  // Code size      145 (0x91)
-  .maxstack  3
-  .locals (int V_0,
-           System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
-           System.Runtime.CompilerServices.YieldAwaitable V_2,
-           System.Exception V_3)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<>c.<<M>b__0_0>d.<>1__state""
-  IL_0006:  stloc.0
-  .try
-  {
-    IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0041
-    IL_000a:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_000f:  stloc.2
-    IL_0010:  ldloca.s   V_2
-    IL_0012:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0017:  stloc.1
-    IL_0018:  ldloca.s   V_1
-    IL_001a:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_001f:  brtrue.s   IL_005d
-    IL_0021:  ldarg.0
-    IL_0022:  ldc.i4.0
-    IL_0023:  dup
-    IL_0024:  stloc.0
-    IL_0025:  stfld      ""int C.<>c.<<M>b__0_0>d.<>1__state""
-    IL_002a:  ldarg.0
-    IL_002b:  ldloc.1
-    IL_002c:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<>c.<<M>b__0_0>d.<>u__1""
-    IL_0031:  ldarg.0
-    IL_0032:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<>c.<<M>b__0_0>d.<>t__builder""
-    IL_0037:  ldloca.s   V_1
-    IL_0039:  ldarg.0
-    IL_003a:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<>c.<<M>b__0_0>d>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<>c.<<M>b__0_0>d)""
-    IL_003f:  leave.s    IL_0090
-    IL_0041:  ldarg.0
-    IL_0042:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<>c.<<M>b__0_0>d.<>u__1""
-    IL_0047:  stloc.1
-    IL_0048:  ldarg.0
-    IL_0049:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<>c.<<M>b__0_0>d.<>u__1""
-    IL_004e:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0054:  ldarg.0
-    IL_0055:  ldc.i4.m1
-    IL_0056:  dup
-    IL_0057:  stloc.0
-    IL_0058:  stfld      ""int C.<>c.<<M>b__0_0>d.<>1__state""
-    IL_005d:  ldloca.s   V_1
-    IL_005f:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0064:  leave.s    IL_007d
-  }
-  catch System.Exception
-  {
-    IL_0066:  stloc.3
-    IL_0067:  ldarg.0
-    IL_0068:  ldc.i4.s   -2
-    IL_006a:  stfld      ""int C.<>c.<<M>b__0_0>d.<>1__state""
-    IL_006f:  ldarg.0
-    IL_0070:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<>c.<<M>b__0_0>d.<>t__builder""
-    IL_0075:  ldloc.3
-    IL_0076:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
-    IL_007b:  leave.s    IL_0090
-  }
-  IL_007d:  ldarg.0
-  IL_007e:  ldc.i4.s   -2
-  IL_0080:  stfld      ""int C.<>c.<<M>b__0_0>d.<>1__state""
-  IL_0085:  ldarg.0
-  IL_0086:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<>c.<<M>b__0_0>d.<>t__builder""
-  IL_008b:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
-  IL_0090:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.<>c.<<M>b__0_0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext"));
         }
 
         [Fact]
@@ -9949,99 +9132,11 @@ public class C
 
             var comp = CompileAndVerify(source);
 
-            comp.VerifyIL("<>f__AnonymousType0<<Value>j__TPar>.GetHashCode", @"
-{
-  // Code size       29 (0x1d)
-  .maxstack  3
-  IL_0000:  ldc.i4     0x5298af41
-  IL_0005:  ldc.i4     0xa5555529
-  IL_000a:  mul
-  IL_000b:  call       ""System.Collections.Generic.EqualityComparer<<Value>j__TPar> System.Collections.Generic.EqualityComparer<<Value>j__TPar>.Default.get""
-  IL_0010:  ldarg.0
-  IL_0011:  ldfld      ""<Value>j__TPar <>f__AnonymousType0<<Value>j__TPar>.<Value>i__Field""
-  IL_0016:  callvirt   ""int System.Collections.Generic.EqualityComparer<<Value>j__TPar>.GetHashCode(<Value>j__TPar)""
-  IL_001b:  add
-  IL_001c:  ret
-}");
-
-            comp.VerifyIL("<>f__AnonymousType0<<Value>j__TPar>..ctor", @"
-{
-  // Code size       14 (0xe)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""object..ctor()""
-  IL_0006:  ldarg.0
-  IL_0007:  ldarg.1
-  IL_0008:  stfld      ""<Value>j__TPar <>f__AnonymousType0<<Value>j__TPar>.<Value>i__Field""
-  IL_000d:  ret
-}");
-
-            comp.VerifyIL("<>f__AnonymousType0<<Value>j__TPar>.Equals", @"
-{
-  // Code size       35 (0x23)
-  .maxstack  3
-  .locals init (<>f__AnonymousType0<<Value>j__TPar> V_0)
-  IL_0000:  ldarg.1
-  IL_0001:  isinst     ""<>f__AnonymousType0<<Value>j__TPar>""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0021
-  IL_000a:  call       ""System.Collections.Generic.EqualityComparer<<Value>j__TPar> System.Collections.Generic.EqualityComparer<<Value>j__TPar>.Default.get""
-  IL_000f:  ldarg.0
-  IL_0010:  ldfld      ""<Value>j__TPar <>f__AnonymousType0<<Value>j__TPar>.<Value>i__Field""
-  IL_0015:  ldloc.0
-  IL_0016:  ldfld      ""<Value>j__TPar <>f__AnonymousType0<<Value>j__TPar>.<Value>i__Field""
-  IL_001b:  callvirt   ""bool System.Collections.Generic.EqualityComparer<<Value>j__TPar>.Equals(<Value>j__TPar, <Value>j__TPar)""
-  IL_0020:  ret
-  IL_0021:  ldc.i4.0
-  IL_0022:  ret
-}");
-
-            comp.VerifyIL("<>f__AnonymousType0<<Value>j__TPar>.ToString", @"
-{
-  // Code size       77 (0x4d)
-  .maxstack  7
-  .locals init (<Value>j__TPar V_0,
-                <Value>j__TPar V_1)
-  IL_0000:  ldnull
-  IL_0001:  ldstr      ""{{ Value = {0} }}""
-  IL_0006:  ldc.i4.1
-  IL_0007:  newarr     ""object""
-  IL_000c:  dup
-  IL_000d:  ldc.i4.0
-  IL_000e:  ldarg.0
-  IL_000f:  ldfld      ""<Value>j__TPar <>f__AnonymousType0<<Value>j__TPar>.<Value>i__Field""
-  IL_0014:  stloc.0
-  IL_0015:  ldloca.s   V_0
-  IL_0017:  ldloca.s   V_1
-  IL_0019:  initobj    ""<Value>j__TPar""
-  IL_001f:  ldloc.1
-  IL_0020:  box        ""<Value>j__TPar""
-  IL_0025:  brtrue.s   IL_003b
-  IL_0027:  ldobj      ""<Value>j__TPar""
-  IL_002c:  stloc.1
-  IL_002d:  ldloca.s   V_1
-  IL_002f:  ldloc.1
-  IL_0030:  box        ""<Value>j__TPar""
-  IL_0035:  brtrue.s   IL_003b
-  IL_0037:  pop
-  IL_0038:  ldnull
-  IL_0039:  br.s       IL_0046
-  IL_003b:  constrained. ""<Value>j__TPar""
-  IL_0041:  callvirt   ""string object.ToString()""
-  IL_0046:  stelem.ref
-  IL_0047:  call       ""string string.Format(System.IFormatProvider, string, params object[])""
-  IL_004c:  ret
-}");
-
-            comp.VerifyIL("<>f__AnonymousType0<<Value>j__TPar>.Value.get", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""<Value>j__TPar <>f__AnonymousType0<<Value>j__TPar>.<Value>i__Field""
-  IL_0006:  ret
-}");
+            Assert.Null(comp.HasLocalsInit("<>f__AnonymousType0<<Value>j__TPar>.GetHashCode"));
+            Assert.Null(comp.HasLocalsInit("<>f__AnonymousType0<<Value>j__TPar>..ctor"));
+            Assert.True(comp.HasLocalsInit("<>f__AnonymousType0<<Value>j__TPar>.Equals"));
+            Assert.True(comp.HasLocalsInit("<>f__AnonymousType0<<Value>j__TPar>.ToString"));
+            Assert.Null(comp.HasLocalsInit("<>f__AnonymousType0<<Value>j__TPar>.Value.get"));
         }
 
         [Fact]
@@ -10068,14 +9163,7 @@ public class C
 
             var comp = CompileAndVerify(source);
 
-            comp.VerifyIL("C.<>c__DisplayClass0_0..ctor", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""object..ctor()""
-  IL_0006:  ret
-}");
+            Assert.Null(comp.HasLocalsInit("C.<>c__DisplayClass0_0..ctor"));
         }
 
         [Fact]
@@ -10102,23 +9190,8 @@ public class C
 
             var comp = CompileAndVerify(source);
 
-            comp.VerifyIL("Microsoft.CodeAnalysis.EmbeddedAttribute..ctor", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""System.Attribute..ctor()""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("System.Runtime.CompilerServices.IsReadOnlyAttribute..ctor", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  call       ""System.Attribute..ctor()""
-  IL_0006:  ret
-}");
+            Assert.Null(comp.HasLocalsInit("Microsoft.CodeAnalysis.EmbeddedAttribute..ctor"));
+            Assert.Null(comp.HasLocalsInit("System.Runtime.CompilerServices.IsReadOnlyAttribute..ctor"));
         }
 
         [Fact]
@@ -10156,37 +9229,8 @@ public class C_skip
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C_init.M", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C_skip.M", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.True(comp.HasLocalsInit("C_init.M"));
+            Assert.False(comp.HasLocalsInit("C_skip.M"));
         }
 
         [Fact]
@@ -10237,67 +9281,10 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.P_skip.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P_init.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P_skip.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.P_init.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.4
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.P_skip.get"));
+            Assert.True(comp.HasLocalsInit("C.P_init.get"));
+            Assert.False(comp.HasLocalsInit("C.P_skip.set"));
+            Assert.True(comp.HasLocalsInit("C.P_init.set"));
         }
 
         [Fact]
@@ -10366,98 +9353,12 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.P1.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P1.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.P2.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P2.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.4
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.P3.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.5
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P3.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.6
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.P1.get"));
+            Assert.True(comp.HasLocalsInit("C.P1.set"));
+            Assert.True(comp.HasLocalsInit("C.P2.get"));
+            Assert.False(comp.HasLocalsInit("C.P2.set"));
+            Assert.False(comp.HasLocalsInit("C.P3.get"));
+            Assert.False(comp.HasLocalsInit("C.P3.set"));
         }
 
         [Fact]
@@ -10487,77 +9388,8 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.<get_P>d__1.System.Collections.IEnumerator.MoveNext", @"
-{
-  // Code size       92 (0x5c)
-  .maxstack  2
-  .locals (int V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<get_P>d__1.<>1__state""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  switch    (
-        IL_001b,
-        IL_0037,
-        IL_0053)
-  IL_0019:  ldc.i4.0
-  IL_001a:  ret
-  IL_001b:  ldarg.0
-  IL_001c:  ldc.i4.m1
-  IL_001d:  stfld      ""int C.<get_P>d__1.<>1__state""
-  IL_0022:  ldarg.0
-  IL_0023:  ldc.i4.1
-  IL_0024:  box        ""int""
-  IL_0029:  stfld      ""object C.<get_P>d__1.<>2__current""
-  IL_002e:  ldarg.0
-  IL_002f:  ldc.i4.1
-  IL_0030:  stfld      ""int C.<get_P>d__1.<>1__state""
-  IL_0035:  ldc.i4.1
-  IL_0036:  ret
-  IL_0037:  ldarg.0
-  IL_0038:  ldc.i4.m1
-  IL_0039:  stfld      ""int C.<get_P>d__1.<>1__state""
-  IL_003e:  ldarg.0
-  IL_003f:  ldc.i4.2
-  IL_0040:  box        ""int""
-  IL_0045:  stfld      ""object C.<get_P>d__1.<>2__current""
-  IL_004a:  ldarg.0
-  IL_004b:  ldc.i4.2
-  IL_004c:  stfld      ""int C.<get_P>d__1.<>1__state""
-  IL_0051:  ldc.i4.1
-  IL_0052:  ret
-  IL_0053:  ldarg.0
-  IL_0054:  ldc.i4.m1
-  IL_0055:  stfld      ""int C.<get_P>d__1.<>1__state""
-  IL_005a:  ldc.i4.0
-  IL_005b:  ret
-}");
-
-            comp.VerifyIL("C.<get_P>d__1.System.Collections.Generic.IEnumerable<object>.GetEnumerator", @"
-{
-  // Code size       43 (0x2b)
-  .maxstack  2
-  .locals (C.<get_P>d__1 V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<get_P>d__1.<>1__state""
-  IL_0006:  ldc.i4.s   -2
-  IL_0008:  bne.un.s   IL_0022
-  IL_000a:  ldarg.0
-  IL_000b:  ldfld      ""int C.<get_P>d__1.<>l__initialThreadId""
-  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0015:  bne.un.s   IL_0022
-  IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.0
-  IL_0019:  stfld      ""int C.<get_P>d__1.<>1__state""
-  IL_001e:  ldarg.0
-  IL_001f:  stloc.0
-  IL_0020:  br.s       IL_0029
-  IL_0022:  ldc.i4.0
-  IL_0023:  newobj     ""C.<get_P>d__1..ctor(int)""
-  IL_0028:  stloc.0
-  IL_0029:  ldloc.0
-  IL_002a:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.<get_P>d__1.System.Collections.IEnumerator.MoveNext"));
+            Assert.False(comp.HasLocalsInit("C.<get_P>d__1.System.Collections.Generic.IEnumerable<object>.GetEnumerator"));
         }
 
         [Fact]
@@ -10629,98 +9461,12 @@ public class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.P1.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P1.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.P2.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P2.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.4
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.P3.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.5
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P3.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.6
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.P1.get"));
+            Assert.False(comp.HasLocalsInit("C.P1.set"));
+            Assert.False(comp.HasLocalsInit("C.P2.get"));
+            Assert.False(comp.HasLocalsInit("C.P2.set"));
+            Assert.False(comp.HasLocalsInit("C.P3.get"));
+            Assert.False(comp.HasLocalsInit("C.P3.set"));
         }
 
         [Fact]
@@ -10776,67 +9522,10 @@ public class C_skip
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C_init.P.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C_skip.P.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C_init.P.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C_skip.P.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.4
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.True(comp.HasLocalsInit("C_init.P.get"));
+            Assert.False(comp.HasLocalsInit("C_skip.P.get"));
+            Assert.True(comp.HasLocalsInit("C_init.P.set"));
+            Assert.False(comp.HasLocalsInit("C_skip.P.set"));
         }
 
         [Fact]
@@ -10864,24 +9553,8 @@ public class C
 
             // No locals are expected. We are just making sure it still works.
 
-            comp.VerifyIL("C.P.get", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<P>k__BackingField""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("C.P.set", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldarg.1
-  IL_0002:  stfld      ""int C.<P>k__BackingField""
-  IL_0007:  ret
-}");
+            Assert.Null(comp.HasLocalsInit("C.P.get"));
+            Assert.Null(comp.HasLocalsInit("C.P.set"));
         }
 
         [Fact]
@@ -10926,52 +9599,11 @@ public class C
 
             // No locals are expected. We are just making sure it still works.
 
-            comp.VerifyIL("C.P.get", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.p""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("C.P.set", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldarg.1
-  IL_0002:  stfld      ""int C.p""
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P2.get", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.p2""
-  IL_0006:  ret
-}");
-
-            comp.VerifyIL("C.P2.set", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldarg.1
-  IL_0002:  stfld      ""int C.p2""
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.P3.get", @"
-{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.p3""
-  IL_0006:  ret
-}");
+            Assert.Null(comp.HasLocalsInit("C.P.get"));
+            Assert.Null(comp.HasLocalsInit("C.P.set"));
+            Assert.Null(comp.HasLocalsInit("C.P2.get"));
+            Assert.Null(comp.HasLocalsInit("C.P2.set"));
+            Assert.Null(comp.HasLocalsInit("C.P3.get"));
         }
 
         [Fact]
@@ -11055,131 +9687,14 @@ class C_init
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C_init.P.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C_skip.P.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C_init.P.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C_skip.P.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C_init.M", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C_skip.M", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C_init.C2.M2", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.4
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C_skip.C2.M2", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.4
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.True(comp.HasLocalsInit("C_init.P.get"));
+            Assert.False(comp.HasLocalsInit("C_skip.P.get"));
+            Assert.True(comp.HasLocalsInit("C_init.P.set"));
+            Assert.False(comp.HasLocalsInit("C_skip.P.set"));
+            Assert.True(comp.HasLocalsInit("C_init.M"));
+            Assert.False(comp.HasLocalsInit("C_skip.M"));
+            Assert.True(comp.HasLocalsInit("C_init.C2.M2"));
+            Assert.False(comp.HasLocalsInit("C_skip.C2.M2"));
         }
 
         [Fact]
@@ -11218,37 +9733,8 @@ class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.C2.M2", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.C2.C3.M3", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.C2.M2"));
+            Assert.False(comp.HasLocalsInit("C.C2.C3.M3"));
         }
 
         [Fact]
@@ -11302,68 +9788,10 @@ class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.C2.P2.get", @"
-{
-  // Code size        8 (0x8)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  ret
-}");
-
-            comp.VerifyIL("C.C2.P2.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.C2.M2", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.C2.C3.M3", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.4
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.C2.P2.get"));
+            Assert.False(comp.HasLocalsInit("C.C2.P2.set"));
+            Assert.False(comp.HasLocalsInit("C.C2.M2"));
+            Assert.False(comp.HasLocalsInit("C.C2.C3.M3"));
         }
 
         [Fact]
@@ -11418,70 +9846,10 @@ partial class C
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C.P.get", @"
-{
-  // Code size       10 (0xa)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  dup
-  IL_0008:  stloc.0
-  IL_0009:  ret
-}");
-
-            comp.VerifyIL("C.P.set", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.2
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.M", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C.C2.M2", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.4
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.False(comp.HasLocalsInit("C.P.get"));
+            Assert.False(comp.HasLocalsInit("C.P.set"));
+            Assert.False(comp.HasLocalsInit("C.M"));
+            Assert.False(comp.HasLocalsInit("C.C2.M2"));
         }
 
         [Fact]
@@ -11525,37 +9893,8 @@ public class C_skip
 
             var comp = CompileAndVerify(source, verify: Verification.Fails);
 
-            comp.VerifyIL("C_init.C.M", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals init (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
-
-            comp.VerifyIL("C_skip.C.M", @"
-{
-  // Code size        9 (0x9)
-  .maxstack  2
-  .locals (int V_0) //x
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  add
-  IL_0005:  ldloc.0
-  IL_0006:  add
-  IL_0007:  stloc.0
-  IL_0008:  ret
-}");
+            Assert.True(comp.HasLocalsInit("C_init.C.M"));
+            Assert.False(comp.HasLocalsInit("C_skip.C.M"));
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -11484,6 +11484,80 @@ partial class C
 }");
         }
 
+        [Fact]
+        public void SourceNamedTypeSymbolDelegatesToContainingTypeWhenSkipLocalsInitAttributeIsNotFound()
+        {
+            var source = @"
+namespace System.Runtime.CompilerServices
+{
+    public class SkipLocalsInitAttribute : System.Attribute
+    {
+    }
+}
+
+class C_init
+{
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    class C
+    {
+        void M()
+        {
+            int x = 1;
+            x = x + x + x;
+        }
+    }
+}
+
+[System.Runtime.CompilerServices.SkipLocalsInitAttribute]
+public class C_skip
+{
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    class C
+    {
+        void M()
+        {
+            int x = 1;
+            x = x + x + x;
+        }
+    }
+}
+";
+
+            var comp = CompileAndVerify(source, verify: Verification.Fails);
+
+            comp.VerifyIL("C_init.C.M", @"
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  .locals init (int V_0) //x
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  add
+  IL_0005:  ldloc.0
+  IL_0006:  add
+  IL_0007:  stloc.0
+  IL_0008:  ret
+}");
+
+            comp.VerifyIL("C_skip.C.M", @"
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  .locals (int V_0) //x
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  add
+  IL_0005:  ldloc.0
+  IL_0006:  add
+  IL_0007:  stloc.0
+  IL_0008:  ret
+}");
+        }
+
         #endregion
 
         [Fact, WorkItem(807, "https://github.com/dotnet/roslyn/issues/807")]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -10860,8 +10860,118 @@ public class C
 }
 ";
 
-            // No locals are expected. We are just making sure it still works.
             var comp = CompileAndVerify(source);
+
+            // No locals are expected. We are just making sure it still works.
+
+            comp.VerifyIL("C.P.get", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<P>k__BackingField""
+  IL_0006:  ret
+}");
+
+            comp.VerifyIL("C.P.set", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  stfld      ""int C.<P>k__BackingField""
+  IL_0007:  ret
+}");
+        }
+
+        [Fact]
+        public void SkipLocalsInitAttributeOnExpressionBodiedProperty()
+        {
+            var source = @"
+namespace System.Runtime.CompilerServices
+{
+    public class SkipLocalsInitAttribute : System.Attribute
+    {
+    }
+}
+
+public class C
+{
+    int p;
+    int p2;
+    int p3;
+
+    [System.Runtime.CompilerServices.SkipLocalsInitAttribute]
+    public int P
+    {
+        get => p;
+        set => p = value;
+    }
+
+    public int P2
+    {
+        [System.Runtime.CompilerServices.SkipLocalsInitAttribute]
+        get => p2;
+
+        [System.Runtime.CompilerServices.SkipLocalsInitAttribute]
+        set => p2 = value;
+    }
+
+    [System.Runtime.CompilerServices.SkipLocalsInitAttribute]
+    public int P3 => p3;
+}
+";
+
+            var comp = CompileAndVerify(source);
+
+            // No locals are expected. We are just making sure it still works.
+
+            comp.VerifyIL("C.P.get", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.p""
+  IL_0006:  ret
+}");
+
+            comp.VerifyIL("C.P.set", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  stfld      ""int C.p""
+  IL_0007:  ret
+}");
+
+            comp.VerifyIL("C.P2.get", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.p2""
+  IL_0006:  ret
+}");
+
+            comp.VerifyIL("C.P2.set", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  stfld      ""int C.p2""
+  IL_0007:  ret
+}");
+
+            comp.VerifyIL("C.P3.get", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.p3""
+  IL_0006:  ret
+}");
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonMethodWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonMethodWellKnownAttributeData.cs
@@ -122,24 +122,6 @@ namespace Microsoft.CodeAnalysis
         }
         #endregion
 
-        #region SkipLocalsInitAttribute
-        private bool _hasSkipLocalsInitAttribute;
-        public bool HasSkipLocalsInitAttribute
-        {
-            get
-            {
-                VerifySealed(expected: true);
-                return _hasSkipLocalsInitAttribute;
-            }
-            set
-            {
-                VerifySealed(expected: false);
-                _hasSkipLocalsInitAttribute = value;
-                SetDataStored();
-            }
-        }
-        #endregion
-
         #region SpecialNameAttribute
         private bool _hasSpecialNameAttribute;
         public bool HasSpecialNameAttribute

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonPropertyWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonPropertyWellKnownAttributeData.cs
@@ -47,23 +47,5 @@ namespace Microsoft.CodeAnalysis
         }
 
         #endregion
-
-        #region SkipLocalsInitAttribute
-        private bool _hasSkipLocalsInitAttribute;
-        public bool HasSkipLocalsInitAttribute
-        {
-            get
-            {
-                VerifySealed(expected: true);
-                return _hasSkipLocalsInitAttribute;
-            }
-            set
-            {
-                VerifySealed(expected: false);
-                _hasSkipLocalsInitAttribute = value;
-                SetDataStored();
-            }
-        }
-        #endregion
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeWellKnownAttributeData.cs
@@ -246,5 +246,23 @@ namespace Microsoft.CodeAnalysis
         }
 
         #endregion
+
+        #region SkipLocalsInitAttribute
+        private bool _hasSkipLocalsInitAttribute;
+        public bool HasSkipLocalsInitAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasSkipLocalsInitAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasSkipLocalsInitAttribute = value;
+                SetDataStored();
+            }
+        }
+        #endregion
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeWellKnownAttributeData.cs
@@ -246,23 +246,5 @@ namespace Microsoft.CodeAnalysis
         }
 
         #endregion
-
-        #region SkipLocalsInitAttribute
-        private bool _hasSkipLocalsInitAttribute;
-        public bool HasSkipLocalsInitAttribute
-        {
-            get
-            {
-                VerifySealed(expected: true);
-                return _hasSkipLocalsInitAttribute;
-            }
-            set
-            {
-                VerifySealed(expected: false);
-                _hasSkipLocalsInitAttribute = value;
-                SetDataStored();
-            }
-        }
-        #endregion
     }
 }


### PR DESCRIPTION
This change enables applying SkipLocalsInitAttribute directly on classes. It can be put on a global level class or on a nested one.