### PR TITLE
Fix failure to initialize RemoteWorkspace in the out-of-process host

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -381,7 +381,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var storage = new AssetStorage();
             var source = new TestAssetSource(storage, map);
             var remoteWorkspace = new RemoteWorkspace();
-            var service = new SolutionService(new AssetService(sessionId, storage, remoteWorkspace), remoteWorkspace);
+            var service = new SolutionService(new AssetService(sessionId, storage, remoteWorkspace));
 
             return service;
         }

--- a/src/Workspaces/Remote/Core/Services/RoslynServices.cs
+++ b/src/Workspaces/Remote/Core/Services/RoslynServices.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Remote
             var workspace = (RemoteWorkspace)primaryWorkspace.Workspace ?? new RemoteWorkspace();
 
             AssetService = new AssetService(_scopeId, storage, workspace);
-            SolutionService = new SolutionService(AssetService, workspace);
+            SolutionService = new SolutionService(AssetService);
             CompilationService = new CompilationService(SolutionService);
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     token.ThrowIfCancellationRequested();
 
-                    var service = RoslynServices.SolutionService.PrimaryWorkspace.Services.GetService<IPerformanceTrackerService>();
+                    var service = SolutionService.PrimaryWorkspace.Services.GetService<IPerformanceTrackerService>();
                     if (service == null)
                     {
                         return;

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -220,10 +220,10 @@ namespace Microsoft.CodeAnalysis.Remote
             FatalError.NonFatalHandler = WatsonReporter.Report;
 
             // start performance reporter
-            var diagnosticAnalyzerPerformanceTracker = RoslynServices.SolutionService.PrimaryWorkspace.Services.GetService<IPerformanceTrackerService>();
+            var diagnosticAnalyzerPerformanceTracker = SolutionService.PrimaryWorkspace.Services.GetService<IPerformanceTrackerService>();
             if (diagnosticAnalyzerPerformanceTracker != null)
             {
-                var globalOperationNotificationService = RoslynServices.SolutionService.PrimaryWorkspace.Services.GetService<IGlobalOperationNotificationService>();
+                var globalOperationNotificationService = SolutionService.PrimaryWorkspace.Services.GetService<IGlobalOperationNotificationService>();
                 _performanceReporter = new PerformanceReporter(Logger, diagnosticAnalyzerPerformanceTracker, globalOperationNotificationService, s_reportInterval, ShutdownCancellationToken);
             }
         }
@@ -265,12 +265,12 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private RemotePersistentStorageLocationService GetPersistentStorageService()
         {
-            return (RemotePersistentStorageLocationService)RoslynServices.SolutionService.PrimaryWorkspace.Services.GetService<IPersistentStorageLocationService>();
+            return (RemotePersistentStorageLocationService)SolutionService.PrimaryWorkspace.Services.GetService<IPersistentStorageLocationService>();
         }
 
         private RemoteGlobalOperationNotificationService GetGlobalOperationNotificationService()
         {
-            var notificationService = RoslynServices.SolutionService.PrimaryWorkspace.Services.GetService<IGlobalOperationNotificationService>() as RemoteGlobalOperationNotificationService;
+            var notificationService = SolutionService.PrimaryWorkspace.Services.GetService<IGlobalOperationNotificationService>() as RemoteGlobalOperationNotificationService;
             return notificationService;
         }
 


### PR DESCRIPTION
### Customer scenario

Visual Studio crashes as soon as a project is opened.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/590114
### Workarounds, if any

None.

### Risk

Relatively low.

### Performance impact

N/A

### Is this a regression from a previous update?

Yes, caused by f12bda83376471482a3c3d2cd4fef52560f55e81

### Root cause analysis

There were two contributing factors to this:

1. After deciding on a pattern to follow in 37a1d2c4e9cc9aca97c1f5c7b4e8bf59e85e3ece, I failed to undo related changes in f12bda83376471482a3c3d2cd4fef52560f55e81 to account for the simpler approach.
2. Despite efforts to validate every incremental change in #25558, I did not realize that integration tests were disabled at the time. Knowing that unit tests simulate the remote host in-process, I was counting on integration tests to catch any errors in the true remoting layer. Once I saw the builds go green, I didn't look into the details to verify that the integration tests were actually providing the validation I expected.

### How was the bug found?

We turned integration tests back on.

### Test documentation updated?

N/A