### PR TITLE
Export classification type definitions for new classification types

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/ClassificationTypeDefinitions.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/ClassificationTypeDefinitions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text.Classification;
@@ -71,6 +70,61 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.TypeParameterName)]
         [BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)]
         internal readonly ClassificationTypeDefinition UserTypeTypeParametersTypeDefinition;
+        #endregion
+
+        #region Field Name
+        [Export]
+        [Name(ClassificationTypeNames.FieldName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition FieldNameTypeDefinition;
+        #endregion
+        #region Enum Member Name
+        [Export]
+        [Name(ClassificationTypeNames.EnumMemberName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition EnumMemberNameTypeDefinition;
+        #endregion
+        #region Constant Name
+        [Export]
+        [Name(ClassificationTypeNames.ConstantName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition ConstantNameTypeDefinition;
+        #endregion
+        #region Local Name
+        [Export]
+        [Name(ClassificationTypeNames.LocalName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition LocalNameTypeDefinition;
+        #endregion
+        #region Parameter Name
+        [Export]
+        [Name(ClassificationTypeNames.ParameterName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition ParameterNameTypeDefinition;
+        #endregion
+        #region Method Name
+        [Export]
+        [Name(ClassificationTypeNames.MethodName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition MethodNameTypeDefinition;
+        #endregion
+        #region Extension Method Name
+        [Export]
+        [Name(ClassificationTypeNames.ExtensionMethodName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition ExtensionMethodNameTypeDefinition;
+        #endregion
+        #region Property Name
+        [Export]
+        [Name(ClassificationTypeNames.PropertyName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition PropertyNameTypeDefinition;
+        #endregion
+        #region Event Name
+        [Export]
+        [Name(ClassificationTypeNames.EventName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition EventNameTypeDefinition;
         #endregion
 
         #region XML Doc Comments - Attribute Name 

--- a/src/EditorFeatures/Test/Workspaces/ClassificationTypeNamesTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/ClassificationTypeNamesTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.VisualStudio.Text.Classification;
@@ -29,26 +27,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         [WorkItem(25716, "https://github.com/dotnet/roslyn/issues/25716")]
         public void ClassificationTypeExported(string fieldName, object constantValue)
         {
-            Assert.IsType<string>(constantValue);
-            string classificationTypeName = (string)constantValue;
+            var classificationTypeName = Assert.IsType<string>(constantValue);
             var exportProvider = TestExportProvider.ExportProviderWithCSharpAndVisualBasic;
-            var exports = exportProvider.GetExports<ClassificationTypeDefinition, IClassificationTypeDefinitionMetadata>();
-            var export = exports.FirstOrDefault(x => x.Metadata.Name == classificationTypeName);
-            Assert.True(export != null, $"{nameof(ClassificationTypeNames)}.{fieldName} has value \"{classificationTypeName}\", but no matching {nameof(ClassificationTypeDefinition)} was exported.");
-        }
-
-        public interface IClassificationTypeDefinitionMetadata
-        {
-            string Name
-            {
-                get;
-            }
-
-            [DefaultValue(null)]
-            IEnumerable<string> BaseDefinition
-            {
-                get;
-            }
+            var classificationTypeRegistryService = exportProvider.GetExport<IClassificationTypeRegistryService>().Value;
+            var classificationType = classificationTypeRegistryService.GetClassificationType(classificationTypeName);
+            Assert.True(classificationType != null, $"{nameof(ClassificationTypeNames)}.{fieldName} has value \"{classificationTypeName}\", but no matching {nameof(ClassificationTypeDefinition)} was exported.");
         }
     }
 }

--- a/src/EditorFeatures/Test/Workspaces/ClassificationTypeNamesTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/ClassificationTypeNamesTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.VisualStudio.Text.Classification;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+{
+    public class ClassificationTypeNamesTests
+    {
+        public static IEnumerable<object[]> AllClassificationTypeNames
+        {
+            get
+            {
+                foreach (var field in typeof(ClassificationTypeNames).GetFields(BindingFlags.Static | BindingFlags.Public))
+                {
+                    yield return new object[] { field.Name, field.GetRawConstantValue() };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AllClassificationTypeNames))]
+        [WorkItem(25716, "https://github.com/dotnet/roslyn/issues/25716")]
+        public void ClassificationTypeExported(string fieldName, object constantValue)
+        {
+            Assert.IsType<string>(constantValue);
+            string classificationTypeName = (string)constantValue;
+            var exportProvider = TestExportProvider.ExportProviderWithCSharpAndVisualBasic;
+            var exports = exportProvider.GetExports<ClassificationTypeDefinition, IClassificationTypeDefinitionMetadata>();
+            var export = exports.FirstOrDefault(x => x.Metadata.Name == classificationTypeName);
+            Assert.True(export != null, $"{nameof(ClassificationTypeNames)}.{fieldName} has value \"{classificationTypeName}\", but no matching {nameof(ClassificationTypeDefinition)} was exported.");
+        }
+
+        public interface IClassificationTypeDefinitionMetadata
+        {
+            string Name
+            {
+                get;
+            }
+
+            [DefaultValue(null)]
+            IEnumerable<string> BaseDefinition
+            {
+                get;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #25716

### Customer scenario

Find all references fails to show code preview on lines with method names and other similar cases.

### Bugs this fixes

Fixes #25716

### Workarounds, if any

None.

### Risk

Low.

### Performance impact

N/A

### Is this a regression from a previous update?

Yes, introduced by 1063c092d2ca0a48f4bd189e53002ae714348955.

### Root cause analysis

The failure occurs in the presentation layer of the Find All References window, where exceptions are caught and fields are simply displayed as empty to avoid crashing the IDE. Our integration tests operate against the model rather than the view, so errors in the presentation logic are not revealed by automated testing.

The underlying cause was a failure to export a `ClassificationTypeDefinition` for new classification types used in IDE code. A reflection-based test was added to detect regressions of this exact type, though no general protection is offered against other types of failures in the presentation layer. A failure of the new test will result in output like the following:

> Message: ClassificationTypeNames.FieldName has value "field name", but no matching ClassificationTypeDefinition was exported.
> Expected: True
> Actual:   False

### How was the bug found?

Dogfooding

### Test documentation updated?

No