### PR TITLE
Assert duplicate named arguments produce correct diagnostics

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -284,11 +284,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ArrayBuilder<BoundExpression> boundNamedArgumentsBuilder = null;
                 HashSet<string> boundNamedArgumentsSet = null;
 
-                // Avoid "cascading" errors for constructor arguments.
-                // We will still generate errors for each duplicate named attribute argument,
-                // matching Dev10 compiler behavior.
-                bool hadError = false;
-
                 // Only report the first "non-trailing named args required C# 7.2" error,
                 // so as to avoid "cascading" errors.
                 bool hadLangVersionError = false;
@@ -308,19 +303,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         this.BindArgumentAndName(
                             boundConstructorArguments,
                             diagnostics,
-                            ref hadError,
                             ref hadLangVersionError,
                             argument,
                             BindArgumentExpression(diagnostics, argument.Expression, RefKind.None, allowArglist: false),
                             argument.NameColon,
                             refKind: RefKind.None);
-
-                        if (boundNamedArgumentsBuilder != null)
-                        {
-                            // Error CS1016: Named attribute argument expected
-                            // This has been reported by the parser.
-                            hadError = true;
-                        }
                     }
                     else
                     {
@@ -338,7 +325,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             // Duplicate named argument
                             Error(diagnostics, ErrorCode.ERR_DuplicateNamedAttributeArgument, argument, argumentName);
-                            hadError = true;
                         }
 
                         BoundExpression boundNamedArgument = BindNamedAttributeArgument(argument, attributeType, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2240,7 +2240,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindArgumentAndName(
                 result,
                 diagnostics,
-                ref hadError,
                 ref hadLangVersionError,
                 argumentSyntax,
                 boundArgument,
@@ -2414,7 +2413,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void BindArgumentAndName(
             AnalyzedArguments result,
             DiagnosticBag diagnostics,
-            ref bool hadError,
             ref bool hadLangVersionError,
             CSharpSyntaxNode argumentSyntax,
             BoundExpression boundArgumentExpression,
@@ -2457,28 +2455,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         result.Names.Add(null);
                     }
-                }
-
-                string name = nameColonSyntax.Name.Identifier.ValueText;
-
-                // Note that because of this nested loop this is an O(n^2) algorithm; 
-                // however, the set of named arguments in an invocation is likely to be small.
-
-                bool hasNameCollision = false;
-                for (int i = 0; i < result.Names.Count; ++i)
-                {
-                    if (result.Name(i) == name)
-                    {
-                        hasNameCollision = true;
-                        break;
-                    }
-                }
-
-                if (hasNameCollision && !hadError)
-                {
-                    // CS: Named argument '{0}' cannot be specified multiple times
-                    Error(diagnostics, ErrorCode.ERR_DuplicateNamedArgument, nameColonSyntax.Name, name);
-                    hadError = true;
                 }
 
                 result.Names.Add(nameColonSyntax.Name);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
@@ -57,9 +57,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new ArgumentAnalysisResult(ArgumentAnalysisResultKind.NoCorrespondingNamedParameter, argumentPosition, 0, default(ImmutableArray<int>));
         }
 
-        public static ArgumentAnalysisResult DuplicateNamedArguments(int argumentPosition)
+        public static ArgumentAnalysisResult DuplicateNamedArgument(int argumentPosition)
         {
-            return new ArgumentAnalysisResult(ArgumentAnalysisResultKind.DuplicateNamedArguments, argumentPosition, 0, default(ImmutableArray<int>));
+            return new ArgumentAnalysisResult(ArgumentAnalysisResultKind.DuplicateNamedArgument, argumentPosition, 0, default(ImmutableArray<int>));
         }
 
         public static ArgumentAnalysisResult RequiredParameterMissing(int parameterPosition)
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ArgumentAnalysisResultKind.NameUsedForPositional:
                     s += "Invalid because argument " + ArgumentPosition + " had a name.";
                     break;
-                case ArgumentAnalysisResultKind.DuplicateNamedArguments:
+                case ArgumentAnalysisResultKind.DuplicateNamedArgument:
                     s += "Invalid because named argument " + ArgumentPosition + " was specified twice.";
                     break;
                 case ArgumentAnalysisResultKind.NoCorrespondingParameter:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
@@ -57,6 +57,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new ArgumentAnalysisResult(ArgumentAnalysisResultKind.NoCorrespondingNamedParameter, argumentPosition, 0, default(ImmutableArray<int>));
         }
 
+        public static ArgumentAnalysisResult DuplicateNamedArguments(int argumentPosition)
+        {
+            return new ArgumentAnalysisResult(ArgumentAnalysisResultKind.DuplicateNamedArguments, argumentPosition, 0, default(ImmutableArray<int>));
+        }
+
         public static ArgumentAnalysisResult RequiredParameterMissing(int parameterPosition)
         {
             return new ArgumentAnalysisResult(ArgumentAnalysisResultKind.RequiredParameterMissing, 0, parameterPosition, default(ImmutableArray<int>));
@@ -91,6 +96,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
                 case ArgumentAnalysisResultKind.NameUsedForPositional:
                     s += "Invalid because argument " + ArgumentPosition + " had a name.";
+                    break;
+                case ArgumentAnalysisResultKind.DuplicateNamedArguments:
+                    s += "Invalid because named argument " + ArgumentPosition + " was specified twice.";
                     break;
                 case ArgumentAnalysisResultKind.NoCorrespondingParameter:
                     s += "Invalid because argument " + ArgumentPosition + " has no corresponding parameter.";

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResultKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResultKind.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         NoCorrespondingParameter,
         FirstInvalid = NoCorrespondingParameter,
         NoCorrespondingNamedParameter,
+        DuplicateNamedArguments,
         RequiredParameterMissing,
         NameUsedForPositional,
         BadNonTrailingNamedArgument // if a named argument refers to a different position, all following arguments must be named

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResultKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResultKind.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         NoCorrespondingParameter,
         FirstInvalid = NoCorrespondingParameter,
         NoCorrespondingNamedParameter,
-        DuplicateNamedArguments,
+        DuplicateNamedArgument,
         RequiredParameterMissing,
         NameUsedForPositional,
         BadNonTrailingNamedArgument // if a named argument refers to a different position, all following arguments must be named

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 case MemberResolutionKind.NoCorrespondingParameter:
                 case MemberResolutionKind.NoCorrespondingNamedParameter:
-                case MemberResolutionKind.DuplicateNamedArguments:
+                case MemberResolutionKind.DuplicateNamedArgument:
                 case MemberResolutionKind.NameUsedForPositional:
                 case MemberResolutionKind.RequiredParameterMissing:
                 case MemberResolutionKind.LessDerived:
@@ -151,8 +151,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return NoCorrespondingParameter(argAnalysis.ArgumentPosition);
                 case ArgumentAnalysisResultKind.NoCorrespondingNamedParameter:
                     return NoCorrespondingNamedParameter(argAnalysis.ArgumentPosition);
-                case ArgumentAnalysisResultKind.DuplicateNamedArguments:
-                    return DuplicateNamedArguments(argAnalysis.ArgumentPosition);
+                case ArgumentAnalysisResultKind.DuplicateNamedArgument:
+                    return DuplicateNamedArgument(argAnalysis.ArgumentPosition);
                 case ArgumentAnalysisResultKind.RequiredParameterMissing:
                     return RequiredParameterMissing(argAnalysis.ParameterPosition);
                 case ArgumentAnalysisResultKind.NameUsedForPositional:
@@ -192,10 +192,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 badArgumentsOpt: ImmutableArray.Create<int>(argumentPosition));
         }
 
-        public static MemberAnalysisResult DuplicateNamedArguments(int argumentPosition)
+        public static MemberAnalysisResult DuplicateNamedArgument(int argumentPosition)
         {
             return new MemberAnalysisResult(
-                MemberResolutionKind.DuplicateNamedArguments,
+                MemberResolutionKind.DuplicateNamedArgument,
                 badArgumentsOpt: ImmutableArray.Create<int>(argumentPosition));
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
@@ -131,6 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 case MemberResolutionKind.NoCorrespondingParameter:
                 case MemberResolutionKind.NoCorrespondingNamedParameter:
+                case MemberResolutionKind.DuplicateNamedArguments:
                 case MemberResolutionKind.NameUsedForPositional:
                 case MemberResolutionKind.RequiredParameterMissing:
                 case MemberResolutionKind.LessDerived:
@@ -150,6 +151,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return NoCorrespondingParameter(argAnalysis.ArgumentPosition);
                 case ArgumentAnalysisResultKind.NoCorrespondingNamedParameter:
                     return NoCorrespondingNamedParameter(argAnalysis.ArgumentPosition);
+                case ArgumentAnalysisResultKind.DuplicateNamedArguments:
+                    return DuplicateNamedArguments(argAnalysis.ArgumentPosition);
                 case ArgumentAnalysisResultKind.RequiredParameterMissing:
                     return RequiredParameterMissing(argAnalysis.ParameterPosition);
                 case ArgumentAnalysisResultKind.NameUsedForPositional:
@@ -189,6 +192,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 badArgumentsOpt: ImmutableArray.Create<int>(argumentPosition));
         }
 
+        public static MemberAnalysisResult DuplicateNamedArguments(int argumentPosition)
+        {
+            return new MemberAnalysisResult(
+                MemberResolutionKind.DuplicateNamedArguments,
+                badArgumentsOpt: ImmutableArray.Create<int>(argumentPosition));
+        }
+
         public static MemberAnalysisResult RequiredParameterMissing(int parameterPosition)
         {
             return new MemberAnalysisResult(
@@ -211,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(conversions.Length != 0);
             Debug.Assert(badArguments.Length != 0);
             return new MemberAnalysisResult(
-                MemberResolutionKind.BadArguments,
+                MemberResolutionKind.BadArgumentConversion,
                 badArguments,
                 argsToParamsOpt,
                 conversions);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberResolutionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberResolutionKind.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// The candidate member was rejected because there were two named arguments with the same parameter name.
         /// </summary>
-        DuplicateNamedArguments,
+        DuplicateNamedArgument,
 
         /// <summary>
         /// The candidate member was rejected because an required parameter had no corresponding argument.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberResolutionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberResolutionKind.cs
@@ -47,6 +47,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         NoCorrespondingNamedParameter,
 
         /// <summary>
+        /// The candidate member was rejected because there were two named arguments with the same parameter name.
+        /// </summary>
+        DuplicateNamedArguments,
+
+        /// <summary>
         /// The candidate member was rejected because an required parameter had no corresponding argument.
         /// </summary>
         RequiredParameterMissing,
@@ -79,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// The candidate member was rejected because an argument could not be converted to the appropriate parameter
         /// type.
         /// </summary>
-        BadArguments,
+        BadArgumentConversion,
 
         /// <summary>
         /// The candidate member was rejected because type inference failed.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2920,6 +2920,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     case ArgumentAnalysisResultKind.RequiredParameterMissing:
                     case ArgumentAnalysisResultKind.NoCorrespondingParameter:
+                    case ArgumentAnalysisResultKind.DuplicateNamedArgument:
                         if (!completeResults) goto default;
                         // When we are producing more complete results, and we have the wrong number of arguments, we push on
                         // through type inference so that lambda arguments can be bound to their delegate-typed parameters,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -787,6 +787,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         case MemberResolutionKind.NoCorrespondingNamedParameter:
                         case MemberResolutionKind.UseSiteError:
                         case MemberResolutionKind.BadNonTrailingNamedArgument:
+                        case MemberResolutionKind.DuplicateNamedArgument:
                             return true;
                     }
                     break;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -779,7 +779,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MemberResolutionKind.NoCorrespondingParameter:
                     switch (expandedResult.Kind)
                     {
-                        case MemberResolutionKind.BadArguments:
+                        case MemberResolutionKind.BadArgumentConversion:
                         case MemberResolutionKind.NameUsedForPositional:
                         case MemberResolutionKind.TypeInferenceFailed:
                         case MemberResolutionKind.TypeInferenceExtensionInstanceArgument:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
-using System;
 
 #if DEBUG
 using System.Text;
@@ -299,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Since we didn't return...
-            AssertNone(MemberResolutionKind.BadArguments);
+            AssertNone(MemberResolutionKind.BadArgumentConversion);
 
             // Otherwise, if there is any such method where type inference succeeded but inferred
             // type arguments that violate the constraints on the method, then the first such method is 
@@ -372,12 +371,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             MemberResolutionResult<TMember> firstSupported = default(MemberResolutionResult<TMember>);
             MemberResolutionResult<TMember> firstUnsupported = default(MemberResolutionResult<TMember>);
 
-            var supportedInPriorityOrder = new MemberResolutionResult<TMember>[5]; // from highest to lowest priority
-            const int requiredParameterMissingPriority = 0;
-            const int nameUsedForPositionalPriority = 1;
-            const int noCorrespondingNamedParameterPriority = 2;
-            const int noCorrespondingParameterPriority = 3;
-            const int badNonTrailingNamedArgument = 4;
+            var supportedInPriorityOrder = new MemberResolutionResult<TMember>[6]; // from highest to lowest priority
+            const int duplicateNamedArguments = 0;
+            const int requiredParameterMissingPriority = 1;
+            const int nameUsedForPositionalPriority = 2;
+            const int noCorrespondingNamedParameterPriority = 3;
+            const int noCorrespondingParameterPriority = 4;
+            const int badNonTrailingNamedArgument = 5;
 
             foreach (MemberResolutionResult<TMember> result in this.ResultsBuilder)
             {
@@ -425,6 +425,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                             result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[badNonTrailingNamedArgument].Result.BadArgumentsOpt[0])
                         {
                             supportedInPriorityOrder[badNonTrailingNamedArgument] = result;
+                        }
+                        break;
+                    case MemberResolutionKind.DuplicateNamedArguments:
+                        {
+                            if (supportedInPriorityOrder[duplicateNamedArguments].IsNull ||
+                            result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[duplicateNamedArguments].Result.BadArgumentsOpt[0])
+                            {
+                                supportedInPriorityOrder[duplicateNamedArguments] = result;
+                            }
                         }
                         break;
                     default:
@@ -481,6 +490,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // and followed by unnamed arguments.
                         case MemberResolutionKind.BadNonTrailingNamedArgument:
                             ReportBadNonTrailingNamedArgument(firstSupported, diagnostics, arguments, symbols);
+                            return;
+
+                        case MemberResolutionKind.DuplicateNamedArguments:
+                            ReportDuplicateNamedArguments(firstSupported, diagnostics, arguments);
                             return;
                     }
                 }
@@ -740,6 +753,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 symbols), location);
         }
 
+        private void ReportDuplicateNamedArguments(MemberResolutionResult<TMember> result, DiagnosticBag diagnostics, AnalyzedArguments arguments)
+        {
+            Debug.Assert(result.Result.BadArgumentsOpt.Length == 1);
+            var name = arguments.Names[result.Result.BadArgumentsOpt[0]];
+            Debug.Assert(name != null);
+
+            // CS: Named argument '{0}' cannot be specified multiple times
+            diagnostics.Add(new CSDiagnosticInfo(ErrorCode.ERR_DuplicateNamedArgument, name.Identifier.Text), name.Location);
+        }
+
         private static void ReportNoCorrespondingNamedParameter(
             MemberResolutionResult<TMember> bad,
             string methodName,
@@ -980,7 +1003,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BinderFlags flags,
             bool isMethodGroupConversion)
         {
-            var badArg = GetFirstMemberKind(MemberResolutionKind.BadArguments);
+            var badArg = GetFirstMemberKind(MemberResolutionKind.BadArgumentConversion);
             if (badArg.IsNull)
             {
                 return false;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -372,12 +372,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             MemberResolutionResult<TMember> firstUnsupported = default(MemberResolutionResult<TMember>);
 
             var supportedInPriorityOrder = new MemberResolutionResult<TMember>[6]; // from highest to lowest priority
-            const int duplicateNamedArguments = 0;
+            const int duplicateNamedArgumentPriority = 0;
             const int requiredParameterMissingPriority = 1;
             const int nameUsedForPositionalPriority = 2;
             const int noCorrespondingNamedParameterPriority = 3;
             const int noCorrespondingParameterPriority = 4;
-            const int badNonTrailingNamedArgument = 5;
+            const int badNonTrailingNamedArgumentPriority = 5;
 
             foreach (MemberResolutionResult<TMember> result in this.ResultsBuilder)
             {
@@ -421,18 +421,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         break;
                     case MemberResolutionKind.BadNonTrailingNamedArgument:
-                        if (supportedInPriorityOrder[badNonTrailingNamedArgument].IsNull ||
-                            result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[badNonTrailingNamedArgument].Result.BadArgumentsOpt[0])
+                        if (supportedInPriorityOrder[badNonTrailingNamedArgumentPriority].IsNull ||
+                            result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[badNonTrailingNamedArgumentPriority].Result.BadArgumentsOpt[0])
                         {
-                            supportedInPriorityOrder[badNonTrailingNamedArgument] = result;
+                            supportedInPriorityOrder[badNonTrailingNamedArgumentPriority] = result;
                         }
                         break;
-                    case MemberResolutionKind.DuplicateNamedArguments:
+                    case MemberResolutionKind.DuplicateNamedArgument:
                         {
-                            if (supportedInPriorityOrder[duplicateNamedArguments].IsNull ||
-                            result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[duplicateNamedArguments].Result.BadArgumentsOpt[0])
+                            if (supportedInPriorityOrder[duplicateNamedArgumentPriority].IsNull ||
+                            result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[duplicateNamedArgumentPriority].Result.BadArgumentsOpt[0])
                             {
-                                supportedInPriorityOrder[duplicateNamedArguments] = result;
+                                supportedInPriorityOrder[duplicateNamedArgumentPriority] = result;
                             }
                         }
                         break;
@@ -492,8 +492,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ReportBadNonTrailingNamedArgument(firstSupported, diagnostics, arguments, symbols);
                             return;
 
-                        case MemberResolutionKind.DuplicateNamedArguments:
-                            ReportDuplicateNamedArguments(firstSupported, diagnostics, arguments);
+                        case MemberResolutionKind.DuplicateNamedArgument:
+                            ReportDuplicateNamedArgument(firstSupported, diagnostics, arguments);
                             return;
                     }
                 }
@@ -753,10 +753,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 symbols), location);
         }
 
-        private void ReportDuplicateNamedArguments(MemberResolutionResult<TMember> result, DiagnosticBag diagnostics, AnalyzedArguments arguments)
+        private void ReportDuplicateNamedArgument(MemberResolutionResult<TMember> result, DiagnosticBag diagnostics, AnalyzedArguments arguments)
         {
             Debug.Assert(result.Result.BadArgumentsOpt.Length == 1);
-            var name = arguments.Names[result.Result.BadArgumentsOpt[0]];
+            IdentifierNameSyntax name = arguments.Names[result.Result.BadArgumentsOpt[0]];
             Debug.Assert(name != null);
 
             // CS: Named argument '{0}' cannot be specified multiple times

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -115,12 +115,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We have analyzed every argument and tried to make it correspond to a particular parameter. 
             // We must now answer the following questions:
             //
-            // (1) Is there any named argument that were specified twice?
-            // (2) Is there any named argument used out-of-position and followed by unnamed arguments?
-            // (3) Is there any argument without a corresponding parameter?
-            // (4) Was there any named argument that specified a parameter that was already
+            // (1) Is there any named argument used out-of-position and followed by unnamed arguments?
+            // (2) Is there any argument without a corresponding parameter?
+            // (3) Was there any named argument that specified a parameter that was already
             //     supplied with a positional parameter?
-            // (5) Is there any non-optional parameter without a corresponding argument?
+            // (4) Is there any non-optional parameter without a corresponding argument?
+            // (5) Is there any named argument that were specified twice?
             //
             // If the answer to any of these questions is "yes" then the method is not applicable.
             // It is possible that the answer to any number of these questions is "yes", and so
@@ -128,15 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // should we need to report why a given method is not applicable. We prioritize
             // them in the given order.
 
-            // (1) Is there any named argument that were specified twice?
-
-            int? duplicateNamedArgument = CheckForDuplicateNamedArguments(arguments);
-            if (duplicateNamedArgument != null)
-            {
-                return ArgumentAnalysisResult.DuplicateNamedArguments(duplicateNamedArgument.Value);
-            }
-
-            // (2) Is there any named argument used out-of-position and followed by unnamed arguments?
+            // (1) Is there any named argument used out-of-position and followed by unnamed arguments?
 
             int? badNonTrailingNamedArgument = CheckForBadNonTrailingNamedArgument(arguments, argsToParameters, parameters);
             if (badNonTrailingNamedArgument != null)
@@ -144,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return ArgumentAnalysisResult.BadNonTrailingNamedArgument(badNonTrailingNamedArgument.Value);
             }
 
-            // (3) Is there any argument without a corresponding parameter?
+            // (2) Is there any argument without a corresponding parameter?
 
             if (unmatchedArgumentIndex != null)
             {
@@ -158,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            // (4) was there any named argument that specified a parameter that was already
+            // (3) was there any named argument that specified a parameter that was already
             //     supplied with a positional parameter?
 
             int? nameUsedForPositional = NameUsedForPositional(arguments, argsToParameters);
@@ -167,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return ArgumentAnalysisResult.NameUsedForPositional(nameUsedForPositional.Value);
             }
 
-            // (5) Is there any non-optional parameter without a corresponding argument?
+            // (4) Is there any non-optional parameter without a corresponding argument?
 
             int? requiredParameterMissing = CheckForMissingRequiredParameter(argsToParameters, parameters, isMethodGroupConversion, expanded);
             if (requiredParameterMissing != null)
@@ -179,6 +171,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (arguments.Names.Any() && arguments.Names.Last() != null && isVararg)
             {
                 return ArgumentAnalysisResult.RequiredParameterMissing(parameters.Length);
+            }
+
+            // (5) Is there any named argument that were specified twice?
+
+            int? duplicateNamedArgument = CheckForDuplicateNamedArgument(arguments);
+            if (duplicateNamedArgument != null)
+            {
+                return ArgumentAnalysisResult.DuplicateNamedArgument(duplicateNamedArgument.Value);
             }
 
             // We're good; this one might be applicable in the given form.
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        private static int? CheckForDuplicateNamedArguments(AnalyzedArguments arguments)
+        private static int? CheckForDuplicateNamedArgument(AnalyzedArguments arguments)
         {
             if (arguments.Names.IsEmpty())
             {

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_InvalidExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_InvalidExpression.cs
@@ -634,7 +634,7 @@ IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax:
         [Fact]
         [CompilerTrait(CompilerFeature.IOperation)]
         [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
-        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_CorrectArgumentsOrder_Lambdas()
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_CorrectArgumentsOrder_Delegates()
         {
             string source = @"
 public delegate void D(int a, int b, int c = 4);
@@ -764,7 +764,7 @@ IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax:
         [Fact]
         [CompilerTrait(CompilerFeature.IOperation)]
         [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
-        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_IncorrectArgumentsOrder_Lambdas()
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_IncorrectArgumentsOrder_Delegates()
         {
             string source = @"
 public delegate void D(int a, int b, int c = 4);

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_InvalidExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_InvalidExpression.cs
@@ -570,5 +570,97 @@ IParameterInitializerOperation (Parameter: [System.Int32 p = default(System.Int3
 
             VerifyOperationTreeAndDiagnosticsForTest<EqualsValueClauseSyntax>(source, expectedOperationTree, expectedDiagnostics);
         }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_Repro()
+        {
+            string source = @"
+public class C
+{
+    void M()
+    {
+        /*<bind>*/string.Format(format: """", format: """")/*</bind>*/;
+    }
+}";
+            string expectedOperationTree = @"
+IInvalidOperation (OperationKind.Invalid, Type: System.String, IsInvalid) (Syntax: 'string.Form ... format: """")')
+  Children(3):
+      IOperation:  (OperationKind.None, Type: null) (Syntax: 'string')
+      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: """") (Syntax: '""""')
+      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: """") (Syntax: '""""')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: new DiagnosticDescription[]
+            {
+                // file.cs(6,45): error CS1740: Named argument 'format' cannot be specified multiple times
+                //         /*<bind>*/string.Format(format: "", format: "")/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "format").WithArguments("format").WithLocation(6, 45)
+            });
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_CorrectArgumentsOrder()
+        {
+            string source = @"
+public class C
+{
+    void N(int a, int b, int c = 4)
+    {
+    }
+
+    void M()
+    {
+        /*<bind>*/N(a: 1, a: 2, b: 3)/*</bind>*/;
+    }
+}";
+            string expectedOperationTree = @"
+IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'N(a: 1, a: 2, b: 3)')
+  Children(3):
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: new DiagnosticDescription[]
+            {
+                // file.cs(10,27): error CS1740: Named argument 'a' cannot be specified multiple times
+                //         /*<bind>*/N(a: 1, a: 2)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "a").WithArguments("a").WithLocation(10, 27)
+            });
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_IncorrectArgumentsOrder()
+        {
+            string source = @"
+public class C
+{
+    void N(int a, int b, int c = 4)
+    {
+    }
+
+    void M()
+    {
+        /*<bind>*/N(b: 1, a: 2, a: 3)/*</bind>*/;
+    }
+}";
+            string expectedOperationTree = @"
+IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'N(b: 1, a: 2, a: 3)')
+  Children(3):
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: new DiagnosticDescription[]
+            {
+                // file.cs(10,33): error CS1740: Named argument 'a' cannot be specified multiple times
+                //         /*<bind>*/N(b: 1, a: 2, a: 3)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "a").WithArguments("a").WithLocation(10, 33)
+            });
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_InvalidExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_InvalidExpression.cs
@@ -602,7 +602,7 @@ IInvalidOperation (OperationKind.Invalid, Type: System.String, IsInvalid) (Synta
         [Fact]
         [CompilerTrait(CompilerFeature.IOperation)]
         [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
-        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_CorrectArgumentsOrder()
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_CorrectArgumentsOrder_Methods()
         {
             string source = @"
 public class C
@@ -634,7 +634,105 @@ IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax:
         [Fact]
         [CompilerTrait(CompilerFeature.IOperation)]
         [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
-        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_IncorrectArgumentsOrder()
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_CorrectArgumentsOrder_Lambdas()
+        {
+            string source = @"
+public delegate void D(int a, int b, int c = 4);
+public class C
+{
+    void N(D lambda)
+    {
+        /*<bind>*/lambda(a: 1, a: 2, b: 3)/*</bind>*/;
+    }
+}";
+            string expectedOperationTree = @"
+IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'lambda(a: 1, a: 2, b: 3)')
+  Children(4):
+      IParameterReferenceOperation: lambda (OperationKind.ParameterReference, Type: D) (Syntax: 'lambda')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: new DiagnosticDescription[]
+            {
+                // file.cs(7,32): error CS1740: Named argument 'a' cannot be specified multiple times
+                //         /*<bind>*/lambda(a: 1, a: 2, b: 3)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "a").WithArguments("a").WithLocation(7, 32)
+            });
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_CorrectArgumentsOrder_Indexers_Getter()
+        {
+            string source = @"
+public class C
+{
+    int this[int a, int b, int c = 4]
+    {
+        get => 0;
+    }
+
+    void M()
+    {
+        var result = /*<bind>*/this[a: 1, a: 2, b: 3]/*</bind>*/;
+    }
+}";
+            string expectedOperationTree = @"
+IInvalidOperation (OperationKind.Invalid, Type: System.Int32, IsInvalid) (Syntax: 'this[a: 1, a: 2, b: 3]')
+  Children(4):
+      IInstanceReferenceOperation (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<ElementAccessExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: new DiagnosticDescription[]
+            {
+                // file.cs(11,43): error CS1740: Named argument 'a' cannot be specified multiple times
+                //         var result = /*<bind>*/this[a: 1, a: 2, b: 3]/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "a").WithArguments("a").WithLocation(11, 43)
+            });
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_CorrectArgumentsOrder_Indexers_Setter()
+        {
+            string source = @"
+public class C
+{
+    int this[int a, int b, int c = 4]
+    {
+        set {}
+    }
+
+    void M()
+    {
+        /*<bind>*/this[a: 1, a: 2, b: 3]/*</bind>*/ = 0;
+    }
+}";
+            string expectedOperationTree = @"
+IInvalidOperation (OperationKind.Invalid, Type: System.Int32, IsInvalid) (Syntax: 'this[a: 1, a: 2, b: 3]')
+  Children(4):
+      IInstanceReferenceOperation (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<ElementAccessExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: new DiagnosticDescription[]
+            {
+                // file.cs(11,30): error CS1740: Named argument 'a' cannot be specified multiple times
+                //         /*<bind>*/this[a: 1, a: 2, b: 3]/*</bind>*/ = 0;
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "a").WithArguments("a").WithLocation(11, 30)
+            });
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_IncorrectArgumentsOrder_Methods()
         {
             string source = @"
 public class C
@@ -660,6 +758,104 @@ IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax:
                 // file.cs(10,33): error CS1740: Named argument 'a' cannot be specified multiple times
                 //         /*<bind>*/N(b: 1, a: 2, a: 3)/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "a").WithArguments("a").WithLocation(10, 33)
+            });
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_IncorrectArgumentsOrder_Lambdas()
+        {
+            string source = @"
+public delegate void D(int a, int b, int c = 4);
+public class C
+{
+    void N(D lambda)
+    {
+        /*<bind>*/lambda(b: 1, a: 2, a: 3)/*</bind>*/;
+    }
+}";
+            string expectedOperationTree = @"
+IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'lambda(b: 1, a: 2, a: 3)')
+  Children(4):
+      IParameterReferenceOperation: lambda (OperationKind.ParameterReference, Type: D) (Syntax: 'lambda')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: new DiagnosticDescription[]
+            {
+                // file.cs(7,38): error CS1740: Named argument 'a' cannot be specified multiple times
+                //         /*<bind>*/lambda(b: 1, a: 2, a: 3)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "a").WithArguments("a").WithLocation(7, 38)
+            });
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_IncorrectArgumentsOrder_Indexers_Getter()
+        {
+            string source = @"
+public class C
+{
+    int this[int a, int b, int c = 4]
+    {
+        get => 0;
+    }
+
+    void M()
+    {
+        var result = /*<bind>*/this[b: 1, a: 2, a: 3]/*</bind>*/;
+    }
+}";
+            string expectedOperationTree = @"
+IInvalidOperation (OperationKind.Invalid, Type: System.Int32, IsInvalid) (Syntax: 'this[b: 1, a: 2, a: 3]')
+  Children(4):
+      IInstanceReferenceOperation (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<ElementAccessExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: new DiagnosticDescription[]
+            {
+                // file.cs(11,49): error CS1740: Named argument 'a' cannot be specified multiple times
+                //         var result = /*<bind>*/this[b: 1, a: 2, a: 3]/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "a").WithArguments("a").WithLocation(11, 49)
+            });
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [WorkItem(20050, "https://github.com/dotnet/roslyn/issues/20050")]
+        public void BuildsArgumentsOperationsForDuplicateExplicitArguments_IncorrectArgumentsOrder_Indexers_Setter()
+        {
+            string source = @"
+public class C
+{
+    int this[int a, int b, int c = 4]
+    {
+        set {}
+    }
+
+    void M()
+    {
+        /*<bind>*/this[b: 1, a: 2, a: 3]/*</bind>*/ = 0;
+    }
+}";
+            string expectedOperationTree = @"
+IInvalidOperation (OperationKind.Invalid, Type: System.Int32, IsInvalid) (Syntax: 'this[b: 1, a: 2, a: 3]')
+  Children(4):
+      IInstanceReferenceOperation (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<ElementAccessExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: new DiagnosticDescription[]
+            {
+                // file.cs(11,36): error CS1740: Named argument 'a' cannot be specified multiple times
+                //         /*<bind>*/this[b: 1, a: 2, a: 3]/*</bind>*/ = 0;
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "a").WithArguments("a").WithLocation(11, 36)
             });
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2125,9 +2125,9 @@ namespace System.ServiceModel
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (7,13): error CS1740: Named argument 'arg' cannot be specified multiple times
-                //             arg: null);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg").WithArguments("arg").WithLocation(7, 13));
+                // (5,9): error CS1501: No overload for method 'M' takes 3 arguments
+                //         M("",
+                Diagnostic(ErrorCode.ERR_BadArgCount, "M").WithArguments("M", "3").WithLocation(5, 9));
         }
 
         [WorkItem(543820, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543820")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2127,11 +2127,7 @@ namespace System.ServiceModel
             CreateCompilation(source).VerifyDiagnostics(
                 // (7,13): error CS1740: Named argument 'arg' cannot be specified multiple times
                 //             arg: null);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg").WithArguments("arg").WithLocation(7, 13),
-                // (5,9): error CS1501: No overload for method 'M' takes 3 arguments
-                //         M("",
-                Diagnostic(ErrorCode.ERR_BadArgCount, "M").WithArguments("M", "3").WithLocation(5, 9)
-                );
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg").WithArguments("arg").WithLocation(7, 13));
         }
 
         [WorkItem(543820, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543820")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3590,5 +3590,32 @@ static class E
             var info = model.GetSymbolInfo(node);
             Assert.Equal("System.Object A.G(System.String s)", info.Symbol.ToTestDisplayString());
         }
+
+        [Fact]
+        public void BindingLambdaArguments_DuplicateNamedArguments()
+        {
+            var compilation = CreateCompilation(@"
+using System;
+class X
+{
+    void M<T>(T arg1, Func<T, T> arg2)
+    {
+    }
+    void N()
+    {
+        M(arg1: 5, arg2: x => x, arg2: y => y);
+    }
+}").VerifyDiagnostics(
+                // (10,34): error CS1740: Named argument 'arg2' cannot be specified multiple times
+                //         M(arg1: 5, arg2: x => 0, arg2: y => 0);
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg2").WithArguments("arg2").WithLocation(10, 34));
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree, ignoreAccessibility: true);
+
+            var lambda = tree.GetRoot().DescendantNodes().OfType<SimpleLambdaExpressionSyntax>().Single(s => s.Parameter.Identifier.Text == "x");
+            var typeInfo = model.GetTypeInfo(lambda.Body);
+            Assert.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -531,6 +531,7 @@ class C
             Assert.Equal("M(x: 1, x: 2)", invocation.ToString());
 
             var symbolInfo = model.GetSymbolInfo(invocation);
+            Assert.Null(symbolInfo.Symbol);
             Assert.Equal(CandidateReason.OverloadResolutionFailure, symbolInfo.CandidateReason);
             Assert.Equal("void C.M(params System.Int32[] x)", symbolInfo.CandidateSymbols.Single().ToTestDisplayString());
         }
@@ -551,12 +552,12 @@ class C
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1);
             comp.VerifyDiagnostics(
-                // (9,17): error CS1740: Named argument 'x' cannot be specified multiple times
-                //         M(x: 1, x: 2, 3);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(9, 17),
                 // (9,23): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //         M(x: 1, x: 2, 3);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "3").WithArguments("7.2").WithLocation(9, 23));
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "3").WithArguments("7.2").WithLocation(9, 23),
+                // (9,17): error CS8323: Named argument 'x' is used out-of-position but is followed by an unnamed argument
+                //         M(x: 1, x: 2, 3);
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "x").WithArguments("x").WithLocation(9, 17));
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
@@ -1032,9 +1033,9 @@ class C
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (6,17): error CS1740: Named argument 'x' cannot be specified multiple times
+                // (6,11): error CS1739: The best overload for 'M' does not have a parameter named 'x'
                 //         M(x: 1, x: 2, __arglist());
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 17));
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("M", "x").WithLocation(6, 11));
         }
 
         [Fact]
@@ -1119,9 +1120,9 @@ class C
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (4,22): error CS1740: Named argument 'x' cannot be specified multiple times
+                // (4,16): error CS1739: The best overload for '.ctor' does not have a parameter named 'x'
                 //     C() : this(x: 1, x: 2, 3) { }
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(4, 22));
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments(".ctor", "x").WithLocation(4, 16));
         }
 
         [Fact]
@@ -1137,9 +1138,9 @@ class C
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (6,21): error CS1740: Named argument 'x' cannot be specified multiple times
+                // (6,15): error CS1739: The best overload for 'C' does not have a parameter named 'x'
                 //         new C(x: 1, x: 2, 3);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 21));
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("C", "x").WithLocation(6, 15));
         }
 
         [Fact]
@@ -1157,9 +1158,9 @@ class C
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (8,38): error CS1740: Named argument 'x' cannot be specified multiple times
+                // (8,32): error CS1739: The best overload for 'this' does not have a parameter named 'x'
                 //         System.Console.Write(c[x: 1, x: 2, 3]);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(8, 38));
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("this", "x").WithLocation(8, 32));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -529,7 +529,10 @@ class C
             var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
             var invocation = nodes.OfType<InvocationExpressionSyntax>().Single();
             Assert.Equal("M(x: 1, x: 2)", invocation.ToString());
-            Assert.Equal("void C.M(params System.Int32[] x)", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+
+            var symbolInfo = model.GetSymbolInfo(invocation);
+            Assert.Equal(CandidateReason.OverloadResolutionFailure, symbolInfo.CandidateReason);
+            Assert.Equal("void C.M(params System.Int32[] x)", symbolInfo.CandidateSymbols.Single().ToTestDisplayString());
         }
 
         [Fact]
@@ -553,11 +556,7 @@ class C
                 Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(9, 17),
                 // (9,23): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //         M(x: 1, x: 2, 3);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "3").WithArguments("7.2").WithLocation(9, 23),
-                // (9,17): error CS8321: Named argument 'x' is used out-of-position but is followed by an unnamed argument
-                //         M(x: 1, x: 2, 3);
-                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "x").WithArguments("x").WithLocation(9, 17)
-                );
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "3").WithArguments("7.2").WithLocation(9, 23));
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
@@ -1035,11 +1034,7 @@ class C
             comp.VerifyDiagnostics(
                 // (6,17): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         M(x: 1, x: 2, __arglist());
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 17),
-                // (6,11): error CS1739: The best overload for 'M' does not have a parameter named 'x'
-                //         M(x: 1, x: 2, __arglist());
-                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("M", "x").WithLocation(6, 11)
-                );
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 17));
         }
 
         [Fact]
@@ -1055,13 +1050,9 @@ class C
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (6,27): error CS1740: Named argument 'x' cannot be specified multiple times
-                //         M(__arglist(x: 1, x: 2, __arglist()));
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 27),
                 // (6,33): error CS0226: An __arglist expression may only appear inside of a call or new expression
                 //         M(__arglist(x: 1, x: 2, __arglist()));
-                Diagnostic(ErrorCode.ERR_IllegalArglist, "__arglist()").WithLocation(6, 33)
-                );
+                Diagnostic(ErrorCode.ERR_IllegalArglist, "__arglist()").WithLocation(6, 33));
         }
 
         [Fact]
@@ -1130,11 +1121,7 @@ class C
             comp.VerifyDiagnostics(
                 // (4,22): error CS1740: Named argument 'x' cannot be specified multiple times
                 //     C() : this(x: 1, x: 2, 3) { }
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(4, 22),
-                // (4,16): error CS1739: The best overload for '.ctor' does not have a parameter named 'x'
-                //     C() : this(x: 1, x: 2, 3) { }
-                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments(".ctor", "x").WithLocation(4, 16)
-                );
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(4, 22));
         }
 
         [Fact]
@@ -1152,11 +1139,7 @@ class C
             comp.VerifyDiagnostics(
                 // (6,21): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         new C(x: 1, x: 2, 3);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 21),
-                // (6,15): error CS1739: The best overload for 'C' does not have a parameter named 'x'
-                //         new C(x: 1, x: 2, 3);
-                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("C", "x").WithLocation(6, 15)
-                );
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 21));
         }
 
         [Fact]
@@ -1176,11 +1159,7 @@ class C
             comp.VerifyDiagnostics(
                 // (8,38): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         System.Console.Write(c[x: 1, x: 2, 3]);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(8, 38),
-                // (8,32): error CS1739: The best overload for 'this' does not have a parameter named 'x'
-                //         System.Console.Write(c[x: 1, x: 2, 3]);
-                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("this", "x").WithLocation(8, 32)
-                );
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(8, 38));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -19795,18 +19795,12 @@ public class Cls
     {
     }
 }";
-            var compilation = CreateCompilation(text,
-                                                            options: TestOptions.ReleaseExe,
-                                                            parseOptions: TestOptions.Regular);
+            var compilation = CreateCompilation(text, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular);
 
             compilation.VerifyDiagnostics(
                 // (7,25): error CS1740: Named argument 'y' cannot be specified multiple times
                 //         Test1(y: ref x, y: out var y);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "y").WithArguments("y").WithLocation(7, 25),
-                // (7,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'x' of 'Cls.Test1(int, ref int)'
-                //         Test1(y: ref x, y: out var y);
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test1").WithArguments("x", "Cls.Test1(int, ref int)").WithLocation(7, 9)
-                );
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "y").WithArguments("y").WithLocation(7, 25));
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -19798,9 +19798,9 @@ public class Cls
             var compilation = CreateCompilation(text, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular);
 
             compilation.VerifyDiagnostics(
-                // (7,25): error CS1740: Named argument 'y' cannot be specified multiple times
+                // (7,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'x' of 'Cls.Test1(int, ref int)'
                 //         Test1(y: ref x, y: out var y);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "y").WithArguments("y").WithLocation(7, 25));
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test1").WithArguments("x", "Cls.Test1(int, ref int)").WithLocation(7, 9));
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -16233,18 +16233,19 @@ public class C
 public class C
 {
     public static int Main()
-        {
-            Test(Name: ""5"", Name: """");
+    {
+        Test(age: 5, Name: ""5"", Name: """");
         return 0;
-        }
-    public static void Test(int age , string Name)
-    { }
+    }
+    public static void Test(int age, string Name)
+    {
+    }
 }";
             var compilation = CSharpTestBase.CreateCompilation(text);
             compilation.VerifyDiagnostics(
-                // (6,29): error CS1740: Named argument 'Name' cannot be specified multiple times
-                //             Test(Name: "5", Name: "");
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "Name").WithArguments("Name").WithLocation(6, 29));
+                // (6,33): error CS1740: Named argument 'Name' cannot be specified multiple times
+                //         Test(age: 5, Name: "5", Name: "");
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "Name").WithArguments("Name").WithLocation(6, 33));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -16244,11 +16244,7 @@ public class C
             compilation.VerifyDiagnostics(
                 // (6,29): error CS1740: Named argument 'Name' cannot be specified multiple times
                 //             Test(Name: "5", Name: "");
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "Name").WithArguments("Name").WithLocation(6, 29),
-                // (6,13): error CS7036: There is no argument given that corresponds to the required formal parameter 'age' of 'C.Test(int, string)'
-                //             Test(Name: "5", Name: "");
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test").WithArguments("age", "C.Test(int, string)").WithLocation(6, 13)
-                );
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "Name").WithArguments("Name").WithLocation(6, 29));
         }
 
         [Fact]


### PR DESCRIPTION
### Customer scenario
Getting IOperations trees on call expressions that have duplicate explicitly named arguments, will cause a `Debug.Assert()` to throw in the compiler. Example:
```C#
    public class C
    {
        void M()
        {
            string.Format(format: "", format: "");
        }
    }
```
### Bugs this fixes
Fixes #20050 
### Workarounds, if any
None.
### Risk
Low. One line fix.
### Is this a regression from a previous update?
No.
### Root cause analysis
It is a case where we didn't count for invalid arguments when constructing the IOperations tree.
### How was the bug found?
Reported on GitHub.