### PR TITLE
Fix loc issue on "Manage Specifications" and "Manage styles" dialogs

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1236,20 +1236,20 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Manage naming styles.
+        /// </summary>
+        internal static string Manage_naming_styles {
+            get {
+                return ResourceManager.GetString("Manage_naming_styles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Manage specifications.
         /// </summary>
         internal static string Manage_specifications {
             get {
                 return ResourceManager.GetString("Manage_specifications", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Manage styles.
-        /// </summary>
-        internal static string Manage_styles {
-            get {
-                return ResourceManager.GetString("Manage_styles", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -783,8 +783,8 @@ Additional information: {1}</value>
   <data name="Manage_specifications" xml:space="preserve">
     <value>Manage specifications</value>
   </data>
-  <data name="Manage_styles" xml:space="preserve">
-    <value>Manage styles</value>
+  <data name="Manage_naming_styles" xml:space="preserve">
+    <value>Manage naming styles</value>
   </data>
   <data name="Reorder" xml:space="preserve">
     <value>Reorder</value>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1103,11 +1103,6 @@ Další informace: {1}</target>
         <target state="translated">Spravovat specifikace</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">Spravovat styly</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">Přeskupit</target>
@@ -1506,6 +1501,11 @@ Souhlasím se všemi výše uvedenými podmínkami:</target>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1103,11 +1103,6 @@ Zusätzliche Informationen: {1}</target>
         <target state="translated">Spezifikationen verwalten</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">Stile verwalten</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">Neu anordnen</target>
@@ -1506,6 +1501,11 @@ Ich stimme allen vorstehenden Bedingungen zu:</target>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1103,11 +1103,6 @@ Información adicional: {1}</target>
         <target state="translated">Administrar especificaciones</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">Administrar estilos</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">Reordenar</target>
@@ -1506,6 +1501,11 @@ Estoy de acuerdo con todo lo anterior:</target>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1103,11 +1103,6 @@ Informations supplémentaires : {1}</target>
         <target state="translated">Gérer les spécifications</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">Gérer les styles</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">Réorganiser</target>
@@ -1506,6 +1501,11 @@ Je suis d'accord avec tout ce qui précède :</target>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1103,11 +1103,6 @@ Informazioni aggiuntive: {1}</target>
         <target state="translated">Gestisci specifiche</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">Gestisci stili</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">Riordina</target>
@@ -1506,6 +1501,11 @@ L'utente accetta le condizioni sopra riportate:</target>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1103,11 +1103,6 @@ Additional information: {1}</source>
         <target state="translated">仕様の管理</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">スタイルの管理</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">並べ替え</target>
@@ -1506,6 +1501,11 @@ I agree to all of the foregoing:</source>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1103,11 +1103,6 @@ Additional information: {1}</source>
         <target state="translated">사양 관리</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">스타일 관리</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">다시 정렬</target>
@@ -1506,6 +1501,11 @@ I agree to all of the foregoing:</source>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1103,11 +1103,6 @@ Dodatkowe informacje: {1}</target>
         <target state="translated">Zarządzaj specyfikacjami</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">Zarządzaj stylami</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">Zmień kolejność</target>
@@ -1506,6 +1501,11 @@ Wyrażam zgodę na wszystkie następujące postanowienia:</target>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1103,11 +1103,6 @@ Informações adicionais: {1}</target>
         <target state="translated">Gerenciar especificações</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">Gerenciar estilos</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">Reordenar</target>
@@ -1506,6 +1501,11 @@ Eu concordo com todo o conteúdo supracitado:</target>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1103,11 +1103,6 @@ Additional information: {1}</source>
         <target state="translated">Управление спецификациями</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">Управление стилями</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">Переупорядочить</target>
@@ -1506,6 +1501,11 @@ I agree to all of the foregoing:</source>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1103,11 +1103,6 @@ Ek bilgiler: {1}</target>
         <target state="translated">Belirtimleri yönet</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">Stilleri yönet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">Yeniden sırala</target>
@@ -1506,6 +1501,11 @@ Aşağıdakilerin tümünü onaylıyorum:</target>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1103,11 +1103,6 @@ Additional information: {1}</source>
         <target state="translated">管理规范</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">管理样式</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">重新排序</target>
@@ -1506,6 +1501,11 @@ I agree to all of the foregoing:</source>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1103,11 +1103,6 @@ Additional information: {1}</source>
         <target state="translated">管理規格</target>
         <note />
       </trans-unit>
-      <trans-unit id="Manage_styles">
-        <source>Manage styles</source>
-        <target state="translated">管理樣式</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Reorder">
         <source>Reorder</source>
         <target state="translated">重新排序</target>
@@ -1506,6 +1501,11 @@ I agree to all of the foregoing:</source>
       <trans-unit id="Sync_Class_View_Command_Handler">
         <source>Sync Class View Command Handler</source>
         <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Manage_naming_styles">
+        <source>Manage naming styles</source>
+        <target state="new">Manage naming styles</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageViewModel.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
     internal class NamingStyleOptionPageViewModel : AbstractNotifyPropertyChanged
     {
         public string ManageSpecificationsButtonText => ServicesVSResources.Manage_specifications;
-        public string ManageStylesButtonText => ServicesVSResources.Manage_styles;
+        public string ManageStylesButtonText => ServicesVSResources.Manage_naming_styles;
 
         private readonly NotificationOptionViewModel[] _notifications = new[]
         {

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyles/ManageNamingStylesDialogViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyles/ManageNamingStylesDialogViewModel.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
 
         public ObservableCollection<INamingStylesInfoDialogViewModel> Items { get; set; }
 
-        public string DialogTitle => "Manage Naming Styles";
+        public string DialogTitle => ServicesVSResources.Manage_naming_styles;
 
         public ManageNamingStylesDialogViewModel(
             ObservableCollection<MutableNamingStyle> namingStyles, 

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/ManageSymbolSpecificationsDialogViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/ManageSymbolSpecificationsDialogViewModel.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
         public ObservableCollection<INamingStylesInfoDialogViewModel> Items { get; set; }
         public string LanguageName { get; private set; }
 
-        public string DialogTitle => "Manage Specifications";
+        public string DialogTitle => ServicesVSResources.Manage_specifications;
 
         public ManageSymbolSpecificationsDialogViewModel(
             ObservableCollection<SymbolSpecification> specifications, 


### PR DESCRIPTION
Fixes VS bug #473121

### Customer scenario
Launch VS and navigate to Tools->Options->Text Editor->Basic->Code Style->Naming: click "Manage Specifications" and "Manage styles" buttons.  The dialog that is displayed does not have the title localized.

### Bugs this fixes
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_queries?id=473121&_a=edit&triage=true

### Workarounds, if any
none

### Risk
None

### Performance impact
None

### Is this a regression from a previous update?
No

### Root cause analysis


### How was the bug found?
Test team

### Test documentation updated?
n/a
