### PR TITLE
Fix inference when tuple names differ

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2635,7 +2635,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 for (int p = 0; p < anonymousFunction.ParameterCount; ++p)
                 {
-                    if (anonymousFunction.ParameterType(p) != fixedDelegateParameters[p].Type)
+                    if (!anonymousFunction.ParameterType(p).Equals(fixedDelegateParameters[p].Type, TypeCompareKind.IgnoreDynamicAndTupleNames))
                     {
                         return null;
                     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -24281,8 +24281,10 @@ public class Class1
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
-            var varType = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().Single().Declaration.Type;
-            Assert.Equal("IResult<System.Int32>", model.GetTypeInfo(varType).Type.ToTestDisplayString());
+            var doSyntax = tree.GetCompilationUnitRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            Assert.Equal("impl.Do(((int x, int y) a) => a.x * a.y)", doSyntax.ToString());
+            var doSymbol = (IMethodSymbol)model.GetSymbolInfo(doSyntax).Symbol;
+            Assert.Equal("IResult<System.Int32>", doSymbol.ReturnType.ToTestDisplayString());
         }
 
         [Fact, WorkItem(24781, "https://github.com/dotnet/roslyn/issues/24781")]
@@ -24312,8 +24314,10 @@ public class Class1
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
-            var varType = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().Single().Declaration.Type;
-            Assert.Equal("IResult<System.Int32>", model.GetTypeInfo(varType).Type.ToTestDisplayString());
+            var doSyntax = tree.GetCompilationUnitRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            Assert.Equal("impl.Do((dynamic a) => 1)", doSyntax.ToString());
+            var doSymbol = (IMethodSymbol)model.GetSymbolInfo(doSyntax).Symbol;
+            Assert.Equal("IResult<System.Int32>", doSymbol.ReturnType.ToTestDisplayString());
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -24255,7 +24255,7 @@ namespace System
         }
 
         [Fact, WorkItem(24781, "https://github.com/dotnet/roslyn/issues/24781")]
-        public void InferenceWithTuple()
+        public void InferenceWithTuple_AddingNames()
         {
             string source = @"
 using System;
@@ -24283,6 +24283,72 @@ public class Class1
             var model = comp.GetSemanticModel(tree);
             var doSyntax = tree.GetCompilationUnitRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
             Assert.Equal("impl.Do(((int x, int y) a) => a.x * a.y)", doSyntax.ToString());
+            var doSymbol = (IMethodSymbol)model.GetSymbolInfo(doSyntax).Symbol;
+            Assert.Equal("IResult<System.Int32>", doSymbol.ReturnType.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem(24781, "https://github.com/dotnet/roslyn/issues/24781")]
+        public void InferenceWithTuple_DifferentNames()
+        {
+            string source = @"
+using System;
+public interface IDo<T>
+{
+    IResult<TReturn> Do<TReturn>(Func<T, TReturn> fn);
+}
+
+public interface IResult<TReturn>
+{
+}
+
+public class Class1
+{
+    public void Test1(IDo<(int a, int b)> impl)
+    {
+        var case3 = impl.Do(((int x, int y) a) => a.x * a.y);
+    }
+}";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var doSyntax = tree.GetCompilationUnitRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            Assert.Equal("impl.Do(((int x, int y) a) => a.x * a.y)", doSyntax.ToString());
+            var doSymbol = (IMethodSymbol)model.GetSymbolInfo(doSyntax).Symbol;
+            Assert.Equal("IResult<System.Int32>", doSymbol.ReturnType.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem(24781, "https://github.com/dotnet/roslyn/issues/24781")]
+        public void InferenceWithTuple_DroppingNames()
+        {
+            string source = @"
+using System;
+public interface IDo<T>
+{
+    IResult<TReturn> Do<TReturn>(Func<T, TReturn> fn);
+}
+
+public interface IResult<TReturn>
+{
+}
+
+public class Class1
+{
+    public void Test1(IDo<(int a, int b)> impl)
+    {
+        var case3 = impl.Do(((int, int) a) => a.Item1 * a.Item2);
+    }
+}";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var doSyntax = tree.GetCompilationUnitRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            Assert.Equal("impl.Do(((int, int) a) => a.Item1 * a.Item2)", doSyntax.ToString());
             var doSymbol = (IMethodSymbol)model.GetSymbolInfo(doSyntax).Symbol;
             Assert.Equal("IResult<System.Int32>", doSymbol.ReturnType.ToTestDisplayString());
         }

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -21511,9 +21511,11 @@ End Module
 
             Dim model = comp.GetSemanticModel(tree)
             Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
-            Dim case3 = nodes.OfType(Of LocalDeclarationStatementSyntax)().Single().Declarators.Single().Names.Single()
+            Dim actSyntax = nodes.OfType(Of InvocationExpressionSyntax)().Single()
+            Assert.Equal("impl.Act(Function(a As (x As Integer, y As Integer)) a.x * a.y)", actSyntax.ToString())
 
-            Assert.Equal("case3 As IResult(Of System.Int32)", model.GetDeclaredSymbol(case3).ToTestDisplayString())
+            Dim actSymbol = DirectCast(model.GetSymbolInfo(actSyntax).Symbol, IMethodSymbol)
+            Assert.Equal("IResult(Of System.Int32)", actSymbol.ReturnType.ToTestDisplayString())
         End Sub
 
     End Class


### PR DESCRIPTION
### Customer scenario
Use a lambda in a method type inference, but have the element names between the lambda and the `Func<... tuple ...>` differ. This will fail the inference.
There is a similar bug with difference in dynamic-ness (ie. `dynamic` vs. `object`), which this PR also fixes.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24781

### Workarounds, if any
Specify type arguments to avoid relying on type inference.

### Risk
### Performance impact
Low. One line fix.

### Is this a regression from a previous update?
No.

### Root cause analysis
This bug has been there since the tuples feature shipped. It stems from using the `==` comparison between type symbols (which compares everything), instead of the `Equals` method with comparison options.
We have an issue to remove usage of this `==` (and `!=`) in the compiler code: https://github.com/dotnet/roslyn/issues/22067

### How was the bug found?
Reported by customer.