### PR TITLE
Update PATH to our xcopy CLI

### DIFF
--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -136,7 +136,6 @@ function Ensure-NuGet() {
 # Ensure the proper SDK in installed in our %PATH%. This is how MSBuild locates the 
 # SDK. Returns the location to the dotnet exe
 function Ensure-DotnetSdk() {
-
     # Check to see if the specified dotnet installations meets our build requirements
     function Test-DotnetDir([string]$dotnetDir, [string]$runtimeVersion, [string]$sdkVersion) {
         $sdkPath = Join-Path $dotnetDir "sdk\$sdkVersion"
@@ -179,6 +178,9 @@ function Ensure-DotnetSdk() {
         $webClient.DownloadFile("https://dot.net/v1/dotnet-install.ps1", $destFile)
         Exec-Block { & $destFile -Version $sdkVersion -InstallDir $cliDir } | Out-Null
         Exec-Block { & $destFile -Version $runtimeVersion -SharedRuntime -InstallDir $cliDir } | Out-Null
+    }
+    else {
+        ${env:PATH} = "$cliDir;${env:PATH}"
     }
 
     return (Join-Path $cliDir "dotnet.exe")

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -180,7 +180,10 @@ function Restore-Packages() {
         Write-Host "Restoring $($both[0])"
         $projectFilePath = $both[1]
         $projectFileName = [IO.Path]::GetFileNameWithoutExtension($projectFilePath)
-        $logFilePath = Join-Path $logsDir "Restore-$($projectFileName).binlog"
+        $logFilePath = ""
+        if ($binaryLog) { 
+            $logFilePath = Join-Path $logsDir "Restore-$($projectFileName).binlog"
+        }
         Restore-Project $dotnet $both[1] $logFilePath
     }
 }


### PR DESCRIPTION
In the case the CLI was previously downloaded but not yet on `%PATH%` we
need to manually add it there. Not doing it leads to cases where MSBuild
can't find the proper SDK and as a result failing the build.

closes #25649

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
