### PR TITLE
recursive-patterns(13): Address issues from previous recursive-patterns code reviews

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/PatternSwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternSwitchBinder.cs
@@ -89,10 +89,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            var sectionBuilder = ArrayBuilder<BoundPatternSwitchSection>.GetInstance();
+            var sectionBuilder = ArrayBuilder<BoundPatternSwitchSection>.GetInstance(switchSections.Length);
             foreach (var oldSection in switchSections)
             {
-                var labelBuilder = ArrayBuilder<BoundPatternSwitchLabel>.GetInstance();
+                var labelBuilder = ArrayBuilder<BoundPatternSwitchLabel>.GetInstance(oldSection.SwitchLabels.Length);
                 foreach (var label in oldSection.SwitchLabels)
                 {
                     var newLabel = label;
@@ -102,7 +102,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         switch (syntax)
                         {
                             case CasePatternSwitchLabelSyntax p:
-                                diagnostics.Add(ErrorCode.ERR_SwitchCaseSubsumed, p.Pattern.Location);
+                                if (!p.Pattern.HasErrors)
+                                {
+                                    diagnostics.Add(ErrorCode.ERR_SwitchCaseSubsumed, p.Pattern.Location);
+                                }
                                 break;
                             case CaseSwitchLabelSyntax p:
                                 if (label.Pattern is BoundConstantPattern cp && !cp.ConstantValue.IsBad && FindMatchingSwitchCaseLabel(cp.ConstantValue, p) != label.Label)
@@ -110,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     // We use the traditional diagnostic when possible
                                     diagnostics.Add(ErrorCode.ERR_DuplicateCaseLabel, syntax.Location, cp.ConstantValue.GetValueToDisplay());
                                 }
-                                else
+                                else if (!label.Pattern.HasErrors)
                                 {
                                     diagnostics.Add(ErrorCode.ERR_SwitchCaseSubsumed, p.Value.Location);
                                 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -195,6 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
+        [Conditional("DEBUG")]
         public void CheckLocalsDefined()
         {
 #if DEBUG
@@ -218,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 localsScanner.Free();
             }
 
-            void AddAll(ImmutableArray<LocalSymbol> locals)
+            private void AddAll(ImmutableArray<LocalSymbol> locals)
             {
                 foreach (var local in locals)
                 {
@@ -229,7 +230,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            void RemoveAll(ImmutableArray<LocalSymbol> locals)
+            private void RemoveAll(ImmutableArray<LocalSymbol> locals)
             {
                 foreach (var local in locals)
                 {
@@ -240,7 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            void CheckDeclared(LocalSymbol local)
+            private void CheckDeclared(LocalSymbol local)
             {
                 if (!DeclaredLocals.Contains(local))
                 {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4445,7 +4445,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An expression tree may not contain a switch-expression..
+        ///   Looks up a localized string similar to An expression tree may not contain a switch expression..
         /// </summary>
         internal static string ERR_ExpressionTreeContainsSwitchExpression {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5349,6 +5349,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The switch expression does not handle all possible inputs (it is not exhaustive).</value>
   </data>
   <data name="ERR_ExpressionTreeContainsSwitchExpression" xml:space="preserve">
-    <value>An expression tree may not contain a switch-expression.</value>
+    <value>An expression tree may not contain a switch expression.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     F.Goto(breakLabel));
 
                 body = F.Block(
-                    F.Switch(state, sections),
+                    F.Switch(state, sections.ToImmutableArray()),
                     F.Label(breakLabel));
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BasePatternSwitchLocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BasePatternSwitchLocalRewriter.cs
@@ -127,22 +127,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </summary>
             private void LowerDecisionDag(ImmutableArray<BoundDecisionDagNode> sortedNodes)
             {
-                switch (sortedNodes[0])
+                var firstNode = sortedNodes[0];
+                switch (firstNode)
                 {
-                    case BoundWhenDecisionDagNode wc:
-                        // If the first node is in a when clause's section rather than the code for the
+                    case BoundWhenDecisionDagNode _:
+                    case BoundLeafDecisionDagNode _:
+                        // If the first node is a leaf or when clause rather than the code for the
                         // lowered decision dag, jump there to start.
-                        _loweredDecisionDag.Add(_factory.Goto(GetDagNodeLabel(wc)));
-                        break;
-                    case BoundLeafDecisionDagNode d:
-                        // If the first node is a leaf rather than the code for the
-                        // lowered decision dag, jump there to start.
-                        _loweredDecisionDag.Add(_factory.Goto(GetDagNodeLabel(d)));
+                        _loweredDecisionDag.Add(_factory.Goto(GetDagNodeLabel(firstNode)));
                         break;
                 }
 
                 // Note that a when-clause can contain an assignment to a
-                // pattern variable declared in a different when-clause, so we only apply the optimization
+                // pattern variable declared in a different when-clause (e.g. in the same section, or
+                // in a different section via the use of a local function), so we only apply the optimization
                 // of using user-declared pattern variables as pattern-matching automaton temps
                 // when there are no nontrivial when-clauses at all.
                 if (!sortedNodes.OfType<BoundWhenDecisionDagNode>().Where(w => w.WhenExpression != null && w.WhenExpression.ConstantValue != ConstantValue.True).Any())
@@ -460,7 +458,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     case BoundTestDecisionDagNode testNode:
                         {
-                            // PROTOTYPE(patterns2): should translate a chain of constant value tests into a switch instruction as before
                             BoundExpression test = base.LowerTest(testNode.Test);
                             GenerateTest(test, testNode.WhenTrue, testNode.WhenFalse, nextNode);
                         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
@@ -42,8 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             /// <summary>
             /// We revise the returned label for a leaf so that all leafs in the same switch section are given the same label.
-            /// This permits all the leafs in a
-            /// section to share the label, which enables the switch emitter to produce better code.
+            /// This enables the switch emitter to produce better code.
             /// </summary>
             protected override LabelSymbol GetDagNodeLabel(BoundDecisionDagNode dag)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -208,61 +208,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (test)
                 {
                     case BoundDagNonNullTest d:
-                        // If the actual input is a constant, short-circuit this test
-                        if (d.Input == _inputTemp && _loweredInput.ConstantValue != null)
-                        {
-                            bool testResult = _loweredInput.ConstantValue != ConstantValue.Null;
-                            if (!testResult)
-                            {
-                                return _factory.Literal(testResult);
-                            }
-                        }
-                        else
-                        {
-                            return _localRewriter.MakeNullCheck(d.Syntax, input, input.Type.IsNullableType() ? BinaryOperatorKind.NullableNullNotEqual : BinaryOperatorKind.NotEqual);
-                        }
-
-                        return null;
+                        // If the actual input is a constant, the test should have been removed from the decision dag
+                        Debug.Assert(!(d.Input == _inputTemp && _loweredInput.ConstantValue != null));
+                        return _localRewriter.MakeNullCheck(d.Syntax, input, input.Type.IsNullableType() ? BinaryOperatorKind.NullableNullNotEqual : BinaryOperatorKind.NotEqual);
 
                     case BoundDagTypeTest d:
-                        {
-                            // Note that this tests for non-null as a side-effect. We depend on that to sometimes avoid the null check.
-                            return _factory.Is(input, d.Type);
-                        }
+                        // Note that this tests for non-null as a side-effect. We depend on that to sometimes avoid the null check.
+                        return _factory.Is(input, d.Type);
 
                     case BoundDagNullTest d:
-                        if (d.Input == _inputTemp && _loweredInput.ConstantValue != null)
-                        {
-                            bool testResult = _loweredInput.ConstantValue == ConstantValue.Null;
-                            if (!testResult)
-                            {
-                                return _factory.Literal(testResult);
-                            }
-                        }
-                        else
-                        {
-                            return _localRewriter.MakeNullCheck(d.Syntax, input, input.Type.IsNullableType() ? BinaryOperatorKind.NullableNullEqual : BinaryOperatorKind.Equal);
-                        }
-
-                        return null;
+                        // If the actual input is a constant, the test should have been removed from the decision dag
+                        Debug.Assert(!(d.Input == _inputTemp && _loweredInput.ConstantValue != null));
+                        return _localRewriter.MakeNullCheck(d.Syntax, input, input.Type.IsNullableType() ? BinaryOperatorKind.NullableNullEqual : BinaryOperatorKind.Equal);
 
                     case BoundDagValueTest d:
-                        // If the actual input is a constant, short-circuit this test
-                        if (d.Input == _inputTemp && _loweredInput.ConstantValue != null)
-                        {
-                            bool testResult = _loweredInput.ConstantValue == d.Value;
-                            if (!testResult)
-                            {
-                                return _factory.Literal(testResult);
-                            }
-                        }
-                        else
-                        {
-                            Debug.Assert(!input.Type.IsNullableType());
-                            return _localRewriter.MakeEqual(_localRewriter.MakeLiteral(d.Syntax, d.Value, input.Type), input);
-                        }
-
-                        return null;
+                        // If the actual input is a constant, the test should have been removed from the decision dag
+                        Debug.Assert(!(d.Input == _inputTemp && _loweredInput.ConstantValue != null));
+                        Debug.Assert(!input.Type.IsNullableType());
+                        return _localRewriter.MakeEqual(_localRewriter.MakeLiteral(d.Syntax, d.Value, input.Type), input);
 
                     default:
                         throw ExceptionUtilities.UnexpectedValue(test);

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -537,7 +537,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(node.Locals.All(l => l.SynthesizedKind.IsLongLived()));
             var builder = new BoundSpillSequenceBuilder();
+
+            // Ensure later errors (e.g. in async rewriting) are associated with the correct node.
             _F.Syntax = node.Syntax;
+
             builder.AddStatements(VisitList(node.SideEffects));
             builder.AddLocals(node.Locals);
             var value = VisitExpression(ref builder, node.Value);

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -475,6 +475,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region Statement Visitors
 
+        public override BoundNode VisitSwitchDispatch(BoundSwitchDispatch node)
+        {
+            BoundSpillSequenceBuilder builder = null;
+            var expression = VisitExpression(ref builder, node.Expression);
+            return UpdateStatement(builder, node.Update(expression, node.Cases, node.DefaultLabel, node.EqualityMethod));
+        }
+
         public override BoundNode VisitThrowStatement(BoundThrowStatement node)
         {
             BoundSpillSequenceBuilder builder = null;
@@ -496,13 +503,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundSpillSequenceBuilder builder = null;
             var condition = VisitExpression(ref builder, node.Condition);
             return UpdateStatement(builder, node.Update(condition, node.JumpIfTrue, node.Label));
-        }
-
-        public override BoundNode VisitSwitchDispatch(BoundSwitchDispatch node)
-        {
-            BoundSpillSequenceBuilder builder = null;
-            var expression = VisitExpression(ref builder, node.Expression);
-            return UpdateStatement(builder, node.Update(expression, node.Cases, node.DefaultLabel, node.EqualityMethod));
         }
 
         public override BoundNode VisitReturnStatement(BoundReturnStatement node)

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -77,6 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (variable is SynthesizedLocal local && local.SynthesizedKind == SynthesizedLocalKind.Spill)
                     {
+                        Debug.Assert(local.Type.IsRestrictedType());
                         diagnostics.Add(ErrorCode.ERR_ByRefTypeAndAwait, local.Locations[0], local.Type);
                     }
                     else

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected BoundStatement Dispatch()
         {
             return F.Switch(F.Local(cachedState),
-                    from kv in _dispatches orderby kv.Value[0] select F.SwitchSection(kv.Value, F.Goto(kv.Key))
+                    (from kv in _dispatches orderby kv.Value[0] select F.SwitchSection(kv.Value, F.Goto(kv.Key))).ToImmutableArray()
                     );
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -831,7 +831,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Produce an int switch.
         /// </summary>
-        public BoundStatement Switch(BoundExpression ex, params SyntheticSwitchSection[] sections)
+        public BoundStatement Switch(BoundExpression ex, ImmutableArray<SyntheticSwitchSection> sections)
         {
             Debug.Assert(ex.Type.SpecialType == CodeAnalysis.SpecialType.System_Int32);
 
@@ -874,19 +874,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Produce an int switch.
-        /// </summary>
-        public BoundStatement Switch(BoundExpression ex, IEnumerable<SyntheticSwitchSection> sections)
-        {
-            return Switch(ex, sections.ToArray());
-        }
-
-        /// <summary>
         /// Check for (and assert that there are no) duplicate case labels in the switch.
         /// </summary>
         /// <param name="sections"></param>
         [Conditional("DEBUG")]
-        private static void CheckSwitchSections(SyntheticSwitchSection[] sections)
+        private static void CheckSwitchSections(ImmutableArray<SyntheticSwitchSection> sections)
         {
             var labels = new HashSet<int>();
             foreach (var s in sections)

--- a/src/Compilers/CSharp/Portable/Syntax/LambdaUtilities.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LambdaUtilities.cs
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.SwitchExpression:
                 case SyntaxKind.AwaitExpression:
                     // These translate into a BoundSpillSequence, which is then translated into a block
-                    // containins temps required for spilling subexpressions. That block has the syntax of the switch
+                    // containing temps required for spilling subexpressions. That block has the syntax of the switch
                     // expression or await expression.
                     return true;
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8771,8 +8771,8 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8771,8 +8771,8 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8771,8 +8771,8 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8771,8 +8771,8 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8771,8 +8771,8 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8771,8 +8771,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8771,8 +8771,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8771,8 +8771,8 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8771,8 +8771,8 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8771,8 +8771,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8771,8 +8771,8 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8771,8 +8771,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8771,8 +8771,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
-        <source>An expression tree may not contain a switch-expression.</source>
-        <target state="new">An expression tree may not contain a switch-expression.</target>
+        <source>An expression tree may not contain a switch expression.</source>
+        <target state="new">An expression tree may not contain a switch expression.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -23843,5 +23843,27 @@ class B : System.Attribute {
                 Diagnostic(ErrorCode.ERR_AttributeCtorInParameter, "A(1)").WithArguments("A.A(in int)").WithLocation(2, 2)
                 );
         }
+
+        [Fact]
+        public void ERR_ExpressionTreeContainsSwitchExpression()
+        {
+            var text = @"
+using System;
+using System.Linq.Expressions;
+
+public class C
+{
+    public int Test()
+    {
+        Expression<Func<int, int>> e = a => a switch { 0 => 1, _ => 2 }; // CS8411
+        return 1;
+    }
+}";
+            CreateCompilationWithMscorlib40AndSystemCore(text, parseOptions: TestOptions.RegularWithRecursivePatterns).VerifyDiagnostics(
+                // (9,45): error CS8411: An expression tree may not contain a switch expression.
+                //         Expression<Func<int, int>> e = a => a switch { 0 => 1, _ => 2 }; // CS8411
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsSwitchExpression, "a switch { 0 => 1, _ => 2 }").WithLocation(9, 45)
+                );
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Collections/IOrderedReadOnlySet.cs
+++ b/src/Compilers/Core/Portable/Collections/IOrderedReadOnlySet.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Generic;
-using System.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Collections

--- a/src/Compilers/Core/Portable/Symbols/RefKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/RefKind.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis
 
         // Used internally to track `In` arguments that were specified with `In` modifier
         // as opposed to those that were specified with no modifiers and matched `In` parameter.
-        // There is at least one kind of anlysis that cares about this distinction - hoisting
+        // There is at least one kind of analysis that cares about this distinction - hoisting
         // of variables to the frame for async rewriting: a variable that was passed without the
         // `In` modifier may be correctly captured by value or by reference.
         internal const RefKind StrictIn = RefKind.In + 1;


### PR DESCRIPTION
**ONLY THE LAST DELTA IS UNIQUE THIS PR and needs to be reviewed**. Others are from previous PRs.

Fixes #25663

### From https://github.com/dotnet/roslyn/pull/24059

- In `CheckConsistentDecision`, use some notation like `v != null --> !(v == null)` for more clarity than the English language comment.
- Add a private constructor to prevent construction of `DagStateEquivalence`
- Hint creation of builder size in `CheckSwitchErrors`
- Suppress subsumption errors on switch expression case if the pattern has an error.
- In `LowerTest`, we have special handling for decisions on constant-valued input. But such decisions should already have been removed from the decision dag. Assert that this situation cannot occur and remove the special handling code.
- Merge two cases in `switch (sortedNodes[0])` in `LowerDecisionDag`
- Comment on `GetDagNodeLabel` is now less redundant.

### From https://github.com/dotnet/roslyn/pull/25544

- In `AwaitExpressionSpiller.cs`, move `VisitSwitchDispatch` to right before `VisitThrowStatement` so it is in the same place where `VisitSwitchStatement` used to be to make deltas more clear in the end.
- Remove `params` overload `public BoundStatement Switch(BoundExpression ex, params SyntheticSwitchSection[] sections)` and force caller to properly construct an immutable array.
