### PR TITLE
Rename CurrentMethodOrNestedFunction to CurrentFunction

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.Lowered.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.Lowered.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
         {
             SyntheticBoundNodeFactory F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
-            F.CurrentMethodOrNestedFunction = this;
+            F.CurrentFunction = this;
 
             try
             {
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
         {
             SyntheticBoundNodeFactory F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
-            F.CurrentMethodOrNestedFunction = (MethodSymbol)this.OriginalDefinition;
+            F.CurrentFunction = (MethodSymbol)this.OriginalDefinition;
 
             try
             {
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
         {
             SyntheticBoundNodeFactory F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
-            F.CurrentMethodOrNestedFunction = (MethodSymbol)this.OriginalDefinition;
+            F.CurrentFunction = (MethodSymbol)this.OriginalDefinition;
 
             try
             {
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
             {
                 SyntheticBoundNodeFactory F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
-                F.CurrentMethodOrNestedFunction = this.OriginalDefinition;
+                F.CurrentFunction = this.OriginalDefinition;
 
                 try
                 {
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var argBuilder = ArrayBuilder<BoundExpression>.GetInstance();
             //var refKindBuilder = ArrayBuilder<RefKind>.GetInstance();
 
-            foreach (var param in F.CurrentMethodOrNestedFunction.Parameters)
+            foreach (var param in F.CurrentFunction.Parameters)
             {
                 argBuilder.Add(F.Parameter(param));
                 //refKindBuilder.Add(param.RefKind);
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                 methodToInvoke,
                                                 argBuilder.ToImmutableAndFree());
 
-            return F.CurrentMethodOrNestedFunction.ReturnsVoid
+            return F.CurrentFunction.ReturnsVoid
                         ? F.Block(F.ExpressionStatement(invocation), F.Return())
                         : F.Block(F.Return(invocation));
         }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             CSharpSyntaxNode syntax = this.GetNonNullSyntaxNode();
             SyntheticBoundNodeFactory factory = new SyntheticBoundNodeFactory(this, syntax, compilationState, diagnostics);
-            factory.CurrentMethodOrNestedFunction = this;
+            factory.CurrentFunction = this;
             ArrayBuilder<BoundStatement> body = ArrayBuilder<BoundStatement>.GetInstance();
 
             // Initialize the payload root for each kind of dynamic analysis instrumentation.

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AwaitInFinallyAnalysis analysis)
         {
             _F = factory;
-            _F.CurrentMethodOrNestedFunction = containingMethod;
+            _F.CurrentFunction = containingMethod;
             Debug.Assert(factory.CurrentType == (containingType ?? containingMethod.ContainingType));
             _diagnostics = diagnostics;
             _analysis = analysis;
@@ -175,9 +175,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             PopFrame();
 
             var exceptionType = _F.SpecialType(SpecialType.System_Object);
-            var pendingExceptionLocal = new SynthesizedLocal(_F.CurrentMethodOrNestedFunction, exceptionType, SynthesizedLocalKind.TryAwaitPendingException, tryStatementSyntax);
+            var pendingExceptionLocal = new SynthesizedLocal(_F.CurrentFunction, exceptionType, SynthesizedLocalKind.TryAwaitPendingException, tryStatementSyntax);
             var finallyLabel = _F.GenerateLabel("finallyLabel");
-            var pendingBranchVar = new SynthesizedLocal(_F.CurrentMethodOrNestedFunction, _F.SpecialType(SpecialType.System_Int32), SynthesizedLocalKind.TryAwaitPendingBranch, tryStatementSyntax);
+            var pendingBranchVar = new SynthesizedLocal(_F.CurrentFunction, _F.SpecialType(SpecialType.System_Int32), SynthesizedLocalKind.TryAwaitPendingBranch, tryStatementSyntax);
 
             var catchAll = _F.Catch(_F.Local(pendingExceptionLocal), _F.Block());
 
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 SynthesizedLocal returnValue;
                 BoundStatement unpendReturn;
 
-                var returnLabel = parent.ProxyReturnIfNeeded(_F.CurrentMethodOrNestedFunction, pendingValue, out returnValue);
+                var returnLabel = parent.ProxyReturnIfNeeded(_F.CurrentFunction, pendingValue, out returnValue);
 
                 if (returnLabel == null)
                 {
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             SynthesizedLocal returnValue;
             var returnLabel = _currentAwaitFinallyFrame.ProxyReturnIfNeeded(
-                _F.CurrentMethodOrNestedFunction,
+                _F.CurrentFunction,
                 node.ExpressionOpt,
                 out returnValue);
 
@@ -658,15 +658,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLambda(BoundLambda node)
         {
-            var oldContainingSymbol = _F.CurrentMethodOrNestedFunction;
+            var oldContainingSymbol = _F.CurrentFunction;
             var oldAwaitFinallyFrame = _currentAwaitFinallyFrame;
 
-            _F.CurrentMethodOrNestedFunction = node.Symbol;
+            _F.CurrentFunction = node.Symbol;
             _currentAwaitFinallyFrame = new AwaitFinallyFrame();
 
             var result = base.VisitLambda(node);
 
-            _F.CurrentMethodOrNestedFunction = oldContainingSymbol;
+            _F.CurrentFunction = oldContainingSymbol;
             _currentAwaitFinallyFrame = oldAwaitFinallyFrame;
 
             return result;
@@ -674,15 +674,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
-            var oldContainingSymbol = _F.CurrentMethodOrNestedFunction;
+            var oldContainingSymbol = _F.CurrentFunction;
             var oldAwaitFinallyFrame = _currentAwaitFinallyFrame;
 
-            _F.CurrentMethodOrNestedFunction = node.Symbol;
+            _F.CurrentFunction = node.Symbol;
             _currentAwaitFinallyFrame = new AwaitFinallyFrame();
 
             var result = base.VisitLocalFunctionStatement(node);
 
-            _F.CurrentMethodOrNestedFunction = oldContainingSymbol;
+            _F.CurrentFunction = oldContainingSymbol;
             _currentAwaitFinallyFrame = oldAwaitFinallyFrame;
 
             return result;
@@ -991,8 +991,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public AwaitCatchFrame(SyntheticBoundNodeFactory F, TryStatementSyntax tryStatementSyntax)
             {
-                this.pendingCaughtException = new SynthesizedLocal(F.CurrentMethodOrNestedFunction, F.SpecialType(SpecialType.System_Object), SynthesizedLocalKind.TryAwaitPendingCaughtException, tryStatementSyntax);
-                this.pendingCatch = new SynthesizedLocal(F.CurrentMethodOrNestedFunction, F.SpecialType(SpecialType.System_Int32), SynthesizedLocalKind.TryAwaitPendingCatch, tryStatementSyntax);
+                this.pendingCaughtException = new SynthesizedLocal(F.CurrentFunction, F.SpecialType(SpecialType.System_Object), SynthesizedLocalKind.TryAwaitPendingCaughtException, tryStatementSyntax);
+                this.pendingCatch = new SynthesizedLocal(F.CurrentFunction, F.SpecialType(SpecialType.System_Int32), SynthesizedLocalKind.TryAwaitPendingCatch, tryStatementSyntax);
 
                 this.handlers = new List<BoundBlock>();
                 _hoistedLocals = new Dictionary<LocalSymbol, LocalSymbol>();

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal void GenerateMoveNext(BoundStatement body, MethodSymbol moveNextMethod)
         {
-            F.CurrentMethodOrNestedFunction = moveNextMethod;
+            F.CurrentFunction = moveNextMethod;
 
             BoundStatement rewrittenBody = (BoundStatement)Visit(body);
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -146,14 +146,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                             F.Call(
                                 F.Field(F.This(), _builderField),
                                 _asyncMethodBuilderMemberCollection.SetStateMachine,
-                                new BoundExpression[] { F.Parameter(F.CurrentMethodOrNestedFunction.Parameters[0]) })),
+                                new BoundExpression[] { F.Parameter(F.CurrentFunction.Parameters[0]) })),
                         F.Return()));
             }
 
             // Constructor
             if (stateMachineType.TypeKind == TypeKind.Class)
             {
-                F.CurrentMethodOrNestedFunction = stateMachineType.Constructor;
+                F.CurrentFunction = stateMachineType.Constructor;
                 F.CloseMethod(F.Block(ImmutableArray.Create(F.BaseInitialization(), F.Return())));
             }
         }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -110,8 +110,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             _methodBodyFactory = methodBodyFactory;
 
             // Set the factory context to generate nodes for the current method
-            var oldMethod = methodBodyFactory.CurrentMethodOrNestedFunction;
-            methodBodyFactory.CurrentMethodOrNestedFunction = method;
+            var oldMethod = methodBodyFactory.CurrentFunction;
+            methodBodyFactory.CurrentFunction = method;
 
             _methodPayload = methodBodyFactory.SynthesizedLocal(_payloadType, kind: SynthesizedLocalKind.InstrumentationPayload, syntax: methodBody.Syntax);
             // The first point indicates entry into the method and has the span of the method definition.
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Restore context
-            methodBodyFactory.CurrentMethodOrNestedFunction = oldMethod;
+            methodBodyFactory.CurrentFunction = oldMethod;
         }
 
         private static bool IsExcludedFromCodeCoverage(MethodSymbol method)

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Generate the body for MoveNext()
             ///////////////////////////////////
 
-            F.CurrentMethodOrNestedFunction = moveNextMethod;
+            F.CurrentFunction = moveNextMethod;
             int initialState;
             GeneratedLabelSymbol initialLabel;
             AddState(out initialState, out initialLabel);
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /////////////////////////////////// 
             // Generate the body for Dispose().
             ///////////////////////////////////
-            F.CurrentMethodOrNestedFunction = disposeMethod;
+            F.CurrentFunction = disposeMethod;
             var rootFrame = _currentFinallyFrame;
 
             if (rootFrame.knownStates == null)
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression caseExpressionOpt = (BoundExpression)this.Visit(node.CaseExpressionOpt);
             BoundLabel labelExpressionOpt = (BoundLabel)this.Visit(node.LabelExpressionOpt);
             var proxyLabel = _currentFinallyFrame.ProxyLabelIfNeeded(node.Label);
-            Debug.Assert(node.Label == proxyLabel || !(F.CurrentMethodOrNestedFunction is IteratorFinallyMethodSymbol), "should not be proxying branches in finally");
+            Debug.Assert(node.Label == proxyLabel || !(F.CurrentFunction is IteratorFinallyMethodSymbol), "should not be proxying branches in finally");
             return node.Update(proxyLabel, caseExpressionOpt, labelExpressionOpt);
         }
 
@@ -375,10 +375,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(frame.parent.knownStates.ContainsValue(frame), "parent must be aware about states in the child frame");
 
             var finallyMethod = frame.handler;
-            var origMethod = F.CurrentMethodOrNestedFunction;
+            var origMethod = F.CurrentFunction;
 
             // rewrite finally block into a Finally method.
-            F.CurrentMethodOrNestedFunction = finallyMethod;
+            F.CurrentFunction = finallyMethod;
             var rewrittenHandler = (BoundStatement)this.Visit(node.FinallyBlockOpt);
 
             _tryNestingLevel--;
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             );
 
             F.CloseMethod(rewrittenHandler);
-            F.CurrentMethodOrNestedFunction = origMethod;
+            F.CurrentFunction = origMethod;
 
 
             var bodyStatements = ArrayBuilder<BoundStatement>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
@@ -359,10 +359,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void GenerateConstructor(BoundExpression managedThreadId)
         {
-            F.CurrentMethodOrNestedFunction = stateMachineType.Constructor;
+            F.CurrentFunction = stateMachineType.Constructor;
             var bodyBuilder = ArrayBuilder<BoundStatement>.GetInstance();
             bodyBuilder.Add(F.BaseInitialization());
-            bodyBuilder.Add(F.Assignment(F.Field(F.This(), stateField), F.Parameter(F.CurrentMethodOrNestedFunction.Parameters[0]))); // this.state = state;
+            bodyBuilder.Add(F.Assignment(F.Field(F.This(), stateField), F.Parameter(F.CurrentFunction.Parameters[0]))); // this.state = state;
 
             if (managedThreadId != null)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             _compilation = compilation;
             _factory = factory;
-            _factory.CurrentMethodOrNestedFunction = containingMethod;
+            _factory.CurrentFunction = containingMethod;
             Debug.Assert(factory.CurrentType == (containingType ?? containingMethod.ContainingType));
             _dynamicFactory = new LoweredDynamicOperationFactory(factory, containingMethodOrdinal);
             _previousSubmissionFields = previousSubmissionFields;
@@ -217,15 +217,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             _sawLambdas = true;
             CheckRefReadOnlySymbols(node.Symbol);
 
-            var oldContainingSymbol = _factory.CurrentMethodOrNestedFunction;
+            var oldContainingSymbol = _factory.CurrentFunction;
             try
             {
-                _factory.CurrentMethodOrNestedFunction = node.Symbol;
+                _factory.CurrentFunction = node.Symbol;
                 return base.VisitLambda(node);
             }
             finally
             {
-                _factory.CurrentMethodOrNestedFunction = oldContainingSymbol;
+                _factory.CurrentFunction = oldContainingSymbol;
             }
         }
 
@@ -234,15 +234,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             _sawLocalFunctions = true;
             CheckRefReadOnlySymbols(node.Symbol);
 
-            var oldContainingSymbol = _factory.CurrentMethodOrNestedFunction;
+            var oldContainingSymbol = _factory.CurrentFunction;
             try
             {
-                _factory.CurrentMethodOrNestedFunction = node.Symbol;
+                _factory.CurrentFunction = node.Symbol;
                 return base.VisitLocalFunctionStatement(node);
             }
             finally
             {
-                _factory.CurrentMethodOrNestedFunction = oldContainingSymbol;
+                _factory.CurrentFunction = oldContainingSymbol;
             }
         }
 
@@ -453,7 +453,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (statements[i] == null || (optimize && IsFieldOrPropertyInitializer(originalStatements[i]) && ShouldOptimizeOutInitializer(statements[i])))
                 {
                     optimizedInitializers++;
-                    if (!_factory.CurrentMethodOrNestedFunction.IsStatic)
+                    if (!_factory.CurrentFunction.IsStatic)
                     {
                         // NOTE: Dev11 removes static initializers if ONLY all of them are optimized out
                         statements[i] = null;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var outLocals = ArrayBuilder<BoundExpression>.GetInstance(outputPlaceholders.Length);
             foreach (var outputPlaceholder in outputPlaceholders)
             {
-                var localSymbol = new SynthesizedLocal(_factory.CurrentMethodOrNestedFunction, outputPlaceholder.Type, SynthesizedLocalKind.LoweringTemp);
+                var localSymbol = new SynthesizedLocal(_factory.CurrentFunction, outputPlaceholder.Type, SynthesizedLocalKind.LoweringTemp);
 
                 var localBound = new BoundLocal(target.Syntax, localSymbol, constantValueOpt: null, type: outputPlaceholder.Type)
                 { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -170,13 +170,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Binder.ReportDiagnosticsIfObsolete(_diagnostics, disposeMethod, forEachSyntax,
                                                    hasBaseReceiver: false,
-                                                   containingMember: _factory.CurrentMethodOrNestedFunction,
+                                                   containingMember: _factory.CurrentFunction,
                                                    containingType: _factory.CurrentType,
                                                    location: enumeratorInfo.Location);
 
                 BoundBlock finallyBlockOpt;
                 var idisposableTypeSymbol = disposeMethod.ContainingType;
-                var conversions = new TypeConversions(_factory.CurrentMethodOrNestedFunction.ContainingAssembly.CorLibrary);
+                var conversions = new TypeConversions(_factory.CurrentFunction.ContainingAssembly.CorLibrary);
 
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 var isImplicit = conversions.ClassifyImplicitConversionFromType(enumeratorType, idisposableTypeSymbol, ref useSiteDiagnostics).IsImplicit;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Literal.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Literal.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // If we are building static constructor of System.Decimal, accessing static fields 
                 // would be bad.
-                var curMethod = _factory.CurrentMethodOrNestedFunction;
+                var curMethod = _factory.CurrentFunction;
                 if ((curMethod.MethodKind != MethodKind.SharedConstructor ||
                    curMethod.ContainingType.SpecialType != SpecialType.System_Decimal) &&
                    !_inExpressionLambda)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             private ArrayBuilder<BoundStatement> _loweredDecisionTree = ArrayBuilder<BoundStatement>.GetInstance();
 
             private PatternSwitchLocalRewriter(LocalRewriter localRewriter, BoundPatternSwitchStatement node)
-                : base(localRewriter._factory.CurrentMethodOrNestedFunction, (SwitchStatementSyntax)node.Syntax, localRewriter._factory.Compilation.Conversions)
+                : base(localRewriter._factory.CurrentFunction, (SwitchStatementSyntax)node.Syntax, localRewriter._factory.Compilation.Conversions)
             {
                 this._localRewriter = localRewriter;
                 this._factory = localRewriter._factory;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ReturnStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ReturnStatement.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (!node.WasCompilerGenerated ||
                  (node.ExpressionOpt != null ?
                         IsLambdaOrExpressionBodiedMember :
-                        (node.Syntax.Kind() == SyntaxKind.Block && _factory.CurrentMethodOrNestedFunction?.IsAsync == false))))
+                        (node.Syntax.Kind() == SyntaxKind.Block && _factory.CurrentFunction?.IsAsync == false))))
             {
                 rewritten = _instrumenter.InstrumentReturnStatement(node, rewritten);
             }
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var method = _factory.CurrentMethodOrNestedFunction;
+                var method = _factory.CurrentFunction;
                 if (method is LambdaSymbol)
                 {
                     return true;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Yield.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Yield.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // (added by FlowAnalysisPass.AppendImplicitReturn). Implicitly added "yield break" for async method 
             // does not need sequence points added here since it would be done later (presumably during Async rewrite).
             if (this.Instrument && 
-                (!node.WasCompilerGenerated || (node.Syntax.Kind() == SyntaxKind.Block && _factory.CurrentMethodOrNestedFunction?.IsAsync == false)))
+                (!node.WasCompilerGenerated || (node.Syntax.Kind() == SyntaxKind.Block && _factory.CurrentFunction?.IsAsync == false)))
             {
                 result = _instrumenter.InstrumentYieldBreakStatement(node, result);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override MethodSymbol CurrentMethod
         {
-            get { return F.CurrentMethodOrNestedFunction; }
+            get { return F.CurrentFunction; }
         }
 
         protected override NamedTypeSymbol ContainingType

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement GenerateKickoffMethodBody()
         {
-            F.CurrentMethodOrNestedFunction = method;
+            F.CurrentFunction = method;
             var bodyBuilder = ArrayBuilder<BoundStatement>.GetInstance();
 
             var frameType = method.IsGenericMethod ? stateMachineType.Construct(method.TypeArguments) : stateMachineType;
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var result = new SynthesizedStateMachineDebuggerHiddenMethod(methodName, methodToImplement, (StateMachineTypeSymbol)F.CurrentType, null, hasMethodBodyDependency);
             F.ModuleBuilderOpt.AddSynthesizedDefinition(F.CurrentType, result);
-            F.CurrentMethodOrNestedFunction = result;
+            F.CurrentFunction = result;
             return result;
         }
 
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var getter = prop.GetMethod;
             F.ModuleBuilderOpt.AddSynthesizedDefinition(F.CurrentType, getter);
 
-            F.CurrentMethodOrNestedFunction = getter;
+            F.CurrentFunction = getter;
             return getter;
         }
 
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var result = new SynthesizedStateMachineMoveNextMethod(methodToImplement, (StateMachineTypeSymbol)F.CurrentType);
             F.ModuleBuilderOpt.AddSynthesizedDefinition(F.CurrentType, result);
-            F.CurrentMethodOrNestedFunction = result;
+            F.CurrentFunction = result;
             return result;
         }
     }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             RefKind refKind = RefKind.None,
             SynthesizedLocalKind kind = SynthesizedLocalKind.LoweringTemp)
         {
-            return new SynthesizedLocal(CurrentMethodOrNestedFunction, type, kind, syntax, isPinned, refKind);
+            return new SynthesizedLocal(CurrentFunction, type, kind, syntax, isPinned, refKind);
         }
 #endif
 

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -55,13 +55,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // current method, possibly a lambda or local function, or null if not available
-        private MethodSymbol _currentMethodOrNestedFunction;
-        public MethodSymbol CurrentMethodOrNestedFunction
+        private MethodSymbol _currentFunction;
+        public MethodSymbol CurrentFunction
         {
-            get { return _currentMethodOrNestedFunction; }
+            get { return _currentFunction; }
             set
             {
-                _currentMethodOrNestedFunction = value;
+                _currentFunction = value;
                 if ((object)value != null &&
                     value.MethodKind != MethodKind.AnonymousFunction &&
                     value.MethodKind != MethodKind.LocalFunction)
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _factory = factory;
             }
 
-            internal override Symbol ContainingMemberOrLambda { get { return _factory.CurrentMethodOrNestedFunction; } }
+            internal override Symbol ContainingMemberOrLambda { get { return _factory.CurrentFunction; } }
             internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo> useSiteDiagnostics, ConsList<Symbol> basesBeingResolved)
             {
                 return AccessCheck.IsSymbolAccessible(symbol, _factory.CurrentType, accessThroughType, out failedThroughTypeCheck, ref useSiteDiagnostics, basesBeingResolved);
@@ -176,10 +176,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // user-defined methods, rather than the EE-defined methods for which we are generating
                 // bound nodes. This is because the containing symbols are used to determine the type
                 // of the "this" parameter, which we need to be the user-defined types.
-                Debug.Assert((object)CurrentMethodOrNestedFunction == null ||
-                    CurrentMethodOrNestedFunction.MethodKind == MethodKind.AnonymousFunction ||
-                    CurrentMethodOrNestedFunction.MethodKind == MethodKind.LocalFunction ||
-                    CurrentMethodOrNestedFunction.ContainingType == CurrentType);
+                Debug.Assert((object)CurrentFunction == null ||
+                    CurrentFunction.MethodKind == MethodKind.AnonymousFunction ||
+                    CurrentFunction.MethodKind == MethodKind.LocalFunction ||
+                    CurrentFunction.ContainingType == CurrentType);
             }
         }
 
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // single enclosing class.  This breaks that.  It would be nice to reintroduce that
             // invariant.
             AddNestedType(nestedType);
-            CurrentMethodOrNestedFunction = null;
+            CurrentFunction = null;
             TopLevelMethod = null;
             CurrentType = nestedType;
         }
@@ -237,8 +237,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundThisReference This()
         {
-            Debug.Assert((object)CurrentMethodOrNestedFunction != null && !CurrentMethodOrNestedFunction.IsStatic);
-            return new BoundThisReference(Syntax, CurrentMethodOrNestedFunction.ThisParameter.Type) { WasCompilerGenerated = true };
+            Debug.Assert((object)CurrentFunction != null && !CurrentFunction.IsStatic);
+            return new BoundThisReference(Syntax, CurrentFunction.ThisParameter.Type) { WasCompilerGenerated = true };
         }
 
         public BoundExpression This(LocalSymbol thisTempOpt)
@@ -248,8 +248,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundBaseReference Base()
         {
-            Debug.Assert((object)CurrentMethodOrNestedFunction != null && !CurrentMethodOrNestedFunction.IsStatic);
-            return new BoundBaseReference(Syntax, CurrentMethodOrNestedFunction.ThisParameter.Type.BaseTypeNoUseSiteDiagnostics) { WasCompilerGenerated = true };
+            Debug.Assert((object)CurrentFunction != null && !CurrentFunction.IsStatic);
+            return new BoundBaseReference(Syntax, CurrentFunction.ThisParameter.Type.BaseTypeNoUseSiteDiagnostics) { WasCompilerGenerated = true };
         }
 
         public BoundBadExpression BadExpression(TypeSymbol type)
@@ -437,29 +437,29 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // If necessary, add a conversion on the return expression.
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                var conversion = Compilation.Conversions.ClassifyConversionFromType(expression.Type, CurrentMethodOrNestedFunction.ReturnType, ref useSiteDiagnostics);
+                var conversion = Compilation.Conversions.ClassifyConversionFromType(expression.Type, CurrentFunction.ReturnType, ref useSiteDiagnostics);
                 Debug.Assert(useSiteDiagnostics.IsNullOrEmpty());
                 Debug.Assert(conversion.Kind != ConversionKind.NoConversion);
                 if (conversion.Kind != ConversionKind.Identity)
                 {
-                    Debug.Assert(CurrentMethodOrNestedFunction.RefKind == RefKind.None);
-                    expression = BoundConversion.Synthesized(Syntax, expression, conversion, false, false, ConstantValue.NotAvailable, CurrentMethodOrNestedFunction.ReturnType);
+                    Debug.Assert(CurrentFunction.RefKind == RefKind.None);
+                    expression = BoundConversion.Synthesized(Syntax, expression, conversion, false, false, ConstantValue.NotAvailable, CurrentFunction.ReturnType);
                 }
             }
 
-            return new BoundReturnStatement(Syntax, CurrentMethodOrNestedFunction.RefKind, expression) { WasCompilerGenerated = true };
+            return new BoundReturnStatement(Syntax, CurrentFunction.RefKind, expression) { WasCompilerGenerated = true };
         }
 
         public void CloseMethod(BoundStatement body)
         {
-            Debug.Assert((object)CurrentMethodOrNestedFunction != null);
+            Debug.Assert((object)CurrentFunction != null);
             if (body.Kind != BoundKind.Block)
             {
                 body = Block(body);
             }
 
-            CompilationState.AddSynthesizedMethod(CurrentMethodOrNestedFunction, body);
-            CurrentMethodOrNestedFunction = null;
+            CompilationState.AddSynthesizedMethod(CurrentFunction, body);
+            CurrentFunction = null;
         }
 
 #if DEBUG
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             [CallerLineNumber]int createdAtLineNumber = 0,
             [CallerFilePath]string createdAtFilePath = null)
         {
-            return new SynthesizedLocal(CurrentMethodOrNestedFunction, type, kind, syntax, isPinned, refKind, createdAtLineNumber, createdAtFilePath);
+            return new SynthesizedLocal(CurrentFunction, type, kind, syntax, isPinned, refKind, createdAtLineNumber, createdAtFilePath);
         }
 #else
         public LocalSymbol SynthesizedLocal(
@@ -926,7 +926,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundStatement BaseInitialization()
         {
             // TODO: add diagnostics for when things fall apart
-            var ctor = CurrentMethodOrNestedFunction.ThisParameter.Type.BaseTypeNoUseSiteDiagnostics.InstanceConstructors.Single(c => c.ParameterCount == 0);
+            var ctor = CurrentFunction.ThisParameter.Type.BaseTypeNoUseSiteDiagnostics.InstanceConstructors.Single(c => c.ParameterCount == 0);
             return new BoundExpressionStatement(Syntax, Call(Base(), ctor)) { WasCompilerGenerated = true };
         }
 
@@ -1278,7 +1278,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 refKind = RefKind.Ref;
             }
 
-            MethodSymbol containingMethod = this.CurrentMethodOrNestedFunction;
+            MethodSymbol containingMethod = this.CurrentFunction;
             var syntax = argument.Syntax;
             var type = argument.Type;
 
@@ -1323,7 +1323,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal BoundLocal MakeTempForDiscard(BoundDiscardExpression node, out LocalSymbol temp)
         {
-            temp = new SynthesizedLocal(this.CurrentMethodOrNestedFunction, node.Type, SynthesizedLocalKind.LoweringTemp);
+            temp = new SynthesizedLocal(this.CurrentFunction, node.Type, SynthesizedLocalKind.LoweringTemp);
 
             return new BoundLocal(node.Syntax, temp, constantValueOpt: null, type: node.Type) { WasCompilerGenerated = true };
         }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.SynthesizedMethodBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.SynthesizedMethodBase.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             protected SyntheticBoundNodeFactory CreateBoundNodeFactory(TypeCompilationState compilationState, DiagnosticBag diagnostics)
             {
                 var F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
-                F.CurrentMethodOrNestedFunction = this;
+                F.CurrentFunction = this;
                 return F;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var factory = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
-                factory.CurrentMethodOrNestedFunction = this;
+                factory.CurrentFunction = this;
 
                 var baseConstructorCall = MethodCompiler.GenerateBaseParameterlessConstructorInitializer(this, diagnostics);
                 if (baseConstructorCall == null)


### PR DESCRIPTION
This is just a refactoring to rename the property, following PR discussion https://github.com/dotnet/roslyn/pull/24921#pullrequestreview-107431468

Fixes https://github.com/dotnet/roslyn/issues/25768

Tagging @gafter @agocke