### PR TITLE
added more logging for completion to track some test failures where c…

### DIFF
--- a/src/EditorFeatures/Core/CommandHandlers/AbstractCompletionCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/AbstractCompletionCommandHandler.cs
@@ -3,6 +3,7 @@
 using System;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
@@ -119,6 +120,8 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         void IChainedCommandHandler<TypeCharCommandArgs>.ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
+
+            Logger.Log(FunctionId.Completion_ExecuteCommand_TypeChar, a => a.TypedChar.ToString(), args);
             ExecuteCommandWorker(args, nextHandler, context);
         }
 

--- a/src/EditorFeatures/Core/Implementation/Commands/CommandHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/Commands/CommandHandlerService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Commands
 
         void ICommandHandlerService.Execute<T>(IContentType contentType, T args, Action lastHandler)
         {
-            using (Logger.LogBlock(FunctionId.CommandHandler_ExecuteHandlers, CancellationToken.None))
+            using (Logger.LogBlock(FunctionId.CommandHandler_ExecuteHandlers, a => a?.ToString(), args, CancellationToken.None))
             {
                 ExecuteHandlers(GetHandlers<T>(contentType), args, lastHandler);
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_ComputeModel.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
@@ -11,9 +10,9 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
@@ -50,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 private readonly SnapshotPoint _subjectBufferCaretPosition;
                 private readonly SourceText _text;
                 private readonly ImmutableHashSet<string> _roles;
- 
+
                 private Document _documentOpt;
                 private bool _useSuggestionMode;
                 private readonly DisconnectedBufferGraph _disconnectedBufferGraph;
@@ -92,6 +91,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                         {
                             // both completionService and options can be null if given buffer is not registered to workspace yet.
                             // could happen in razor more frequently
+                            Logger.Log(FunctionId.Completion_ModelComputer_DoInBackground,
+                                (c, o) => $"service: {c != null}, options: {o != null}", _completionService, _options);
+
                             return null;
                         }
 
@@ -104,6 +106,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                             _documentOpt, _subjectBufferCaretPosition, _trigger, _roles, _options, cancellationToken).ConfigureAwait(false);
                         if (completionList == null)
                         {
+                            Logger.Log(FunctionId.Completion_ModelComputer_DoInBackground, 
+                                d => $"No completionList, document: {d != null}, document open: {d?.IsOpen()}", _documentOpt);
+
                             return null;
                         }
 

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -412,5 +412,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         AbstractProject_PushedToWorkspace,
         ExternalErrorDiagnosticUpdateSource_AddError,
         DiagnosticIncrementalAnalyzer_SynchronizeWithBuildAsync,
+        Completion_ExecuteCommand_TypeChar,
     }
 }


### PR DESCRIPTION
…ompletion doesn't show up when it should have.

all these logging is No-op without logging enabled. and they are not enabled in product. only in test.

### Customer scenario

This is test only change. this change doesn't do anything in product without test logging enabled.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/587964?src=alerts&src-action=summary_id_link

### Workarounds, if any

no workaround

### Risk

It doesn't do anything in production.

### Performance impact

No impact

### Is this a regression from a previous update?

No

### Root cause analysis

DDRIT tests are sometimes failing because it expects completion set but it doesn't show up. right now, we only knows that whether it showed up or not, but no info on what happened internally. this should let us to have better idea on whether we even got the request, if we got the request, whether we reached the end and showed completion set or bailed out before that. 

### How was the bug found?

DDRIT