### PR TITLE
use latest language version for Miscellaneous Files workspace

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -129,13 +129,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // 2) the old file was a different extension that we weren't tracking, which may have now changed
                 if (TryUntrackClosingDocument(docCookie, pszMkDocumentOld) || TryGetLanguageInformation(pszMkDocumentOld) == null)
                 {
-                    // Add the new one, if appropriate. 
+                    // Add the new one, if appropriate.
                     TrackOpenedDocument(docCookie, pszMkDocumentNew);
                 }
             }
 
-            // When starting a diff, the RDT doesn't call OnBeforeDocumentWindowShow, but it does call 
-            // OnAfterAttributeChangeEx for the temporary buffer. The native IDE used this even to 
+            // When starting a diff, the RDT doesn't call OnBeforeDocumentWindowShow, but it does call
+            // OnAfterAttributeChangeEx for the temporary buffer. The native IDE used this even to
             // add misc files, so we'll do the same.
             if ((grfAttribs & (uint)__VSRDTATTRIB.RDTA_DocDataReloaded) != 0)
             {
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return;
             }
 
-            // We don't want to realize the document here unless it's already initialized. Document initialization is watched in 
+            // We don't want to realize the document here unless it's already initialized. Document initialization is watched in
             // OnAfterAttributeChangeEx and will retrigger this if it wasn't already done.
             if (_runningDocumentTable.IsDocumentInitialized(docCookie) && !_docCookieToWorkspaceRegistration.ContainsKey(docCookie))
             {
@@ -354,8 +354,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var languageServices = Services.GetLanguageServices(languageInformation.LanguageName);
             var compilationOptionsOpt = languageServices.GetService<ICompilationFactoryService>()?.GetDefaultCompilationOptions();
 
-            // We only have one code file without project file here, so we cannot find out language version of the project  
-            // Use latest language version which is more permissive. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/575761  
+            // Use latest language version which is more permissive, as we cannot find out language version of the project which the file belongs to
+            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/575761
             var parseOptionsOpt = languageServices.GetService<ISyntaxTreeFactoryService>()?.GetDefaultParseOptionsWithLatestLanguageVersion();
 
             if (parseOptionsOpt != null &&
@@ -372,7 +372,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 var baseDirectory = PathUtilities.GetDirectoryName(filePath);
 
-                // TODO (https://github.com/dotnet/roslyn/issues/5325, https://github.com/dotnet/roslyn/issues/13886): 
+                // TODO (https://github.com/dotnet/roslyn/issues/5325, https://github.com/dotnet/roslyn/issues/13886):
                 // - Need to have a way to specify these somewhere in VS options.
                 // - Use RuntimeMetadataReferenceResolver like in InteractiveEvaluator.CreateMetadataReferenceResolver
                 // - Add default namespace imports, default metadata references to match csi.rsp

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -353,7 +353,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             var languageServices = Services.GetLanguageServices(languageInformation.LanguageName);
             var compilationOptionsOpt = languageServices.GetService<ICompilationFactoryService>()?.GetDefaultCompilationOptions();
-            var parseOptionsOpt = languageServices.GetService<ISyntaxTreeFactoryService>()?.GetDefaultParseOptions();
+
+            // We only have one code file without project file here, so we cannot find out language version of the project  
+            // Use latest language version which is more permissive. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/575761  
+            var parseOptionsOpt = languageServices.GetService<ISyntaxTreeFactoryService>()?.GetDefaultParseOptionsWithLatestLanguageVersion();
 
             if (parseOptionsOpt != null &&
                 compilationOptionsOpt != null &&

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp
     [ExportLanguageServiceFactory(typeof(ISyntaxTreeFactoryService), LanguageNames.CSharp), Shared]
     internal partial class CSharpSyntaxTreeFactoryServiceFactory : ILanguageServiceFactory
     {
+        static private CSharpParseOptions _parseOptionWithLatestLanguageVersion = new CSharpParseOptions(LanguageVersion.Latest);
+
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
         {
             return new CSharpSyntaxTreeFactoryService(provider);
@@ -29,6 +31,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override ParseOptions GetDefaultParseOptions()
             {
                 return CSharpParseOptions.Default;
+            }
+
+            public override ParseOptions GetDefaultParseOptionsWithLatestLanguageVersion()
+            {
+                return _parseOptionWithLatestLanguageVersion;
             }
 
             public override SyntaxTree CreateSyntaxTree(string fileName, ParseOptions options, Encoding encoding, SyntaxNode root)

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     [ExportLanguageServiceFactory(typeof(ISyntaxTreeFactoryService), LanguageNames.CSharp), Shared]
     internal partial class CSharpSyntaxTreeFactoryServiceFactory : ILanguageServiceFactory
     {
-        private static CSharpParseOptions _parseOptionWithLatestLanguageVersion = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+        private static readonly CSharpParseOptions _parseOptionWithLatestLanguageVersion = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
         {

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     [ExportLanguageServiceFactory(typeof(ISyntaxTreeFactoryService), LanguageNames.CSharp), Shared]
     internal partial class CSharpSyntaxTreeFactoryServiceFactory : ILanguageServiceFactory
     {
-        static private CSharpParseOptions _parseOptionWithLatestLanguageVersion = new CSharpParseOptions(LanguageVersion.Latest);
+        private static CSharpParseOptions _parseOptionWithLatestLanguageVersion = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.Host
         public abstract SyntaxTree ParseSyntaxTree(string filePath, ParseOptions options, SourceText text, CancellationToken cancellationToken);
         public abstract SyntaxTree CreateRecoverableTree(ProjectId cacheKey, string filePath, ParseOptions options, ValueSource<TextAndVersion> text, Encoding encoding, SyntaxNode root);
         public abstract SyntaxNode DeserializeNodeFrom(Stream stream, CancellationToken cancellationToken);
+        public abstract ParseOptions GetDefaultParseOptionsWithLatestLanguageVersion();
 
         public virtual bool CanCreateRecoverableTree(SyntaxNode root)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/ISyntaxTreeFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/ISyntaxTreeFactoryService.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.Host
     {
         ParseOptions GetDefaultParseOptions();
 
+        ParseOptions GetDefaultParseOptionsWithLatestLanguageVersion();
+
         // new tree from root node
         SyntaxTree CreateSyntaxTree(string filePath, ParseOptions options, Encoding encoding, SyntaxNode root);
 

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
@@ -16,7 +16,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Shared ReadOnly _parseOptionsWithLatestLanguageVersion As VisualBasicParseOptions = VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest)
 
-
         Public Function CreateLanguageService(provider As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
             Return New VisualBasicSyntaxTreeFactoryService(provider)
         End Function

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
@@ -14,6 +14,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Friend Class VisualBasicSyntaxTreeFactoryServiceFactory
         Implements ILanguageServiceFactory
 
+        Private Shared _parseOptionsWithLatestLanguageVersion As VisualBasicParseOptions = New VisualBasicParseOptions(LanguageVersion.Latest)
+
+
         Public Function CreateLanguageService(provider As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
             Return New VisualBasicSyntaxTreeFactoryService(provider)
         End Function
@@ -27,6 +30,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Public Overloads Overrides Function GetDefaultParseOptions() As ParseOptions
                 Return VisualBasicParseOptions.Default
+            End Function
+
+            Public Overloads Overrides Function GetDefaultParseOptionsWithLatestLanguageVersion() As ParseOptions
+                Return _parseOptionsWithLatestLanguageVersion
             End Function
 
             Public Overloads Overrides Function ParseSyntaxTree(fileName As String, options As ParseOptions, text As SourceText, cancellationToken As CancellationToken) As SyntaxTree

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Friend Class VisualBasicSyntaxTreeFactoryServiceFactory
         Implements ILanguageServiceFactory
 
-        Private Shared _parseOptionsWithLatestLanguageVersion As VisualBasicParseOptions = VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest)
+        Private Shared ReadOnly _parseOptionsWithLatestLanguageVersion As VisualBasicParseOptions = VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest)
 
 
         Public Function CreateLanguageService(provider As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Friend Class VisualBasicSyntaxTreeFactoryServiceFactory
         Implements ILanguageServiceFactory
 
-        Private Shared _parseOptionsWithLatestLanguageVersion As VisualBasicParseOptions = New VisualBasicParseOptions(LanguageVersion.Latest)
+        Private Shared _parseOptionsWithLatestLanguageVersion As VisualBasicParseOptions = VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest)
 
 
         Public Function CreateLanguageService(provider As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService


### PR DESCRIPTION
<details><summary>use latest language version for Miscellaneous Files workspace</summary>

### Customer scenario
Diff window uses the default language version instead of the project language version. So when a code file contains a new feature which does not exist in the default language version, the diff window shows error which is confusing to customers.

### Bugs this fixes
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/575761

### Workarounds, if any
No

### Risk
Low, only uses the latest language version instead of the default language version for ParserOptions when opening a historical version of code file

### Performance impact
Low, no extra allocations/no complexity changes

### Is this a regression from a previous update?
Not sure

### Root cause analysis
NA

### How was the bug found?
Customer reported on vs feedback

### Test documentation updated?
No

</details>
