### PR TITLE
Add InternalsVisibleTo from Workspaces to Microsoft.Test.Apex.VisualStudio

### DIFF
--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -291,6 +291,7 @@
     <InternalsVisibleToRemoteLS Include="Microsoft.VisualStudio.LanguageServices.Remote" />
     <InternalsVisibleToRemoteLS Include="Microsoft.VisualStudio.LanguageServices.Remote.CSharp" />
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleToVisualStudio Include="Microsoft.Test.Apex.VisualStudio" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\UnicodeCharacterUtilities.cs">


### PR DESCRIPTION
### Customer scenario

N/A (Internal build block)

### Bugs this fixes

Fixes the insertion to Visual Studio.

### Workarounds, if any

None.

### Risk

Low. The IVT existed previously from the features layer so Apex has access to `IAsynchronousOperationListenerProvider`. This type was moved to Workspaces with a type forwarder, but IVT is still required.

### Performance impact

None.

### Is this a regression from a previous update?

Yes, introduced by #25558 (specifically ce44aa778d811e90e3728a523a86c01c75d32a58).

### Root cause analysis

We checked with some but not all downstream consumers during the review for this pull request.

### How was the bug found?

Automated build.

### Test documentation updated?

N/A