### PR TITLE
Make escape analysis over unexpected nodes to return conservative results

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2328,8 +2328,20 @@ moreArguments:
                     // Unsafe code will always be allowed to escape.
                     return Binder.ExternalScope;
 
+                case BoundKind.AsOperator:
+                case BoundKind.AwaitExpression:
+                case BoundKind.ConditionalAccess:
+                case BoundKind.NullCoalescingOperator:
+                case BoundKind.ArrayAccess:
+                    // only possible in error cases (if possible at all)
+                    return scopeOfTheContainingExpression;
+
                 default:
-                    throw ExceptionUtilities.UnexpectedValue($"{expr.Kind} expression of {expr.Type} type");
+                    // in error situations some unexpected nodes could make here
+                    // returning "scopeOfTheContainingExpression" seems safer than throwing.
+                    // we will still assert to make sure that all nodes are accounted for. 
+                    Debug.Assert(false, $"{expr.Kind} expression of {expr.Type} type");
+                    return scopeOfTheContainingExpression;
             }
         }
 
@@ -2643,8 +2655,20 @@ moreArguments:
                     var operandExpression = ((BoundPointerIndirectionOperator)expr).Operand;
                     return CheckValEscape(operandExpression.Syntax, operandExpression, escapeFrom, escapeTo, checkingReceiver, diagnostics);
 
+                case BoundKind.AsOperator:
+                case BoundKind.AwaitExpression:
+                case BoundKind.ConditionalAccess:
+                case BoundKind.NullCoalescingOperator:
+                case BoundKind.ArrayAccess:
+                    // only possible in error cases (if possible at all)
+                    return false;
+
                 default:
-                    throw ExceptionUtilities.UnexpectedValue($"{expr.Kind} expression of {expr.Type} type");
+                    // in error situations some unexpected nodes could make here
+                    // returning "false" seems safer than throwing.
+                    // we will still assert to make sure that all nodes are accounted for. 
+                    Debug.Assert(false, $"{expr.Kind} expression of {expr.Type} type");
+                    return false;
 
                 #region "cannot produce ref-like values"
 //                case BoundKind.ThrowExpression:
@@ -2652,11 +2676,7 @@ moreArguments:
 //                case BoundKind.ArgList:
 //                case BoundKind.RefTypeOperator:
 //                case BoundKind.AddressOfOperator:
-//                case BoundKind.AsOperator:
 //                case BoundKind.TypeOfOperator:
-//                case BoundKind.ArrayAccess:
-//                case BoundKind.NullCoalescingOperator:
-//                case BoundKind.AwaitExpression:
 //                case BoundKind.IsOperator:
 //                case BoundKind.SizeOfOperator:
 //                case BoundKind.DynamicMemberAccess:
@@ -2674,7 +2694,6 @@ moreArguments:
 //                case BoundKind.NoPiaObjectCreationExpression:
 //                case BoundKind.BaseReference:
 //                case BoundKind.Literal:
-//                case BoundKind.ConditionalAccess:
 //                case BoundKind.IsPatternExpression:
 //                case BoundKind.DeconstructionAssignmentOperator:
 //                case BoundKind.EventAccess:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -3272,8 +3272,6 @@ class C
 
         var r = t.Result;
         M(await t, ref r);
-        
-        return default;
     }
 
     void M(S t, ref S t1)
@@ -3291,10 +3289,7 @@ class C
                 Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "var").WithArguments("S").WithLocation(14, 9),
                 // (15,9): error CS8350: This combination of arguments to 'C.M(S, ref S)' is disallowed because it may expose variables referenced by parameter 't' outside of their declaration scope
                 //         M(await t, ref r);
-                Diagnostic(ErrorCode.ERR_CallArgMixing, "M(await t, ref r)").WithArguments("C.M(S, ref S)", "t").WithLocation(15, 9),
-                // (17,9): error CS1997: Since 'C.M(Task<S>)' is an async method that returns 'Task', a return keyword must not be followed by an object expression. Did you intend to return 'Task<T>'?
-                //         return default;
-                Diagnostic(ErrorCode.ERR_TaskRetNoObjectRequired, "return").WithArguments("C.M(System.Threading.Tasks.Task<S>)").WithLocation(17, 9)
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "M(await t, ref r)").WithArguments("C.M(S, ref S)", "t").WithLocation(15, 9)
                 );
         }
 
@@ -3303,8 +3298,6 @@ class C
         public void CoalesceRefStruct()
         {
             CreateCompilation(@"
-using System.Threading.Tasks;
-
 ref struct S { }
 
 class C
@@ -3316,15 +3309,12 @@ class C
         var a = (S?)null ?? default;
     }
 }", options: TestOptions.ReleaseDll).VerifyDiagnostics(
-                // (10,14): error CS0306: The type 'S' may not be used as a type argument
+                // (8,14): error CS0306: The type 'S' may not be used as a type argument
                 //         _ = (S?)null ?? default;
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "S?").WithArguments("S").WithLocation(10, 14),
-                // (12,18): error CS0306: The type 'S' may not be used as a type argument
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "S?").WithArguments("S").WithLocation(8, 14),
+                // (10,18): error CS0306: The type 'S' may not be used as a type argument
                 //         var a = (S?)null ?? default;
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "S?").WithArguments("S").WithLocation(12, 18),
-                // (2,1): hidden CS8019: Unnecessary using directive.
-                // using System.Threading.Tasks;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Threading.Tasks;").WithLocation(2, 1)
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "S?").WithArguments("S").WithLocation(10, 18)
                 );
         }
 
@@ -3333,8 +3323,6 @@ class C
         public void ArrayAccessRefStruct()
         {
             CreateCompilation(@"
-using System.Threading.Tasks;
-
 ref struct S { }
 
 class C
@@ -3346,15 +3334,12 @@ class C
         var a = ((S[])null)[0];
     }
 }", options: TestOptions.ReleaseDll).VerifyDiagnostics(
-                // (10,15): error CS0611: Array elements cannot be of type 'S'
+                // (8,15): error CS0611: Array elements cannot be of type 'S'
                 //         _ = ((S[])null)[0];
-                Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "S").WithArguments("S").WithLocation(10, 15),
-                // (12,19): error CS0611: Array elements cannot be of type 'S'
+                Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "S").WithArguments("S").WithLocation(8, 15),
+                // (10,19): error CS0611: Array elements cannot be of type 'S'
                 //         var a = ((S[])null)[0];
-                Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "S").WithArguments("S").WithLocation(12, 19),
-                // (2,1): hidden CS8019: Unnecessary using directive.
-                // using System.Threading.Tasks;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Threading.Tasks;").WithLocation(2, 1)
+                Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "S").WithArguments("S").WithLocation(10, 19)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -3252,5 +3252,137 @@ public class C
                 //     public static unsafe void Test(TestStruct[] ar)
                 Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "TestStruct").WithArguments("TestStruct").WithLocation(8, 36));
         }
+
+        [Fact]
+        [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
+        public void AwaitRefStruct()
+        {
+            CreateCompilation(@"
+using System.Threading.Tasks;
+
+ref struct S { }
+
+class C
+{
+    async Task M(Task<S> t)
+    {
+        _ = await t;
+
+        var a = await t;
+
+        var r = t.Result;
+        M(await t, ref r);
+        
+        return default;
+    }
+
+    void M(S t, ref S t1)
+    {
+    }
+}", options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (8,26): error CS0306: The type 'S' may not be used as a type argument
+                //     async Task M(Task<S> t)
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("S").WithLocation(8, 26),
+                // (12,9): error CS4012: Parameters or locals of type 'S' cannot be declared in async methods or lambda expressions.
+                //         var a = await t;
+                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "var").WithArguments("S").WithLocation(12, 9),
+                // (14,9): error CS4012: Parameters or locals of type 'S' cannot be declared in async methods or lambda expressions.
+                //         var r = t.Result;
+                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "var").WithArguments("S").WithLocation(14, 9),
+                // (15,9): error CS8350: This combination of arguments to 'C.M(S, ref S)' is disallowed because it may expose variables referenced by parameter 't' outside of their declaration scope
+                //         M(await t, ref r);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "M(await t, ref r)").WithArguments("C.M(S, ref S)", "t").WithLocation(15, 9),
+                // (17,9): error CS1997: Since 'C.M(Task<S>)' is an async method that returns 'Task', a return keyword must not be followed by an object expression. Did you intend to return 'Task<T>'?
+                //         return default;
+                Diagnostic(ErrorCode.ERR_TaskRetNoObjectRequired, "return").WithArguments("C.M(System.Threading.Tasks.Task<S>)").WithLocation(17, 9)
+                );
+        }
+
+        [Fact]
+        [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
+        public void CoalesceRefStruct()
+        {
+            CreateCompilation(@"
+using System.Threading.Tasks;
+
+ref struct S { }
+
+class C
+{
+    void M()
+    {       
+        _ = (S?)null ?? default;
+
+        var a = (S?)null ?? default;
+    }
+}", options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (10,14): error CS0306: The type 'S' may not be used as a type argument
+                //         _ = (S?)null ?? default;
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "S?").WithArguments("S").WithLocation(10, 14),
+                // (12,18): error CS0306: The type 'S' may not be used as a type argument
+                //         var a = (S?)null ?? default;
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "S?").WithArguments("S").WithLocation(12, 18),
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System.Threading.Tasks;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Threading.Tasks;").WithLocation(2, 1)
+                );
+        }
+
+        [Fact]
+        [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
+        public void ArrayAccessRefStruct()
+        {
+            CreateCompilation(@"
+using System.Threading.Tasks;
+
+ref struct S { }
+
+class C
+{
+    void M()
+    {       
+        _ = ((S[])null)[0];
+
+        var a = ((S[])null)[0];
+    }
+}", options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (10,15): error CS0611: Array elements cannot be of type 'S'
+                //         _ = ((S[])null)[0];
+                Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "S").WithArguments("S").WithLocation(10, 15),
+                // (12,19): error CS0611: Array elements cannot be of type 'S'
+                //         var a = ((S[])null)[0];
+                Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "S").WithArguments("S").WithLocation(12, 19),
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System.Threading.Tasks;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Threading.Tasks;").WithLocation(2, 1)
+                );
+        }
+
+        [Fact]
+        [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
+        public void ConditionalRefStruct()
+        {
+            CreateCompilation(@"
+ref struct S { }
+
+class C
+{
+    void M()
+    {       
+        _ = ((C)null)?.Test();
+
+        var a = ((C)null)?.Test();
+    }
+    
+    S Test() => default;        
+}", options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (8,22): error CS0023: Operator '?' cannot be applied to operand of type 'S'
+                //         _ = ((C)null)?.Test();
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "?").WithArguments("?", "S").WithLocation(8, 22),
+                // (10,26): error CS0023: Operator '?' cannot be applied to operand of type 'S'
+                //         var a = ((C)null)?.Test();
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "?").WithArguments("?", "S").WithLocation(10, 26)
+                );
+        }
     }
 }


### PR DESCRIPTION
There are expressions for which ref-struct escape analysis does not make sense. Yet we keep finding ourselves in situations where we have to do it. Generally in error conditions.
So, instead of throwing "unreachable" we will return the most conservative results.

There is still an assert here so that if new bound nodes are added, there will be a chance to think whether there is a need for nontrivial handling of the node.

Fixes:#25398
Fixes:#25485
