### PR TITLE
Update links to Samples.sln location

### DIFF
--- a/docs/analyzers/Analyzer Samples.md
+++ b/docs/analyzers/Analyzer Samples.md
@@ -1,6 +1,6 @@
 **Samples Location:**
 
-Sample analyzers to demonstrate recommended implementation models for different analysis scenarios have been added to [CSharpAnalyzers.sln](..//..//src//Samples//CSharp//Analyzers//CSharpAnalyzers.sln) and [BasicAnalyzers.sln](..//..//src//Samples//VisualBasic//Analyzers//BasicAnalyzers.sln).
+Sample analyzers to demonstrate recommended implementation models for different analysis scenarios have been added to [Samples.sln](https://github.com/dotnet/roslyn-sdk/tree/master/Samples.sln).
 
 **Description:**
 


### PR DESCRIPTION
Make it actual according to roslyn/roslyn-sdk split

<details><summary>Ask Mode template completed</summary>

### Customer scenario
As a customer, I want to get actual roslyn sdk samples and stumbled into incorrect link. It takes sometime for me to found correct location.

### Bugs this fixes

n/a

### Workarounds, if any

Search manually

### Risk

n/a

### Performance impact

n/a (doc only change)

### Is this a regression from a previous update?

Yes, from roslyn / roslyn-sdk split

### Root cause analysis

n/a

### How was the bug found?

n/a

### Test documentation updated?

n/a

</details>
