### PR TITLE
Fix signing of swix project output

### DIFF
--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -144,7 +144,9 @@
         "Vsix\\VisualStudioSetup.Next\\Roslyn.VisualStudio.Setup.Next.vsix",
         "Vsix\\VisualStudioSetup\\Roslyn.VisualStudio.Setup.vsix",
         "Vsix\\Roslyn\\RoslynDeployment.vsix",
-        "Vsix\\VisualStudioIntegrationTestSetup\\Microsoft.VisualStudio.IntegrationTest.Setup.vsix"
+        "Vsix\\VisualStudioIntegrationTestSetup\\Microsoft.VisualStudio.IntegrationTest.Setup.vsix",
+        "Vsix\\CodeAnalysisCompilers\\Microsoft.CodeAnalysis.Compilers.vsix",
+        "Vsix\\PortableFacades\\PortableFacades.vsix"
       ]
     },
     {
@@ -224,14 +226,19 @@
     "System.IO.Pipes.AccessControl.dll",
     "System.IO.Pipes.dll",
     "System.IO.dll",
+    "System.Net.Security.dll",
+    "System.Net.Sockets.dll",
     "System.Reflection.Metadata.1.0.21.nupkg",
     "System.Reflection.Metadata.dll",
+    "System.Reflection.TypeExtensions.dll",
     "System.Reflection.dll",
     "System.Resources.Reader.dll",
     "System.Runtime.InteropServices.RuntimeInformation.dll",
+    "System.Runtime.Serialization.Primitives.dll",
     "System.Security.AccessControl.dll",
     "System.Security.Claims.dll",
     "System.Security.Cryptography.Algorithms.dll",
+    "System.Security.Cryptography.Csp.dll",
     "System.Security.Cryptography.Encoding.dll",
     "System.Security.Cryptography.Primitives.dll",
     "System.Security.Cryptography.X509Certificates.dll",

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -286,6 +286,10 @@ function Build-ExtraSignArtifacts() {
         Run-MSBuild "..\Compilers\Server\VBCSCompiler\VBCSCompiler.csproj" "/p:TargetFramework=netcoreapp2.0 /t:PublishWithoutBuilding"
         Write-Host "Publishing MSBuildTask"
         Run-MSBuild "..\Compilers\Core\MSBuildTask\MSBuildTask.csproj" "/p:TargetFramework=netcoreapp2.0 /t:PublishWithoutBuilding"
+        Write-Host "Building PortableFacades Swix"
+        Run-MSBuild "DevDivVsix\PortableFacades\PortableFacades.swixproj"
+        Write-Host "Building CompilersCodeAnalysis Swix"
+        Run-MSBuild "DevDivVsix\CompilersPackage\Microsoft.CodeAnalysis.Compilers.swixproj"
 
         $dest = @($configDir)
         foreach ($dir in $dest) { 

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.vsmanproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.vsmanproj
@@ -22,10 +22,6 @@
 
   <Import Project="$(SwixBuildPath)build\MicroBuild.Plugins.*.targets" />
 
-  <Target Name="BeforeBuild">
-    <MSBuild Projects="Microsoft.CodeAnalysis.Compilers.swixproj" Targets="Build" />
-  </Target>
-
   <Target Name="ValidateManifest" />
 
   <!-- Disable automatic signing. This will be signed in the batch phase -->

--- a/src/Setup/DevDivVsix/PortableFacades/PortableFacades.vsmanproj
+++ b/src/Setup/DevDivVsix/PortableFacades/PortableFacades.vsmanproj
@@ -22,10 +22,6 @@
 
   <Import Project="$(SwixBuildPath)build\MicroBuild.Plugins.*.targets" />
 
-  <Target Name="BeforeBuild">
-    <MSBuild Projects="PortableFacades.swixproj" Targets="Build" />
-  </Target>
-
   <Target Name="ValidateManifest" />
 
   <!-- Disable automatic signing. This will be signed in the batch phase -->


### PR DESCRIPTION
This fixes a signing regression caused be #25751. That changed us to
directly call the SWIX build props / targets vs. getting them implicitly
from the microbuild props / targets. One of the behaviors that the
microbuild props / targets had that wasn't accounted for was the signing
of the VSIX after they are constructed. Hence this lead to signing
errors on insertion.

This PR fixes that by making the following changes:

1. Adds SWIX VSIX to SignToolData.json so they are accounted for during
normal batch signing.
1. Moves the SWIX build to the pre-sign portion of our build.
1. Removes the references from VSMAN -> SWIX. These references are there
only to enforce ordering which is unnecessary. Having them remain risks
that building the VSMAN will cause the SWIX to be re-built which could
possibly invalidate signing.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
