### PR TITLE
Added tests for propagating escape errors through array elements

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -3369,5 +3369,27 @@ class C
                 Diagnostic(ErrorCode.ERR_BadUnaryOp, "?").WithArguments("?", "S").WithLocation(10, 26)
                 );
         }
+
+        [Fact]
+        [WorkItem(25485, "https://github.com/dotnet/roslyn/issues/25485")]
+        public void ArrayAccess_CrashesEscapeRules()
+        {
+            CreateCompilationWithMscorlibAndSpan(@"
+using System;
+public class Class1
+{
+    public void Foo(Span<Thing>[] first, Thing[] second)
+    {
+        var x = first[0];
+    }
+}
+public struct Thing
+{
+}
+").VerifyDiagnostics(
+                // (5,21): error CS0611: Array elements cannot be of type 'Span<Thing>'
+                //     public void Foo(Span<Thing>[] first, Thing[] second)
+                Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "Span<Thing>").WithArguments("System.Span<Thing>").WithLocation(5, 21));
+        }
     }
 }


### PR DESCRIPTION
Closes #25485
The bug was already fixed in #25819 
This PR just adds a test to close the bug.

cc @VSadov @dotnet/roslyn-compiler 