### PR TITLE
Use SignTool that supports binary logging

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -149,10 +149,10 @@
     <RoslynBuildUtilVersion>0.9.8-beta</RoslynBuildUtilVersion>
     <RoslynDependenciesOptimizationDataVersion>2.7.0-beta3-62526-01-2</RoslynDependenciesOptimizationDataVersion>
     <RoslynToolsMicrosoftLocateVSVersion>0.2.4-beta</RoslynToolsMicrosoftLocateVSVersion>
-    <RoslynToolsMicrosoftSignToolVersion>0.3.7-beta</RoslynToolsMicrosoftSignToolVersion>
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.4.0-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
     <RoslynToolsMSBuildVersion>0.4.0-alpha</RoslynToolsMSBuildVersion>
     <RoslynToolsReferenceAssembliesVersion>0.1.3</RoslynToolsReferenceAssembliesVersion>
+    <RoslynToolsSignToolVersion>1.0.0-beta2-dev2</RoslynToolsSignToolVersion>
     <RoslynMicrosoftVisualStudioExtensionManagerVersion>0.0.4</RoslynMicrosoftVisualStudioExtensionManagerVersion>
     <StreamJsonRpcVersion>1.1.92</StreamJsonRpcVersion>
     <SystemAppContextVersion>4.3.0</SystemAppContextVersion>

--- a/build/ToolsetPackages/RoslynToolset.csproj
+++ b/build/ToolsetPackages/RoslynToolset.csproj
@@ -30,9 +30,9 @@
     <PackageReference Include="Roslyn.Build.Util" Version="$(RoslynBuildUtilVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynDependencies.OptimizationData" Version="$(RoslynDependenciesOptimizationDataVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynTools.Microsoft.LocateVS" Version="$(RoslynToolsMicrosoftLocateVSVersion)" ExcludeAssets="all" />
-    <PackageReference Include="RoslynTools.Microsoft.SignTool" Version="$(RoslynToolsMicrosoftSignToolVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynTools.Microsoft.VSIXExpInstaller" Version="$(RoslynToolsMicrosoftVSIXExpInstallerVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynTools.MSBuild" Version="$(RoslynToolsMSBuildVersion)" ExcludeAssets="all" />
+    <PackageReference Include="RoslynTools.SignTool" Version="$(RoslynToolsSignToolVersion)" ExcludeAssets="all" />
     <PackageReference Include="xunit.runner.wpf" Version="$(xunitrunnerwpfVersion)" ExcludeAssets="all" />
     <PackageReference Include="vswhere" Version="$(vswhereVersion)" ExcludeAssets="all" />
   </ItemGroup>

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -576,8 +576,9 @@ function Deploy-VsixViaTool() {
 function Run-SignTool() { 
     Push-Location $repoDir
     try {
-        $signTool = Join-Path (Get-PackageDir "RoslynTools.Microsoft.SignTool") "tools\SignTool.exe"
+        $signTool = Join-Path (Get-PackageDir "RoslynTools.SignTool") "tools\SignTool.exe"
         $signToolArgs = "-msbuildPath `"$msbuild`""
+        $signToolArgs += " -msbuildBinaryLog $logsDir\Signing.binlog"
         switch ($signType) {
             "real" { break; }
             "test" { $signToolArgs += " -testSign"; break; }


### PR DESCRIPTION
Need to generate a binary log during signing so we can understand why
our builds are failing when new signing is enabled.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
