### PR TITLE
Don't include AnalyzerFileReference.Display in equality checking

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -460,18 +460,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public bool Equals(AnalyzerReference other)
         {
-            if (other != null)
+            if ((object)other == this)
             {
-                return other.Display == this.Display &&
-                       other.FullPath == this.FullPath;
+                return true;
             }
 
-            return base.Equals(other);
+            if (other != null)
+            {
+                return other.FullPath == this.FullPath;
+            }
+
+            return false;
         }
 
         public override int GetHashCode()
         {
-            return Hash.Combine(this.Display, this.FullPath.GetHashCode());
+            return this.FullPath.GetHashCode();
         }
 
         public Assembly GetAssembly()


### PR DESCRIPTION
We were including AnalyzerFileReference.Display as a part of equality checking in AnalyzerFileReference. This is expensive to acquire, as it hits the disk and loads the assembly image to read the assembly name and identity from metadata. This isn't necessary to do: since we were already using FullPath as equality checking, the only way this would ever matter is if you had two AnalyzerFileReferences that were created
at different times, with the assembly being modified in between. Since AnalyzerFileReference still had no concept of snapshotting, the behavior was still undefined. According to @heejaechang the analyzer runner already filters out "identical" analyzers with the same .NET assembly identity (since have no way to load both anyways...) so this was even more silly.

This was showing up in various traces, as the workspace has various "does this AnalyzerReference exist in this project", which was hitting disk (often on the UI thread) when it wasn't needed.

<details><summary>Ask Mode template</summary>

### Customer scenario

User opens a solution that contains many analyzers in use. Solution load is slower than it should, at least if disk IO is slow.

### Bugs this fixes

One identified issue looking at traces from https://devdiv.visualstudio.com/DevDiv/_workitems/edit/590848

### Workarounds, if any

Don't use analyzers.

### Risk

Reasonably low, the only way this would change behavior is if analyzers are being changed on disk in strange ways, which this code wasn't equipped to deal with in the first place.

### Performance impact

Removing I/O in a common path, so should be better.

### Is this a regression from a previous update?

No, this has been like this since this type was originally published to GitHub.

### Root cause analysis

Our AnalyzerFileReference.Equals() method called an expensive and unnecessary property.

### How was the bug found?

Customer PerfWatson traces.

</details>
