### PR TITLE
Move Roslyn.sln to newer analyzers (with Dispose rules disabled)

### DIFF
--- a/build/Rulesets/NonShippingProject_BuildRules.ruleset
+++ b/build/Rulesets/NonShippingProject_BuildRules.ruleset
@@ -2,35 +2,45 @@
 <RuleSet Name="Common diagnostic rules for all non-shipping projects" Description="Enables/disable rules specific to all non-shipping projects." ToolsVersion="14.0">
   <Include Path=".\Roslyn_BuildRules.ruleset" Action="Default" />
 
-  <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.Analyzers">
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
     <!-- For tests, the ConfigureAwait(true) is good enough. Either they are already running on a thread pool
          thread where ConfigureAwait(false) does nothing, or we're running the workload from an STA thread
          where we want to marshal the continuations back to it. -->
     <Rule Id="CA2007" Action="None" />
-  </Rules>
 
-  <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
     <!-- Avoid zero length allocations - suppress for non-shipping/test projects (originally RS0007) -->
     <Rule Id="CA1825" Action="None" />
-    <!-- Do not use Enumerable methods on indexable collections - suppressed because we have lot of violations in non-shipping/test projects.
+
+    <!-- Do not use Enumerable methods on indexable collections (originally RS0014) - suppressed because we have lot of violations in non-shipping/test projects.
          We can fix all violations once we have a code fix with fix all, and then remove this suppression.
     -->
-    <Rule Id="RS0014" Action="None" />
+    <Rule Id="CA1826" Action="None" />
+
+    <!-- Mark constant field as 'const' instead of static readonly - not useful for tests -->
+    <Rule Id="CA1802" Action="None" />
+
+    <!-- Properties should not return arrays - not useful for tests -->
+    <Rule Id="CA1819" Action="None" />
   </Rules>
 
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
     <Rule Id="RS1001" Action="None" />
-    <!-- CodeFix providers should override GetFixAllProvider - suppress for non-shipping/test projects (RS1016) -->
-    <Rule Id="RS1016" Action="None" /> 
-  </Rules>
 
-  <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
+    <!-- CodeFix providers should override GetFixAllProvider - suppress for non-shipping/test projects -->
+    <Rule Id="RS1016" Action="None" />
+
+    <!-- DiagnosticId must be unique across analyzers - suppress for non-shipping/test projects -->
+    <Rule Id="RS1019" Action="None" />
+
     <!-- Do not use generic CodeAction.Create to create CodeAction - not useful for tests -->
     <Rule Id="RS0005" Action="None" />
   </Rules>
   
-  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers.QualityGuidelines" RuleNamespace="Microsoft.CodeQuality.Analyzers.QualityGuidelines">
-    <!-- Mark constant field as 'const' instead of static readonly - not useful for tests -->
-    <Rule Id="CA1802" Action="None" />
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers.Exp" RuleNamespace="Microsoft.CodeQuality.Analyzers.Exp">
+    <!-- Dispose rules turned off for non-shipping projects due to large number of violation count -->
+    <!-- https://github.com/dotnet/roslyn/issues/25129 tracks fixing/suppressing these violations and removing the below entries -->
+    <Rule Id="CA2000" Action="None" />
+    <Rule Id="CA2213" Action="None" />
+    <Rule Id="CA1063" Action="None" />
   </Rules>  
 </RuleSet>

--- a/build/Rulesets/Roslyn_BuildRules.ruleset
+++ b/build/Rulesets/Roslyn_BuildRules.ruleset
@@ -21,6 +21,7 @@
     <Rule Id="CA1055" Action="None" />
     <Rule Id="CA1056" Action="None" />
     <Rule Id="CA1061" Action="None" /> <!-- "do not hide base class methods": currently violations in the compiler -->
+    <Rule Id="CA1063" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25134: Enable rule CA1063 (Implement IDisposable correctly) for Roslyn.sln -->
     <Rule Id="CA1064" Action="None" />
     <Rule Id="CA1065" Action="None" />
     <Rule Id="CA1066" Action="None" />
@@ -44,10 +45,13 @@
     <Rule Id="CA1814" Action="None" /> <!-- prefer jagged arrays to multidimensional: a silly piece of advice -->
     <Rule Id="CA1815" Action="None" />
     <Rule Id="CA1821" Action="Warning" />
+    <Rule Id="CA1822" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25132: Enable rule CA1822 (Mark members as static) on Roslyn.sln -->
     <Rule Id="CA1823" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/20404: Enable rule CA1823 (remove unused field) once we have a fixer for it -->
     <Rule Id="CA1824" Action="None" /> <!-- mark assemblies with NeutralResourcesLanguageAttribute -->
+    <Rule Id="CA2000" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25880 -->
     <Rule Id="CA2007" Action="Warning" />
     <Rule Id="CA2211" Action="None" />
+    <Rule Id="CA2213" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25880 -->
     <Rule Id="CA2214" Action="None" /> <!-- do not call overridable methods in constructors: done in various places -->
     <Rule Id="CA2218" Action="None" />
     <Rule Id="CA2222" Action="None" />
@@ -121,7 +125,7 @@
     <Rule Id="RS0018" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="XmlDocumentationComments.Analyzers" RuleNamespace="XmlDocumentationComments.Analyzers">
-    <Rule Id="RS0010" Action="Warning" />
+    <Rule Id="CA1200" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
     <Rule Id="CA9999" Action="None" /> <!-- We know the analyzers will fail during a bootstrap build -->

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -55,10 +55,10 @@
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
     <!-- Using a private build of Microsoft.Net.Test.SDK to work around issue https://github.com/Microsoft/vstest/issues/373 -->
     <MicrosoftNETTestSdkVersion>15.6.0-dev</MicrosoftNETTestSdkVersion>
-    <MicrosoftNetCompilersVersion>2.6.0</MicrosoftNetCompilersVersion>
-    <MicrosoftNetRoslynDiagnosticsVersion>2.6.0-beta2</MicrosoftNetRoslynDiagnosticsVersion>
+    <MicrosoftNetCompilersVersion>2.6.1</MicrosoftNetCompilersVersion>
+    <MicrosoftNetRoslynDiagnosticsVersion>2.6.1-beta1-62702-01</MicrosoftNetRoslynDiagnosticsVersion>
     <MicrosoftNetCoreILAsmVersion>2.0.0</MicrosoftNetCoreILAsmVersion>
-    <MicrosoftNETCoreCompilersVersion>2.8.0-beta2-62712-07</MicrosoftNETCoreCompilersVersion>
+    <MicrosoftNETCoreCompilersVersion>2.7.0-beta3-62720-08</MicrosoftNETCoreCompilersVersion>
     <MicrosoftNETCoreVersion>5.0.0</MicrosoftNETCoreVersion>
     <MicrosoftNETCoreAppVersion>2.0.0</MicrosoftNETCoreAppVersion>
     <MicrosoftNETCorePlatformsVersion>2.0.0</MicrosoftNETCorePlatformsVersion>

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -10,7 +10,7 @@ using ExceptionUtilities = Roslyn.Utilities.ExceptionUtilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
     /// <summary>
     /// Displays a value in the C# style.
     /// </summary>
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// the Formatter project and we don't want it to be public there.
     /// </remarks>
     /// <seealso cref="T:Microsoft.CodeAnalysis.VisualBasic.Symbols.ObjectDisplay"/>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
     internal static class ObjectDisplay
     {
         /// <summary>

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
@@ -7,12 +7,12 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
     /// <summary>
     /// Displays a symbol in the C# style.
     /// </summary>
     /// <seealso cref="T:Microsoft.CodeAnalysis.VisualBasic.Symbols.SymbolDisplay"/>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
     public static class SymbolDisplay
     {
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -938,13 +938,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
         /// <summary>
         /// Returns true if the type is one of the restricted types, namely: <see cref="T:System.TypedReference"/>, 
         /// <see cref="T:System.ArgIterator"/>, or <see cref="T:System.RuntimeArgumentHandle"/>.
         /// or a ref-like type.
         /// </summary>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
         internal static bool IsRestrictedType(this TypeSymbol type,
                                                 bool ignoreSpanLikeTypes = false)
         {

--- a/src/Compilers/Core/Portable/Operations/IConversionOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IConversionOperation.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IMethodSymbol OperatorMethod { get; }
 
-#pragma warning disable RS0010 // Avoid using cref tags with a prefix
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
         /// <summary>
         /// Gets the underlying common conversion information.
         /// </summary>
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// <see cref="T:Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(IConversionOperation)"/> or
         /// <see cref="T:Microsoft.CodeAnalysis.VisualBasic.VisualBasicExtensions.GetConversion(IConversionOperation)"/>.
         /// </remarks>
-#pragma warning restore RS0010 // Avoid using cref tags with a prefix
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
         CommonConversion Conversion { get; }
         /// <summary>
         /// False if the conversion will fail with a <see cref="InvalidCastException"/> at runtime if the cast fails. This is true for C#'s

--- a/src/Compilers/Core/Portable/SpecialType.cs
+++ b/src/Compilers/Core/Portable/SpecialType.cs
@@ -200,25 +200,25 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         System_IDisposable = 35,
 
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
         /// <summary>
         /// Indicates that the type is <see cref="T:System.TypedReference"/>.
         /// </summary>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
         System_TypedReference = 36,
 
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
         /// <summary>
         /// Indicates that the type is <see cref="T:System.ArgIterator"/>.
         /// </summary>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
         System_ArgIterator = 37,
 
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
         /// <summary>
         /// Indicates that the type is <see cref="T:System.RuntimeArgumentHandle"/>.
         /// </summary>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
         System_RuntimeArgumentHandle = 38,
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Syntax/ISkippedTokensTriviaSyntax.cs
+++ b/src/Compilers/Core/Portable/Syntax/ISkippedTokensTriviaSyntax.cs
@@ -2,13 +2,13 @@
 
 namespace Microsoft.CodeAnalysis
 {
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
     /// <summary>
     /// Represents structured trivia that contains skipped tokens. This is implemented by
     /// <see cref="T:Microsoft.CodeAnalysis.CSharp.Syntax.SkippedTokensTriviaSyntax"/> and
     /// <see cref="T:Microsoft.CodeAnalysis.VisualBasic.Syntax.SkippedTokensTriviaSyntax"/>.
     /// </summary>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
     public interface ISkippedTokensTriviaSyntax
     {
         SyntaxTokenList Tokens { get; }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -12,12 +12,12 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
     /// <summary>
     /// Represents a non-terminal node in the syntax tree. This is the language agnostic equivalent of <see
     /// cref="T:Microsoft.CodeAnalysis.CSharp.SyntaxNode"/> and <see cref="T:Microsoft.CodeAnalysis.VisualBasic.SyntaxNode"/>.
     /// </summary>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     public abstract partial class SyntaxNode
     {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -10,12 +10,12 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
     /// <summary>
     /// Represents a token in the syntax tree. This is the language agnostic equivalent of <see
     /// cref="T:Microsoft.CodeAnalysis.CSharp.SyntaxToken"/> and <see cref="T:Microsoft.CodeAnalysis.VisualBasic.SyntaxToken"/>.
     /// </summary>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
     [StructLayout(LayoutKind.Auto)]
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     public struct SyntaxToken : IEquatable<SyntaxToken>

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTrivia.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTrivia.cs
@@ -9,12 +9,12 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
     /// <summary>
     /// Represents a trivia in the syntax tree. This is the language agnostic equivalent of <see
     /// cref="T:Microsoft.CodeAnalysis.CSharp.SyntaxTrivia"/> and <see cref="T:Microsoft.CodeAnalysis.VisualBasic.SyntaxTrivia"/>.
     /// </summary>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     [StructLayout(LayoutKind.Auto)]
     public struct SyntaxTrivia : IEquatable<SyntaxTrivia>

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
@@ -6,12 +6,12 @@ Imports Microsoft.CodeAnalysis.PooledObjects
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
 
-#Disable Warning RS0010
+#Disable Warning CA1200 ' Avoid using cref tags with a prefix
     ''' <summary>
     ''' Displays a value in the VisualBasic style.
     ''' </summary>
     ''' <seealso cref="T:Microsoft.CodeAnalysis.CSharp.Symbols.ObjectDisplay"/>
-#Enable Warning RS0010
+#Enable Warning CA1200 ' Avoid using cref tags with a prefix
     Friend Module ObjectDisplay
 
         Private Const s_nullChar As Char = ChrW(0)

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
@@ -5,12 +5,12 @@ Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
-#Disable Warning RS0010
+#Disable Warning CA1200 ' Avoid using cref tags with a prefix
     ''' <summary>
     ''' Displays a symbol in the VisualBasic style.
     ''' </summary>
     ''' <seealso cref="T:Microsoft.CodeAnalysis.CSharp.Symbols.SymbolDisplay"/>
-#Enable Warning RS0010
+#Enable Warning CA1200 ' Avoid using cref tags with a prefix
     Public Module SymbolDisplay
         ''' <summary>
         ''' Displays a symbol in the Visual Basic style, based on a <see cref="SymbolDisplayFormat"/>.

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -329,7 +329,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Public MustOverride ReadOnly Property ExplicitInterfaceImplementations As ImmutableArray(Of MethodSymbol)
 
-#Disable Warning RS0010
+#Disable Warning CA1200 ' Avoid using cref tags with a prefix
         ''' <summary>
         ''' Returns true if this method is not implemented in IL of the assembly it is defined in.
         ''' </summary>
@@ -342,7 +342,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         '''    <see cref="T:System.Runtime.CompilerServices.MethodCodeType.Runtime"/> flags.
         ''' 4) Synthesized constructors of ComImport types
         ''' </remarks>
-#Enable Warning RS0010
+#Enable Warning CA1200 ' Avoid using cref tags with a prefix
         Public MustOverride ReadOnly Property IsExternalMethod As Boolean
 
         ''' <summary>

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 using System.Text;
 using Microsoft.CodeAnalysis.PooledObjects;
 
-#pragma warning disable RS0010 // Avoid using cref tags with a prefix
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
 
 namespace Microsoft.CodeAnalysis.Debugging
 {

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -201,14 +201,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return null;
         }
 
-#pragma warning disable RS0010
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix
         /// <remarks>
         /// The corresponding native code is in EEUserStringBuilder::ErrTryAppendConstantEnum.
         /// The corresponding roslyn code is in 
         /// <see cref="M:Microsoft.CodeAnalysis.SymbolDisplay.AbstractSymbolDisplayVisitor`1.AddEnumConstantValue(Microsoft.CodeAnalysis.INamedTypeSymbol, System.Object, System.Boolean)"/>.
         /// NOTE: no curlies for enum values.
         /// </remarks>
-#pragma warning restore RS0010
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
         private string GetEnumDisplayString(Type lmrType, DkmClrValue value, ObjectDisplayOptions options, bool includeTypeName, DkmInspectionContext inspectionContext)
         {
             Debug.Assert(lmrType.IsEnum);

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/SuppressDiagnosticsBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/SuppressDiagnosticsBinder.vb
@@ -2,14 +2,14 @@
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
-#Disable Warning RS0010
+#Disable Warning CA1200 ' Avoid using cref tags with a prefix
     ''' <summary>
     ''' Causes all diagnostics related to <see cref="ObsoleteAttribute"/>
     ''' and <see cref="T:Windows.Foundation.MetadataDeprecatedAttribute"/> 
     ''' to be suppressed.
     ''' </summary>
     Friend NotInheritable Class SuppressDiagnosticsBinder
-#Enable Warning RS0010
+#Enable Warning CA1200 ' Avoid using cref tags with a prefix
         Inherits Binder
 
         Public Sub New(containingBinder As Binder)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -439,14 +439,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
-#Disable Warning RS0010
+#Disable Warning CA1200 ' Avoid using cref tags with a prefix
         ''' <remarks>
         ''' The corresponding C# method, 
         ''' <see cref="M:Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.EEMethodSymbol.GenerateMethodBody(Microsoft.CodeAnalysis.CSharp.TypeCompilationState,Microsoft.CodeAnalysis.DiagnosticBag)"/>, 
         ''' invokes the <see cref="LocalRewriter"/> and the <see cref="LambdaRewriter"/> explicitly.
         ''' In VB, the caller (of this method) does that.
         ''' </remarks>
-#Enable Warning RS0010
+#Enable Warning CA1200 ' Avoid using cref tags with a prefix
         Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, <Out> ByRef Optional methodBodyBinder As Binder = Nothing) As BoundBlock
             Dim body = _generateMethodBody(Me, diagnostics, _lazyResultProperties)
             Debug.Assert(body IsNot Nothing)


### PR DESCRIPTION
<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
