### PR TITLE
Increase the UseExportProviderAttribute cleanup timeout to 1 minute

### DIFF
--- a/src/Workspaces/CoreTestUtilities/UseExportProviderAttribute.cs
+++ b/src/Workspaces/CoreTestUtilities/UseExportProviderAttribute.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// to completion. If this timeout is exceeded by the asynchronous operations running after a test completes,
         /// the test is failed.
         /// </summary>
-        private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(15);
+        private static readonly TimeSpan CleanupTimeout = TimeSpan.FromMinutes(1);
 
         // Cache the export provider factory for RoslynServices.RemoteHostAssemblies
         private static readonly Lazy<IExportProviderFactory> s_remoteHostExportProviderFactory = new Lazy<IExportProviderFactory>(


### PR DESCRIPTION
Test only change to separate machine slowness from hangs.