### PR TITLE
Partial methods implementation should match declaration parameter ref kinds

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -98,3 +98,4 @@ Example: `Func<int> f = default(TypedReference).GetHashCode; // new error CS0123
 
 - Visual Studio 2017 version 15.7: https://github.com/dotnet/roslyn/issues/19792 C# compiler will now reject [IsReadOnly] symbols that should have an [InAttribute] modreq, but don't.
 - Visual Studio 2017 version 15.7: https://github.com/dotnet/roslyn/pull/25131 C# compiler will now check `stackalloc T [count]` expressions to see if T matches constraints of `Span<T>`.
+- Visual Studio 2017 version 15.7: https://github.com/dotnet/roslyn/issues/25399 C# compiler will now produce errors if partial methods parameters have different ref-kinds in implementation vs definition.

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -99,6 +99,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerCustomModifiers: false); //shouldn't actually matter for source members
 
         /// <summary>
+        /// This instance is used to determine if a partial method implementation matches the definition.
+        /// It is the same as <see cref="DuplicateSourceComparer"/> except it considers ref kinds as well.
+        /// </summary>
+        public static readonly MemberSignatureComparer PartialMethodsComparer = new MemberSignatureComparer(
+            considerName: true,
+            considerExplicitlyImplementedInterfaces: true,
+            considerReturnType: false,
+            considerTypeConstraints: false,
+            considerCallingConvention: false,
+            considerRefKindDifferences: true,
+            considerCustomModifiers: false);
+
+        /// <summary>
         /// This instance is used to check whether one member overrides another, according to the C# definition.
         /// </summary>
         public static readonly MemberSignatureComparer CSharpOverrideComparer = new MemberSignatureComparer(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2448,7 +2448,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag diagnostics)
         {
             //key and value will be the same object
-            var methodsBySignature = new Dictionary<MethodSymbol, SourceMemberMethodSymbol>(MemberSignatureComparer.DuplicateSourceComparer);
+            var methodsBySignature = new Dictionary<MethodSymbol, SourceMemberMethodSymbol>(MemberSignatureComparer.PartialMethodsComparer);
 
             foreach (var name in memberNames)
             {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -16465,5 +16465,75 @@ class Test2
   IL_0006:  ret
 }");
         }
+
+        [Fact]
+        public void PartialMethodsWithInParameter_WithBody()
+        {
+            CompileAndVerify(@"
+partial class C
+{
+    public void Call()
+    {
+        M(5);
+    }
+    partial void M(in int i);
+}
+partial class C
+{
+    partial void M(in int i)
+    {
+        System.Console.WriteLine(i);
+    }
+}
+static class Program
+{
+    static void Main()
+    {
+        new C().Call();
+    }
+}",
+                expectedOutput: "5")
+                .VerifyIL("C.Call", @"
+
+{
+  // Code size       11 (0xb)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.5
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  call       ""void C.M(in int)""
+  IL_000a:  ret
+}");
+        }
+
+        [Fact]
+        public void PartialMethodsWithInParameter_NoBody()
+        {
+            CompileAndVerify(@"
+partial class C
+{
+    public void Call()
+    {
+        M(5);
+    }
+    partial void M(in int i);
+}
+static class Program
+{
+    static void Main()
+    {
+        new C().Call();
+    }
+}")
+                .VerifyIL("C.Call", @"
+
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -5167,7 +5166,7 @@ System.ApplicationException[]System.ApplicationException: helloSystem.Applicatio
   IL_0025:  ret
 }
 ");
-            compilation = CompileAndVerify(source, expectedOutput: @"hi",  verify: Verification.Passes, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            compilation = CompileAndVerify(source, expectedOutput: @"hi", verify: Verification.Passes, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             compilation.VerifyIL("Program.Main(string[])",
 @"
@@ -12256,7 +12255,7 @@ struct MyManagedStruct
 }
 ");
 
-            comp = CompileAndVerify(source, expectedOutput: @"42", verify: Verification.Passes, parseOptions:TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CompileAndVerify(source, expectedOutput: @"42", verify: Verification.Passes, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             comp.VerifyIL("Program.Main",
 @"
@@ -13437,7 +13436,7 @@ public static class P
 }
 ";
 
-            var comp = CreateCompilation(code, references: new[] { reference});
+            var comp = CreateCompilation(code, references: new[] { reference });
             comp.VerifyDiagnostics(
                 // (15,16): error CS0630: 'MyVarArgs2.Invoke(__arglist)' cannot implement interface member 'IVarArgs.Invoke(__arglist)' in type 'MyVarArgs2' because it has an __arglist parameter
                 //     public int Invoke(__arglist) => throw null;
@@ -16534,6 +16533,108 @@ static class Program
   .maxstack  0
   IL_0000:  ret
 }");
+        }
+
+        [Fact]
+        public void OverloadingPartialMethods_RefKindInWithNone_ImplementIn()
+        {
+            CompileAndVerify(@"
+partial class C
+{
+    public void Call()
+    {
+        int x = 0;
+        M(x);
+        M(in x);
+    }
+    partial void M(in int i);
+    partial void M(int i);
+}
+partial class C
+{
+    partial void M(in int i)
+    {
+        System.Console.WriteLine(""in called"");
+    }
+}
+static class Program
+{
+    static void Main()
+    {
+        new C().Call();
+    }
+}",
+                expectedOutput: "in called");
+        }
+
+        [Fact]
+        public void OverloadingPartialMethods_RefKindInWithNone_ImplementNone()
+        {
+            CompileAndVerify(@"
+partial class C
+{
+    public void Call()
+    {
+        int x = 0;
+        M(x);
+        M(in x);
+    }
+    partial void M(in int i);
+    partial void M(int i);
+}
+partial class C
+{
+    partial void M(int i)
+    {
+        System.Console.WriteLine(""none called"");
+    }
+}
+static class Program
+{
+    static void Main()
+    {
+        new C().Call();
+    }
+}",
+                expectedOutput: "none called");
+        }
+
+        [Fact]
+        public void OverloadingPartialMethods_RefKindInWithNone_ImplementBoth()
+        {
+            CompileAndVerify(@"
+partial class C
+{
+    public void Call()
+    {
+        int x = 0;
+        M(x);
+        M(in x);
+    }
+    partial void M(in int i);
+    partial void M(int i);
+}
+partial class C
+{
+    partial void M(int i)
+    {
+        System.Console.WriteLine(""none called"");
+    }
+    partial void M(in int i)
+    {
+        System.Console.WriteLine(""in called"");
+    }
+}
+static class Program
+{
+    static void Main()
+    {
+        new C().Call();
+    }
+}",
+                expectedOutput: @"
+none called
+in called");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -20096,5 +20096,83 @@ namespace A
                 //             ClassB.MethodB(obj);
                 Diagnostic(ErrorCode.ERR_TypeForwardedToMultipleAssemblies, "ClassB.MethodB").WithArguments("C.dll", "C, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C.ClassC", "D, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "E, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(11, 13));
         }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_NoneWithRef()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(int i);
+    partial void M(ref int i) {}  
+}").VerifyDiagnostics(
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(ref int)'
+                //     partial void M(ref int i) {}  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(ref int)").WithLocation(4, 18));
+        }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_NoneWithIn()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(int i);
+    partial void M(in int i) {}  
+}").VerifyDiagnostics(
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(in int)'
+                //     partial void M(in int i) {}  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(in int)").WithLocation(4, 18));
+        }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_RefWithNone()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(ref int i);
+    partial void M(int i) {}  
+}").VerifyDiagnostics(
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(int)'
+                //     partial void M(int i) {}  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(int)").WithLocation(4, 18));
+        }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_RefWithIn()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(ref int i);
+    partial void M(in int i) {}  
+}").VerifyDiagnostics(
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(in int)'
+                //     partial void M(in int i) {}  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(in int)").WithLocation(4, 18));
+        }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_InWithNone()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(in int i);
+    partial void M(int i) {}  
+}").VerifyDiagnostics(
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(int)'
+                //     partial void M(int i) {}  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(int)").WithLocation(4, 18));
+        }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_InWithRef()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(in int i);
+    partial void M(ref int i) {}  
+}").VerifyDiagnostics(
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(ref int)'
+                //     partial void M(ref int i) {}  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(ref int)").WithLocation(4, 18));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -20124,6 +20124,22 @@ partial class C {
         }
 
         [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_NoneWithOut()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(int i);
+    partial void M(out int i) { i = 0; }  
+}").VerifyDiagnostics(
+                // (4,18): error CS0752: A partial method cannot have out parameters
+                //     partial void M(out int i) { i = 0; }  
+                Diagnostic(ErrorCode.ERR_PartialMethodCannotHaveOutParameters, "M").WithLocation(4, 18),
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(out int)'
+                //     partial void M(out int i) { i = 0; }  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(out int)").WithLocation(4, 18));
+        }
+
+        [Fact]
         public void PartialMethodsConsiderRefKindDifferences_RefWithNone()
         {
             CreateCompilation(@"
@@ -20150,6 +20166,22 @@ partial class C {
         }
 
         [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_RefWithOut()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(ref int i);
+    partial void M(out int i) { i = 0; }  
+}").VerifyDiagnostics(
+                // (4,18): error CS0752: A partial method cannot have out parameters
+                //     partial void M(out int i) { i = 0; }  
+                Diagnostic(ErrorCode.ERR_PartialMethodCannotHaveOutParameters, "M").WithLocation(4, 18),
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(out int)'
+                //     partial void M(out int i) { i = 0; }  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(out int)").WithLocation(4, 18));
+        }
+
+        [Fact]
         public void PartialMethodsConsiderRefKindDifferences_InWithNone()
         {
             CreateCompilation(@"
@@ -20173,6 +20205,70 @@ partial class C {
                 // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(ref int)'
                 //     partial void M(ref int i) {}  
                 Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(ref int)").WithLocation(4, 18));
+        }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_InWithOut()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(in int i);
+    partial void M(out int i) { i = 0; }  
+}").VerifyDiagnostics(
+                // (4,18): error CS0752: A partial method cannot have out parameters
+                //     partial void M(out int i) { i = 0; }  
+                Diagnostic(ErrorCode.ERR_PartialMethodCannotHaveOutParameters, "M").WithLocation(4, 18),
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(out int)'
+                //     partial void M(out int i) { i = 0; }  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(out int)").WithLocation(4, 18));
+        }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_OutWithNone()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(out int i);
+    partial void M(int i) {}  
+}").VerifyDiagnostics(
+                // (3,18): error CS0752: A partial method cannot have out parameters
+                //     partial void M(out int i);
+                Diagnostic(ErrorCode.ERR_PartialMethodCannotHaveOutParameters, "M").WithLocation(3, 18),
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(int)'
+                //     partial void M(int i) {}  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(int)").WithLocation(4, 18));
+        }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_OutWithRef()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(out int i);
+    partial void M(ref int i) {}  
+}").VerifyDiagnostics(
+                // (3,18): error CS0752: A partial method cannot have out parameters
+                //     partial void M(out int i);
+                Diagnostic(ErrorCode.ERR_PartialMethodCannotHaveOutParameters, "M").WithLocation(3, 18),
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(ref int)'
+                //     partial void M(ref int i) {}  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(ref int)").WithLocation(4, 18));
+        }
+
+        [Fact]
+        public void PartialMethodsConsiderRefKindDifferences_OutWithIn()
+        {
+            CreateCompilation(@"
+partial class C {
+    partial void M(out int i);
+    partial void M(in int i) {}  
+}").VerifyDiagnostics(
+                // (3,18): error CS0752: A partial method cannot have out parameters
+                //     partial void M(out int i);
+                Diagnostic(ErrorCode.ERR_PartialMethodCannotHaveOutParameters, "M").WithLocation(3, 18),
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(in int)'
+                //     partial void M(in int i) {}  
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M(in int)").WithLocation(4, 18));
         }
     }
 }


### PR DESCRIPTION
### Customer scenario

Customers should not be able to implement partial methods having parameters with a different ref kind than the definition. The compiler should produce diagnostics and prevent that. Currently, the following invalid code passes without errors:

```csharp
partial class C {
    partial void M(in int i);
    partial void M(ref int i) {}  
}
```

Since this is a breaking change, @dotnet/roslyn-compat-council will be notified and will get approval before merging.

### Bugs this fixes

Fixes #25399

### Workarounds, if any

None.

### Risk

Low risk. This is producing an error in a corner case scenario where code shouldn't have been allowed in first place.

### Performance impact

Negligible.

### Is this a regression from a previous update?

It is a breaking change.

### How was the bug found?

Reported on GitHub by a contributor.

cc @dotnet/roslyn-compiler for review.