### PR TITLE
InternalsVisibleTo for the completion test framework

### DIFF
--- a/build/Targets/GenerateInternalsVisibleTo.targets
+++ b/build/Targets/GenerateInternalsVisibleTo.targets
@@ -42,6 +42,9 @@
     <InternalsVisibleToRemoteLS>
       <Visible>false</Visible>
     </InternalsVisibleToRemoteLS>
+    <InternalsVisibleToCompletionTests>
+      <Visible>false</Visible>
+    </InternalsVisibleToCompletionTests>
   </ItemDefinitionGroup>
 
   <PropertyGroup Condition="'$(PublicKey)' != '' AND '$(SignAssembly)' == 'True'">
@@ -118,6 +121,11 @@
     <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
                 AdditionalMetadata="_Parameter1=%(InternalsVisibleToRazor.Identity), PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb"
                 Condition="'@(InternalsVisibleToRazor)' != ''">
+      <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
+    </CreateItem>
+    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
+                AdditionalMetadata="_Parameter1=%(InternalsVisibleToCompletionTests.Identity), PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9"
+                Condition="'@(InternalsVisibleToCompletionTests)' != ''">
       <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
     </CreateItem>
 

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -35,6 +35,7 @@
     <InternalsVisibleToTest Include="Roslyn.Services.Test.Utilities" />
     <InternalsVisibleToTest Include="Roslyn.Services.Test.Utilities2" />
     <InternalsVisibleToTest Include="Roslyn.VisualStudio.Next.UnitTests" />
+    <InternalsVisibleToCompletionTests Include="Microsoft.VisualStudio.Completion.Tests" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\CSharp\Portable\Syntax\LambdaUtilities.cs">

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -84,6 +84,7 @@
     <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.CodeSense.Roslyn" />
     <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.CodeSense.ReferencesProvider" />
     <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.CodeSense.TestsProvider" />
+    <InternalsVisibleToCompletionTests Include="Microsoft.VisualStudio.Completion.Tests" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Shared\DesktopShim.cs">

--- a/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
+++ b/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
@@ -39,6 +39,7 @@
     <InternalsVisibleToTest Include="Roslyn.Services.Test.Utilities" />
     <InternalsVisibleToTest Include="Roslyn.Services.Test.Utilities2" />
     <InternalsVisibleToTest Include="Roslyn.VisualStudio.Next.UnitTests" />
+    <InternalsVisibleToCompletionTests Include="Microsoft.VisualStudio.Completion.Tests" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="CSharpWorkspaceResources.Designer.cs">

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -292,6 +292,7 @@
     <InternalsVisibleToRemoteLS Include="Microsoft.VisualStudio.LanguageServices.Remote.CSharp" />
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
     <InternalsVisibleToVisualStudio Include="Microsoft.Test.Apex.VisualStudio" />
+    <InternalsVisibleToCompletionTests Include="Microsoft.VisualStudio.Completion.Tests" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\UnicodeCharacterUtilities.cs">

--- a/src/Workspaces/Remote/Core/RemoteWorkspaces.csproj
+++ b/src/Workspaces/Remote/Core/RemoteWorkspaces.csproj
@@ -39,5 +39,6 @@
     <InternalsVisibleToTest Include="Roslyn.Services.Test.Utilities" />
     <InternalsVisibleToTest Include="Roslyn.Services.Test.Utilities2" />
     <InternalsVisibleToTest Include="Roslyn.Services.UnitTests.Utilities" />
+    <InternalsVisibleToCompletionTests Include="Microsoft.VisualStudio.Completion.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Workspaces/Remote/ServiceHub/ServiceHub.csproj
+++ b/src/Workspaces/Remote/ServiceHub/ServiceHub.csproj
@@ -52,5 +52,6 @@
     <InternalsVisibleToTest Include="Roslyn.Services.Test.Utilities" />
     <InternalsVisibleToTest Include="Roslyn.Services.Test.Utilities2" />
     <InternalsVisibleToTest Include="Roslyn.VisualStudio.Next.UnitTests" />
+    <InternalsVisibleToCompletionTests Include="Microsoft.VisualStudio.Completion.Tests" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add InternalsVisibleTo for the completion test framework

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
