### PR TITLE
Misc infrastructure fixes

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -585,7 +585,9 @@ function Run-SignTool() {
     try {
         $signTool = Join-Path (Get-PackageDir "RoslynTools.SignTool") "tools\SignTool.exe"
         $signToolArgs = "-msbuildPath `"$msbuild`""
-        $signToolArgs += " -msbuildBinaryLog $logsDir\Signing.binlog"
+        if ($binaryLog) {
+            $signToolArgs += " -msbuildBinaryLog $logsDir\Signing.binlog"
+        }
         switch ($signType) {
             "real" { break; }
             "test" { $signToolArgs += " -testSign"; break; }

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -155,7 +155,16 @@ namespace RunTests
 
             async Task DumpProcess(Process targetProcess, string dumpFilePath)
             {
-                Console.Write($"Dumping {targetProcess.ProcessName} {targetProcess.Id} to {dumpFilePath} ... ");
+                var name = targetProcess.ProcessName;
+
+                // Our space for saving dump files is limited. Skip dumping for processes that won't contribute
+                // to bug investigations.
+                if (name == "procdump" || name == "conhost")
+                {
+                    return;
+                }
+
+                Console.Write($"Dumping {name} {targetProcess.Id} to {dumpFilePath} ... ");
                 try
                 {
                     var args = $"-accepteula -ma {targetProcess.Id} {dumpFilePath}";


### PR DESCRIPTION
Fixes:

- Don't create dump files for procdump and conhost
- Only generate binary log for SignTool when requested