### PR TITLE
Use elastic crlf where applicable

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -319,6 +319,7 @@ End Class"
     Sub M()
         Dim x = 1
         Dim {|Rename:v|} As Boolean = x = 1
+
         While v
         End While
     End Sub
@@ -1020,6 +1021,7 @@ Module Program
         If True Then
             Dim {|Rename:p|} As Object = Sub()
                               End Sub
+
             q = p
         End If
     End Sub
@@ -2127,6 +2129,7 @@ Module Program
     Sub Main()
         Dim {|Rename:p|} = Sub()
                 End Sub
+
         Dim x = Function() p
     End Sub
 End Module
@@ -2321,6 +2324,7 @@ Module Program
         Dim s = ""Text""
         Dim x = 42
         Dim {|Rename:length|} As Integer = s.Length
+
         If (length.CompareTo(x) > 0 AndAlso
             length.CompareTo(x) > 0) Then
         End If
@@ -2747,6 +2751,7 @@ end class",
     sub Method(span as MySpan)
         dim pos as integer = span.Start
         Dim {|Rename:start1|} As Integer = span.Start
+
         while pos < start1
             dim start as integer = pos
         end while

--- a/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAutoPropertyToFullProperty
         internal SyntaxNode AddStatement(SyntaxNode accessor, SyntaxNode statement)
         {
             var blockSyntax = SyntaxFactory.Block(
-                SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed),
+                SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed),
                 new SyntaxList<StatementSyntax>((StatementSyntax)statement),
                 SyntaxFactory.Token(SyntaxKind.CloseBraceToken)
                     .WithTrailingTrivia(((AccessorDeclarationSyntax)accessor).SemicolonToken.TrailingTrivia));

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -654,14 +654,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return methodDefinition.ReplaceToken(
                             methodDefinition.Body.OpenBraceToken,
                             methodDefinition.Body.OpenBraceToken.WithAppendedTrailingTrivia(
-                                SpecializedCollections.SingletonEnumerable(SyntaxFactory.CarriageReturnLineFeed)));
+                                SpecializedCollections.SingletonEnumerable(SyntaxFactory.ElasticCarriageReturnLineFeed)));
                 }
                 else if (methodDefinition.ExpressionBody != null)
                 {
                     return methodDefinition.ReplaceToken(
                             methodDefinition.ExpressionBody.ArrowToken,
                             methodDefinition.ExpressionBody.ArrowToken.WithPrependedLeadingTrivia(
-                                SpecializedCollections.SingletonEnumerable(SyntaxFactory.CarriageReturnLineFeed)));
+                                SpecializedCollections.SingletonEnumerable(SyntaxFactory.ElasticCarriageReturnLineFeed)));
                 }
                 else
                 {

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceService.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceService.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
             decls[decls.Length - 1] = decls[decls.Length - 1].WithAppendedTrailingTrivia(
                 SyntaxFactory.TriviaList(
                     SyntaxFactory.Trivia(SyntaxFactory.EndRegionDirectiveTrivia(true)),
-                    SyntaxFactory.CarriageReturnLineFeed));
+                    SyntaxFactory.ElasticCarriageReturnLineFeed));
 
             // Ensure that open and close brace tokens are generated in case they are missing.
             var newNode = classDecl.EnsureOpenAndCloseBraceTokens().AddMembers(decls);

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/InvertIf/InvertIfCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/InvertIf/InvertIfCodeRefactoringProvider.vb
@@ -205,7 +205,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InvertIf
                     originalIfNode,
                     invertedIfNode.WithTrailingTrivia(
                         invertedIfNode.GetTrailingTrivia().Select(
-                            Function(t) If(t.Kind = SyntaxKind.ColonTrivia, SyntaxFactory.CarriageReturnLineFeed, t)))))
+                            Function(t) If(t.Kind = SyntaxKind.ColonTrivia, SyntaxFactory.ElasticCarriageReturnLineFeed, t)))))
         End Function
 #End If
 

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -384,7 +384,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Dim newMethodDefinition =
                         methodDefinition.ReplaceToken(lastTokenOfBeginStatement,
                                                       lastTokenOfBeginStatement.WithAppendedTrailingTrivia(
-                                                            SpecializedCollections.SingletonEnumerable(SyntaxFactory.CarriageReturnLineFeed)))
+                                                            SpecializedCollections.SingletonEnumerable(SyntaxFactory.ElasticCarriageReturnLineFeed)))
 
                     newDocument = Await newDocument.WithSyntaxRootAsync(root.ReplaceNode(methodDefinition, newMethodDefinition), cancellationToken).ConfigureAwait(False)
                 End If

--- a/src/Features/VisualBasic/Portable/ImplementInterface/VisualBasicImplementInterfaceService.vb
+++ b/src/Features/VisualBasic/Portable/ImplementInterface/VisualBasicImplementInterfaceService.vb
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ImplementInterface
             decls(decls.Length - 1) = decls(decls.Length - 1).WithAppendedTrailingTrivia(
                 SyntaxFactory.TriviaList(
                     SyntaxFactory.Trivia(SyntaxFactory.EndRegionDirectiveTrivia()),
-                    SyntaxFactory.CarriageReturnLineFeed))
+                    SyntaxFactory.ElasticCarriageReturnLineFeed))
 
             ' Ensure that open and close brace tokens are generated in case they are missing.
             Dim newNode = classBlock.AddMembers(decls).FixTerminators()

--- a/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceLocal.vb
+++ b/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceLocal.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
                         SyntaxFactory.EqualsValue(value:=expression.WithoutTrailingTrivia().WithoutLeadingTrivia()))))
 
             If Not declarationStatement.GetTrailingTrivia().Any(SyntaxKind.EndOfLineTrivia) Then
-                declarationStatement = declarationStatement.WithAppendedTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed)
+                declarationStatement = declarationStatement.WithAppendedTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)
             End If
 
             If TypeOf container Is SingleLineLambdaExpressionSyntax Then

--- a/src/Workspaces/CSharp/Portable/Extensions/TypeDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/TypeDeclarationSyntaxExtensions.cs
@@ -98,8 +98,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         {
             if (token.IsMissing)
             {
-                var leadingTrivia = prependNewLineIfMissing ? token.LeadingTrivia.Insert(0, SyntaxFactory.CarriageReturnLineFeed) : token.LeadingTrivia;
-                var trailingTrivia = appendNewLineIfMissing ? token.TrailingTrivia.Insert(0, SyntaxFactory.CarriageReturnLineFeed) : token.TrailingTrivia;
+                var leadingTrivia = prependNewLineIfMissing ? token.LeadingTrivia.Insert(0, SyntaxFactory.ElasticCarriageReturnLineFeed) : token.LeadingTrivia;
+                var trailingTrivia = appendNewLineIfMissing ? token.TrailingTrivia.Insert(0, SyntaxFactory.ElasticCarriageReturnLineFeed) : token.TrailingTrivia;
                 return SyntaxFactory.Token(leadingTrivia, token.Kind(), trailingTrivia).WithAdditionalAnnotations(Formatter.Annotation);
             }
 

--- a/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesOrganizer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesOrganizer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 {
     internal static partial class UsingsAndExternAliasesOrganizer
     {
-        private static readonly SyntaxTrivia s_newLine = SyntaxFactory.CarriageReturnLineFeed;
+        private static readonly SyntaxTrivia s_newLine = SyntaxFactory.ElasticCarriageReturnLineFeed;
 
         public static void Organize(
             SyntaxList<ExternAliasDirectiveSyntax> externAliasList,

--- a/src/Workspaces/VisualBasic/Portable/Extensions/TypeBlockSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/TypeBlockSyntaxExtensions.vb
@@ -40,14 +40,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         Private Function ReplaceTrailingColonToEndOfLineTrivia(Of TNode As SyntaxNode)(node As TNode) As TNode
-            Return node.WithTrailingTrivia(node.GetTrailingTrivia().Select(Function(t) If(t.Kind = SyntaxKind.ColonTrivia, SyntaxFactory.CarriageReturnLineFeed, t)))
+            Return node.WithTrailingTrivia(node.GetTrailingTrivia().Select(Function(t) If(t.Kind = SyntaxKind.ColonTrivia, SyntaxFactory.ElasticCarriageReturnLineFeed, t)))
         End Function
 
         Private Function EnsureProperList(Of TSyntax As SyntaxNode)(list As SyntaxList(Of TSyntax)) As SyntaxList(Of TSyntax)
             Dim allElements = list
             If Not allElements.Last().GetTrailingTrivia().Any(Function(t) t.Kind = SyntaxKind.EndOfLineTrivia OrElse t.Kind = SyntaxKind.ColonTrivia) Then
                 Return SyntaxFactory.SingletonList(Of TSyntax)(
-                    allElements.Last().WithAppendedTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed))
+                    allElements.Last().WithAppendedTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed))
             ElseIf allElements.Last().GetTrailingTrivia().Any(Function(t) t.Kind = SyntaxKind.ColonTrivia) Then
                 Return SyntaxFactory.List(Of TSyntax)(
                     allElements.Take(allElements.Count - 1).Concat(ReplaceTrailingColonToEndOfLineTrivia(allElements.Last())))

--- a/src/Workspaces/VisualBasic/Portable/Utilities/ImportsOrganizer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/ImportsOrganizer.vb
@@ -6,7 +6,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
     Partial Friend Class ImportsOrganizer
-        Private Shared ReadOnly s_newLine As SyntaxTrivia = SyntaxFactory.CarriageReturnLineFeed
+        Private Shared ReadOnly s_newLine As SyntaxTrivia = SyntaxFactory.ElasticCarriageReturnLineFeed
 
         Public Shared Function Organize([imports] As SyntaxList(Of ImportsStatementSyntax),
                                         placeSystemNamespaceFirst As Boolean,


### PR DESCRIPTION
The changes switch End of Line trivia to use Elastic on code paths which end up being formatted by code actions or explicit elastic annotation formatting

<details>
### Customer scenario

See repro in https://github.com/dotnet/roslyn/issues/25927

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/25927

### Workarounds, if any

Reformat the piece of code

### Risk

?

### Performance impact

Only modified the crlf trivia in case of code going into code actions. That triggers elastic trivia formatting, even if the code itself is not marked to format via annotation.

### Is this a regression from a previous update?

### Root cause analysis

I'm not sure how to add tests for this.

### How was the bug found?

Found via ad-hoc testing in vsmac.


</details>
