### PR TITLE
Remove un-necessary tuplification code

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -609,9 +609,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // Dynamify object type if necessary
             var returnType = paramInfo[0].Type.AsDynamicIfNoPia(_containingType);
 
-            // Check for tuple type
-            returnType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(returnType, paramInfo[0].Handle, moduleSymbol);
-
             paramInfo[0].Type = returnType;
 
             var returnParam = PEParameterSymbol.Create(


### PR DESCRIPTION
When looking at this method in the nullable feature branch (which looks a bit different) I noticed this un-necessary tuplification.
The `PEParameterSymbol.Create` call below, which ultimately rests on the `PEParameterSymbol`, tuplifies in all cases (with names if we have a parameter handle and that handle has the attribute for tuple names).

I'm leaving the call to dynamify (`AsDynamicIfNoPia`, on line above), since I think it does something different than what `PEParameterSymbol` does.