### PR TITLE
fix the KnownImageIds.LocalVariable which was missed in the previous PR

### DIFF
--- a/src/EditorFeatures/Core/Shared/Extensions/GlyphExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/GlyphExtensions.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 
                 case Glyph.Parameter:
                 case Glyph.Local:
-                    return new ImageId(KnownMonikers.LocalVariable.Guid, KnownMonikers.LocalVariable.Id);
+                    return new ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.LocalVariable);
 
                 case Glyph.Namespace:
                     return new ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.Namespace);
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
                 case Glyph.Reference:
                     return new ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.Reference);
 
-                //// this is not a copy-paste mistake, we were using these before in the previous GetImageMoniker()               
+                //// this is not a copy-paste mistake, we were using these before in the previous GetImageMoniker()
                 //case Glyph.StructurePublic:
                 //    return KnownMonikers.ValueTypePublic;
                 //case Glyph.StructureProtected:
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
                 //    return KnownMonikers.ValueTypePrivate;
                 //case Glyph.StructureInternal:
                 //    return KnownMonikers.ValueTypeInternal;
-                
+
                 case Glyph.StructurePublic:
                     return new ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.ValueTypePublic);
                 case Glyph.StructureProtected:
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
                 case Glyph.StatusInformation:
                     return new ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.StatusInformation);
 
-                case Glyph.NuGet:                    
+                case Glyph.NuGet:
                     return new ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.NuGet);
 
                 default:


### PR DESCRIPTION
<details><summary>fix the KnownImageIds.LocalVariable which was missed in the previous PR</summary>

### Customer scenario
We made the change to create ImageId using KnownImageIds, I missed one of the mapping in the previous PR, so I need to fix it in this PR

### Bugs this fixes
Part of the work for https://github.com/dotnet/roslyn/issues/24094
The previous PR is https://github.com/dotnet/roslyn/pull/25142

### Workarounds, if any
No

### Risk
Low, it reads the field from KnowImageIds instead of KnowMonikers for this one case.

### Performance impact
No

### Is this a regression from a previous update?
No

### Root cause analysis
NA

### How was the bug found?
When implementing the similar function with TypeScript solution, we found this one mismatch

### Test documentation updated?
No

</details>
