### PR TITLE
Visit default value in local function parameters

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -8,6 +8,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class LocalFunctions : FlowTestBase
     {
         [Fact]
+        public void LocalFunctionDefaultParamUnused()
+        {
+            var comp = CreateCompilation(@"
+using System;
+public class C
+{
+    public void M(string p)
+    {
+        void Local() {}
+        void Local2(string s = nameof(Local)) => Console.WriteLine(s);
+        const string s2 = ""test"";
+        void Local3(string s = s2) => Console.WriteLine(s);
+        Local2();
+        Local3();
+    }
+}");
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         [WorkItem(17829, "https://github.com/dotnet/roslyn/issues/17829")]
         public void UncalledLambdaInLocalFunction()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3320,12 +3320,7 @@ class C
             CompileAndVerify(source, expectedOutput: "23", sourceSymbolValidator: m =>
             {
                 var compilation = m.DeclaringCompilation;
-                // See https://github.com/dotnet/roslyn/issues/16454; this should actually produce no errors
-                compilation.VerifyDiagnostics(
-                    // (6,19): warning CS0219: The variable 'N' is assigned but its value is never used
-                    //         const int N = 2;
-                    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "N").WithArguments("N").WithLocation(6, 19)
-                    );
+                compilation.VerifyDiagnostics();
                 var tree = compilation.SyntaxTrees[0];
                 var model = compilation.GetSemanticModel(tree);
                 var descendents = tree.GetRoot().DescendantNodes();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -32953,6 +32953,12 @@ class C
                 // (9,22): error CS0103: The name 'z2' does not exist in the current context
                 //         int x = z1 + z2;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(9, 22),
+                // (6,55): error CS0165: Use of unassigned local variable 'z1'
+                //         void Local2(bool b = M(nameof(M(out int z1)), z1), int s2 = z1) { var t = z1; }
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "z1").WithArguments("z1").WithLocation(6, 55),
+                // (7,55): error CS0165: Use of unassigned local variable 'z2'
+                //         void Local5(bool b = M(nameof(M(out var z2)), z2), int s2 = z2) { var t = z2; }
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "z2").WithArguments("z2").WithLocation(7, 55),
                 // (6,14): warning CS8321: The local function 'Local2' is declared but never used
                 //         void Local2(bool b = M(nameof(M(out int z1)), z1), int s2 = z1) { var t = z1; }
                 Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local2").WithArguments("Local2").WithLocation(6, 14),


### PR DESCRIPTION
### Customer scenario

The definite assignment pass did not visit local function default value
expressions, which could result in incorrect warnings about unused
variables or missing definite assignment errors. This change fixes that
problem, however it requires us to rebind default value expressions to
produce bound nodes, since the bound nodes are not otherwise stored
after calculating the constant value.

### Bugs this fixes

Fixes #16821

### Workarounds, if any

None.

### Risk

This should just be duplicating work we're already doing in other places. When
new definite assignment errors would be produced, other errors should also
be produced since only constant values are permitted in default value expressions
and all constant values are definitely assigned.

### Performance impact

Probably not too big, but this could cause a slow down due to extra binding.

### Is this a regression from a previous update?

No.

### Root cause analysis

Unique problem to local functions. Methods do not have the problem since they
are checked for warnings about fields in a completely different way. Lambdas
do not have a problem since they cannot have optional parameters with default
values.

### How was the bug found?

Customer reported
