### PR TITLE
fixed flaky test.

### DIFF
--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -1280,12 +1280,6 @@ End Class";
             #endregion
         }
 
-        [ExportWorkspaceService(typeof(IGlobalOperationNotificationService), SolutionCrawler), Shared, PartNotDiscoverable]
-        private class TestGlobalOperationService : GlobalOperationNotificationService
-        {
-            // this test only global notification service
-        }
-
 #if false
         private string GetListenerTrace(ExportProvider provider)
         {

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -898,10 +898,10 @@ End Class";
                     var crawlerListener = (AsynchronousOperationListener)GetListenerProvider(workspace.ExportProvider).GetListener(FeatureAttribute.SolutionCrawler);
 
                     // first, wait for first work to be queued.
-                    await crawlerListener.CreateWaitTask(tokens => tokens.Any(token => token.Name == "EnqueueWorkItemAsync"));
+                    await crawlerListener.WaitUntilCondiationIsMetAsync(tokens => tokens.Any(token => token.Name == "EnqueueWorkItemAsync"));
 
                     // and then wait them to be processed
-                    await crawlerListener.CreateWaitTask(tokens => tokens.Where(token => token.Tag == workspace).IsEmpty());
+                    await crawlerListener.WaitUntilCondiationIsMetAsync(tokens => tokens.Where(token => token.Tag == workspace).IsEmpty());
 
                     // let analyzer to process
                     operation.Done();
@@ -1261,7 +1261,7 @@ End Class";
             #endregion
         }
 
-        [ExportWorkspaceService(typeof(IGlobalOperationNotificationService), SolutionCrawler), Shared]
+        [ExportWorkspaceService(typeof(IGlobalOperationNotificationService), SolutionCrawler), Shared, PartNotDiscoverable]
         private class TestGlobalOperationService : GlobalOperationNotificationService
         {
             // this test only global notification service

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -1087,12 +1087,11 @@ End Class";
 
         private class WorkCoordinatorWorkspace : TestWorkspace
         {
-            private static readonly IExportProviderFactory s_exportFactory = CreateExportProviderFactory();
             private readonly IAsynchronousOperationWaiter _workspaceWaiter;
             private readonly IAsynchronousOperationWaiter _solutionCrawlerWaiter;
 
             public WorkCoordinatorWorkspace(string workspaceKind = null, bool disablePartialSolutions = true)
-                : base(s_exportFactory.CreateExportProvider(), workspaceKind, disablePartialSolutions)
+                : base(EditorServicesUtil.ExportProvider, workspaceKind, disablePartialSolutions)
             {
                 _workspaceWaiter = GetListenerProvider(ExportProvider).GetWaiter(FeatureAttribute.Workspace);
                 _solutionCrawlerWaiter = GetListenerProvider(ExportProvider).GetWaiter(FeatureAttribute.SolutionCrawler);
@@ -1109,20 +1108,6 @@ End Class";
 
                 Assert.False(_workspaceWaiter.HasPendingWork);
                 Assert.False(_solutionCrawlerWaiter.HasPendingWork);
-            }
-
-            private static IExportProviderFactory CreateExportProviderFactory()
-            {
-                var assemblies = TestExportProvider
-                    .GetCSharpAndVisualBasicAssemblies()
-                    .Concat(new[] { typeof(EditorServicesUtil).Assembly });
-
-                return ExportProviderCache
-                    .GetOrCreateExportProviderFactory(
-                        ExportProviderCache
-                            .GetOrCreateAssemblyCatalog(
-                                assemblies, ExportProviderCache.CreateResolver())
-                            .WithPart(typeof(TestGlobalOperationService)));
             }
         }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -15,6 +15,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
     internal sealed partial class SolutionCrawlerRegistrationService
     {
+        /// <summary>
+        /// this will be used in the unit test to indicate certain action has happened or not.
+        /// </summary>
         public const string EnqueueItem = nameof(EnqueueItem);
 
         private sealed partial class WorkCoordinator
@@ -77,7 +80,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                     var data = Dequeue();
 
-                    try
+                    using (data.AsyncToken)
                     {
                         // we have a hint. check whether we can take advantage of it
                         if (await TryEnqueueFromHint(data.Document, data.ChangedMember).ConfigureAwait(continueOnCapturedContext: false))
@@ -86,10 +89,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         }
 
                         EnqueueFullProjectDependency(data.Document);
-                    }
-                    finally
-                    {
-                        data.AsyncToken.Dispose();
                     }
                 }
 
@@ -421,7 +420,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         var data = Dequeue();
 
-                        try
+                        using (data.AsyncToken)
                         {
                             var project = _registration.CurrentSolution.GetProject(data.ProjectId);
                             if (project == null)
@@ -442,10 +441,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 project = solution.GetProject(projectId);
                                 await EnqueueWorkItemAsync(project).ConfigureAwait(false);
                             }
-                        }
-                        finally
-                        {
-                            data.AsyncToken.Dispose();
                         }
                     }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
     internal sealed partial class SolutionCrawlerRegistrationService
     {
+        public const string EnqueueItem = nameof(EnqueueItem);
+
         private sealed partial class WorkCoordinator
         {
             private sealed class SemanticChangeProcessor : IdleProcessor
@@ -407,7 +409,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         _processor.Enqueue(
                             new WorkItem(document.Id, document.Project.Language, InvocationReasons.SemanticChanged,
-                                isLowPriority, Listener.BeginAsyncOperation(nameof(EnqueueWorkItemAsync))));
+                                isLowPriority, Listener.BeginAsyncOperation(nameof(EnqueueWorkItemAsync), tag: EnqueueItem)));
                     }
 
                     protected override Task WaitAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -114,13 +114,13 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             }
         }
 
-        public async Task CreateWaitTask(Func<IEnumerable<DiagnosticAsyncToken>, bool> condition)
+        public async Task WaitUntilCondiationIsMetAsync(Func<IEnumerable<DiagnosticAsyncToken>, bool> selector)
         {
             Contract.ThrowIfFalse(TrackActiveTokens);
 
             while (true)
             {
-                if (condition(ActiveDiagnosticTokens))
+                if (selector(ActiveDiagnosticTokens))
                 {
                     break;
                 }

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.TestHooks
 {
@@ -109,6 +111,21 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
 
                     return source.Task;
                 }
+            }
+        }
+
+        public async Task CreateWaitTask(Func<IEnumerable<DiagnosticAsyncToken>, bool> condition)
+        {
+            Contract.ThrowIfFalse(TrackActiveTokens);
+
+            while (true)
+            {
+                if (condition(ActiveDiagnosticTokens))
+                {
+                    break;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(10)).ConfigureAwait(false);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -114,13 +114,13 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             }
         }
 
-        public async Task WaitUntilCondiationIsMetAsync(Func<IEnumerable<DiagnosticAsyncToken>, bool> selector)
+        public async Task WaitUntilConditionIsMetAsync(Func<IEnumerable<DiagnosticAsyncToken>, bool> condition)
         {
             Contract.ThrowIfFalse(TrackActiveTokens);
 
             while (true)
             {
-                if (selector(ActiveDiagnosticTokens))
+                if (condition(ActiveDiagnosticTokens))
                 {
                     break;
                 }


### PR DESCRIPTION
the flaky-ness came from the fact that solution crawler has multiple async event queue to delay processing work (such as semantic prapagation event queue).

having multiple event queue is fine if test just wants to see all works queued have been processed since we can use waiter to wait for everything to finish.

but it is problem if we want to see order of work that got processed since event queue such as semantic prapagation queue can change order of things processed due to cancellation. (work A is being processed and semantic propagation want to cancel work A and mark it as semantic changed and re-enqueue the work)

so we want to wait for semantic event queue to finish processing but current big hammer approach of waiter (wait for everything in solution crawler to finish) doesn't let one to do some part of it to be waited.

added ability to the waiter to wait for parts of work to be done.

and now test waits for semantic event queue to finish before running analyzers.

...

### Customer scenario

This is test only fix. doesn't affect product.

### Bugs this fixes

N/A

### Workarounds, if any

N/A

### Risk

N/A

### Performance impact

N/A

### Is this a regression from a previous update?

No

### Root cause analysis

fixed flaky-ness in the test

### How was the bug found?

Jenkins
