### PR TITLE
Trivial fix for potential null-ref in test helper

### DIFF
--- a/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyTestBase.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SymbolId
                     body = accessor.Body;
                 }
 
-                if (body != null || body.Statements.Any())
+                if (body != null && body.Statements.Any())
                 {
                     list.Add(body);
                 }


### PR DESCRIPTION
This is a test-only change that fixes a potential null-reference exception in a test helper. The null-ref isn't actually hit by any tests today. Instead, this was contributed two years ago by a user who has since deleted their account (https://github.com/dotnet/roslyn/pull/11054). The change is trivial, so I'm resubmitting it with as new PR.