### PR TITLE
Reference assemblies reachable from current module only

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         }
 
         internal delegate MetadataContext<CSharpMetadataContext> GetMetadataContextDelegate<TAppDomain>(TAppDomain appDomain);
-        internal delegate void SetMetadataContextDelegate<TAppDomain>(TAppDomain appDomain, MetadataContext<CSharpMetadataContext> metadataContext);
+        internal delegate void SetMetadataContextDelegate<TAppDomain>(TAppDomain appDomain, MetadataContext<CSharpMetadataContext> metadataContext, bool report);
 
         internal override EvaluationContextBase CreateTypeContext(
             DkmClrAppDomain appDomain,
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             return CreateTypeContext(
                 appDomain,
-                ad => ad.GetMetadataContext<MetadataContext<CSharpMetadataContext>>(),
+                ad => ad.GetMetadataContext<CSharpMetadataContext>(),
                 metadataBlocks,
                 moduleVersionId,
                 typeToken,
@@ -55,11 +55,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             int typeToken,
             MakeAssemblyReferencesKind kind)
         {
+            CSharpCompilation compilation;
+
             if (kind == MakeAssemblyReferencesKind.DirectReferencesOnly)
             {
                 // Avoid using the cache for referenced assemblies only
                 // since this should be the exceptional case.
-                var compilation = metadataBlocks.ToCompilationReferencedModulesOnly(moduleVersionId);
+                compilation = metadataBlocks.ToCompilationReferencedModulesOnly(moduleVersionId);
                 return EvaluationContext.CreateTypeContext(
                     compilation,
                     moduleVersionId,
@@ -68,23 +70,29 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             var contextId = MetadataContextId.GetContextId(moduleVersionId, kind);
             var previous = getMetadataContext(appDomain);
-            CSharpMetadataContext previousContext = default;
+            CSharpMetadataContext previousMetadataContext = default;
             if (previous.Matches(metadataBlocks))
             {
-                previous.AssemblyContexts.TryGetValue(contextId, out previousContext);
+                previous.AssemblyContexts.TryGetValue(contextId, out previousMetadataContext);
             }
+
+            // Re-use the previous compilation if possible.
+            compilation = previousMetadataContext.Compilation;
+            if (compilation == null)
+            {
+                compilation = metadataBlocks.ToCompilation(moduleVersionId, kind);
+            }
+
             var context = EvaluationContext.CreateTypeContext(
-                previousContext,
-                metadataBlocks,
+                compilation,
                 moduleVersionId,
-                typeToken,
-                kind);
+                typeToken);
 
             // New type context is not attached to the AppDomain since it is less
             // re-usable than the previous attached method context. (We could hold
             // on to it if we don't have a previous method context but it's unlikely
             // that we evaluated a type-level expression before a method-level.)
-            Debug.Assert(context != previousContext.EvaluationContext);
+            Debug.Assert(context != previousMetadataContext.EvaluationContext);
 
             return context;
         }
@@ -103,8 +111,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             return CreateMethodContext(
                 appDomain,
-                ad => ad.GetMetadataContext<MetadataContext<CSharpMetadataContext>>(),
-                (ad, mc) => ad.SetMetadataContext<MetadataContext<CSharpMetadataContext>>(mc),
+                ad => ad.GetMetadataContext<CSharpMetadataContext>(),
+                (ad, mc, report) => ad.SetMetadataContext<CSharpMetadataContext>(mc, report),
                 metadataBlocks,
                 symReader,
                 moduleVersionId,
@@ -128,45 +136,65 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             int localSignatureToken,
             MakeAssemblyReferencesKind kind)
         {
+            CSharpCompilation compilation;
+            int offset = EvaluationContextBase.NormalizeILOffset(ilOffset);
+
             if (kind == MakeAssemblyReferencesKind.DirectReferencesOnly)
             {
                 // Avoid using the cache for referenced assemblies only
                 // since this should be the exceptional case.
-                var compilation = metadataBlocks.ToCompilationReferencedModulesOnly(moduleVersionId);
+                compilation = metadataBlocks.ToCompilationReferencedModulesOnly(moduleVersionId);
                 return EvaluationContext.CreateMethodContext(
                     compilation,
                     symReader,
                     moduleVersionId,
                     methodToken,
                     methodVersion,
-                    ilOffset,
+                    offset,
                     localSignatureToken);
             }
 
             var contextId = MetadataContextId.GetContextId(moduleVersionId, kind);
             var previous = getMetadataContext(appDomain);
             var assemblyContexts = previous.Matches(metadataBlocks) ? previous.AssemblyContexts : ImmutableDictionary<MetadataContextId, CSharpMetadataContext>.Empty;
-            CSharpMetadataContext previousContext;
-            assemblyContexts.TryGetValue(contextId, out previousContext);
+            CSharpMetadataContext previousMetadataContext;
+            assemblyContexts.TryGetValue(contextId, out previousMetadataContext);
+
+            // Re-use the previous compilation if possible.
+            compilation = previousMetadataContext.Compilation;
+            if (compilation != null)
+            {
+                // Re-use entire context if method scope has not changed.
+                var previousContext = previousMetadataContext.EvaluationContext;
+                if (previousContext != null &&
+                    previousContext.MethodContextReuseConstraints.HasValue &&
+                    previousContext.MethodContextReuseConstraints.GetValueOrDefault().AreSatisfied(moduleVersionId, methodToken, methodVersion, offset))
+                {
+                    return previousContext;
+                }
+            }
+            else
+            {
+                compilation = metadataBlocks.ToCompilation(moduleVersionId, kind);
+            }
 
             var context = EvaluationContext.CreateMethodContext(
-                previousContext,
-                metadataBlocks,
+                compilation,
                 symReader,
                 moduleVersionId,
                 methodToken,
                 methodVersion,
-                ilOffset,
-                localSignatureToken,
-                kind);
+                offset,
+                localSignatureToken);
 
-            if (context != previousContext.EvaluationContext)
+            if (context != previousMetadataContext.EvaluationContext)
             {
                 setMetadataContext(
                     appDomain,
                     new MetadataContext<CSharpMetadataContext>(
                         metadataBlocks,
-                        assemblyContexts.SetItem(contextId, new CSharpMetadataContext(context.Compilation, context))));
+                        assemblyContexts.SetItem(contextId, new CSharpMetadataContext(context.Compilation, context))),
+                    report: kind == MakeAssemblyReferencesKind.AllReferences);
             }
 
             return context;
@@ -174,12 +202,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override void RemoveDataItem(DkmClrAppDomain appDomain)
         {
-            appDomain.RemoveMetadataContext<MetadataContext<CSharpMetadataContext>>();
+            appDomain.RemoveMetadataContext<CSharpMetadataContext>();
         }
 
         internal override ImmutableArray<MetadataBlock> GetMetadataBlocks(DkmClrAppDomain appDomain, DkmClrRuntimeInstance runtimeInstance)
         {
-            var previous = appDomain.GetMetadataContext<MetadataContext<CSharpMetadataContext>>();
+            var previous = appDomain.GetMetadataContext<CSharpMetadataContext>();
             return runtimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks);
         }
     }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             {
                 previous = null;
             }
-            if (previous != null && previous.ModuleVersionId != moduleVersionId)
+            if (previous != null && previous.ModuleVersionId != moduleVersionId) // TODO: ModuleVersionId should be compared against default if AllAssemblies.
             {
                 previous = null;
             }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 metadataBlocks,
                 moduleVersionId,
                 typeToken,
-                useReferencedModulesOnly);
+                GetMakeAssemblyReferencesKind(useReferencedModulesOnly));
         }
 
         internal static EvaluationContext CreateTypeContext<TAppDomain>(
@@ -53,9 +53,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             ImmutableArray<MetadataBlock> metadataBlocks,
             Guid moduleVersionId,
             int typeToken,
-            bool useReferencedModulesOnly)
+            MakeAssemblyReferencesKind kind)
         {
-            if (useReferencedModulesOnly)
+            if (kind == MakeAssemblyReferencesKind.DirectReferencesOnly)
             {
                 // Avoid using the cache for referenced assemblies only
                 // since this should be the exceptional case.
@@ -81,7 +81,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 previousContext,
                 metadataBlocks,
                 moduleVersionId,
-                typeToken);
+                typeToken,
+                kind);
 
             // New type context is not attached to the AppDomain since it is less
             // re-usable than the previous attached method context. (We could hold
@@ -115,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 methodVersion,
                 ilOffset,
                 localSignatureToken,
-                useReferencedModulesOnly);
+                GetMakeAssemblyReferencesKind(useReferencedModulesOnly));
         }
 
         internal static EvaluationContext CreateMethodContext<TAppDomain>(
@@ -129,9 +130,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             int methodVersion,
             uint ilOffset,
             int localSignatureToken,
-            bool useReferencedModulesOnly)
+            MakeAssemblyReferencesKind kind)
         {
-            if (useReferencedModulesOnly)
+            if (kind == MakeAssemblyReferencesKind.DirectReferencesOnly)
             {
                 // Avoid using the cache for referenced assemblies only
                 // since this should be the exceptional case.
@@ -166,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 methodVersion,
                 ilOffset,
                 localSignatureToken,
-                useReferencedAssembliesOnly: true);
+                kind);
 
             if (context != previousContext?.EvaluationContext)
             {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
             else
             {
-                compilation = metadataBlocks.ToCompilation(moduleVersionId, MakeAssemblyReferencesKind.AllReferences);
+                compilation = metadataBlocks.ToCompilation(moduleVersionId, GetMakeAssemblyReferencesKind());
                 appDomain.SetMetadataContext(
                     new AppDomainMetadataContext<CSharpCompilation, EvaluationContext>(
                         metadataBlocks,

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
@@ -136,20 +136,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             var appDomain = moduleInstance.AppDomain;
             var moduleVersionId = moduleInstance.Mvid;
-            var previous = appDomain.GetMetadataContext<AppDomainMetadataContext<CSharpCompilation, EvaluationContext>>();
+            var previous = appDomain.GetMetadataContext<MetadataContext<CSharpMetadataContext>>();
             var metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks);
 
-            if (!previous.Matches(metadataBlocks))
-            {
-                previous = null;
-            }
-            if (previous != null && previous.ModuleVersionId != moduleVersionId)
-            {
-                previous = null;
-            }
-
             CSharpCompilation compilation;
-            if (previous != null)
+            if (previous.Matches(metadataBlocks, moduleVersionId))
             {
                 compilation = previous.AssemblyContext.Compilation;
             }
@@ -157,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             {
                 compilation = metadataBlocks.ToCompilation(moduleVersionId, GetMakeAssemblyReferencesKind());
                 appDomain.SetMetadataContext(
-                    new AppDomainMetadataContext<CSharpCompilation, EvaluationContext>(
+                    new MetadataContext<CSharpMetadataContext>(
                         metadataBlocks,
                         moduleVersionId,
                         new CSharpMetadataContext(compilation)));

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             var appDomain = moduleInstance.AppDomain;
             var moduleVersionId = moduleInstance.Mvid;
-            var previous = appDomain.GetMetadataContext<MetadataContext<CSharpMetadataContext>>();
+            var previous = appDomain.GetMetadataContext<CSharpMetadataContext>();
             var metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks);
 
             var kind = GetMakeAssemblyReferencesKind();
@@ -152,7 +152,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 appDomain.SetMetadataContext(
                     new MetadataContext<CSharpMetadataContext>(
                         metadataBlocks,
-                        assemblyContexts.SetItem(contextId, new CSharpMetadataContext(compilation))));
+                        assemblyContexts.SetItem(contextId, new CSharpMetadataContext(compilation))),
+                    report: kind == MakeAssemblyReferencesKind.AllReferences);
             }
 
             return compilation;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpMetadataContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpMetadataContext.cs
@@ -1,22 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.ExpressionEvaluator;
-
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
-    // Remove this class and use MetadataContext<CSharpCompilation, EvaluationContext> directly.
-    internal sealed class CSharpMetadataContext : MetadataContext<CSharpCompilation, EvaluationContext>
+    internal struct CSharpMetadataContext
     {
-        internal CSharpMetadataContext(CSharpCompilation compilation, EvaluationContext evaluationContext = null) :
-            base(compilation, evaluationContext)
-        {
-        }
+        internal readonly CSharpCompilation Compilation;
+        internal readonly EvaluationContext EvaluationContext;
 
-        // TODO: Remove metadataBlocks parameter.
-        internal CSharpMetadataContext(ImmutableArray<MetadataBlock> metadataBlocks, EvaluationContext evaluationContext) :
-            base(evaluationContext.Compilation, evaluationContext)
+        internal CSharpMetadataContext(CSharpCompilation compilation, EvaluationContext evaluationContext = null)
         {
+            this.Compilation = compilation;
+            this.EvaluationContext = evaluationContext;
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpMetadataContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpMetadataContext.cs
@@ -1,35 +1,22 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
-    internal struct CSharpMetadataContext
+    // Remove this class and use MetadataContext<CSharpCompilation, EvaluationContext> directly.
+    internal sealed class CSharpMetadataContext : MetadataContext<CSharpCompilation, EvaluationContext>
     {
-        internal readonly ImmutableArray<MetadataBlock> MetadataBlocks;
-        internal readonly CSharpCompilation Compilation;
-        internal readonly EvaluationContext EvaluationContext;
-
-        internal CSharpMetadataContext(ImmutableArray<MetadataBlock> metadataBlocks, CSharpCompilation compilation)
+        internal CSharpMetadataContext(CSharpCompilation compilation, EvaluationContext evaluationContext = null) :
+            base(compilation, evaluationContext)
         {
-            this.MetadataBlocks = metadataBlocks;
-            this.Compilation = compilation;
-            this.EvaluationContext = null;
         }
 
-        internal CSharpMetadataContext(ImmutableArray<MetadataBlock> metadataBlocks, EvaluationContext evaluationContext)
+        // TODO: Remove metadataBlocks parameter.
+        internal CSharpMetadataContext(ImmutableArray<MetadataBlock> metadataBlocks, EvaluationContext evaluationContext) :
+            base(evaluationContext.Compilation, evaluationContext)
         {
-            this.MetadataBlocks = metadataBlocks;
-            this.Compilation = evaluationContext.Compilation;
-            this.EvaluationContext = evaluationContext;
-        }
-
-        internal bool Matches(ImmutableArray<MetadataBlock> metadataBlocks)
-        {
-            return !this.MetadataBlocks.IsDefault &&
-                this.MetadataBlocks.SequenceEqual(metadataBlocks);
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -92,13 +92,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal static CSharpCompilation ToCompilation(this ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId, MakeAssemblyReferencesKind kind)
         {
-            Dictionary<string, ImmutableArray<(AssemblyIdentity, MetadataReference)>> referencesByIdentity;
-            var references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer, kind, out referencesByIdentity);
+            var references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer, kind, out var referencesBySimpleName);
             var options = s_compilationOptions;
-            if (referencesByIdentity != null)
+            if (referencesBySimpleName != null)
             {
                 Debug.Assert(kind == MakeAssemblyReferencesKind.AllReferences);
-                var resolver = new EEMetadataReferenceResolver(IdentityComparer, referencesByIdentity);
+                var resolver = new EEMetadataReferenceResolver(IdentityComparer, referencesBySimpleName);
                 options = options.WithMetadataReferenceResolver(resolver);
             }
             return CSharpCompilation.Create(

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -92,13 +92,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal static CSharpCompilation ToCompilation(this ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId, MakeAssemblyReferencesKind kind)
         {
-            Dictionary<AssemblyIdentity, MetadataReference> referencesByIdentity;
+            Dictionary<string, ImmutableArray<(AssemblyIdentity, MetadataReference)>> referencesByIdentity;
             var references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer, kind, out referencesByIdentity);
             var options = s_compilationOptions;
             if (referencesByIdentity != null)
             {
                 Debug.Assert(kind == MakeAssemblyReferencesKind.AllReferences);
-                var resolver = new EEMetadataReferenceResolver(referencesByIdentity);
+                var resolver = new EEMetadataReferenceResolver(IdentityComparer, referencesByIdentity);
                 options = options.WithMetadataReferenceResolver(resolver);
             }
             return CSharpCompilation.Create(

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -83,24 +85,26 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             throw new ArgumentException($"No module found with MVID '{moduleVersionId}'", nameof(moduleVersionId));
         }
 
-        internal static CSharpCompilation ToCompilation(this ImmutableArray<MetadataBlock> metadataBlocks)
-        {
-            var references = metadataBlocks.MakeAssemblyReferences(default(Guid), identityComparer: null);
-            return references.ToCompilation();
-        }
-
         internal static CSharpCompilation ToCompilationReferencedModulesOnly(this ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId)
         {
-            var references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer);
-            return references.ToCompilation();
+            return ToCompilation(metadataBlocks, moduleVersionId, kind: MakeAssemblyReferencesKind.DirectReferencesOnly);
         }
 
-        internal static CSharpCompilation ToCompilation(this ImmutableArray<MetadataReference> references)
+        internal static CSharpCompilation ToCompilation(this ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId, MakeAssemblyReferencesKind kind)
         {
+            Dictionary<AssemblyIdentity, MetadataReference> referencesByIdentity;
+            var references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer, kind, out referencesByIdentity);
+            var options = s_compilationOptions;
+            if (referencesByIdentity != null)
+            {
+                Debug.Assert(kind == MakeAssemblyReferencesKind.AllReferences);
+                var resolver = new EEMetadataReferenceResolver(referencesByIdentity);
+                options = options.WithMetadataReferenceResolver(resolver);
+            }
             return CSharpCompilation.Create(
                 assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
                 references: references,
-                options: s_compilationOptions);
+                options: options);
         }
 
         internal static ReadOnlyCollection<byte> GetCustomTypeInfoPayload(

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -69,15 +69,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         /// No locals since locals are associated with methods, not types.
         /// </remarks>
         internal static EvaluationContext CreateTypeContext(
-            MetadataContext<CSharpCompilation, EvaluationContext> previous,
+            CSharpMetadataContext previous,
             ImmutableArray<MetadataBlock> metadataBlocks,
             Guid moduleVersionId,
             int typeToken,
             MakeAssemblyReferencesKind kind)
         {
             // Re-use the previous compilation if possible.
-            var compilation = previous != null ?
-                previous.Compilation :
+            var compilation = previous.Compilation ??
                 metadataBlocks.ToCompilation(moduleVersionId, kind);
 
             return CreateTypeContext(compilation, moduleVersionId, typeToken);
@@ -116,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         /// <param name="localSignatureToken">Method local signature token</param>
         /// <returns>Evaluation context</returns>
         internal static EvaluationContext CreateMethodContext(
-            MetadataContext<CSharpCompilation, EvaluationContext> previous,
+            CSharpMetadataContext previous,
             ImmutableArray<MetadataBlock> metadataBlocks,
             object symReader,
             Guid moduleVersionId,
@@ -129,8 +128,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var offset = NormalizeILOffset(ilOffset);
 
             // Re-use the previous compilation if possible.
-            CSharpCompilation compilation;
-            if (previous != null)
+            var compilation = previous.Compilation;
+            if (compilation != null)
             {
                 // Re-use entire context if method scope has not changed.
                 var previousContext = previous.EvaluationContext;
@@ -140,7 +139,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 {
                     return previousContext;
                 }
-                compilation = previous.Compilation;
             }
             else
             {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -73,12 +73,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             ImmutableArray<MetadataBlock> metadataBlocks,
             Guid moduleVersionId,
             int typeToken,
-            bool useReferencedAssembliesOnly = false) // TODO: Should not be optional. Make all callers explicit.
+            MakeAssemblyReferencesKind kind = MakeAssemblyReferencesKind.AllAssemblies) // TODO: Should not be optional. Make all callers explicit.
         {
             // Re-use the previous compilation if possible.
             var compilation = previous != null ?
                 previous.Compilation :
-                metadataBlocks.ToCompilation(moduleVersionId, useReferencedAssembliesOnly ? MakeAssemblyReferencesKind.AllReferences : MakeAssemblyReferencesKind.AllAssemblies);
+                metadataBlocks.ToCompilation(moduleVersionId, kind);
 
             return CreateTypeContext(compilation, moduleVersionId, typeToken);
         }
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             int methodVersion,
             uint ilOffset,
             int localSignatureToken,
-            bool useReferencedAssembliesOnly = false) // TODO: Should not be optional. Make all callers explicit.
+            MakeAssemblyReferencesKind kind = MakeAssemblyReferencesKind.AllAssemblies) // TODO: Should not be optional. Make all callers explicit.
         {
             var offset = NormalizeILOffset(ilOffset);
 
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
             else
             {
-                compilation = metadataBlocks.ToCompilation(moduleVersionId, useReferencedAssembliesOnly ? MakeAssemblyReferencesKind.AllReferences : MakeAssemblyReferencesKind.AllAssemblies);
+                compilation = metadataBlocks.ToCompilation(moduleVersionId, kind);
             }
 
             return CreateMethodContext(

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -90,6 +90,42 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         /// <summary>
         /// Create a context for evaluating expressions within a method scope.
         /// </summary>
+        /// <param name="previous">Previous context, if any, for possible re-use.</param>
+        /// <param name="metadataBlocks">Module metadata</param>
+        /// <param name="symReader"><see cref="ISymUnmanagedReader"/> for PDB associated with <paramref name="moduleVersionId"/></param>
+        /// <param name="moduleVersionId">Module containing method</param>
+        /// <param name="methodToken">Method metadata token</param>
+        /// <param name="methodVersion">Method version.</param>
+        /// <param name="ilOffset">IL offset of instruction pointer in method</param>
+        /// <param name="localSignatureToken">Method local signature token</param>
+        /// <returns>Evaluation context</returns>
+        internal static EvaluationContext CreateMethodContext(
+            CSharpMetadataContext previous,
+            ImmutableArray<MetadataBlock> metadataBlocks,
+            object symReader,
+            Guid moduleVersionId,
+            int methodToken,
+            int methodVersion,
+            uint ilOffset,
+            int localSignatureToken)
+        {
+            var offset = NormalizeILOffset(ilOffset);
+
+            CSharpCompilation compilation = metadataBlocks.ToCompilation(default(Guid), MakeAssemblyReferencesKind.AllAssemblies);
+
+            return CreateMethodContext(
+                compilation,
+                symReader,
+                moduleVersionId,
+                methodToken,
+                methodVersion,
+                offset,
+                localSignatureToken);
+        }
+
+        /// <summary>
+        /// Create a context for evaluating expressions within a method scope.
+        /// </summary>
         /// <param name="compilation">Compilation.</param>
         /// <param name="symReader"><see cref="ISymUnmanagedReader"/> for PDB associated with <paramref name="moduleVersionId"/></param>
         /// <param name="moduleVersionId">Module containing method</param>

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             ImmutableArray<MetadataBlock> metadataBlocks,
             Guid moduleVersionId,
             int typeToken,
-            MakeAssemblyReferencesKind kind = MakeAssemblyReferencesKind.AllAssemblies) // TODO: Should not be optional. Make all callers explicit.
+            MakeAssemblyReferencesKind kind)
         {
             // Re-use the previous compilation if possible.
             var compilation = previous != null ?
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             int methodVersion,
             uint ilOffset,
             int localSignatureToken,
-            MakeAssemblyReferencesKind kind = MakeAssemblyReferencesKind.AllAssemblies) // TODO: Should not be optional. Make all callers explicit.
+            MakeAssemblyReferencesKind kind)
         {
             var offset = NormalizeILOffset(ilOffset);
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -167,7 +167,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         internal static EvaluationContext CreateMethodContext(
             AppDomain appDomain,
             ImmutableArray<MetadataBlock> blocks,
-            (Guid ModuleVersionId, ISymUnmanagedReader SymReader, int MethodToken, int LocalSignatureToken, uint ILOffset) state)
+            (Guid ModuleVersionId, ISymUnmanagedReader SymReader, int MethodToken, int LocalSignatureToken, uint ILOffset) state,
+            MakeAssemblyReferencesKind kind =  MakeAssemblyReferencesKind.AllReferences)
         {
             return CreateMethodContext(
                 appDomain,
@@ -178,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 methodVersion: 1,
                 state.ILOffset,
                 state.LocalSignatureToken,
-                MakeAssemblyReferencesKind.AllReferences);
+                kind);
         }
 
         internal static CSharpMetadataContext GetMetadataContext(MetadataContext<CSharpMetadataContext> appDomainContext, Guid mvid = default)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -105,21 +105,21 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 
         internal sealed class AppDomain
         {
-            private AppDomainMetadataContext<CSharpCompilation, EvaluationContext> _metadataContext;
+            private MetadataContext<CSharpMetadataContext> _metadataContext;
 
-            internal AppDomainMetadataContext<CSharpCompilation, EvaluationContext> GetMetadataContext()
+            internal MetadataContext<CSharpMetadataContext> GetMetadataContext()
             {
                 return _metadataContext;
             }
 
-            internal void SetMetadataContext(AppDomainMetadataContext<CSharpCompilation, EvaluationContext> metadataContext)
+            internal void SetMetadataContext(MetadataContext<CSharpMetadataContext> metadataContext)
             {
                 _metadataContext = metadataContext;
             }
 
             internal void RemoveMetadataContext()
             {
-                _metadataContext = null;
+                _metadataContext = default;
             }
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 methodVersion: 1,
                 state.ILOffset,
                 state.LocalSignatureToken,
-                useReferencedModulesOnly: false);
+                MakeAssemblyReferencesKind.AllAssemblies);
         }
 
         internal static (Guid ModuleVersionId, ISymUnmanagedReader SymReader, int MethodToken, int LocalSignatureToken, uint ILOffset) GetContextState(RuntimeInstance runtime, string methodName)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -235,7 +235,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 methodToken: methodToken,
                 methodVersion: 1,
                 ilOffset: ilOffset,
-                localSignatureToken: localSignatureToken);
+                localSignatureToken: localSignatureToken,
+                kind: MakeAssemblyReferencesKind.AllAssemblies);
         }
 
         internal static EvaluationContext CreateTypeContext(
@@ -252,7 +253,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 default(CSharpMetadataContext),
                 blocks,
                 moduleVersionId,
-                typeToken);
+                typeToken,
+                kind: MakeAssemblyReferencesKind.AllAssemblies);
         }
 
         internal CompilationTestData Evaluate(

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -60,7 +60,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     methodToken: methodToken,
                     methodVersion: 1,
                     ilOffset: ilOffset,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    kind: MakeAssemblyReferencesKind.AllAssemblies);
 
                 string error;
                 var result = context.CompileExpression("1", out error);
@@ -76,7 +77,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     methodToken: methodToken,
                     methodVersion: 1,
                     ilOffset: ilOffset,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    kind: MakeAssemblyReferencesKind.AllAssemblies);
 
                 result = context.CompileExpression("2", out error);
                 var mvid2 = result.Assembly.GetModuleVersionId();
@@ -361,16 +363,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             endOffset = outerScope.EndOffset - 1;
 
             // At start of outer scope.
-            var context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)startOffset, localSignatureToken);
+            var context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)startOffset, localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies);
             Assert.Equal(default(CSharpMetadataContext), previous);
             previous = new CSharpMetadataContext(methodBlocks, context);
 
             // At end of outer scope - not reused because of the nested scope.
-            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)endOffset, localSignatureToken);
+            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)endOffset, localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies);
             Assert.NotEqual(context, previous.EvaluationContext); // Not required, just documentary.
 
             // At type context.
-            context = EvaluationContext.CreateTypeContext(previous, typeBlocks, moduleVersionId, typeToken);
+            context = EvaluationContext.CreateTypeContext(previous, typeBlocks, moduleVersionId, typeToken, MakeAssemblyReferencesKind.AllAssemblies);
             Assert.NotEqual(context, previous.EvaluationContext);
             Assert.Null(context.MethodContextReuseConstraints);
             Assert.Equal(context.Compilation, previous.Compilation);
@@ -387,7 +389,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     Assert.Equal(scope == previousScope, constraints.GetValueOrDefault().AreSatisfied(moduleVersionId, methodToken, methodVersion, offset));
                 }
 
-                context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)offset, localSignatureToken);
+                context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)offset, localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies);
                 if (scope == previousScope)
                 {
                     Assert.Equal(context, previous.EvaluationContext);
@@ -412,7 +414,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             GetContextState(runtime, "C.F", out methodBlocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
 
             // Different references. No reuse.
-            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)endOffset, localSignatureToken);
+            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)endOffset, localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies);
             Assert.NotEqual(context, previous.EvaluationContext);
             Assert.True(previous.EvaluationContext.MethodContextReuseConstraints.Value.AreSatisfied(moduleVersionId, methodToken, methodVersion, endOffset));
             Assert.NotEqual(context.Compilation, previous.Compilation);
@@ -420,14 +422,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 
             // Different method. Should reuse Compilation.
             GetContextState(runtime, "C.G", out methodBlocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
-            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, ilOffset: 0, localSignatureToken: localSignatureToken);
+            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, ilOffset: 0, localSignatureToken: localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies);
             Assert.NotEqual(context, previous.EvaluationContext);
             Assert.False(previous.EvaluationContext.MethodContextReuseConstraints.Value.AreSatisfied(moduleVersionId, methodToken, methodVersion, 0));
             Assert.Equal(context.Compilation, previous.Compilation);
 
             // No EvaluationContext. Should reuse Compilation
             previous = new CSharpMetadataContext(previous.Compilation);
-            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, ilOffset: 0, localSignatureToken: localSignatureToken);
+            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, ilOffset: 0, localSignatureToken: localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies);
             Assert.Null(previous.EvaluationContext);
             Assert.NotNull(context);
             Assert.Equal(context.Compilation, previous.Compilation);
@@ -5806,7 +5808,8 @@ public class C
                     methodToken: methodToken,
                     methodVersion: 1,
                     ilOffset: 0,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    kind: MakeAssemblyReferencesKind.AllAssemblies);
 
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
@@ -5825,7 +5828,8 @@ public class C
                     methodToken: methodToken,
                     methodVersion: 2,
                     ilOffset: 0,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    kind: MakeAssemblyReferencesKind.AllAssemblies);
 
                 locals.Clear();
                 context2.CompileGetLocals(
@@ -6060,7 +6064,8 @@ class C
                     methodToken: methodToken,
                     methodVersion: 1,
                     ilOffset: 0,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    kind: MakeAssemblyReferencesKind.AllAssemblies);
                 Assert.Same(previous, context);
 
                 // Verify the context is re-used for NoILOffset.
@@ -6073,7 +6078,8 @@ class C
                     methodToken: methodToken,
                     methodVersion: 1,
                     ilOffset: ExpressionCompilerTestHelpers.NoILOffset,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    kind: MakeAssemblyReferencesKind.AllAssemblies);
                 Assert.Same(previous, context);
             });
         }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -426,7 +426,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             Assert.Equal(context.Compilation, previous.Compilation);
 
             // No EvaluationContext. Should reuse Compilation
-            previous = new CSharpMetadataContext(previous.MetadataBlocks, previous.Compilation);
+            previous = new CSharpMetadataContext(previous.Compilation);
             context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, ilOffset: 0, localSignatureToken: localSignatureToken);
             Assert.Null(previous.EvaluationContext);
             Assert.NotNull(context);
@@ -6028,7 +6028,7 @@ class C
                 GetContextState(runtime, "C.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
 
                 var context = EvaluationContext.CreateMethodContext(
-                    blocks.ToCompilation(),
+                    blocks.ToCompilation(default(Guid), MakeAssemblyReferencesKind.AllAssemblies),
                     symReader,
                     moduleVersionId,
                     methodToken: methodToken,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 Assert.NotEqual(mvid1, Guid.Empty);
 
                 context = EvaluationContext.CreateMethodContext(
-                    new CSharpMetadataContext(blocks, context),
+                    new CSharpMetadataContext(context.Compilation, context),
                     blocks,
                     symReader,
                     moduleVersionId,
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             // At start of outer scope.
             var context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)startOffset, localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies);
             Assert.Equal(default(CSharpMetadataContext), previous);
-            previous = new CSharpMetadataContext(methodBlocks, context);
+            previous = new CSharpMetadataContext(context.Compilation, context);
 
             // At end of outer scope - not reused because of the nested scope.
             context = EvaluationContext.CreateMethodContext(previous, methodBlocks, symReader, moduleVersionId, methodToken, methodVersion, (uint)endOffset, localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies);
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 
             // Step through entire method.
             var previousScope = (Scope)null;
-            previous = new CSharpMetadataContext(typeBlocks, context);
+            previous = new CSharpMetadataContext(context.Compilation, context);
             for (int offset = startOffset; offset <= endOffset; offset++)
             {
                 var scope = scopes.GetInnermostScope(offset);
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     }
                 }
                 previousScope = scope;
-                previous = new CSharpMetadataContext(methodBlocks, context);
+                previous = new CSharpMetadataContext(context.Compilation, context);
             }
 
             // With different references.
@@ -418,7 +418,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             Assert.NotEqual(context, previous.EvaluationContext);
             Assert.True(previous.EvaluationContext.MethodContextReuseConstraints.Value.AreSatisfied(moduleVersionId, methodToken, methodVersion, endOffset));
             Assert.NotEqual(context.Compilation, previous.Compilation);
-            previous = new CSharpMetadataContext(methodBlocks, context);
+            previous = new CSharpMetadataContext(context.Compilation, context);
 
             // Different method. Should reuse Compilation.
             GetContextState(runtime, "C.G", out methodBlocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
@@ -6057,7 +6057,7 @@ class C
                 // Verify the context is re-used for ILOffset == 0.
                 var previous = context;
                 context = EvaluationContext.CreateMethodContext(
-                    new CSharpMetadataContext(blocks, previous),
+                    new CSharpMetadataContext(previous.Compilation, previous),
                     blocks,
                     symReader,
                     moduleVersionId,
@@ -6071,7 +6071,7 @@ class C
                 // Verify the context is re-used for NoILOffset.
                 previous = context;
                 context = EvaluationContext.CreateMethodContext(
-                    new CSharpMetadataContext(blocks, previous),
+                    new CSharpMetadataContext(previous.Compilation, previous),
                     blocks,
                     symReader,
                     moduleVersionId,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
@@ -1386,7 +1386,7 @@ class C
 
                 ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber: 200);
                 context = EvaluationContext.CreateMethodContext(
-                    new CSharpMetadataContext(blocks, context),
+                    new CSharpMetadataContext(context.Compilation, context),
                     blocks,
                     symReader,
                     moduleVersionId,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
@@ -1375,7 +1375,8 @@ class C
                     methodToken: methodToken,
                     methodVersion: 1,
                     ilOffset: ilOffset,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    kind: MakeAssemblyReferencesKind.AllAssemblies);
 
                 string error;
                 context.CompileExpression("x", out error);
@@ -1392,7 +1393,8 @@ class C
                     methodToken: methodToken,
                     methodVersion: 1,
                     ilOffset: ilOffset,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    kind: MakeAssemblyReferencesKind.AllAssemblies);
 
                 context.CompileExpression("x", out error);
                 Assert.Null(error);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
@@ -1366,9 +1366,10 @@ class C
                 int localSignatureToken;
                 GetContextState(runtime, "C.<M>d__0.MoveNext", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
 
+                var appDomain = new AppDomain();
                 uint ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber: 100);
-                var context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
+                var context = CreateMethodContext(
+                    appDomain,
                     blocks,
                     symReader,
                     moduleVersionId,
@@ -1385,8 +1386,8 @@ class C
                 Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
 
                 ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber: 200);
-                context = EvaluationContext.CreateMethodContext(
-                    new CSharpMetadataContext(context.Compilation, context),
+                context = CreateMethodContext(
+                    appDomain,
                     blocks,
                     symReader,
                     moduleVersionId,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
@@ -445,7 +445,7 @@ class C
             var runtime = CreateRuntimeInstance(compilation);
             var moduleInstances = runtime.Modules;
             var blocks = moduleInstances.SelectAsArray(m => m.MetadataBlock);
-            compilation = blocks.ToCompilation();
+            compilation = blocks.ToCompilation(default(Guid), MakeAssemblyReferencesKind.AllAssemblies);
             var frame = (PEMethodSymbol)GetMethodOrTypeBySignature(compilation, methodName);
 
             // Once we have the method token, we want to look up the method (again)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -5075,7 +5075,8 @@ class C
                 methodToken,
                 methodVersion: 1,
                 ilOffset: 0,
-                localSignatureToken: localSignatureToken);
+                localSignatureToken: localSignatureToken,
+                kind: MakeAssemblyReferencesKind.AllAssemblies);
 
             string typeName;
             var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: null);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -5067,8 +5067,8 @@ class C
                 {
                     {methodToken, debugInfo}
                 }.ToImmutableDictionary());
-            var context = EvaluationContext.CreateMethodContext(
-                default(CSharpMetadataContext),
+            var context = CreateMethodContext(
+                new AppDomain(),
                 blocks,
                 symReader,
                 moduleVersionId,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -916,7 +916,14 @@ LanguageVersion.CSharp7_1);
                         runtime.Modules.Select(m => m.MetadataBlock).ToImmutableArray(),
                         expression,
                         ImmutableArray<Alias>.Empty,
-                        (b, u) => EvaluationContext.CreateMethodContext(b.ToCompilation(), symReader, moduleVersionId, methodToken, methodVersion: 1, ilOffset: 0, localSignatureToken: localSignatureToken),
+                        (b, u) => EvaluationContext.CreateMethodContext(
+                            b.ToCompilation(default(Guid), MakeAssemblyReferencesKind.AllAssemblies),
+                            symReader,
+                            moduleVersionId,
+                            methodToken,
+                            methodVersion: 1,
+                            ilOffset: 0,
+                            localSignatureToken: localSignatureToken),
                         (AssemblyIdentity assemblyIdentity, out uint uSize) =>
                         {
                             retryCount++;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -326,7 +326,7 @@ IL_0005:  ret
                 var stateB2 = GetContextState(runtime, "B2.M");
 
                 EvaluationContext context;
-                AppDomainMetadataContext<CSharpCompilation, EvaluationContext> previous;
+                MetadataContext<CSharpMetadataContext> previous;
 
                 // B1 -> B2 -> A1 -> A2 -> A3
                 // B1.M:
@@ -547,7 +547,7 @@ IL_0005:  ret
                 testData = new CompilationTestData();
                 context.CompileExpression("new B()", out error, testData);
                 Assert.Null(error);
-                var previous = new CSharpMetadataContext(typeBlocks, context);
+                var previous = new CSharpMetadataContext(context.Compilation, context);
 
                 // Compile expression with type context with referenced modules only.
                 context = EvaluationContext.CreateTypeContext(

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -152,6 +152,51 @@ IL_0000:  newobj     ""C1..ctor()""
 IL_0005:  ret
 }");
                 VerifyResolutionRequests(context, (identityB2, identityB2, 1), (identityA1, identityA1, 1), (identityA2, identityA2, 1));
+
+                // Other EvaluationContext.CreateMethodContext overload.
+                // A1.M with all assemblies.
+                var allBlocks = ImmutableArray.Create(moduleMscorlib, moduleA1, moduleA2, moduleB1, moduleB2, moduleC).SelectAsArray(m => m.MetadataBlock);
+                context = EvaluationContext.CreateMethodContext(
+                    new CSharpMetadataContext(),
+                    allBlocks,
+                    stateA1.SymReader,
+                    stateA1.ModuleVersionId,
+                    stateA1.MethodToken,
+                    methodVersion: 1,
+                    stateA1.ILOffset,
+                    stateA1.LocalSignatureToken);
+                testData = new CompilationTestData();
+                context.CompileExpression("new B1()", out error, testData);
+                methodData = testData.GetMethodData("<>x.<>m0");
+                methodData.VerifyIL(
+@"{
+// Code size        6 (0x6)
+.maxstack  1
+IL_0000:  newobj     ""B1..ctor()""
+IL_0005:  ret
+}");
+
+                // Other EvaluationContext.CreateMethodContext overload.
+                // A1.M with all assemblies, offset outside of IL.
+                context = EvaluationContext.CreateMethodContext(
+                    new CSharpMetadataContext(),
+                    allBlocks,
+                    stateA1.SymReader,
+                    stateA1.ModuleVersionId,
+                    stateA1.MethodToken,
+                    methodVersion: 1,
+                    uint.MaxValue,
+                    stateA1.LocalSignatureToken);
+                testData = new CompilationTestData();
+                context.CompileExpression("new C1()", out error, testData);
+                methodData = testData.GetMethodData("<>x.<>m0");
+                methodData.VerifyIL(
+@"{
+// Code size        6 (0x6)
+.maxstack  1
+IL_0000:  newobj     ""C1..ctor()""
+IL_0005:  ret
+}");
             }
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -337,81 +337,76 @@ IL_0005:  ret
                 previous = appDomain.GetMetadataContext();
                 context = CreateMethodContext(appDomain, blocks, stateB1);
                 VerifyResolutionRequests(context, (identityA1, identityA1, 1));
-                VerifyAppDomainMetadataContext(appDomain, stateB1.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidB1);
                 // B2.M:
                 previous = appDomain.GetMetadataContext();
                 context = CreateMethodContext(appDomain, blocks, stateB2);
                 Assert.NotSame(context, GetMetadataContext(previous, mvidB1).EvaluationContext);
                 Assert.Same(context.Compilation, GetMetadataContext(previous, mvidB1).Compilation);
                 VerifyResolutionRequests(context, (identityA1, identityA1, 1));
-                VerifyAppDomainMetadataContext(appDomain, stateB1.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidB1);
                 // A1.M:
                 previous = appDomain.GetMetadataContext();
                 context = CreateMethodContext(appDomain, blocks, stateA1);
                 Assert.NotSame(context, GetMetadataContext(previous, mvidB1).EvaluationContext);
                 Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidB1).Compilation);
                 VerifyResolutionRequests(context);
-                VerifyAppDomainMetadataContext(appDomain, stateB1.ModuleVersionId, stateA1.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidB1, mvidA1);
                 // A2.M:
                 previous = appDomain.GetMetadataContext();
                 context = CreateMethodContext(appDomain, blocks, stateA2);
                 Assert.NotSame(context, GetMetadataContext(previous, mvidA1).EvaluationContext);
                 Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidA1).Compilation);
                 VerifyResolutionRequests(context);
-                VerifyAppDomainMetadataContext(appDomain, stateB1.ModuleVersionId, stateA1.ModuleVersionId, stateA2.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidB1, mvidA1, mvidA2);
                 // A3.M:
                 previous = appDomain.GetMetadataContext();
                 context = CreateMethodContext(appDomain, blocks, stateA3);
                 Assert.NotSame(context, GetMetadataContext(previous, mvidA2).EvaluationContext);
                 Assert.Same(context.Compilation, GetMetadataContext(previous, mvidA2).Compilation);
                 VerifyResolutionRequests(context);
-                VerifyAppDomainMetadataContext(appDomain, stateB1.ModuleVersionId, stateA1.ModuleVersionId, stateA2.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidB1, mvidA1, mvidA2);
 
                 // A1 -> A2 -> A3 -> B1 -> B2
                 // A1.M:
                 appDomain = new AppDomain();
                 context = CreateMethodContext(appDomain, blocks, stateA1);
                 VerifyResolutionRequests(context);
-                VerifyAppDomainMetadataContext(appDomain, stateA1.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidA1);
                 // A2.M:
                 previous = appDomain.GetMetadataContext();
                 context = CreateMethodContext(appDomain, blocks, stateA2);
                 Assert.NotSame(context, GetMetadataContext(previous, mvidA1).EvaluationContext);
                 Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidA1).Compilation);
                 VerifyResolutionRequests(context);
-                VerifyAppDomainMetadataContext(appDomain, stateA1.ModuleVersionId, stateA2.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidA1, mvidA2);
                 // A3.M:
                 previous = appDomain.GetMetadataContext();
                 context = CreateMethodContext(appDomain, blocks, stateA3);
                 Assert.NotSame(context, GetMetadataContext(previous, mvidA2).EvaluationContext);
                 Assert.Same(context.Compilation, GetMetadataContext(previous, mvidA2).Compilation);
                 VerifyResolutionRequests(context);
-                VerifyAppDomainMetadataContext(appDomain, stateA1.ModuleVersionId, stateA2.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidA1, mvidA2);
                 // B1.M:
                 previous = appDomain.GetMetadataContext();
                 context = CreateMethodContext(appDomain, blocks, stateB1);
                 Assert.NotSame(context, GetMetadataContext(previous, mvidA2).EvaluationContext);
                 Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidA2).Compilation);
                 VerifyResolutionRequests(context, (identityA1, identityA1, 1));
-                VerifyAppDomainMetadataContext(appDomain, stateA1.ModuleVersionId, stateA2.ModuleVersionId, stateB1.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidA1, mvidA2, mvidB1);
                 // B2.M:
                 previous = appDomain.GetMetadataContext();
                 context = CreateMethodContext(appDomain, blocks, stateB2);
                 Assert.NotSame(context, GetMetadataContext(previous, mvidB1).EvaluationContext);
                 Assert.Same(context.Compilation, GetMetadataContext(previous, mvidB1).Compilation);
                 VerifyResolutionRequests(context, (identityA1, identityA1, 1));
-                VerifyAppDomainMetadataContext(appDomain, stateA1.ModuleVersionId, stateA2.ModuleVersionId, stateB1.ModuleVersionId);
+                VerifyAppDomainMetadataContext(appDomain, mvidA1, mvidA2, mvidB1);
             }
         }
 
         private static void VerifyAppDomainMetadataContext(AppDomain appDomain, params Guid[] moduleVersionIds)
         {
-            var assemblyContexts = appDomain.GetMetadataContext().AssemblyContexts;
-            var actualIds = assemblyContexts.Keys.Select(key => key.ModuleVersionId.ToString()).ToArray();
-            Array.Sort(actualIds);
-            var expectedIds = moduleVersionIds.Select(mvid => mvid.ToString()).ToArray();
-            Array.Sort(expectedIds);
-            AssertEx.Equal(expectedIds, actualIds);
+            ExpressionCompilerTestHelpers.VerifyAppDomainMetadataContext(appDomain.GetMetadataContext(), moduleVersionIds);
         }
 
         [WorkItem(1141029, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1141029")]
@@ -733,23 +728,9 @@ IL_0005:  ret
 
         private static void VerifyResolutionRequests(EvaluationContext context, params (AssemblyIdentity, AssemblyIdentity, int)[] expectedRequests)
         {
-#if DEBUG
-            var resolver = (EEMetadataReferenceResolver)context.Compilation.Options.MetadataReferenceResolver;
-            var expected = ArrayBuilder<(AssemblyIdentity, AssemblyIdentity, int)>.GetInstance();
-            var actual = ArrayBuilder<(AssemblyIdentity, AssemblyIdentity, int)>.GetInstance();
-            expected.AddRange(expectedRequests);
-            sort(expected);
-            actual.AddRange(resolver.Requests.Select(pair => (pair.Key, pair.Value.Identity, pair.Value.Count)));
-            sort(actual);
-            AssertEx.Equal(expected, actual);
-            actual.Free();
-            expected.Free();
-
-            void sort(ArrayBuilder<(AssemblyIdentity, AssemblyIdentity, int)> builder)
-            {
-                builder.Sort((x, y) => AssemblyIdentityComparer.SimpleNameComparer.Compare(x.Item1.GetDisplayName(), y.Item1.GetDisplayName()));
-            }
-#endif
+            ExpressionCompilerTestHelpers.VerifyResolutionRequests(
+                (EEMetadataReferenceResolver)context.Compilation.Options.MetadataReferenceResolver,
+                expectedRequests);
         }
 
         [Fact]

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -738,6 +738,7 @@ IL_0005:  ret
 
         private static void VerifyResolutionRequests(EvaluationContext context, params (AssemblyIdentity, AssemblyIdentity, int)[] expectedRequests)
         {
+#if DEBUG
             var resolver = (EEMetadataReferenceResolver)context.Compilation.Options.MetadataReferenceResolver;
             var expected = ArrayBuilder<(AssemblyIdentity, AssemblyIdentity, int)>.GetInstance();
             var actual = ArrayBuilder<(AssemblyIdentity, AssemblyIdentity, int)>.GetInstance();
@@ -753,6 +754,7 @@ IL_0005:  ret
             {
                 builder.Sort((x, y) => AssemblyIdentityComparer.SimpleNameComparer.Compare(x.Item1, y.Item1));
             }
+#endif
         }
 
         [Fact]

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var (moduleVersionId, symReader, methodToken, localSignatureToken, ilOffset) = GetContextState(runtime, "B2.M");
 
                 // Missing A1.
-                var context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
+                var context = CreateMethodContext(
+                    new AppDomain(),
                     ImmutableArray.Create(moduleMscorlib, moduleA2, moduleB1, moduleB2, moduleC).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
@@ -71,8 +71,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 AssertEx.Equal(new[] { identityA1 }, missingAssemblyIdentities);
                 VerifyResolutionRequests(context, (identityA1, null, 1));
 
-                context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
+                context = CreateMethodContext(
+                    new AppDomain(),
                     ImmutableArray.Create(moduleMscorlib, moduleA1, moduleA2, moduleB1, moduleB2, moduleC).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
@@ -93,8 +93,8 @@ IL_0005:  ret
 }");
                 VerifyResolutionRequests(context, (identityA1, identityA1, 1));
 
-                context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
+                context = CreateMethodContext(
+                    new AppDomain(),
                     ImmutableArray.Create(moduleC, moduleB2, moduleB1, moduleA2, moduleA1, moduleMscorlib, moduleIntrinsic).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
@@ -135,8 +135,8 @@ IL_0005:  ret
                 var (moduleVersionId, symReader, methodToken, localSignatureToken, ilOffset) = GetContextState(runtime, "B.M");
 
                 // Expected version of A.
-                var context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
+                var context = CreateMethodContext(
+                    new AppDomain(),
                     ImmutableArray.Create(moduleMscorlib, moduleA2, moduleB1).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
@@ -159,8 +159,8 @@ IL_0005:  ret
                 VerifyResolutionRequests(context, (identityA2, identityA2, 1));
 
                 // Higher version of A.
-                context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
+                context = CreateMethodContext(
+                    new AppDomain(),
                     ImmutableArray.Create(moduleMscorlib, moduleA3, moduleB1).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
@@ -182,8 +182,8 @@ IL_0005:  ret
                 VerifyResolutionRequests(context, (identityA2, identityA3, 1));
 
                 // Lower version of A.
-                context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
+                context = CreateMethodContext(
+                    new AppDomain(),
                     ImmutableArray.Create(moduleMscorlib, moduleA1, moduleB1).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
@@ -198,8 +198,8 @@ IL_0005:  ret
                 VerifyResolutionRequests(context, (identityA2, identityA1, 1));
 
                 // Multiple versions of A.
-                context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
+                context = CreateMethodContext(
+                    new AppDomain(),
                     ImmutableArray.Create(moduleMscorlib, moduleA1, moduleA3, moduleA2, moduleB1).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
@@ -221,8 +221,8 @@ IL_0005:  ret
                 VerifyResolutionRequests(context, (identityA2, identityA2, 1));
 
                 // Duplicate versions of A.
-                context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
+                context = CreateMethodContext(
+                    new AppDomain(),
                     ImmutableArray.Create(moduleMscorlib, moduleA3, moduleA1, moduleA3, moduleA1, moduleB1).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
@@ -245,22 +245,25 @@ IL_0005:  ret
             }
         }
 
-        [Fact]
+        // Not handling duplicate corlib when using referenced assemblies
+        // only (bug #...).
+        [Fact(Skip = "TODO")]
         public void DuplicateNamedCorLib()
         {
-            var publicKeyA = ImmutableArray.CreateRange(new byte[] { 0x00, 0x24, 0x00, 0x00, 0x04, 0x80, 0x00, 0x00, 0x94, 0x00, 0x00, 0x00, 0x06, 0x02, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x52, 0x53, 0x41, 0x31, 0x00, 0x04, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0xED, 0xD3, 0x22, 0xCB, 0x6B, 0xF8, 0xD4, 0xA2, 0xFC, 0xCC, 0x87, 0x37, 0x04, 0x06, 0x04, 0xCE, 0xE7, 0xB2, 0xA6, 0xF8, 0x4A, 0xEE, 0xF3, 0x19, 0xDF, 0x5B, 0x95, 0xE3, 0x7A, 0x6A, 0x28, 0x24, 0xA4, 0x0A, 0x83, 0x83, 0xBD, 0xBA, 0xF2, 0xF2, 0x52, 0x20, 0xE9, 0xAA, 0x3B, 0xD1, 0xDD, 0xE4, 0x9A, 0x9A, 0x9C, 0xC0, 0x30, 0x8F, 0x01, 0x40, 0x06, 0xE0, 0x2B, 0x95, 0x62, 0x89, 0x2A, 0x34, 0x75, 0x22, 0x68, 0x64, 0x6E, 0x7C, 0x2E, 0x83, 0x50, 0x5A, 0xCE, 0x7B, 0x0B, 0xE8, 0xF8, 0x71, 0xE6, 0xF7, 0x73, 0x8E, 0xEB, 0x84, 0xD2, 0x73, 0x5D, 0x9D, 0xBE, 0x5E, 0xF5, 0x90, 0xF9, 0xAB, 0x0A, 0x10, 0x7E, 0x23, 0x48, 0xF4, 0xAD, 0x70, 0x2E, 0xF7, 0xD4, 0x51, 0xD5, 0x8B, 0x3A, 0xF7, 0xCA, 0x90, 0x4C, 0xDC, 0x80, 0x19, 0x26, 0x65, 0xC9, 0x37, 0xBD, 0x52, 0x81, 0xF1, 0x8B, 0xCD });
+            var publicKeyOther = ImmutableArray.CreateRange(new byte[] { 0x00, 0x24, 0x00, 0x00, 0x04, 0x80, 0x00, 0x00, 0x94, 0x00, 0x00, 0x00, 0x06, 0x02, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x52, 0x53, 0x41, 0x31, 0x00, 0x04, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0xED, 0xD3, 0x22, 0xCB, 0x6B, 0xF8, 0xD4, 0xA2, 0xFC, 0xCC, 0x87, 0x37, 0x04, 0x06, 0x04, 0xCE, 0xE7, 0xB2, 0xA6, 0xF8, 0x4A, 0xEE, 0xF3, 0x19, 0xDF, 0x5B, 0x95, 0xE3, 0x7A, 0x6A, 0x28, 0x24, 0xA4, 0x0A, 0x83, 0x83, 0xBD, 0xBA, 0xF2, 0xF2, 0x52, 0x20, 0xE9, 0xAA, 0x3B, 0xD1, 0xDD, 0xE4, 0x9A, 0x9A, 0x9C, 0xC0, 0x30, 0x8F, 0x01, 0x40, 0x06, 0xE0, 0x2B, 0x95, 0x62, 0x89, 0x2A, 0x34, 0x75, 0x22, 0x68, 0x64, 0x6E, 0x7C, 0x2E, 0x83, 0x50, 0x5A, 0xCE, 0x7B, 0x0B, 0xE8, 0xF8, 0x71, 0xE6, 0xF7, 0x73, 0x8E, 0xEB, 0x84, 0xD2, 0x73, 0x5D, 0x9D, 0xBE, 0x5E, 0xF5, 0x90, 0xF9, 0xAB, 0x0A, 0x10, 0x7E, 0x23, 0x48, 0xF4, 0xAD, 0x70, 0x2E, 0xF7, 0xD4, 0x51, 0xD5, 0x8B, 0x3A, 0xF7, 0xCA, 0x90, 0x4C, 0xDC, 0x80, 0x19, 0x26, 0x65, 0xC9, 0x37, 0xBD, 0x52, 0x81, 0xF1, 0x8B, 0xCD });
             var options = TestOptions.DebugDll.WithDelaySign(true);
             var (identityMscorlib, moduleMscorlib) = (MscorlibRef.GetAssemblyIdentity(), MscorlibRef.ToModuleInstance());
-            var (identityA, moduleA, refA) = Compile(new AssemblyIdentity(identityMscorlib.Name, new Version(1, 1, 1, 1), publicKeyOrToken: publicKeyA, hasPublicKey: true), "public class A { }", options, MscorlibRef);
-            var (identityB, moduleB, refB) = Compile(new AssemblyIdentity("B", new Version(1, 1, 1, 1)), "public class B : A { static void M() { } }", TestOptions.DebugDll, refA, MscorlibRef);
+            var (identityOther, moduleOther, refOther) = Compile(new AssemblyIdentity(identityMscorlib.Name, new Version(1, 1, 1, 1), publicKeyOrToken: publicKeyOther, hasPublicKey: true), "class Other { }", options, MscorlibRef);
+            var (identityA, moduleA, refA) = Compile(new AssemblyIdentity("A", new Version(1, 1, 1, 1)), "public class A { }", TestOptions.DebugDll, refOther, MscorlibRef);
+            var (identityB, moduleB, refB) = Compile(new AssemblyIdentity("B", new Version(1, 1, 1, 1)), "public class B : A { static void M() { } }", TestOptions.DebugDll, refA, refOther, MscorlibRef);
 
             using (var runtime = CreateRuntimeInstance(new[] { moduleMscorlib, moduleA, moduleB }))
             {
                 var (moduleVersionId, symReader, methodToken, localSignatureToken, ilOffset) = GetContextState(runtime, "B.M");
 
-                var context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
-                    ImmutableArray.Create(moduleMscorlib, moduleA, moduleB).SelectAsArray(m => m.MetadataBlock),
+                var context = CreateMethodContext(
+                    new AppDomain(),
+                    ImmutableArray.Create(moduleMscorlib, moduleOther, moduleA, moduleB).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
                     methodToken: methodToken,
@@ -281,9 +284,9 @@ IL_0005:  ret
 }");
                 VerifyResolutionRequests(context, (identityA, identityA, 1));
 
-                context = EvaluationContext.CreateMethodContext(
-                    default(CSharpMetadataContext),
-                    ImmutableArray.Create(moduleB, moduleA, moduleMscorlib).SelectAsArray(m => m.MetadataBlock),
+                context = CreateMethodContext(
+                    new AppDomain(),
+                    ImmutableArray.Create(moduleB, moduleA, moduleOther, moduleMscorlib).SelectAsArray(m => m.MetadataBlock),
                     symReader,
                     moduleVersionId,
                     methodToken: methodToken,
@@ -325,6 +328,11 @@ IL_0005:  ret
                 var stateB1 = GetContextState(runtime, "B1.M");
                 var stateB2 = GetContextState(runtime, "B2.M");
 
+                var mvidA1 = stateA1.ModuleVersionId;
+                var mvidA2 = stateA2.ModuleVersionId;
+                var mvidB1 = stateB1.ModuleVersionId;
+                Assert.Equal(mvidB1, stateB2.ModuleVersionId);
+
                 EvaluationContext context;
                 MetadataContext<CSharpMetadataContext> previous;
 
@@ -332,69 +340,78 @@ IL_0005:  ret
                 // B1.M:
                 var appDomain = new AppDomain();
                 previous = appDomain.GetMetadataContext();
-                context = CreateMethodContext(appDomain, blocks, stateB1);
+                context = createMethodContext(appDomain, blocks, stateB1);
                 // B2.M:
                 previous = appDomain.GetMetadataContext();
-                context = CreateMethodContext(appDomain, blocks, stateB2);
-                Assert.NotSame(context, GetMetadataContext(previous).EvaluationContext);
-                Assert.Same(context.Compilation, GetMetadataContext(previous).Compilation);
+                context = createMethodContext(appDomain, blocks, stateB2);
+                Assert.NotSame(context, GetMetadataContext(previous, mvidB1).EvaluationContext);
+                Assert.Same(context.Compilation, GetMetadataContext(previous, mvidB1).Compilation);
                 VerifyResolutionRequests(context, (identityA1, identityA1, 1));
                 // A1.M:
                 previous = appDomain.GetMetadataContext();
-                context = CreateMethodContext(appDomain, blocks, stateA1);
-                Assert.NotSame(context, GetMetadataContext(previous).EvaluationContext);
-                Assert.NotSame(context.Compilation, GetMetadataContext(previous).Compilation);
+                context = createMethodContext(appDomain, blocks, stateA1);
+                Assert.NotSame(context, GetMetadataContext(previous, mvidB1).EvaluationContext);
+                Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidB1).Compilation);
                 VerifyResolutionRequests(context);
                 // A2.M:
                 previous = appDomain.GetMetadataContext();
-                context = CreateMethodContext(appDomain, blocks, stateA2);
-                Assert.NotSame(context, GetMetadataContext(previous).EvaluationContext);
-                Assert.NotSame(context.Compilation, GetMetadataContext(previous).Compilation);
+                context = createMethodContext(appDomain, blocks, stateA2);
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA1).EvaluationContext);
+                Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidA1).Compilation);
                 VerifyResolutionRequests(context);
                 // A3.M:
                 previous = appDomain.GetMetadataContext();
-                context = CreateMethodContext(appDomain, blocks, stateA3);
-                Assert.NotSame(context, GetMetadataContext(previous).EvaluationContext);
-                Assert.Same(context.Compilation, GetMetadataContext(previous).Compilation);
+                context = createMethodContext(appDomain, blocks, stateA3);
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA2).EvaluationContext);
+                Assert.Same(context.Compilation, GetMetadataContext(previous, mvidA2).Compilation);
                 VerifyResolutionRequests(context);
 
                 // A1 -> A2 -> A3 -> B1 -> B2
                 // A1.M:
                 appDomain = new AppDomain();
-                context = CreateMethodContext(appDomain, blocks, stateA1);
+                context = createMethodContext(appDomain, blocks, stateA1);
                 // A2.M:
                 previous = appDomain.GetMetadataContext();
-                context = CreateMethodContext(appDomain, blocks, stateA2);
-                Assert.NotSame(context, GetMetadataContext(previous).EvaluationContext);
-                Assert.NotSame(context.Compilation, GetMetadataContext(previous).Compilation);
+                context = createMethodContext(appDomain, blocks, stateA2);
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA1).EvaluationContext);
+                Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidA1).Compilation);
                 VerifyResolutionRequests(context);
                 // A3.M:
                 previous = appDomain.GetMetadataContext();
-                context = CreateMethodContext(appDomain, blocks, stateA3);
-                Assert.NotSame(context, GetMetadataContext(previous).EvaluationContext);
-                Assert.Same(context.Compilation, GetMetadataContext(previous).Compilation);
+                context = createMethodContext(appDomain, blocks, stateA3);
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA2).EvaluationContext);
+                Assert.Same(context.Compilation, GetMetadataContext(previous, mvidA2).Compilation);
                 VerifyResolutionRequests(context);
                 // B1.M:
                 previous = appDomain.GetMetadataContext();
-                context = CreateMethodContext(appDomain, blocks, stateB1);
-                Assert.NotSame(context, GetMetadataContext(previous).EvaluationContext);
-                Assert.NotSame(context.Compilation, GetMetadataContext(previous).Compilation);
+                context = createMethodContext(appDomain, blocks, stateB1);
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA2).EvaluationContext);
+                Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidA2).Compilation);
                 VerifyResolutionRequests(context, (identityA1, identityA1, 1));
                 // B2.M:
                 previous = appDomain.GetMetadataContext();
-                context = CreateMethodContext(appDomain, blocks, stateB2);
-                Assert.NotSame(context, GetMetadataContext(previous).EvaluationContext);
-                Assert.Same(context.Compilation, GetMetadataContext(previous).Compilation);
+                context = createMethodContext(appDomain, blocks, stateB2);
+                Assert.NotSame(context, GetMetadataContext(previous, mvidB1).EvaluationContext);
+                Assert.Same(context.Compilation, GetMetadataContext(previous, mvidB1).Compilation);
                 VerifyResolutionRequests(context, (identityA1, identityA1, 1));
             }
-        }
 
-        private static CSharpMetadataContext GetMetadataContext(MetadataContext<CSharpMetadataContext> appDomainContext)
-        {
-            var assemblyContexts = appDomainContext.AssemblyContexts;
-            return assemblyContexts != null && assemblyContexts.TryGetValue(default(MetadataContextId), out CSharpMetadataContext context) ?
-                context :
-                default;
+            EvaluationContext createMethodContext(
+                AppDomain appDomain,
+                ImmutableArray<MetadataBlock> blocks,
+                (Guid ModuleVersionId, ISymUnmanagedReader SymReader, int MethodToken, int LocalSignatureToken, uint ILOffset) state)
+            {
+                return CreateMethodContext(
+                    appDomain,
+                    blocks,
+                    state.SymReader,
+                    state.ModuleVersionId,
+                    state.MethodToken,
+                    methodVersion: 1,
+                    state.ILOffset,
+                    state.LocalSignatureToken,
+                    MakeAssemblyReferencesKind.AllReferences);
+            }
         }
 
         private static void VerifyAppDomainMetadataContext(AppDomain appDomain)
@@ -536,8 +553,9 @@ IL_0005:  ret
                 uint ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader);
 
                 // Compile expression with type context with all modules.
-                var context = EvaluationContext.CreateTypeContext(
-                    default(CSharpMetadataContext),
+                var appDomain = new AppDomain();
+                var context = CreateTypeContext(
+                    appDomain,
                     typeBlocks,
                     moduleVersionId,
                     typeToken,
@@ -555,13 +573,19 @@ IL_0005:  ret
                 testData = new CompilationTestData();
                 context.CompileExpression("new B()", out error, testData);
                 Assert.Null(error);
-                var previous = new CSharpMetadataContext(context.Compilation, context);
+                appDomain.SetMetadataContext(
+                    SetMetadataContext(
+                        new MetadataContext<CSharpMetadataContext>(typeBlocks, ImmutableDictionary<MetadataContextId, CSharpMetadataContext>.Empty),
+                        default(Guid),
+                        new CSharpMetadataContext(context.Compilation)));
 
                 // Compile expression with type context with referenced modules only.
-                context = EvaluationContext.CreateTypeContext(
-                    typeBlocks.ToCompilationReferencedModulesOnly(moduleVersionId),
+                context = CreateTypeContext(
+                    appDomain,
+                    typeBlocks,
                     moduleVersionId,
-                    typeToken);
+                    typeToken,
+                    MakeAssemblyReferencesKind.DirectReferencesOnly);
                 // A is unrecognized since there were no direct references to AS1 or AS2.
                 testData = new CompilationTestData();
                 context.CompileExpression("new A()", out error, testData);
@@ -595,8 +619,9 @@ IL_0005:  ret
                 AssertEx.Equal(missingAssemblyIdentities, ImmutableArray.Create(identityAS2));
 
                 // Compile expression with method context with all modules.
-                context = EvaluationContext.CreateMethodContext(
-                    previous,
+                var previous = appDomain.GetMetadataContext();
+                context = CreateMethodContext(
+                    appDomain,
                     methodBlocks,
                     symReader,
                     moduleVersionId,
@@ -605,7 +630,8 @@ IL_0005:  ret
                     ilOffset: ilOffset,
                     localSignatureToken: localSignatureToken,
                     MakeAssemblyReferencesKind.AllAssemblies);
-                Assert.Equal(previous.Compilation, context.Compilation); // re-use type context compilation
+                Assert.NotSame(GetMetadataContext(previous).EvaluationContext, context);
+                Assert.Same(GetMetadataContext(previous).Compilation, context.Compilation); // re-use type context compilation
                 testData = new CompilationTestData();
                 // A could be ambiguous, but the ambiguity is resolved in favor of the newer assembly.
                 testData = new CompilationTestData();
@@ -617,14 +643,16 @@ IL_0005:  ret
                 Assert.Null(error);
 
                 // Compile expression with method context with referenced modules only.
-                context = EvaluationContext.CreateMethodContext(
-                    methodBlocks.ToCompilationReferencedModulesOnly(moduleVersionId),
+                context = CreateMethodContext(
+                    appDomain,
+                    methodBlocks,
                     symReader,
                     moduleVersionId,
                     methodToken: methodToken,
                     methodVersion: 1,
                     ilOffset: ilOffset,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    MakeAssemblyReferencesKind.DirectReferencesOnly);
                 // A is unrecognized since there were no direct references to AS1 or AS2.
                 testData = new CompilationTestData();
                 context.CompileExpression("new A()", out error, testData);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -532,7 +532,8 @@ IL_0005:  ret
                     default(CSharpMetadataContext),
                     typeBlocks,
                     moduleVersionId,
-                    typeToken);
+                    typeToken,
+                    MakeAssemblyReferencesKind.AllAssemblies);
 
                 Assert.Equal(identityAS2, context.Compilation.GlobalNamespace.GetMembers("A").OfType<INamedTypeSymbol>().Single().ContainingAssembly.Identity);
                 Assert.Equal(identityBS2, context.Compilation.GlobalNamespace.GetMembers("B").OfType<INamedTypeSymbol>().Single().ContainingAssembly.Identity);
@@ -594,7 +595,8 @@ IL_0005:  ret
                     methodToken: methodToken,
                     methodVersion: 1,
                     ilOffset: ilOffset,
-                    localSignatureToken: localSignatureToken);
+                    localSignatureToken: localSignatureToken,
+                    MakeAssemblyReferencesKind.AllAssemblies);
                 Assert.Equal(previous.Compilation, context.Compilation); // re-use type context compilation
                 testData = new CompilationTestData();
                 // A could be ambiguous, but the ambiguity is resolved in favor of the newer assembly.

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     methodVersion: 1,
                     ilOffset: ilOffset,
                     localSignatureToken: localSignatureToken,
-                    useReferencedAssembliesOnly: true);
+                    kind: MakeAssemblyReferencesKind.AllReferences);
                 ResultProperties resultProperties;
                 string error;
                 ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     methodVersion: 1,
                     ilOffset: ilOffset,
                     localSignatureToken: localSignatureToken,
-                    useReferencedAssembliesOnly: true);
+                    kind: MakeAssemblyReferencesKind.AllReferences);
                 var testData = new CompilationTestData();
                 context.CompileExpression("new B2()", out error, testData);
                 var methodData = testData.GetMethodData("<>x.<>m0");
@@ -102,7 +102,7 @@ IL_0005:  ret
                     methodVersion: 1,
                     ilOffset: ilOffset,
                     localSignatureToken: localSignatureToken,
-                    useReferencedAssembliesOnly: true);
+                    kind: MakeAssemblyReferencesKind.AllReferences);
                 testData = new CompilationTestData();
                 context.CompileExpression("new B2()", out error, testData);
                 methodData = testData.GetMethodData("<>x.<>m0");

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -302,23 +302,34 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return (flags & desired) == desired;
         }
 
-        internal static TMetadataContext GetMetadataContext<TMetadataContext>(this DkmClrAppDomain appDomain)
-            where TMetadataContext : struct
+        internal static MetadataContext<TAssemblyContext> GetMetadataContext<TAssemblyContext>(this DkmClrAppDomain appDomain)
+            where TAssemblyContext : struct
         {
-            var dataItem = appDomain.GetDataItem<MetadataContextItem<TMetadataContext>>();
-            return (dataItem == null) ? default(TMetadataContext) : dataItem.MetadataContext;
+            var dataItem = appDomain.GetDataItem<MetadataContextItem<MetadataContext<TAssemblyContext>>>();
+            return (dataItem == null) ? default(MetadataContext<TAssemblyContext>) : dataItem.MetadataContext;
         }
 
-        internal static void SetMetadataContext<TMetadataContext>(this DkmClrAppDomain appDomain, TMetadataContext context)
-            where TMetadataContext : struct
+        internal static void SetMetadataContext<TAssemblyContext>(this DkmClrAppDomain appDomain, MetadataContext<TAssemblyContext> context, bool report)
+            where TAssemblyContext : struct
         {
-            appDomain.SetDataItem(DkmDataCreationDisposition.CreateAlways, new MetadataContextItem<TMetadataContext>(context));
+            if (report)
+            {
+                var process = appDomain.Process;
+                DkmUserMessage.Create(
+                    process.Connection,
+                    process,
+                    DkmUserMessageOutputKind.UnfilteredOutputWindowMessage,
+                    $"EE: AppDomain {appDomain.Id}, blocks {context.MetadataBlocks}, contexts {context.AssemblyContexts}",
+                    MessageBoxFlags.MB_OK,
+                    0);
+            }
+            appDomain.SetDataItem(DkmDataCreationDisposition.CreateAlways, new MetadataContextItem<MetadataContext<TAssemblyContext>>(context));
         }
 
-        internal static void RemoveMetadataContext<TMetadataContext>(this DkmClrAppDomain appDomain)
-            where TMetadataContext : struct
+        internal static void RemoveMetadataContext<TAssemblyContext>(this DkmClrAppDomain appDomain)
+            where TAssemblyContext : struct
         {
-            appDomain.RemoveDataItem<MetadataContextItem<TMetadataContext>>();
+            appDomain.RemoveDataItem<MetadataContextItem<TAssemblyContext>>();
         }
 
         private sealed class MetadataContextItem<TMetadataContext> : DkmDataItem

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -303,21 +303,33 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         }
 
         internal static TMetadataContext GetMetadataContext<TMetadataContext>(this DkmClrAppDomain appDomain)
-            where TMetadataContext : DkmDataItem
+            where TMetadataContext : struct
         {
-            return appDomain.GetDataItem<TMetadataContext>();
+            var dataItem = appDomain.GetDataItem<MetadataContextItem<TMetadataContext>>();
+            return (dataItem == null) ? default(TMetadataContext) : dataItem.MetadataContext;
         }
 
         internal static void SetMetadataContext<TMetadataContext>(this DkmClrAppDomain appDomain, TMetadataContext context)
-            where TMetadataContext : DkmDataItem
+            where TMetadataContext : struct
         {
-            appDomain.SetDataItem(DkmDataCreationDisposition.CreateAlways, context);
+            appDomain.SetDataItem(DkmDataCreationDisposition.CreateAlways, new MetadataContextItem<TMetadataContext>(context));
         }
 
         internal static void RemoveMetadataContext<TMetadataContext>(this DkmClrAppDomain appDomain)
-            where TMetadataContext : DkmDataItem
+            where TMetadataContext : struct
         {
-            appDomain.RemoveDataItem<TMetadataContext>();
+            appDomain.RemoveDataItem<MetadataContextItem<TMetadataContext>>();
+        }
+
+        private sealed class MetadataContextItem<TMetadataContext> : DkmDataItem
+            where TMetadataContext : struct
+        {
+            internal readonly TMetadataContext MetadataContext;
+
+            internal MetadataContextItem(TMetadataContext metadataContext)
+            {
+                this.MetadataContext = metadataContext;
+            }
         }
 
         private sealed class AppDomainLifetimeDataItem : DkmDataItem { }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -303,33 +303,21 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         }
 
         internal static TMetadataContext GetMetadataContext<TMetadataContext>(this DkmClrAppDomain appDomain)
-            where TMetadataContext : struct
+            where TMetadataContext : DkmDataItem
         {
-            var dataItem = appDomain.GetDataItem<MetadataContextItem<TMetadataContext>>();
-            return (dataItem == null) ? default(TMetadataContext) : dataItem.MetadataContext;
+            return appDomain.GetDataItem<TMetadataContext>();
         }
 
         internal static void SetMetadataContext<TMetadataContext>(this DkmClrAppDomain appDomain, TMetadataContext context)
-            where TMetadataContext : struct
+            where TMetadataContext : DkmDataItem
         {
-            appDomain.SetDataItem(DkmDataCreationDisposition.CreateAlways, new MetadataContextItem<TMetadataContext>(context));
+            appDomain.SetDataItem(DkmDataCreationDisposition.CreateAlways, context);
         }
 
         internal static void RemoveMetadataContext<TMetadataContext>(this DkmClrAppDomain appDomain)
-            where TMetadataContext : struct
+            where TMetadataContext : DkmDataItem
         {
-            appDomain.RemoveDataItem<MetadataContextItem<TMetadataContext>>();
-        }
-
-        private sealed class MetadataContextItem<TMetadataContext> : DkmDataItem
-            where TMetadataContext : struct
-        {
-            internal readonly TMetadataContext MetadataContext;
-
-            internal MetadataContextItem(TMetadataContext metadataContext)
-            {
-                this.MetadataContext = metadataContext;
-            }
+            appDomain.RemoveDataItem<TMetadataContext>();
         }
 
         private sealed class AppDomainLifetimeDataItem : DkmDataItem { }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -315,13 +315,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             if (report)
             {
                 var process = appDomain.Process;
-                DkmUserMessage.Create(
+                var message = DkmUserMessage.Create(
                     process.Connection,
                     process,
                     DkmUserMessageOutputKind.UnfilteredOutputWindowMessage,
-                    $"EE: AppDomain {appDomain.Id}, blocks {context.MetadataBlocks}, contexts {context.AssemblyContexts}",
+                    $"EE: AppDomain {appDomain.Id}, blocks {context.MetadataBlocks.Length}, contexts {context.AssemblyContexts.Count}" + Environment.NewLine,
                     MessageBoxFlags.MB_OK,
                     0);
+                message.Post();
             }
             appDomain.SetDataItem(DkmDataCreationDisposition.CreateAlways, new MetadataContextItem<MetadataContext<TAssemblyContext>>(context));
         }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EEMetadataReferenceResolver.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EEMetadataReferenceResolver.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal sealed class EEMetadataReferenceResolver : MetadataReferenceResolver
+    {
+        private readonly Dictionary<AssemblyIdentity, MetadataReference> _referencesByIdentity;
+
+#if DEBUG
+        internal readonly Dictionary<AssemblyIdentity, int> Requests = new Dictionary<AssemblyIdentity, int>();
+#endif
+
+        internal EEMetadataReferenceResolver(Dictionary<AssemblyIdentity, MetadataReference> referencesByIdentity)
+        {
+            _referencesByIdentity = referencesByIdentity;
+        }
+
+        public override bool ResolveMissingAssemblies => true;
+
+        public override PortableExecutableReference ResolveMissingAssembly(MetadataReference definition, AssemblyIdentity referenceIdentity)
+        {
+#if DEBUG
+            int n;
+            Requests.TryGetValue(referenceIdentity, out n);
+            Requests[referenceIdentity] = n + 1;
+#endif
+            MetadataReference reference;
+            _referencesByIdentity.TryGetValue(referenceIdentity, out reference);
+            return (PortableExecutableReference)reference;
+        }
+
+        public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        public override bool Equals(object other)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        public override int GetHashCode()
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EvaluationContextBase.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EvaluationContextBase.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         // ILOffset == 0xffffffff indicates an instruction outside of IL.
         // Treat such values as the beginning of the IL.
-        protected static int NormalizeILOffset(uint ilOffset)
+        internal static int NormalizeILOffset(uint ilOffset)
         {
             return (ilOffset == uint.MaxValue) ? 0 : (int)ilOffset;
         }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -397,6 +397,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     // If that doesn't work, we'll fall back to System.Core for subsequent retries.
                     linqLibrary = EvaluationContextBase.SystemCoreIdentity;
 
+                    // Can we remove the `useReferencedModulesOnly` attempt if we're only using
+                    // modules reachable from the current module? In short, can we avoid retrying?
                     if (useReferencedModulesOnly)
                     {
                         Debug.Assert(missingAssemblyIdentities.IsEmpty);

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         // See https://github.com/dotnet/roslyn/issues/22620
         private readonly IDkmLanguageFrameDecoder _languageFrameDecoder;
         private readonly IDkmLanguageInstructionDecoder _languageInstructionDecoder;
+        private readonly bool _useReferencedAssembliesOnly;
 
         static ExpressionCompiler()
         {
@@ -40,6 +41,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         {
             _languageFrameDecoder = languageFrameDecoder;
             _languageInstructionDecoder = languageInstructionDecoder;
+            _useReferencedAssembliesOnly = GetUseReferencedAssembliesOnlySetting();
         }
 
         DkmCompiledClrLocalsQuery IDkmClrExpressionCompiler.GetClrLocalVariableQuery(
@@ -218,6 +220,20 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 throw ExceptionUtilities.Unreachable;
             }
+        }
+
+        internal static bool GetUseReferencedAssembliesOnlySetting()
+        {
+            return RegistryHelpers.GetBoolRegistryValue("UseReferencedAssembliesOnly");
+        }
+
+        internal MakeAssemblyReferencesKind GetMakeAssemblyReferencesKind(bool useReferencedModulesOnly)
+        {
+            if (useReferencedModulesOnly)
+            {
+                return MakeAssemblyReferencesKind.DirectReferencesOnly;
+            }
+            return _useReferencedAssembliesOnly ? MakeAssemblyReferencesKind.AllReferences : MakeAssemblyReferencesKind.AllAssemblies;
         }
 
         /// <remarks>

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
@@ -12,13 +12,11 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
-    internal static class ExpressionEvaluatorFatalError
+    internal static class RegistryHelpers
     {
         private const string RegistryKey = @"Software\Microsoft\ExpressionEvaluator";
-        private const string RegistryValue = "EnableFailFast";
-        internal static bool IsFailFastEnabled;
 
-        static ExpressionEvaluatorFatalError()
+        internal static object GetRegistryValue(string name)
         {
             try
             {
@@ -38,11 +36,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                                 if (eeKey != null)
                                 {
                                     var getValueMethod = eeKey.GetType().GetTypeInfo().GetDeclaredMethod("GetValue", new Type[] { typeof(string) });
-                                    var value = getValueMethod.Invoke(eeKey, new object[] { RegistryValue });
-                                    if ((value != null) && (value is int))
-                                    {
-                                        IsFailFastEnabled = ((int)value == 1);
-                                    }
+                                    return getValueMethod.Invoke(eeKey, new object[] { name });
                                 }
                             }
                         }
@@ -53,7 +47,24 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 Debug.Assert(false, "Failure checking registry key: " + ex.ToString());
             }
+            return null;
         }
+
+        internal static bool GetBoolRegistryValue(string name)
+        {
+            var value = RegistryHelpers.GetRegistryValue(name);
+            if ((value != null) && (value is int))
+            {
+                return (int)value == 1;
+            }
+            return false;
+        }
+    }
+
+    internal static class ExpressionEvaluatorFatalError
+    {
+        private const string RegistryValue = "EnableFailFast";
+        internal static bool IsFailFastEnabled = RegistryHelpers.GetBoolRegistryValue(RegistryValue);
 
         internal static bool CrashIfFailFastEnabled(Exception exception)
         {

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
@@ -53,11 +53,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal static bool GetBoolRegistryValue(string name)
         {
             var value = RegistryHelpers.GetRegistryValue(name);
-            if ((value != null) && (value is int))
-            {
-                return (int)value == 1;
-            }
-            return false;
+            return value is int i && i == 1;
         }
     }
 

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal InstructionDecoder()
         {
+            // Should be passed by the ExpressionCompiler as an argument to this constructor.
             _useReferencedAssembliesOnly = ExpressionCompiler.GetUseReferencedAssembliesOnlySetting();
         }
 

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/InstructionDecoder.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Text;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.Debugger.Clr;
 
@@ -21,6 +19,18 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
             memberOptions: SymbolDisplayMemberOptions.IncludeContainingType | SymbolDisplayMemberOptions.IncludeExplicitInterface,
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+        private readonly bool _useReferencedAssembliesOnly;
+
+        internal InstructionDecoder()
+        {
+            _useReferencedAssembliesOnly = ExpressionCompiler.GetUseReferencedAssembliesOnlySetting();
+        }
+
+        internal MakeAssemblyReferencesKind GetMakeAssemblyReferencesKind()
+        {
+            return _useReferencedAssembliesOnly ? MakeAssemblyReferencesKind.AllReferences : MakeAssemblyReferencesKind.AllAssemblies;
+        }
 
         internal abstract void AppendFullName(StringBuilder builder, TMethodSymbol method);
 

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MakeAssemblyReferencesKind.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MakeAssemblyReferencesKind.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal enum MakeAssemblyReferencesKind
+    {
+        AllAssemblies,
+        AllReferences,
+        DirectReferencesOnly,
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
@@ -1,54 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
-    // Wrapper around Guid to ensure callers have asked for the correct id
-    // rather than simply using the ModuleVersionId (which is unnecessary
-    // when the Compilation references all loaded assemblies).
-    internal struct MetadataContextId : IEquatable<MetadataContextId>
-    {
-        internal readonly Guid ModuleVersionId;
-
-        internal MetadataContextId(Guid moduleVersionId)
-        {
-            ModuleVersionId = moduleVersionId;
-        }
-
-        public bool Equals(MetadataContextId other)
-        {
-            return ModuleVersionId.Equals(other.ModuleVersionId);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is MetadataContextId && this.Equals((MetadataContextId)obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return ModuleVersionId.GetHashCode();
-        }
-
-        internal static MetadataContextId GetContextId(Guid moduleVersionId, MakeAssemblyReferencesKind kind)
-        {
-            switch (kind)
-            {
-                case MakeAssemblyReferencesKind.AllAssemblies:
-                    return default;
-                case MakeAssemblyReferencesKind.AllReferences:
-                    return new MetadataContextId(moduleVersionId);
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(kind);
-            }
-        }
-    }
-
-    internal struct MetadataContext<TAssemblyContext>
+    internal readonly struct MetadataContext<TAssemblyContext>
         where TAssemblyContext : struct
     {
         internal readonly ImmutableArray<MetadataBlock> MetadataBlocks;

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
@@ -4,48 +4,29 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.VisualStudio.Debugger;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
-    internal abstract class MetadataContext<TCompilation, TEvaluationContext>
-        where TCompilation : Compilation
-        where TEvaluationContext : EvaluationContextBase
-    {
-        internal readonly TCompilation Compilation;
-        internal readonly TEvaluationContext EvaluationContext;
-
-        internal MetadataContext(TCompilation compilation, TEvaluationContext evaluationContext)
-        {
-            this.Compilation = compilation;
-            this.EvaluationContext = evaluationContext;
-        }
-    }
-
-    internal sealed class AppDomainMetadataContext<TCompilation, TEvaluationContext> : DkmDataItem
-        where TCompilation : Compilation
-        where TEvaluationContext : EvaluationContextBase
+    internal struct MetadataContext<TAssemblyContext>
+        where TAssemblyContext : struct
     {
         internal readonly ImmutableArray<MetadataBlock> MetadataBlocks;
         internal readonly Guid ModuleVersionId;
-        internal readonly MetadataContext<TCompilation, TEvaluationContext> AssemblyContext;
+        internal readonly TAssemblyContext AssemblyContext;
 
-        internal AppDomainMetadataContext(ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId, MetadataContext<TCompilation, TEvaluationContext> assemblyContext)
+        internal MetadataContext(ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId, TAssemblyContext assemblyContext)
         {
             Debug.Assert(moduleVersionId != default);
             this.MetadataBlocks = metadataBlocks;
             this.ModuleVersionId = moduleVersionId;
             this.AssemblyContext = assemblyContext;
         }
-    }
 
-    internal static class MetadataContextExtensions
-    {
-        internal static bool Matches<TCompilation, TEvaluationContext>(this AppDomainMetadataContext<TCompilation, TEvaluationContext> previousOpt, ImmutableArray<MetadataBlock> metadataBlocks)
-            where TCompilation : Compilation
-            where TEvaluationContext : EvaluationContextBase
+        internal bool Matches(ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId)
         {
-            return previousOpt != null && previousOpt.MetadataBlocks.SequenceEqual(metadataBlocks);
+            return !this.MetadataBlocks.IsDefault &&
+                this.ModuleVersionId == moduleVersionId &&
+                this.MetadataBlocks.SequenceEqual(metadataBlocks);
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
@@ -2,30 +2,67 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
+    // Wrapper around Guid to ensure callers have asked for the correct id
+    // rather than simply using the ModuleVersionId (which is unnecessary
+    // when the Compilation references all loaded assemblies).
+    internal struct MetadataContextId : IEquatable<MetadataContextId>
+    {
+        private readonly Guid _moduleVersionId;
+
+        internal MetadataContextId(Guid moduleVersionId)
+        {
+            _moduleVersionId = moduleVersionId;
+        }
+
+        public bool Equals(MetadataContextId other)
+        {
+            return _moduleVersionId.Equals(other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MetadataContextId && this.Equals((MetadataContextId)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return _moduleVersionId.GetHashCode();
+        }
+
+        internal static MetadataContextId GetContextId(Guid moduleVersionId, MakeAssemblyReferencesKind kind)
+        {
+            switch (kind)
+            {
+                case MakeAssemblyReferencesKind.AllAssemblies:
+                    return default;
+                case MakeAssemblyReferencesKind.AllReferences:
+                    return new MetadataContextId(moduleVersionId);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(kind);
+            }
+        }
+    }
+
     internal struct MetadataContext<TAssemblyContext>
         where TAssemblyContext : struct
     {
         internal readonly ImmutableArray<MetadataBlock> MetadataBlocks;
-        internal readonly Guid ModuleVersionId;
-        internal readonly TAssemblyContext AssemblyContext;
+        internal readonly ImmutableDictionary<MetadataContextId, TAssemblyContext> AssemblyContexts;
 
-        internal MetadataContext(ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId, TAssemblyContext assemblyContext)
+        internal MetadataContext(ImmutableArray<MetadataBlock> metadataBlocks, ImmutableDictionary<MetadataContextId, TAssemblyContext> assemblyContexts)
         {
-            Debug.Assert(moduleVersionId != default);
             this.MetadataBlocks = metadataBlocks;
-            this.ModuleVersionId = moduleVersionId;
-            this.AssemblyContext = assemblyContext;
+            this.AssemblyContexts = assemblyContexts;
         }
 
-        internal bool Matches(ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId)
+        internal bool Matches(ImmutableArray<MetadataBlock> metadataBlocks)
         {
             return !this.MetadataBlocks.IsDefault &&
-                this.ModuleVersionId == moduleVersionId &&
                 this.MetadataBlocks.SequenceEqual(metadataBlocks);
         }
     }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         public bool Equals(MetadataContextId other)
         {
-            return _moduleVersionId.Equals(other);
+            return _moduleVersionId.Equals(other._moduleVersionId);
         }
 
         public override bool Equals(object obj)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.VisualStudio.Debugger;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal abstract class MetadataContext<TCompilation, TEvaluationContext>
+        where TCompilation : Compilation
+        where TEvaluationContext : EvaluationContextBase
+    {
+        internal readonly TCompilation Compilation;
+        internal readonly TEvaluationContext EvaluationContext;
+
+        internal MetadataContext(TCompilation compilation, TEvaluationContext evaluationContext)
+        {
+            this.Compilation = compilation;
+            this.EvaluationContext = evaluationContext;
+        }
+    }
+
+    internal sealed class AppDomainMetadataContext<TCompilation, TEvaluationContext> : DkmDataItem
+        where TCompilation : Compilation
+        where TEvaluationContext : EvaluationContextBase
+    {
+        internal readonly ImmutableArray<MetadataBlock> MetadataBlocks;
+        internal readonly Guid ModuleVersionId;
+        internal readonly MetadataContext<TCompilation, TEvaluationContext> AssemblyContext;
+
+        internal AppDomainMetadataContext(ImmutableArray<MetadataBlock> metadataBlocks, Guid moduleVersionId, MetadataContext<TCompilation, TEvaluationContext> assemblyContext)
+        {
+            Debug.Assert(moduleVersionId != default);
+            this.MetadataBlocks = metadataBlocks;
+            this.ModuleVersionId = moduleVersionId;
+            this.AssemblyContext = assemblyContext;
+        }
+    }
+
+    internal static class MetadataContextExtensions
+    {
+        internal static bool Matches<TCompilation, TEvaluationContext>(this AppDomainMetadataContext<TCompilation, TEvaluationContext> previousOpt, ImmutableArray<MetadataBlock> metadataBlocks)
+            where TCompilation : Compilation
+            where TEvaluationContext : EvaluationContextBase
+        {
+            return previousOpt != null && previousOpt.MetadataBlocks.SequenceEqual(metadataBlocks);
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContext.cs
@@ -12,16 +12,16 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     // when the Compilation references all loaded assemblies).
     internal struct MetadataContextId : IEquatable<MetadataContextId>
     {
-        private readonly Guid _moduleVersionId;
+        internal readonly Guid ModuleVersionId;
 
         internal MetadataContextId(Guid moduleVersionId)
         {
-            _moduleVersionId = moduleVersionId;
+            ModuleVersionId = moduleVersionId;
         }
 
         public bool Equals(MetadataContextId other)
         {
-            return _moduleVersionId.Equals(other._moduleVersionId);
+            return ModuleVersionId.Equals(other.ModuleVersionId);
         }
 
         public override bool Equals(object obj)
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         public override int GetHashCode()
         {
-            return _moduleVersionId.GetHashCode();
+            return ModuleVersionId.GetHashCode();
         }
 
         internal static MetadataContextId GetContextId(Guid moduleVersionId, MakeAssemblyReferencesKind kind)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContextId.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataContextId.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    // Wrapper around Guid to ensure callers have asked for the correct id
+    // rather than simply using the ModuleVersionId (which is unnecessary
+    // when the Compilation references all loaded assemblies).
+    internal readonly struct MetadataContextId : IEquatable<MetadataContextId>
+    {
+        internal readonly Guid ModuleVersionId;
+
+        internal MetadataContextId(Guid moduleVersionId)
+        {
+            ModuleVersionId = moduleVersionId;
+        }
+
+        public bool Equals(MetadataContextId other)
+        {
+            return ModuleVersionId.Equals(other.ModuleVersionId);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MetadataContextId && this.Equals((MetadataContextId)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return ModuleVersionId.GetHashCode();
+        }
+
+        internal static MetadataContextId GetContextId(Guid moduleVersionId, MakeAssemblyReferencesKind kind)
+        {
+            switch (kind)
+            {
+                case MakeAssemblyReferencesKind.AllAssemblies:
+                    return default;
+                case MakeAssemblyReferencesKind.AllReferences:
+                    return new MetadataContextId(moduleVersionId);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(kind);
+            }
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             out Dictionary<string, ImmutableArray<(AssemblyIdentity, MetadataReference)>> referencesByIdentity)
         {
             Debug.Assert(kind == MakeAssemblyReferencesKind.AllAssemblies || moduleVersionId != default(Guid));
-            Debug.Assert(kind == MakeAssemblyReferencesKind.AllAssemblies || identityComparer != null);
+            Debug.Assert(moduleVersionId == default(Guid) || identityComparer != null);
 
             // Get metadata for each module.
             var metadataBuilder = ArrayBuilder<ModuleMetadata>.GetInstance();

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 Debug.Assert(referencesBuilder.Count == 0);
                 // CommonReferenceManager<TCompilation, TAssemblySymbol>.Bind()
-                // expects COR library to be included in the explicit assemblies (see bug #...).
+                // expects COR library to be included in the explicit assemblies.
                 Debug.Assert(corLibrary != null);
                 if (corLibrary != null && referencesByIdentity.TryGetValue(corLibrary.Name, out var corLibraryReferences))
                 {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -18,7 +18,6 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using Microsoft.Cci;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -551,6 +550,36 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             }
 
             Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, expectedGeneric ? Cci.CallingConvention.Generic : Cci.CallingConvention.Default);
+        }
+
+        internal static void VerifyResolutionRequests(EEMetadataReferenceResolver resolver, (AssemblyIdentity, AssemblyIdentity, int)[] expectedRequests)
+        {
+#if DEBUG
+            var expected = ArrayBuilder<(AssemblyIdentity, AssemblyIdentity, int)>.GetInstance();
+            var actual = ArrayBuilder<(AssemblyIdentity, AssemblyIdentity, int)>.GetInstance();
+            expected.AddRange(expectedRequests);
+            sort(expected);
+            actual.AddRange(resolver.Requests.Select(pair => (pair.Key, pair.Value.Identity, pair.Value.Count)));
+            sort(actual);
+            AssertEx.Equal(expected, actual);
+            actual.Free();
+            expected.Free();
+
+            void sort(ArrayBuilder<(AssemblyIdentity, AssemblyIdentity, int)> builder)
+            {
+                builder.Sort((x, y) => AssemblyIdentityComparer.SimpleNameComparer.Compare(x.Item1.GetDisplayName(), y.Item1.GetDisplayName()));
+            }
+#endif
+        }
+
+        internal static void VerifyAppDomainMetadataContext<TAssemblyContext>(MetadataContext<TAssemblyContext> metadataContext, Guid[] moduleVersionIds)
+            where TAssemblyContext : struct
+        {
+            var actualIds = metadataContext.AssemblyContexts.Keys.Select(key => key.ModuleVersionId.ToString()).ToArray();
+            Array.Sort(actualIds);
+            var expectedIds = moduleVersionIds.Select(mvid => mvid.ToString()).ToArray();
+            Array.Sort(expectedIds);
+            AssertEx.Equal(expectedIds, actualIds);
         }
 
         internal static ISymUnmanagedReader ConstructSymReaderWithImports(ImmutableArray<byte> peImage, string methodName, params string[] importStrings)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
@@ -87,12 +87,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         <Extension>
         Friend Function ToCompilation(metadataBlocks As ImmutableArray(Of MetadataBlock), moduleVersionId As Guid, kind As MakeAssemblyReferencesKind) As VisualBasicCompilation
-            Dim referencesByIdentity As Dictionary(Of String, ImmutableArray(Of (AssemblyIdentity, MetadataReference))) = Nothing
-            Dim references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer, kind, referencesByIdentity)
+            Dim referencesBySimpleName As IReadOnlyDictionary(Of String, ImmutableArray(Of (AssemblyIdentity, MetadataReference))) = Nothing
+            Dim references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer, kind, referencesBySimpleName)
             Dim options = s_compilationOptions
-            If referencesByIdentity IsNot Nothing Then
+            If referencesBySimpleName IsNot Nothing Then
                 Debug.Assert(kind = MakeAssemblyReferencesKind.AllReferences)
-                Dim resolver = New EEMetadataReferenceResolver(IdentityComparer, referencesByIdentity)
+                Dim resolver = New EEMetadataReferenceResolver(IdentityComparer, referencesBySimpleName)
                 options = options.WithMetadataReferenceResolver(resolver)
             End If
             Return VisualBasicCompilation.Create(

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
@@ -87,7 +87,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         <Extension>
         Friend Function ToCompilation(metadataBlocks As ImmutableArray(Of MetadataBlock), moduleVersionId As Guid, kind As MakeAssemblyReferencesKind) As VisualBasicCompilation
-            Dim referencesByIdentity As Dictionary(Of AssemblyIdentity, MetadataReference) = Nothing
+            Dim referencesByIdentity As Dictionary(Of String, ImmutableArray(Of (AssemblyIdentity, MetadataReference))) = Nothing
             Dim references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer, kind, referencesByIdentity)
             Dim options = s_compilationOptions
             If referencesByIdentity IsNot Nothing Then

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim options = s_compilationOptions
             If referencesByIdentity IsNot Nothing Then
                 Debug.Assert(kind = MakeAssemblyReferencesKind.AllReferences)
-                Dim resolver = New EEMetadataReferenceResolver(referencesByIdentity)
+                Dim resolver = New EEMetadataReferenceResolver(IdentityComparer, referencesByIdentity)
                 options = options.WithMetadataReferenceResolver(resolver)
             End If
             Return VisualBasicCompilation.Create(

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
@@ -77,22 +77,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         <Extension>
         Friend Function ToCompilation(metadataBlocks As ImmutableArray(Of MetadataBlock)) As VisualBasicCompilation
-            Dim references = metadataBlocks.MakeAssemblyReferences(moduleVersionId:=Nothing, identityComparer:=Nothing)
-            Return references.ToCompilation()
+            Return ToCompilation(metadataBlocks, moduleVersionId:=Nothing, MakeAssemblyReferencesKind.AllAssemblies)
         End Function
 
         <Extension>
         Friend Function ToCompilationReferencedModulesOnly(metadataBlocks As ImmutableArray(Of MetadataBlock), moduleVersionId As Guid) As VisualBasicCompilation
-            Dim references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer)
-            Return references.ToCompilation()
+            Return ToCompilation(metadataBlocks, moduleVersionId, MakeAssemblyReferencesKind.DirectReferencesOnly)
         End Function
 
         <Extension>
-        Friend Function ToCompilation(references As ImmutableArray(Of MetadataReference)) As VisualBasicCompilation
+        Friend Function ToCompilation(metadataBlocks As ImmutableArray(Of MetadataBlock), moduleVersionId As Guid, kind As MakeAssemblyReferencesKind) As VisualBasicCompilation
+            Dim referencesByIdentity As Dictionary(Of AssemblyIdentity, MetadataReference) = Nothing
+            Dim references = metadataBlocks.MakeAssemblyReferences(moduleVersionId, IdentityComparer, kind, referencesByIdentity)
+            Dim options = s_compilationOptions
+            If referencesByIdentity IsNot Nothing Then
+                Debug.Assert(kind = MakeAssemblyReferencesKind.AllReferences)
+                Dim resolver = New EEMetadataReferenceResolver(referencesByIdentity)
+                options = options.WithMetadataReferenceResolver(resolver)
+            End If
             Return VisualBasicCompilation.Create(
                 assemblyName:=ExpressionCompilerUtilities.GenerateUniqueName(),
                 references:=references,
-                options:=s_compilationOptions)
+                options:=options)
         End Function
 
         <Extension>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -71,15 +71,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' No locals since locals are associated with methods, not types.
         ''' </remarks>
         Friend Shared Function CreateTypeContext(
-            previous As MetadataContext(Of VisualBasicCompilation, EvaluationContext),
+            previous As VisualBasicMetadataContext,
             metadataBlocks As ImmutableArray(Of MetadataBlock),
             moduleVersionId As Guid,
             typeToken As Integer,
             kind As MakeAssemblyReferencesKind) As EvaluationContext
 
             ' Re-use the previous compilation if possible.
-            Dim compilation = If(previous IsNot Nothing,
-                previous.Compilation,
+            Dim compilation = If(previous.Compilation,
                 metadataBlocks.ToCompilation(moduleVersionId, kind))
 
             Return CreateTypeContext(compilation, moduleVersionId, typeToken)
@@ -119,7 +118,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' <param name="localSignatureToken">Method local signature token.</param>
         ''' <returns>Evaluation context.</returns>
         Friend Shared Function CreateMethodContext(
-            previous As MetadataContext(Of VisualBasicCompilation, EvaluationContext),
+            previous As VisualBasicMetadataContext,
             metadataBlocks As ImmutableArray(Of MetadataBlock),
             lazyAssemblyReaders As Lazy(Of ImmutableArray(Of AssemblyReaders)),
             symReader As Object,
@@ -133,8 +132,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim offset = NormalizeILOffset(ilOffset)
 
             ' Re-use the previous compilation if possible.
-            Dim compilation As VisualBasicCompilation
-            If previous IsNot Nothing Then
+            Dim compilation = previous.Compilation
+            If compilation IsNot Nothing Then
                 ' Re-use entire context if method scope has not changed.
                 Dim previousContext = previous.EvaluationContext
                 If previousContext IsNot Nothing AndAlso
@@ -142,7 +141,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     previousContext.MethodContextReuseConstraints.GetValueOrDefault().AreSatisfied(moduleVersionId, methodToken, methodVersion, offset) Then
                     Return previousContext
                 End If
-                compilation = previous.Compilation
             Else
                 compilation = metadataBlocks.ToCompilation(moduleVersionId, kind)
             End If

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -71,15 +71,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' No locals since locals are associated with methods, not types.
         ''' </remarks>
         Friend Shared Function CreateTypeContext(
-            previous As VisualBasicMetadataContext,
+            previous As MetadataContext(Of VisualBasicCompilation, EvaluationContext),
             metadataBlocks As ImmutableArray(Of MetadataBlock),
             moduleVersionId As Guid,
-            typeToken As Integer) As EvaluationContext
+            typeToken As Integer,
+            Optional useReferencedAssembliesOnly As Boolean = False) As EvaluationContext
 
             ' Re-use the previous compilation if possible.
-            Dim compilation = If(previous.Matches(metadataBlocks),
+            Dim compilation = If(previous IsNot Nothing,
                 previous.Compilation,
-                metadataBlocks.ToCompilation())
+                metadataBlocks.ToCompilation(moduleVersionId, If(useReferencedAssembliesOnly, MakeAssemblyReferencesKind.AllReferences, MakeAssemblyReferencesKind.AllAssemblies)))
 
             Return CreateTypeContext(compilation, moduleVersionId, typeToken)
         End Function
@@ -118,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' <param name="localSignatureToken">Method local signature token.</param>
         ''' <returns>Evaluation context.</returns>
         Friend Shared Function CreateMethodContext(
-            previous As VisualBasicMetadataContext,
+            previous As MetadataContext(Of VisualBasicCompilation, EvaluationContext),
             metadataBlocks As ImmutableArray(Of MetadataBlock),
             lazyAssemblyReaders As Lazy(Of ImmutableArray(Of AssemblyReaders)),
             symReader As Object,
@@ -126,13 +127,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             methodToken As Integer,
             methodVersion As Integer,
             ilOffset As UInteger,
-            localSignatureToken As Integer) As EvaluationContext
+            localSignatureToken As Integer,
+            Optional useReferencedAssembliesOnly As Boolean = False) As EvaluationContext
 
             Dim offset = NormalizeILOffset(ilOffset)
 
             ' Re-use the previous compilation if possible.
             Dim compilation As VisualBasicCompilation
-            If previous.Matches(metadataBlocks) Then
+            If previous IsNot Nothing Then
                 ' Re-use entire context if method scope has not changed.
                 Dim previousContext = previous.EvaluationContext
                 If previousContext IsNot Nothing AndAlso
@@ -142,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 End If
                 compilation = previous.Compilation
             Else
-                compilation = metadataBlocks.ToCompilation()
+                compilation = metadataBlocks.ToCompilation(moduleVersionId, If(useReferencedAssembliesOnly, MakeAssemblyReferencesKind.AllReferences, MakeAssemblyReferencesKind.AllAssemblies))
             End If
 
             Return CreateMethodContext(

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -62,28 +62,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' <summary>
         ''' Create a context for evaluating expressions at a type scope.
         ''' </summary>
-        ''' <param name="previous">Previous context, if any, for possible re-use.</param>
-        ''' <param name="metadataBlocks">Module metadata.</param>
+        ''' <param name="compilation">Compilation.</param>
         ''' <param name="moduleVersionId">Module containing type.</param>
         ''' <param name="typeToken">Type metadata token.</param>
         ''' <returns>Evaluation context.</returns>
         ''' <remarks>
         ''' No locals since locals are associated with methods, not types.
         ''' </remarks>
-        Friend Shared Function CreateTypeContext(
-            previous As VisualBasicMetadataContext,
-            metadataBlocks As ImmutableArray(Of MetadataBlock),
-            moduleVersionId As Guid,
-            typeToken As Integer,
-            kind As MakeAssemblyReferencesKind) As EvaluationContext
-
-            ' Re-use the previous compilation if possible.
-            Dim compilation = If(previous.Compilation,
-                metadataBlocks.ToCompilation(moduleVersionId, kind))
-
-            Return CreateTypeContext(compilation, moduleVersionId, typeToken)
-        End Function
-
         Friend Shared Function CreateTypeContext(
             compilation As VisualBasicCompilation,
             moduleVersionId As Guid,
@@ -108,8 +93,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' <summary>
         ''' Create a context for evaluating expressions within a method scope.
         ''' </summary>
-        ''' <param name="previous">Previous context, if any, for possible re-use.</param>
-        ''' <param name="metadataBlocks">Module metadata.</param>
+        ''' <param name="compilation">Compilation.</param>
         ''' <param name="symReader"><see cref="ISymUnmanagedReader"/> for PDB associated with <paramref name="moduleVersionId"/>.</param>
         ''' <param name="moduleVersionId">Module containing method.</param>
         ''' <param name="methodToken">Method metadata token.</param>
@@ -118,66 +102,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' <param name="localSignatureToken">Method local signature token.</param>
         ''' <returns>Evaluation context.</returns>
         Friend Shared Function CreateMethodContext(
-            previous As VisualBasicMetadataContext,
-            metadataBlocks As ImmutableArray(Of MetadataBlock),
-            lazyAssemblyReaders As Lazy(Of ImmutableArray(Of AssemblyReaders)),
-            symReader As Object,
-            moduleVersionId As Guid,
-            methodToken As Integer,
-            methodVersion As Integer,
-            ilOffset As UInteger,
-            localSignatureToken As Integer,
-            kind As MakeAssemblyReferencesKind) As EvaluationContext
-
-            Dim offset = NormalizeILOffset(ilOffset)
-
-            ' Re-use the previous compilation if possible.
-            Dim compilation = previous.Compilation
-            If compilation IsNot Nothing Then
-                ' Re-use entire context if method scope has not changed.
-                Dim previousContext = previous.EvaluationContext
-                If previousContext IsNot Nothing AndAlso
-                    previousContext.MethodContextReuseConstraints.HasValue AndAlso
-                    previousContext.MethodContextReuseConstraints.GetValueOrDefault().AreSatisfied(moduleVersionId, methodToken, methodVersion, offset) Then
-                    Return previousContext
-                End If
-            Else
-                compilation = metadataBlocks.ToCompilation(moduleVersionId, kind)
-            End If
-
-            Return CreateMethodContext(
-                compilation,
-                lazyAssemblyReaders,
-                symReader,
-                moduleVersionId,
-                methodToken,
-                methodVersion,
-                offset,
-                localSignatureToken)
-        End Function
-
-        Friend Shared Function CreateMethodContext(
-            compilation As VisualBasicCompilation,
-            lazyAssemblyReaders As Lazy(Of ImmutableArray(Of AssemblyReaders)),
-            symReader As Object,
-            moduleVersionId As Guid,
-            methodToken As Integer,
-            methodVersion As Integer,
-            ilOffset As UInteger,
-            localSignatureToken As Integer) As EvaluationContext
-
-            Return CreateMethodContext(
-                compilation,
-                lazyAssemblyReaders,
-                symReader,
-                moduleVersionId,
-                methodToken,
-                methodVersion,
-                NormalizeILOffset(ilOffset),
-                localSignatureToken)
-        End Function
-
-        Private Shared Function CreateMethodContext(
             compilation As VisualBasicCompilation,
             lazyAssemblyReaders As Lazy(Of ImmutableArray(Of AssemblyReaders)),
             symReader As Object,

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -75,7 +75,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             metadataBlocks As ImmutableArray(Of MetadataBlock),
             moduleVersionId As Guid,
             typeToken As Integer,
-            Optional kind As MakeAssemblyReferencesKind = MakeAssemblyReferencesKind.AllAssemblies) As EvaluationContext
+            kind As MakeAssemblyReferencesKind) As EvaluationContext
 
             ' Re-use the previous compilation if possible.
             Dim compilation = If(previous IsNot Nothing,
@@ -128,7 +128,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             methodVersion As Integer,
             ilOffset As UInteger,
             localSignatureToken As Integer,
-            Optional kind As MakeAssemblyReferencesKind = MakeAssemblyReferencesKind.AllAssemblies) As EvaluationContext
+            kind As MakeAssemblyReferencesKind) As EvaluationContext
 
             Dim offset = NormalizeILOffset(ilOffset)
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -93,6 +93,44 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' <summary>
         ''' Create a context for evaluating expressions within a method scope.
         ''' </summary>
+        ''' <param name="previous">Previous context, if any, for possible re-use.</param>
+        ''' <param name="metadataBlocks">Module metadata.</param>
+        ''' <param name="symReader"><see cref="ISymUnmanagedReader"/> for PDB associated with <paramref name="moduleVersionId"/>.</param>
+        ''' <param name="moduleVersionId">Module containing method.</param>
+        ''' <param name="methodToken">Method metadata token.</param>
+        ''' <param name="methodVersion">Method version.</param>
+        ''' <param name="ilOffset">IL offset of instruction pointer in method.</param>
+        ''' <param name="localSignatureToken">Method local signature token.</param>
+        ''' <returns>Evaluation context.</returns>
+        Friend Shared Function CreateMethodContext(
+            previous As VisualBasicMetadataContext,
+            metadataBlocks As ImmutableArray(Of MetadataBlock),
+            lazyAssemblyReaders As Lazy(Of ImmutableArray(Of AssemblyReaders)),
+            symReader As Object,
+            moduleVersionId As Guid,
+            methodToken As Integer,
+            methodVersion As Integer,
+            ilOffset As UInteger,
+            localSignatureToken As Integer) As EvaluationContext
+
+            Dim offset = NormalizeILOffset(ilOffset)
+
+            Dim compilation As VisualBasicCompilation = metadataBlocks.ToCompilation(Nothing, MakeAssemblyReferencesKind.AllAssemblies)
+
+            Return CreateMethodContext(
+                compilation,
+                lazyAssemblyReaders,
+                symReader,
+                moduleVersionId,
+                methodToken,
+                methodVersion,
+                offset,
+                localSignatureToken)
+        End Function
+
+        ''' <summary>
+        ''' Create a context for evaluating expressions within a method scope.
+        ''' </summary>
         ''' <param name="compilation">Compilation.</param>
         ''' <param name="symReader"><see cref="ISymUnmanagedReader"/> for PDB associated with <paramref name="moduleVersionId"/>.</param>
         ''' <param name="moduleVersionId">Module containing method.</param>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -75,12 +75,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             metadataBlocks As ImmutableArray(Of MetadataBlock),
             moduleVersionId As Guid,
             typeToken As Integer,
-            Optional useReferencedAssembliesOnly As Boolean = False) As EvaluationContext
+            Optional kind As MakeAssemblyReferencesKind = MakeAssemblyReferencesKind.AllAssemblies) As EvaluationContext
 
             ' Re-use the previous compilation if possible.
             Dim compilation = If(previous IsNot Nothing,
                 previous.Compilation,
-                metadataBlocks.ToCompilation(moduleVersionId, If(useReferencedAssembliesOnly, MakeAssemblyReferencesKind.AllReferences, MakeAssemblyReferencesKind.AllAssemblies)))
+                metadataBlocks.ToCompilation(moduleVersionId, kind))
 
             Return CreateTypeContext(compilation, moduleVersionId, typeToken)
         End Function
@@ -128,7 +128,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             methodVersion As Integer,
             ilOffset As UInteger,
             localSignatureToken As Integer,
-            Optional useReferencedAssembliesOnly As Boolean = False) As EvaluationContext
+            Optional kind As MakeAssemblyReferencesKind = MakeAssemblyReferencesKind.AllAssemblies) As EvaluationContext
 
             Dim offset = NormalizeILOffset(ilOffset)
 
@@ -144,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 End If
                 compilation = previous.Compilation
             Else
-                compilation = metadataBlocks.ToCompilation(moduleVersionId, If(useReferencedAssembliesOnly, MakeAssemblyReferencesKind.AllReferences, MakeAssemblyReferencesKind.AllAssemblies))
+                compilation = metadataBlocks.ToCompilation(moduleVersionId, kind)
             End If
 
             Return CreateMethodContext(

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicExpressionCompiler.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicExpressionCompiler.vb
@@ -67,8 +67,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     typeToken)
             End If
 
+            Dim contextId = MetadataContextId.GetContextId(moduleVersionId, kind)
             Dim previous = getMetadataContext(appDomain)
-            Dim previousContext = If(previous.Matches(metadataBlocks, moduleVersionId), previous.AssemblyContext, Nothing)
+            Dim previousContext As VisualBasicMetadataContext = Nothing
+            If previous.Matches(metadataBlocks) Then
+                previous.AssemblyContexts.TryGetValue(contextId, previousContext)
+            End If
             Dim context = EvaluationContext.CreateTypeContext(
                 previousContext,
                 metadataBlocks,
@@ -141,8 +145,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     localSignatureToken)
             End If
 
+            Dim contextId = MetadataContextId.GetContextId(moduleVersionId, kind)
             Dim previous = getMetadataContext(appDomain)
-            Dim previousContext = If(previous.Matches(metadataBlocks, moduleVersionId), previous.AssemblyContext, Nothing)
+            Dim assemblyContexts = If(previous.Matches(metadataBlocks), previous.AssemblyContexts, ImmutableDictionary(Of MetadataContextId, VisualBasicMetadataContext).Empty)
+            Dim previousContext As VisualBasicMetadataContext = Nothing
+            assemblyContexts.TryGetValue(contextId, previousContext)
+
             Dim context = EvaluationContext.CreateMethodContext(
                 previousContext,
                 metadataBlocks,
@@ -160,8 +168,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     appDomain,
                     New MetadataContext(Of VisualBasicMetadataContext)(
                         metadataBlocks,
-                        moduleVersionId,
-                        New VisualBasicMetadataContext(context.Compilation, context)))
+                        assemblyContexts.SetItem(contextId, New VisualBasicMetadataContext(context.Compilation, context))))
             End If
 
             Return context

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicExpressionCompiler.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicExpressionCompiler.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 metadataBlocks,
                 moduleVersionId,
                 typeToken,
-                useReferencedModulesOnly)
+                GetMakeAssemblyReferencesKind(useReferencedModulesOnly))
         End Function
 
         Friend Shared Function CreateTypeContextHelper(Of TAppDomain)(
@@ -55,9 +55,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             metadataBlocks As ImmutableArray(Of MetadataBlock),
             moduleVersionId As Guid,
             typeToken As Integer,
-            useReferencedModulesOnly As Boolean) As EvaluationContextBase
+            kind As MakeAssemblyReferencesKind) As EvaluationContextBase
 
-            If useReferencedModulesOnly Then
+            If kind = MakeAssemblyReferencesKind.DirectReferencesOnly Then
                 ' Avoid using the cache for referenced assemblies only
                 ' since this should be the exceptional case.
                 Dim compilation = metadataBlocks.ToCompilationReferencedModulesOnly(moduleVersionId)
@@ -80,7 +80,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 previousContext,
                 metadataBlocks,
                 moduleVersionId,
-                typeToken)
+                typeToken,
+                kind)
 
             ' New type context is not attached to the AppDomain since it is less
             ' re-usable than the previous attached method context. (We could hold
@@ -115,7 +116,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 methodVersion,
                 ilOffset,
                 localSignatureToken,
-                useReferencedModulesOnly)
+                GetMakeAssemblyReferencesKind(useReferencedModulesOnly))
         End Function
 
         Friend Shared Function CreateMethodContextHelper(Of TAppDomain)(
@@ -130,9 +131,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             methodVersion As Integer,
             ilOffset As UInteger,
             localSignatureToken As Integer,
-            useReferencedModulesOnly As Boolean) As EvaluationContextBase
+            kind As MakeAssemblyReferencesKind) As EvaluationContextBase
 
-            If useReferencedModulesOnly Then
+            If kind = MakeAssemblyReferencesKind.DirectReferencesOnly Then
                 ' Avoid using the cache for referenced assemblies only
                 ' since this should be the exceptional case.
                 Dim compilation = metadataBlocks.ToCompilationReferencedModulesOnly(moduleVersionId)
@@ -166,7 +167,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 methodVersion,
                 ilOffset,
                 localSignatureToken,
-                useReferencedAssembliesOnly:=True)
+                kind)
 
             If context IsNot previousContext?.EvaluationContext Then
                 setMetadataContext(

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
@@ -99,7 +99,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             If previous IsNot Nothing Then
                 compilation = previous.AssemblyContext.Compilation
             Else
-                compilation = metadataBlocks.ToCompilation(moduleVersionId, MakeAssemblyReferencesKind.AllReferences)
+                compilation = metadataBlocks.ToCompilation(moduleVersionId, GetMakeAssemblyReferencesKind())
                 appDomain.SetMetadataContext(
                     New AppDomainMetadataContext(Of VisualBasicCompilation, EvaluationContext)(
                         metadataBlocks,

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
@@ -85,23 +85,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Overrides Function GetCompilation(moduleInstance As DkmClrModuleInstance) As VisualBasicCompilation
             Dim appDomain = moduleInstance.AppDomain
             Dim moduleVersionId = moduleInstance.Mvid
-            Dim previous = appDomain.GetMetadataContext(Of AppDomainMetadataContext(Of VisualBasicCompilation, EvaluationContext))()
+            Dim previous = appDomain.GetMetadataContext(Of MetadataContext(Of VisualBasicMetadataContext))()
             Dim metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks)
 
-            If Not previous.Matches(metadataBlocks) Then
-                previous = Nothing
-            End If
-            If previous IsNot Nothing AndAlso previous.ModuleVersionId <> moduleVersionId Then
-                previous = Nothing
-            End If
-
             Dim compilation As VisualBasicCompilation
-            If previous IsNot Nothing Then
+            If previous.Matches(metadataBlocks, moduleVersionId) Then
                 compilation = previous.AssemblyContext.Compilation
             Else
                 compilation = metadataBlocks.ToCompilation(moduleVersionId, GetMakeAssemblyReferencesKind())
                 appDomain.SetMetadataContext(
-                    New AppDomainMetadataContext(Of VisualBasicCompilation, EvaluationContext)(
+                    New MetadataContext(Of VisualBasicMetadataContext)(
                         metadataBlocks,
                         moduleVersionId,
                         New VisualBasicMetadataContext(compilation)))

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
@@ -85,7 +85,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Overrides Function GetCompilation(moduleInstance As DkmClrModuleInstance) As VisualBasicCompilation
             Dim appDomain = moduleInstance.AppDomain
             Dim moduleVersionId = moduleInstance.Mvid
-            Dim previous = appDomain.GetMetadataContext(Of MetadataContext(Of VisualBasicMetadataContext))()
+            Dim previous = appDomain.GetMetadataContext(Of VisualBasicMetadataContext)()
             Dim metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks)
 
             Dim kind = GetMakeAssemblyReferencesKind()
@@ -100,7 +100,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 appDomain.SetMetadataContext(
                     New MetadataContext(Of VisualBasicMetadataContext)(
                         metadataBlocks,
-                        assemblyContexts.SetItem(contextId, New VisualBasicMetadataContext(compilation))))
+                        assemblyContexts.SetItem(contextId, New VisualBasicMetadataContext(compilation))),
+                    report:=kind = MakeAssemblyReferencesKind.AllReferences)
             End If
 
             Return compilation

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicMetadataContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicMetadataContext.vb
@@ -1,23 +1,17 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
-    ' Remove this class and use MetadataContext(Of VisualBasicCompilation, EvaluationContext) directly.
-    Friend NotInheritable Class VisualBasicMetadataContext
-        Inherits MetadataContext(Of VisualBasicCompilation, EvaluationContext)
+    Friend Structure VisualBasicMetadataContext
+
+        Friend ReadOnly Compilation As VisualBasicCompilation
+        Friend ReadOnly EvaluationContext As EvaluationContext
 
         Friend Sub New(compilation As VisualBasicCompilation, Optional evaluationContext As EvaluationContext = Nothing)
-            MyBase.New(compilation, evaluationContext)
+            Me.Compilation = compilation
+            Me.EvaluationContext = evaluationContext
         End Sub
 
-        ' TODO: Remove metadataBlocks parameter.
-        Friend Sub New(metadataBlocks As ImmutableArray(Of MetadataBlock), evaluationContext As EvaluationContext)
-            MyBase.New(evaluationContext.Compilation, evaluationContext)
-        End Sub
-
-    End Class
+    End Structure
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicMetadataContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicMetadataContext.vb
@@ -5,29 +5,19 @@ Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
-    Friend Structure VisualBasicMetadataContext
+    ' Remove this class and use MetadataContext(Of VisualBasicCompilation, EvaluationContext) directly.
+    Friend NotInheritable Class VisualBasicMetadataContext
+        Inherits MetadataContext(Of VisualBasicCompilation, EvaluationContext)
 
-        Friend ReadOnly MetadataBlocks As ImmutableArray(Of MetadataBlock)
-        Friend ReadOnly Compilation As VisualBasicCompilation
-        Friend ReadOnly EvaluationContext As EvaluationContext
-
-        Friend Sub New(metadataBlocks As ImmutableArray(Of MetadataBlock), compilation As VisualBasicCompilation)
-            Me.MetadataBlocks = metadataBlocks
-            Me.Compilation = compilation
-            Me.EvaluationContext = Nothing
+        Friend Sub New(compilation As VisualBasicCompilation, Optional evaluationContext As EvaluationContext = Nothing)
+            MyBase.New(compilation, evaluationContext)
         End Sub
 
+        ' TODO: Remove metadataBlocks parameter.
         Friend Sub New(metadataBlocks As ImmutableArray(Of MetadataBlock), evaluationContext As EvaluationContext)
-            Me.MetadataBlocks = metadataBlocks
-            Me.Compilation = evaluationContext.Compilation
-            Me.EvaluationContext = evaluationContext
+            MyBase.New(evaluationContext.Compilation, evaluationContext)
         End Sub
 
-        Friend Function Matches(metadataBlocks As ImmutableArray(Of MetadataBlock)) As Boolean
-            Return Not Me.MetadataBlocks.IsDefault AndAlso
-                Me.MetadataBlocks.SequenceEqual(metadataBlocks)
-        End Function
-
-    End Structure
+    End Class
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -152,7 +152,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
                 methodToken,
                 methodVersion,
                 ilOffset,
-                localSignatureToken)
+                localSignatureToken,
+                MakeAssemblyReferencesKind.AllAssemblies)
         End Function
 
         Friend Shared Function MakeDummyLazyAssemblyReaders() As Lazy(Of ImmutableArray(Of AssemblyReaders))
@@ -178,7 +179,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
                 Nothing,
                 blocks,
                 moduleVersionId,
-                typeToken)
+                typeToken,
+                MakeAssemblyReferencesKind.AllAssemblies)
         End Function
 
         Friend Function Evaluate(

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -357,7 +357,7 @@ End Class"
             Assert.Equal(context.Compilation, previous.Compilation)
 
             ' No EvaluationContext. Should reuse Compilation
-            previous = New VisualBasicMetadataContext(previous.MetadataBlocks, previous.Compilation)
+            previous = New VisualBasicMetadataContext(previous.Compilation)
             context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, ilOffset:=0, localSignatureToken:=localSignatureToken)
             Assert.Null(previous.EvaluationContext)
             Assert.NotNull(context)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -59,7 +59,8 @@ End Class
                         methodToken,
                         methodVersion,
                         ilOffset,
-                        localSignatureToken)
+                        localSignatureToken,
+                        MakeAssemblyReferencesKind.AllAssemblies)
 
                     Dim errorMessage As String = Nothing
                     Dim result = context.CompileExpression("1", errorMessage)
@@ -76,7 +77,8 @@ End Class
                         methodToken,
                         methodVersion,
                         ilOffset,
-                        localSignatureToken)
+                        localSignatureToken,
+                        MakeAssemblyReferencesKind.AllAssemblies)
 
                     result = context.CompileExpression("2", errorMessage)
                     Dim mvid2 = result.Assembly.GetModuleVersionId()
@@ -293,16 +295,16 @@ End Class"
             endOffset = outerScope.EndOffset
 
             ' At start of outer scope.
-            Dim context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(startOffset, UInteger), localSignatureToken)
+            Dim context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(startOffset, UInteger), localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies)
             Assert.Equal(Nothing, previous)
             previous = New VisualBasicMetadataContext(methodBlocks, context)
 
             ' At end of outer scope - not reused because of the nested scope.
-            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(endOffset, UInteger), localSignatureToken)
+            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(endOffset, UInteger), localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies)
             Assert.NotEqual(context, previous.EvaluationContext) ' Not required, just documentary.
 
             ' At type context.
-            context = EvaluationContext.CreateTypeContext(previous, typeBlocks, moduleVersionId, typeToken)
+            context = EvaluationContext.CreateTypeContext(previous, typeBlocks, moduleVersionId, typeToken, MakeAssemblyReferencesKind.AllAssemblies)
             Assert.NotEqual(context, previous.EvaluationContext)
             Assert.Null(context.MethodContextReuseConstraints)
             Assert.Equal(context.Compilation, previous.Compilation)
@@ -317,7 +319,7 @@ End Class"
                     Assert.Equal(scope Is previousScope, constraints.GetValueOrDefault().AreSatisfied(moduleVersionId, methodToken, methodVersion, offset))
                 End If
 
-                context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(offset, UInteger), localSignatureToken)
+                context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(offset, UInteger), localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies)
                 If scope Is previousScope Then
                     Assert.Equal(context, previous.EvaluationContext)
                 Else
@@ -343,7 +345,7 @@ End Class"
             GetContextState(runtime, "C.F", methodBlocks, moduleVersionId, symReader, methodToken, localSignatureToken)
 
             ' Different references. No reuse.
-            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(endOffset - 1, UInteger), localSignatureToken)
+            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(endOffset - 1, UInteger), localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies)
             Assert.NotEqual(context, previous.EvaluationContext)
             Assert.True(previous.EvaluationContext.MethodContextReuseConstraints.Value.AreSatisfied(moduleVersionId, methodToken, methodVersion, endOffset - 1))
             Assert.NotEqual(context.Compilation, previous.Compilation)
@@ -351,14 +353,14 @@ End Class"
 
             ' Different method. Should reuse Compilation.
             GetContextState(runtime, "C.G", methodBlocks, moduleVersionId, symReader, methodToken, localSignatureToken)
-            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, ilOffset:=0, localSignatureToken:=localSignatureToken)
+            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, ilOffset:=0, localSignatureToken:=localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies)
             Assert.NotEqual(context, previous.EvaluationContext)
             Assert.False(previous.EvaluationContext.MethodContextReuseConstraints.Value.AreSatisfied(moduleVersionId, methodToken, methodVersion, 0))
             Assert.Equal(context.Compilation, previous.Compilation)
 
             ' No EvaluationContext. Should reuse Compilation
             previous = New VisualBasicMetadataContext(previous.Compilation)
-            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, ilOffset:=0, localSignatureToken:=localSignatureToken)
+            context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, ilOffset:=0, localSignatureToken:=localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies)
             Assert.Null(previous.EvaluationContext)
             Assert.NotNull(context)
             Assert.Equal(context.Compilation, previous.Compilation)
@@ -4143,7 +4145,8 @@ End Class
                     methodToken:=methodToken,
                     methodVersion:=1,
                     ilOffset:=0,
-                    localSignatureToken:=localSignatureToken)
+                    localSignatureToken:=localSignatureToken,
+                    kind:=MakeAssemblyReferencesKind.AllAssemblies)
 
                 Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
                 Dim typeName As String = Nothing
@@ -4163,7 +4166,8 @@ End Class
                     methodToken:=methodToken,
                     methodVersion:=2,
                     ilOffset:=0,
-                    localSignatureToken:=localSignatureToken)
+                    localSignatureToken:=localSignatureToken,
+                    kind:=MakeAssemblyReferencesKind.AllAssemblies)
 
                 locals.Clear()
                 context2.CompileGetLocals(
@@ -4555,7 +4559,8 @@ End Class"
                         methodToken,
                         methodVersion:=1,
                         ilOffset:=ExpressionCompilerTestHelpers.NoILOffset,
-                        localSignatureToken:=localSignatureToken)
+                        localSignatureToken:=localSignatureToken,
+                        kind:=MakeAssemblyReferencesKind.AllAssemblies)
 
                     Dim errorMessage As String = Nothing
                     Dim testData = New CompilationTestData()
@@ -4582,7 +4587,8 @@ End Class"
                         methodToken,
                         methodVersion:=1,
                         ilOffset:=0,
-                        localSignatureToken:=localSignatureToken)
+                        localSignatureToken:=localSignatureToken,
+                        kind:=MakeAssemblyReferencesKind.AllAssemblies)
                     Assert.Same(previous, context)
 
                     ' Verify the context is re-used for NoILOffset.
@@ -4596,7 +4602,8 @@ End Class"
                         methodToken,
                         methodVersion:=1,
                         ilOffset:=ExpressionCompilerTestHelpers.NoILOffset,
-                        localSignatureToken:=localSignatureToken)
+                        localSignatureToken:=localSignatureToken,
+                        kind:=MakeAssemblyReferencesKind.AllAssemblies)
                     Assert.Same(previous, context)
                 End Sub)
         End Sub

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -69,7 +69,7 @@ End Class
                     Assert.NotEqual(mvid1, Guid.Empty)
 
                     context = EvaluationContext.CreateMethodContext(
-                        New VisualBasicMetadataContext(blocks, context),
+                        New VisualBasicMetadataContext(context.Compilation, context),
                         blocks,
                         MakeDummyLazyAssemblyReaders(),
                         symReader,
@@ -297,7 +297,7 @@ End Class"
             ' At start of outer scope.
             Dim context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(startOffset, UInteger), localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies)
             Assert.Equal(Nothing, previous)
-            previous = New VisualBasicMetadataContext(methodBlocks, context)
+            previous = New VisualBasicMetadataContext(context.Compilation, context)
 
             ' At end of outer scope - not reused because of the nested scope.
             context = EvaluationContext.CreateMethodContext(previous, methodBlocks, MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion, CType(endOffset, UInteger), localSignatureToken, MakeAssemblyReferencesKind.AllAssemblies)
@@ -311,7 +311,7 @@ End Class"
 
             ' Step through entire method.
             Dim previousScope As Scope = Nothing
-            previous = New VisualBasicMetadataContext(typeBlocks, context)
+            previous = New VisualBasicMetadataContext(context.Compilation, context)
             For offset = startOffset To endOffset - 1
                 Dim scope = scopes.GetInnermostScope(offset)
                 Dim constraints = previous.EvaluationContext.MethodContextReuseConstraints
@@ -331,7 +331,7 @@ End Class"
                     End If
                 End If
                 previousScope = scope
-                previous = New VisualBasicMetadataContext(methodBlocks, context)
+                previous = New VisualBasicMetadataContext(context.Compilation, context)
             Next
 
             ' With different references.
@@ -349,7 +349,7 @@ End Class"
             Assert.NotEqual(context, previous.EvaluationContext)
             Assert.True(previous.EvaluationContext.MethodContextReuseConstraints.Value.AreSatisfied(moduleVersionId, methodToken, methodVersion, endOffset - 1))
             Assert.NotEqual(context.Compilation, previous.Compilation)
-            previous = New VisualBasicMetadataContext(methodBlocks, context)
+            previous = New VisualBasicMetadataContext(context.Compilation, context)
 
             ' Different method. Should reuse Compilation.
             GetContextState(runtime, "C.G", methodBlocks, moduleVersionId, symReader, methodToken, localSignatureToken)
@@ -4579,7 +4579,7 @@ End Class"
                     ' Verify the context is re-used for ILOffset == 0.
                     Dim previous = context
                     context = EvaluationContext.CreateMethodContext(
-                        New VisualBasicMetadataContext(blocks, previous),
+                        New VisualBasicMetadataContext(previous.Compilation, previous),
                         blocks,
                         MakeDummyLazyAssemblyReaders(),
                         symReader,
@@ -4594,7 +4594,7 @@ End Class"
                     ' Verify the context is re-used for NoILOffset.
                     previous = context
                     context = EvaluationContext.CreateMethodContext(
-                        New VisualBasicMetadataContext(blocks, previous),
+                        New VisualBasicMetadataContext(previous.Compilation, previous),
                         blocks,
                         MakeDummyLazyAssemblyReaders(),
                         symReader,

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedStateMachineLocalTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedStateMachineLocalTests.vb
@@ -1446,9 +1446,10 @@ End Class
                     GetContextState(runtime, "C.VB$StateMachine_1_M.MoveNext", blocks, moduleVersionId, symReader, methodToken, localSignatureToken)
                     Const methodVersion = 1
 
+                    Dim appDomain = New AppDomain()
                     Dim ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber:=100)
-                    Dim context = EvaluationContext.CreateMethodContext(
-                        Nothing,
+                    Dim context = CreateMethodContext(
+                        appDomain,
                         blocks,
                         MakeDummyLazyAssemblyReaders(),
                         symReader,
@@ -1466,8 +1467,8 @@ End Class
                     Assert.Equal("error BC30451: 'y' is not declared. It may be inaccessible due to its protection level.", errorMessage)
 
                     ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber:=200)
-                    context = EvaluationContext.CreateMethodContext(
-                        New VisualBasicMetadataContext(context.Compilation, context),
+                    context = CreateMethodContext(
+                        appDomain,
                         blocks,
                         MakeDummyLazyAssemblyReaders(),
                         symReader,

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedStateMachineLocalTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedStateMachineLocalTests.vb
@@ -1467,7 +1467,7 @@ End Class
 
                     ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber:=200)
                     context = EvaluationContext.CreateMethodContext(
-                        New VisualBasicMetadataContext(blocks, context),
+                        New VisualBasicMetadataContext(context.Compilation, context),
                         blocks,
                         MakeDummyLazyAssemblyReaders(),
                         symReader,

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedStateMachineLocalTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedStateMachineLocalTests.vb
@@ -1456,7 +1456,8 @@ End Class
                         methodToken,
                         methodVersion,
                         ilOffset,
-                        localSignatureToken)
+                        localSignatureToken,
+                        MakeAssemblyReferencesKind.AllAssemblies)
 
                     Dim errorMessage As String = Nothing
                     context.CompileExpression("x", errorMessage)
@@ -1474,7 +1475,8 @@ End Class
                         methodToken,
                         methodVersion,
                         ilOffset,
-                        localSignatureToken)
+                        localSignatureToken,
+                        MakeAssemblyReferencesKind.AllAssemblies)
 
                     context.CompileExpression("x", errorMessage)
                     Assert.Null(errorMessage)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -3348,8 +3348,8 @@ End Class"
                 {
                     {methodToken, debugInfo}
                 }.ToImmutableDictionary())
-            Dim context = EvaluationContext.CreateMethodContext(
-                Nothing,
+            Dim context = CreateMethodContext(
+                New AppDomain(),
                 blocks,
                 MakeDummyLazyAssemblyReaders(),
                 symReader,

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -3357,7 +3357,8 @@ End Class"
                 methodToken,
                 methodVersion:=1,
                 ilOffset:=0,
-                localSignatureToken:=localSignatureToken)
+                localSignatureToken:=localSignatureToken,
+                kind:=MakeAssemblyReferencesKind.AllAssemblies)
 
             Dim assembly = context.CompileGetLocals(locals, argumentsOnly:=False, typeName:=Nothing, testData:=Nothing)
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -121,7 +121,7 @@ End Class"
                     Assert.Equal(errorMessage, "error BC30554: 'B' is ambiguous.")
 
                     ' Compile expression with method context.
-                    Dim previous = New VisualBasicMetadataContext(typeBlocks, context)
+                    Dim previous = New VisualBasicMetadataContext(context.Compilation, context)
                     context = EvaluationContext.CreateMethodContext(
                         previous,
                         methodBlocks,

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -4,6 +4,7 @@ Imports System.Collections.Immutable
 Imports System.Reflection.Metadata
 Imports System.Reflection.PortableExecutable
 Imports Microsoft.Cci
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
@@ -13,9 +14,9 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.DiaSymReader
+Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
@@ -28,6 +29,290 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
         ''' <summary>
         ''' MakeAssemblyReferences should drop unreferenced assemblies.
         ''' </summary>
+        <Fact>
+        Public Sub UnreferencedAssemblies()
+            Const sourceA1 =
+"Public Class A1
+    Private Shared Sub M()
+    End Sub
+End Class"
+            Const sourceA2 =
+"Public Class A2
+    Private Shared Sub M()
+    End Sub
+End Class"
+            Const sourceB1 =
+"Public Class B1
+    Inherits A1
+    Private Shared Sub M()
+    End Sub
+End Class"
+            Const sourceB2 =
+"Public Class B2
+    Inherits A1
+    Private Shared Sub M()
+    End Sub
+End Class"
+            Const sourceC =
+"Class C1
+    Inherits B2
+    Private Shared Sub M()
+    End Sub
+End Class
+Class C2
+    Inherits A2
+End Class"
+            Dim moduleMscorlib = (Identity:=MscorlibRef.GetAssemblyIdentity(), [Module]:=MscorlibRef.ToModuleInstance())
+            Dim moduleIntrinsic = (Identity:=ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.GetAssemblyIdentity(), [Module]:=ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance())
+            Dim moduleA1 = Compile("A1", sourceA1)
+            Dim moduleA2 = Compile("A2", sourceA2)
+            Dim moduleB1 = Compile("B1", sourceB1, moduleA1.Reference)
+            Dim moduleB2 = Compile("B2", sourceB2, moduleA1.Reference)
+            Dim moduleC = Compile("C", sourceC, moduleA1.Reference, moduleA2.Reference, moduleB2.Reference)
+
+            Using runtime = CreateRuntimeInstance({moduleMscorlib.Module, moduleA1.Module, moduleA2.Module, moduleB1.Module, moduleB2.Module, moduleC.Module})
+
+                Dim stateB2 = GetContextState(runtime, "B2.M")
+
+                ' B2.M with missing A1.
+                Dim context = CreateMethodContext(
+                    New AppDomain(),
+                    ImmutableArray.Create(moduleMscorlib.Module, moduleA2.Module, moduleB1.Module, moduleB2.Module, moduleC.Module).SelectAsArray(Function(m) m.MetadataBlock),
+                    stateB2)
+                Dim resultProperties As ResultProperties = Nothing
+                Dim errorMessage As String = Nothing
+                Dim testData = New CompilationTestData()
+                Dim missingAssemblyIdentities As ImmutableArray(Of AssemblyIdentity) = Nothing
+                context.CompileExpression(
+                    "New B2()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    resultProperties,
+                    errorMessage,
+                    missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData)
+                Assert.Equal("error BC30652: Reference required to assembly 'A1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' containing the type 'A1'. Add one to your project.", errorMessage)
+                AssertEx.Equal({moduleA1.Identity}, missingAssemblyIdentities)
+                VerifyResolutionRequests(context, (moduleA1.Identity, Nothing, 1))
+
+                ' B2.M with all assemblies.
+                context = CreateMethodContext(
+                    New AppDomain(),
+                    ImmutableArray.Create(moduleMscorlib.Module, moduleA1.Module, moduleA2.Module, moduleB1.Module, moduleB2.Module, moduleC.Module).SelectAsArray(Function(m) m.MetadataBlock),
+                    stateB2)
+                testData = New CompilationTestData()
+                context.CompileExpression("New B2()", errorMessage, testData)
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""Sub B2..ctor()""
+  IL_0005:  ret
+}")
+                VerifyResolutionRequests(context, (moduleA1.Identity, moduleA1.Identity, 1))
+
+                ' B2.M with all assemblies in reverse order.
+                context = CreateMethodContext(
+                    New AppDomain(),
+                    ImmutableArray.Create(moduleC.Module, moduleB2.Module, moduleB1.Module, moduleA2.Module, moduleA1.Module, moduleMscorlib.Module, moduleIntrinsic.Module).SelectAsArray(Function(m) m.MetadataBlock),
+                    stateB2)
+                testData = New CompilationTestData()
+                context.CompileExpression("New B2()", errorMessage, testData)
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""Sub B2..ctor()""
+  IL_0005:  ret
+}")
+                VerifyResolutionRequests(context, (moduleA1.Identity, moduleA1.Identity, 1))
+
+                ' A1.M with all assemblies.
+                Dim stateA1 = GetContextState(runtime, "A1.M")
+                context = CreateMethodContext(
+                    New AppDomain(),
+                    ImmutableArray.Create(moduleMscorlib.Module, moduleA1.Module, moduleA2.Module, moduleB1.Module, moduleB2.Module, moduleC.Module).SelectAsArray(Function(m) m.MetadataBlock),
+                    stateA1)
+                testData = New CompilationTestData()
+                context.CompileExpression("New A1()", errorMessage, testData)
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""Sub A1..ctor()""
+  IL_0005:  ret
+}")
+                VerifyResolutionRequests(context)
+
+                ' B1.M with all assemblies.
+                Dim stateB1 = GetContextState(runtime, "B1.M")
+                context = CreateMethodContext(
+                    New AppDomain(),
+                    ImmutableArray.Create(moduleMscorlib.Module, moduleA1.Module, moduleA2.Module, moduleB1.Module, moduleB2.Module, moduleC.Module).SelectAsArray(Function(m) m.MetadataBlock),
+                    stateB1)
+                testData = New CompilationTestData()
+                context.CompileExpression("New B1()", errorMessage, testData)
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""Sub B1..ctor()""
+  IL_0005:  ret
+}")
+                VerifyResolutionRequests(context, (moduleA1.Identity, moduleA1.Identity, 1))
+
+                ' C1.M with all assemblies.
+                Dim stateC = GetContextState(runtime, "C1.M")
+                context = CreateMethodContext(
+                    New AppDomain(),
+                    ImmutableArray.Create(moduleMscorlib.Module, moduleA1.Module, moduleA2.Module, moduleB1.Module, moduleB2.Module, moduleC.Module).SelectAsArray(Function(m) m.MetadataBlock),
+                    stateC)
+                testData = New CompilationTestData()
+                context.CompileExpression("New C1()", errorMessage, testData)
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""Sub C1..ctor()""
+  IL_0005:  ret
+}")
+                VerifyResolutionRequests(context, (moduleB2.Identity, moduleB2.Identity, 1), (moduleA1.Identity, moduleA1.Identity, 1), (moduleA2.Identity, moduleA2.Identity, 1))
+
+            End Using
+        End Sub
+
+        ''' <summary>
+        ''' Reuse compilation across evaluations unless current assembly changes.
+        ''' </summary>
+        <Fact>
+        Public Sub ReuseCompilation()
+            Const sourceA1 =
+"Public Class A1
+    Private Shared Sub M()
+    End Sub
+End Class"
+            Const sourceA2 =
+"Public Class A2
+    Private Shared Sub M()
+    End Sub
+End Class
+Public Class A3
+    Private Shared Sub M()
+    End Sub
+End Class"
+            Const sourceB1 =
+"Public Class B1
+    Inherits A1
+    Private Shared Sub M()
+    End Sub
+End Class
+Public Class B2
+    Private Shared Sub M()
+    End Sub
+End Class"
+            Dim moduleMscorlib = (Identity:=MscorlibRef.GetAssemblyIdentity(), [Module]:=MscorlibRef.ToModuleInstance())
+            Dim moduleIntrinsic = (Identity:=ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.GetAssemblyIdentity(), [Module]:=ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance())
+            Dim moduleA1 = Compile("A1", sourceA1)
+            Dim moduleA2 = Compile("A2", sourceA2)
+            Dim moduleB1 = Compile("B1", sourceB1, moduleA1.Reference)
+
+            Using runtime = CreateRuntimeInstance({moduleMscorlib.Module, moduleA1.Module, moduleA2.Module, moduleB1.Module})
+
+                Dim blocks = runtime.Modules.SelectAsArray(Function(m) m.MetadataBlock)
+                Dim stateA1 = GetContextState(runtime, "A1.M")
+                Dim stateA2 = GetContextState(runtime, "A2.M")
+                Dim stateA3 = GetContextState(runtime, "A3.M")
+                Dim stateB1 = GetContextState(runtime, "B1.M")
+                Dim stateB2 = GetContextState(runtime, "B2.M")
+
+                Dim mvidA1 = stateA1.ModuleVersionId
+                Dim mvidA2 = stateA2.ModuleVersionId
+                Dim mvidB1 = stateB1.ModuleVersionId
+
+                Dim context As EvaluationContext
+                Dim previous As MetadataContext(Of VisualBasicMetadataContext)
+
+                ' B1 -> B2 -> A1 -> A2 -> A3
+                ' B1.M:
+                Dim appDomain = New AppDomain()
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateB1)
+                VerifyResolutionRequests(context, (moduleA1.Identity, moduleA1.Identity, 1))
+                VerifyAppDomainMetadataContext(appDomain, mvidB1)
+                ' B2.M:
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateB2)
+                Assert.NotSame(context, GetMetadataContext(previous, mvidB1).EvaluationContext)
+                Assert.Same(context.Compilation, GetMetadataContext(previous, mvidB1).Compilation)
+                VerifyResolutionRequests(context, (moduleA1.Identity, moduleA1.Identity, 1))
+                VerifyAppDomainMetadataContext(appDomain, mvidB1)
+                ' A1.M:
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateA1)
+                Assert.NotSame(context, GetMetadataContext(previous, mvidB1).EvaluationContext)
+                Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidB1).Compilation)
+                VerifyResolutionRequests(context)
+                VerifyAppDomainMetadataContext(appDomain, mvidB1, mvidA1)
+                ' A2.M:
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateA2)
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA1).EvaluationContext)
+                Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidA1).Compilation)
+                VerifyResolutionRequests(context)
+                VerifyAppDomainMetadataContext(appDomain, mvidB1, mvidA1, mvidA2)
+                ' A3.M:
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateA3)
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA2).EvaluationContext)
+                Assert.Same(context.Compilation, GetMetadataContext(previous, mvidA2).Compilation)
+                VerifyResolutionRequests(context)
+                VerifyAppDomainMetadataContext(appDomain, mvidB1, mvidA1, mvidA2)
+
+                ' A1 -> A2 -> A3 -> B1 -> B2
+                ' A1.M:
+                appDomain = New AppDomain()
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateA1)
+                VerifyResolutionRequests(context)
+                VerifyAppDomainMetadataContext(appDomain, mvidA1)
+                ' A2.M:
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateA2)
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA1).EvaluationContext)
+                Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidA1).Compilation)
+                VerifyResolutionRequests(context)
+                VerifyAppDomainMetadataContext(appDomain, mvidA1, mvidA2)
+                ' A3.M:
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateA3)
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA2).EvaluationContext)
+                Assert.Same(context.Compilation, GetMetadataContext(previous, mvidA2).Compilation)
+                VerifyResolutionRequests(context)
+                VerifyAppDomainMetadataContext(appDomain, mvidA1, mvidA2)
+                ' B1.M:
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateB1)
+                Assert.NotSame(context, GetMetadataContext(previous, mvidA2).EvaluationContext)
+                Assert.NotSame(context.Compilation, GetMetadataContext(previous, mvidA2).Compilation)
+                VerifyResolutionRequests(context, (moduleA1.Identity, moduleA1.Identity, 1))
+                VerifyAppDomainMetadataContext(appDomain, mvidA1, mvidA2, mvidB1)
+                ' B2.M:
+                previous = appDomain.GetMetadataContext()
+                context = CreateMethodContext(appDomain, blocks, stateB2)
+                Assert.NotSame(context, GetMetadataContext(previous, mvidB1).EvaluationContext)
+                Assert.Same(context.Compilation, GetMetadataContext(previous, mvidB1).Compilation)
+                VerifyResolutionRequests(context, (moduleA1.Identity, moduleA1.Identity, 1))
+                VerifyAppDomainMetadataContext(appDomain, mvidA1, mvidA2, mvidB1)
+
+            End Using
+        End Sub
+
+        Private Shared Sub VerifyAppDomainMetadataContext(appDomain As AppDomain, ParamArray moduleVersionIds As Guid())
+            ExpressionCompilerTestHelpers.VerifyAppDomainMetadataContext(appDomain.GetMetadataContext(), moduleVersionIds)
+        End Sub
+
         <WorkItem(1141029, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1141029")>
         <Fact>
         Public Sub AssemblyDuplicateReferences()
@@ -145,6 +430,19 @@ End Class"
                     Assert.Equal(errorMessage, "error BC30554: 'B' is ambiguous.")
 
                 End Sub)
+        End Sub
+
+        Private Shared Function Compile(assemblyName As String, source As String, ParamArray references As MetadataReference()) As (Identity As AssemblyIdentity, [Module] As ModuleInstance, Reference As MetadataReference)
+            Dim comp = CreateCompilationWithMscorlib40(source, references, options:=TestOptions.DebugDll, assemblyName:=assemblyName)
+            comp.AssertNoDiagnostics()
+            Dim [module] = comp.ToModuleInstance()
+            Return (comp.Assembly.Identity, [module], [module].GetReference())
+        End Function
+
+        Private Shared Sub VerifyResolutionRequests(context As EvaluationContext, ParamArray expectedResults As (AssemblyIdentity, AssemblyIdentity, Integer)())
+            ExpressionCompilerTestHelpers.VerifyResolutionRequests(
+                DirectCast(context.Compilation.Options.MetadataReferenceResolver, EEMetadataReferenceResolver),
+                expectedResults)
         End Sub
 
         <Fact>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -105,7 +105,8 @@ End Class"
                         Nothing,
                         typeBlocks,
                         moduleVersionId,
-                        typeToken)
+                        typeToken,
+                        MakeAssemblyReferencesKind.AllAssemblies)
 
                     ' If VB supported extern aliases, the following would be true:
                     ' Assert.Equal(identityAS2, context.Compilation.GlobalNamespace.GetMembers("A").OfType(Of INamedTypeSymbol)().Single().ContainingAssembly.Identity)
@@ -130,7 +131,8 @@ End Class"
                         methodToken,
                         methodVersion:=1,
                         ilOffset:=0,
-                        localSignatureToken:=localSignatureToken)
+                        localSignatureToken:=localSignatureToken,
+                        kind:=MakeAssemblyReferencesKind.AllAssemblies)
                     Assert.Equal(previous.Compilation, context.Compilation) ' re-use type context compilation
                     ' Ideally, B should be resolved to BS1.
                     context.CompileExpression("New B()", errorMessage)
@@ -344,7 +346,8 @@ End Class"
                         methodToken,
                         methodVersion:=1,
                         ilOffset:=0,
-                        localSignatureToken:=localSignatureToken)
+                        localSignatureToken:=localSignatureToken,
+                        kind:=MakeAssemblyReferencesKind.AllAssemblies)
                     Dim errorMessage As String = Nothing
                     context.CompileExpression("F()", errorMessage)
                     Assert.Equal(errorMessage, "error BC30562: 'F' is ambiguous between declarations in Modules 'N.M, N.M'.")

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -180,6 +180,51 @@ End Class"
 }")
                 VerifyResolutionRequests(context, (moduleB2.Identity, moduleB2.Identity, 1), (moduleA1.Identity, moduleA1.Identity, 1), (moduleA2.Identity, moduleA2.Identity, 1))
 
+                ' Other EvaluationContext.CreateMethodContext overload.
+                ' A1.M with all assemblies.
+                Dim allBlocks = ImmutableArray.Create(moduleMscorlib.Module, moduleA1.Module, moduleA2.Module, moduleB1.Module, moduleB2.Module, moduleC.Module).SelectAsArray(Function(m) m.MetadataBlock)
+                context = EvaluationContext.CreateMethodContext(
+                    New VisualBasicMetadataContext(),
+                    allBlocks,
+                    MakeDummyLazyAssemblyReaders(),
+                    stateA1.SymReader,
+                    stateA1.ModuleVersionId,
+                    stateA1.MethodToken,
+                    methodVersion:=1,
+                    stateA1.ILOffset,
+                    stateA1.LocalSignatureToken)
+                testData = New CompilationTestData()
+                context.CompileExpression("New B1()", errorMessage, testData)
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""Sub B1..ctor()""
+  IL_0005:  ret
+}")
+
+                ' Other EvaluationContext.CreateMethodContext overload.
+                ' A1.M with all assemblies, offset outside of IL.
+                context = EvaluationContext.CreateMethodContext(
+                    New VisualBasicMetadataContext(),
+                    allBlocks,
+                    MakeDummyLazyAssemblyReaders(),
+                    stateA1.SymReader,
+                    stateA1.ModuleVersionId,
+                    stateA1.MethodToken,
+                    methodVersion:=1,
+                    UInteger.MaxValue,
+                    stateA1.LocalSignatureToken)
+                testData = New CompilationTestData()
+                context.CompileExpression("New C1()", errorMessage, testData)
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""Sub C1..ctor()""
+  IL_0005:  ret
+}")
+
             End Using
         End Sub
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StaticLocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StaticLocalsTests.vb
@@ -189,8 +189,8 @@ End Class"
                     Dim methodToken = 0
                     Dim localSignatureToken = 0
                     GetContextState(runtime, "C.F(Boolean)", blocks, moduleVersionId, symReader, methodToken, localSignatureToken)
-                    Dim context = EvaluationContext.CreateMethodContext(
-                        Nothing,
+                    Dim context = CreateMethodContext(
+                        New AppDomain(),
                         blocks,
                         MakeDummyLazyAssemblyReaders(),
                         symReader,
@@ -232,8 +232,8 @@ End Class"
                     locals.Free()
 
                     GetContextState(runtime, "C.F(Int32)", blocks, moduleVersionId, symReader, methodToken, localSignatureToken)
-                    context = EvaluationContext.CreateMethodContext(
-                        Nothing,
+                    context = CreateMethodContext(
+                        New AppDomain(),
                         blocks,
                         MakeDummyLazyAssemblyReaders(),
                         symReader,

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StaticLocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StaticLocalsTests.vb
@@ -198,7 +198,8 @@ End Class"
                         methodToken,
                         methodVersion:=1,
                         ilOffset:=0,
-                        localSignatureToken:=localSignatureToken)
+                        localSignatureToken:=localSignatureToken,
+                        kind:=MakeAssemblyReferencesKind.AllAssemblies)
                     Dim testData = New CompilationTestData()
                     Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
                     Dim typeName As String = Nothing
@@ -240,7 +241,8 @@ End Class"
                         methodToken,
                         methodVersion:=1,
                         ilOffset:=0,
-                        localSignatureToken:=localSignatureToken)
+                        localSignatureToken:=localSignatureToken,
+                        kind:=MakeAssemblyReferencesKind.AllAssemblies)
                     testData = New CompilationTestData()
                     locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
                     assembly = context.CompileGetLocals(locals, argumentsOnly:=False, typeName:=typeName, testData:=testData)


### PR DESCRIPTION
### Customer scenario

Evaluating expressions in the Locals, Watch, or Callstack windows is slow when the process contains a large number of modules and not all modules are referenced by the current module.

### Bugs this fixes

591114

### Workarounds, if any

None

### Risk

Medium risk. The user must opt-in to the fix via a registry setting, but there are some changes required to maintain the existing behavior alongside the fix.

### Performance impact

No performance impact unless opted-in.

### Is this a regression from a previous update?

No.

### How was the bug found?

Customer reported.
