### PR TITLE
Bind Return key in ChangeSignature dialog

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml
@@ -49,6 +49,7 @@
         <KeyBinding Key="Up" Modifiers="Alt" Command="{StaticResource MoveUp}" />
         <KeyBinding Key="Down" Modifiers="Alt" Command="{StaticResource MoveDown}" />
         <KeyBinding Key="Delete" Command="{StaticResource ToggleRemovedState}" />
+        <KeyBinding Key="Return" Command="{StaticResource ClickOK}" />
     </Window.InputBindings>
     <Grid Name="ContentGrid" Margin="11,6,11,11">
         <Grid.RowDefinitions>


### PR DESCRIPTION
You can use `Alt+Up` and `Alt+Down` as keyboard shortcuts in the ChangeSignature dialog. With this PR, you can use `Return` to commit the change.

Fixes https://github.com/dotnet/roslyn/issues/25580