### PR TITLE
GoToDef on deconstruction assignment and foreach

### DIFF
--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -766,6 +766,76 @@ class C
         End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <WorkItem(16529, "https://github.com/dotnet/roslyn/issues/16529")>
+        Public Sub TestCSharpGoToOverriddenDefinition_FromDeconstructionDeclaration()
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Two { public void Deconstruct(out int x1, out int x2) => throw null; }
+class Four { public void [|Deconstruct|](out int x1, out int x2, out Two x3) => throw null; }
+class C
+{
+    void M(Four four)
+    {
+        var (a, b, (c, d)) $$= four;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(workspace)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <WorkItem(16529, "https://github.com/dotnet/roslyn/issues/16529")>
+        Public Sub TestCSharpGoToOverriddenDefinition_FromDeconstructionAssignment()
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Two { public void Deconstruct(out int x1, out int x2) => throw null; }
+class Four { public void [|Deconstruct|](out int x1, out int x2, out Two x3) => throw null; }
+class C
+{
+    void M(Four four)
+    {
+        int i;
+        (i, i, (i, i)) $$= four;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(workspace)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <WorkItem(16529, "https://github.com/dotnet/roslyn/issues/16529")>
+        Public Sub TestCSharpGoToOverriddenDefinition_FromDeconstructionForeach()
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Two { public void Deconstruct(out int x1, out int x2) => throw null; }
+class Four { public void [|Deconstruct|](out int x1, out int x2, out Two x3) => throw null; }
+class C
+{
+    void M(Four four)
+    {
+        foreach (var (a, b, (c, d)) $$in new[] { four }) { }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(workspace)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Sub TestCSharpGoToOverriddenDefinition_FromOverride()
             Dim workspace =
 <Workspace>

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
@@ -300,7 +300,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                 semanticModel.GetDeclaredSymbol(memberDeclaration, cancellationToken));
         }
 
-        public SymbolInfo GetSymbolInfo(SemanticModel semanticModel, SyntaxNode node, SyntaxToken token, CancellationToken cancellationToken)
+        public ImmutableArray<ISymbol> GetBestOrAllSymbols(SemanticModel semanticModel, SyntaxNode node, SyntaxToken token, CancellationToken cancellationToken)
+        {
+            switch (node)
+            {
+                case AssignmentExpressionSyntax assignment when token.Kind() == SyntaxKind.EqualsToken:
+                    return GetDeconstructionAssignmentMethods(semanticModel, node).As<ISymbol>();
+
+                case ForEachVariableStatementSyntax deconstructionForeach when token.Kind() == SyntaxKind.InKeyword:
+                    return GetDeconstructionForEachMethods(semanticModel, node).As<ISymbol>();
+            }
+
+            return GetSymbolInfo(semanticModel, node, token, cancellationToken).GetBestOrAllSymbols();
+        }
+
+        private SymbolInfo GetSymbolInfo(SemanticModel semanticModel, SyntaxNode node, SyntaxToken token, CancellationToken cancellationToken)
         {
             switch (node)
             {

--- a/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         IEnumerable<ISymbol> GetDeclaredSymbols(SemanticModel semanticModel, SyntaxNode memberDeclaration, CancellationToken cancellationToken);
 
-        SymbolInfo GetSymbolInfo(SemanticModel semanticModel, SyntaxNode node, SyntaxToken token, CancellationToken cancellationToken);
+        ImmutableArray<ISymbol> GetBestOrAllSymbols(SemanticModel semanticModel, SyntaxNode node, SyntaxToken token, CancellationToken cancellationToken);
 
         SyntaxToken GenerateUniqueName(
             SemanticModel semanticModel, SyntaxNode location, 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
@@ -205,8 +205,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 allSymbols = skipSymbolInfoLookup
                     ? ImmutableArray<ISymbol>.Empty
                     : semanticFacts
-                        .GetSymbolInfo(semanticModel, bindableParent, token, cancellationToken)
-                        .GetBestOrAllSymbols()
+                        .GetBestOrAllSymbols(semanticModel, bindableParent, token, cancellationToken)
                         .WhereAsArray(s => !s.Equals(declaredSymbol))
                         .SelectAsArray(s => MapSymbol(s, type));
             }

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -294,8 +294,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return {semanticModel.GetDeclaredSymbol(memberDeclaration, cancellationToken)}
         End Function
 
-        Public Function GetSymbolInfo(semanticModel As SemanticModel, node As SyntaxNode, token As SyntaxToken, cancellationToken As CancellationToken) As SymbolInfo Implements ISemanticFactsService.GetSymbolInfo
-            Return semanticModel.GetSymbolInfo(node, cancellationToken)
+        Public Function GetBestOrAllSymbols(semanticModel As SemanticModel, node As SyntaxNode, token As SyntaxToken, cancellationToken As CancellationToken) As ImmutableArray(Of ISymbol) Implements ISemanticFactsService.GetBestOrAllSymbols
+            Return semanticModel.GetSymbolInfo(node, cancellationToken).GetBestOrAllSymbols()
         End Function
 
         Private Function ISemanticFactsService_GenerateUniqueName(


### PR DESCRIPTION
This PR associates the symbols for various `Deconstruct` methods involved in a deconstruction with the `=` (in deconstruction assignment or deconstruction declaration) or the `in` syntax (in deconstruction foreach).

Note that GoToDef currently assumes that there is only one symbol that is "the definition". I think we should relax that, as a later change. If we did, we could not only list the `Deconstruct` methods, but also the `GetEnumerator` method, and even conversion operators involved in the assignment or foreach.

In the meantime, GoToDef only goes to the first `Deconstruct` method listed, which is the top-level one. That is good enough for most cases (nested deconstructions would be less common).

Fixes https://github.com/dotnet/roslyn/issues/16529
Fixes https://github.com/dotnet/roslyn/issues/24413
Tagging @CyrusNajmabadi FYI

![image](https://user-images.githubusercontent.com/12466233/38405842-d230defc-3926-11e8-9eec-d67694a333b4.png)