### PR TITLE
IntroduceLocal: adjust selection when pointing at trailing trivia

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -4784,6 +4784,60 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [WorkItem(25990, "https://github.com/dotnet/roslyn/issues/25990")]
+        public async Task TestWithLineBreak_WithSimpleComment()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int x = // start [| comment
+            5 * 2 |]
+            ;
+    }
+}",
+@"class C
+{
+    private const int {|Rename:V|} = 5 * 2;
+
+    void M()
+    {
+        int x = // start  comment
+            V
+            ;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [WorkItem(25990, "https://github.com/dotnet/roslyn/issues/25990")]
+        public async Task TestWithLineBreak_WithMultipleComments()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int x = /*comment1*/ [| // comment2
+            /*comment3*/ 5 * 2 |] // comment4
+            /*comment5*/ ; /*comment6*/
+    }
+}",
+@"class C
+{
+    private const int {|Rename:V|} = 5 * 2;
+
+    void M()
+    {
+        int x = /*comment1*/  // comment2
+                              /*comment3*/ V  // comment4
+                            /*comment5*/ ; /*comment6*/
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public async Task TestIntroduceLocalInCallRefExpression()
         {
             // This test indicates that ref-expressions are l-values and

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -431,7 +431,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             {
                 var annotatedItems = fixedRoot.GetAnnotatedNodesAndTokens(annotationKind).OrderBy(s => s.SpanStart).ToList();
 
-                Assert.Equal(expectedSpans.Length, annotatedItems.Count);
+                Assert.True(expectedSpans.Length == annotatedItems.Count,
+                    $"Annotations of kind '{annotationKind}' didn't match. Expected: {expectedSpans.Length}. Actual: {annotatedItems.Count}.");
 
                 for (var i = 0; i < Math.Min(expectedSpans.Length, annotatedItems.Count); i++)
                 {

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -192,6 +192,14 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 }
 
                 var startToken = root.FindToken(textSpan.Start);
+                if (startToken.Span.End < textSpan.Start)
+                {
+                    // If we were pointing in the trailing trivia of a token, we shouldn't include that token
+                    startToken = startToken.GetNextToken();
+                    var newStart = startToken.Span.Start;
+                    textSpan = new TextSpan(newStart, textSpan.End - newStart);
+                }
+
                 var stopToken = root.FindToken(textSpan.End);
 
                 if (textSpan.End <= stopToken.SpanStart)


### PR DESCRIPTION
Repro: try to invoke IntroduceLocal on an expression, but start the selection on a preceding line. The refactoring will not trigger.
For instance:
```C#
int x = [|
     2 * 5 |]
     ;
```

The reason is that the region starts on the trailing trivia of the preceding token, so that preceding token gets included (`=` in this example). But the refactoring cannot proceed on `= 2 * 5` as that is not an expression.

Fixes https://github.com/dotnet/roslyn/issues/25990