### PR TITLE
Allow $$ in lieu of [||] in test markup

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddFileBanner
 @"
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]using System;
+        <Document>$$using System;
 
 class Program1
 {
@@ -69,7 +69,7 @@ class Program2
 @"
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]using System;
+        <Document>$$using System;
 
 class Program1
 {
@@ -121,7 +121,7 @@ class Program2
 @"
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]// I already have a banner
+        <Document>$$// I already have a banner
 
 using System;
 
@@ -149,7 +149,7 @@ class Program2
 @"
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]
+        <Document>$$
 
 using System;
 
@@ -177,7 +177,7 @@ class Program2
 @"
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]
+        <Document>$$
 
 using System;
 

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignatureTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignatureTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature;
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ChangeSignature
             var markup = @"
 class Ext
 {
-    void Goo(int a, int b) => [||]0;
+    void Goo(int a, int b) => $$0;
 }";
 
             await TestChangeSignatureViaCodeActionAsync(markup, expectedCodeAction: false);
@@ -69,7 +69,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        M1(1, 2);[||]
+        M1(1, 2);$$
         M2(1, 2, 3);
     }
 
@@ -88,7 +88,7 @@ class Program
             var markup = @"
 class Ext
 {
-    [||]
+    $$
     void Goo(int a, int b)
     {
     };
@@ -104,7 +104,7 @@ class Ext
             var markup = @"
 class Ext
 {
-    // [||]
+    // $$
     void Goo(int a, int b)
     {
     };
@@ -120,7 +120,7 @@ class Ext
             var markup = @"
 class Ext
 {
-    [||]//
+    $$//
     void Goo(int a, int b)
     {
     };
@@ -136,7 +136,7 @@ class Ext
             var markup = @"
 class Ext
 {
-    /// [||]
+    /// $$
     void Goo(int a, int b)
     {
     };
@@ -152,7 +152,7 @@ class Ext
             var markup = @"
 class Ext
 {
-    [||]///
+    $$///
     void Goo(int a, int b)
     {
     };
@@ -168,7 +168,7 @@ class Ext
             var markup = @"
 class Ext
 {
-    [||][X]
+    $$[X]
     void Goo(int a, int b)
     {
     };
@@ -184,7 +184,7 @@ class Ext
             var markup = @"
 class Ext
 {
-    [[||]X]
+    [$$X]
     void Goo(int a, int b)
     {
     };
@@ -200,7 +200,7 @@ class Ext
             var markup = @"
 class Ext
 {
-    [X][||]
+    [X]$$
     void Goo(int a, int b)
     {
     };
@@ -216,7 +216,7 @@ class Ext
             var markup = @"
 class Ext
 {
-    void Goo<T>(int a, int b) where [||]T : class
+    void Goo<T>(int a, int b) where $$T : class
     {
     };
 }";

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.InvocationLocation.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.InvocationLocation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature;
@@ -191,7 +191,7 @@ class MyClass
 {
     public void Goo(int x, string y)
     {
-        [||]
+        $$
     }
 }";
 
@@ -768,7 +768,7 @@ class Test
 using System;
 class MyClass
 {
-    public void [||]Goo(int x, string y)
+    public void $$Goo(int x, string y)
     {
     }
 }";
@@ -793,7 +793,7 @@ class MyClass
 {
     public void Goo(int x, string y)
     {
-        [||]
+        $$
     }
 }";
             await TestChangeSignatureViaCodeActionAsync(markup, expectedCodeAction: false);
@@ -807,7 +807,7 @@ class Program
 {
     void M(int x)
     {
-        System.Func<int, int, int> f = (a, b)[||] => { return a; };
+        System.Func<int, int, int> f = (a, b)$$ => { return a; };
     }
 }";
             var permutation = new[] { 1, 0 };
@@ -830,7 +830,7 @@ class Program
 {
     void M(int x)
     {
-        System.Func<int, int, int> f = (a, b) => { [||]return a; };
+        System.Func<int, int, int> f = (a, b) => { $$return a; };
     }
 }";
             await TestChangeSignatureViaCodeActionAsync(markup, expectedCodeAction: false);
@@ -869,7 +869,7 @@ class Program
 {
     void M(int x, int y)
     {
-        M([||]5, 6);
+        M($$5, 6);
     }
 }";
             await TestMissingAsync(markup);

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1 || i == 2 || i == 3)
+        $$if (i == 1 || i == 2 || i == 3)
             return;
     }
 }",
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1 || i == 2 || i == 3)
+        $$if (i == 1 || i == 2 || i == 3)
             M(i);
     }
 }",
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1 || 2 == i || i == 3) M(0);
+        $$if (i == 1 || 2 == i || i == 3) M(0);
         else if (i == 4 || 5 == i || i == 6) M(1);
         else M(2);
     }
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(object o)
     {
-        [||]if (o is string s && s.Length > 0) M(0);
+        $$if (o is string s && s.Length > 0) M(0);
         else if (o is int i && i > 0) M(1);
         else return;
     }
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (1 == i || i == 2 || 3 == i)
+        $$if (1 == i || i == 2 || 3 == i)
             return;
     }
 }",
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     void M(int i)
     {
         const int A = 1, B = 2, C = 3;
-        [||]if (A == i || B == i || C == i)
+        $$if (A == i || B == i || C == i)
             return;
     }
 }",
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     void M(int i)
     {
         int A = 1, B = 2, C = 3;
-        [||]if (A == i || B == i || C == i)
+        $$if (A == i || B == i || C == i)
             return;
     }
 }");
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i, int j)
     {
-        [||]if (i == 5 || 6 == j) {}
+        $$if (i == 5 || 6 == j) {}
     }
 }");
         }
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 5) {}
+        $$if (i == 5) {}
     }
 }");
         }
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(object o)
     {
-        [||]if (o is int || o is string || o is C)
+        $$if (o is int || o is string || o is C)
             return;
     }
 }",
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(object o)
     {
-        [||]if (o is int i)
+        $$if (o is int i)
                 return;
             else if (o is string s)
                 return;
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(object o)
     {
-        [||]if (o is string s && s.Length == 5)
+        $$if (o is string s && s.Length == 5)
                 return;
             else if (o is int i)
                 return;
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(object o)
     {
-        [||]if (o is string s && (s.Length > 5 && s.Length < 10))
+        $$if (o is string s && (s.Length > 5 && s.Length < 10))
                 return;
             else if (o is int i)
                 return;
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(object o)
     {
-        [||]if (o is string s && s.Length > 5 && s.Length < 10)
+        $$if (o is string s && s.Length > 5 && s.Length < 10)
                 return;
             else if (o is int i)
                 return;
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(object o)
     {
-        [||]if (o is string s && s.Length > 5 &&
+        $$if (o is string s && s.Length > 5 &&
                                  s.Length < 10)
             {
                 M(o:   0);
@@ -425,7 +425,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        if [||](i == 3) {}
+        if $$(i == 3) {}
     }
 }");
         }
@@ -438,7 +438,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 3)
+        $$if (i == 3)
         {
             var x = i;
         }
@@ -476,7 +476,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         while (true)
         {
-            [||]if (i == 5) break;
+            $$if (i == 5) break;
         }
     }
 }");
@@ -492,7 +492,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         while (true)
         {
-            [||]if (i == 5) M(b, i);
+            $$if (i == 5) M(b, i);
             else break;
         }
     }
@@ -507,7 +507,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1)
+        $$if (i == 1)
         {
             while (true)
             {
@@ -547,7 +547,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     int M(int? i)
     {
-        [||]if (i == null) return 5;
+        $$if (i == null) return 5;
         if (i == 0) return 6;
         return 7;
     }
@@ -576,7 +576,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     int M(int? i)
     {
-        [||]if (i == null) return 5;
+        $$if (i == null) return 5;
         if (i == 0) {}
         if (i == 1) return 6;
         return 7;
@@ -609,7 +609,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         while (true)
         {
-            [||]if (i == null) return 5; else if (i == 1) return 1;
+            $$if (i == null) return 5; else if (i == 1) return 1;
             if (i == 0) break;
             if (i == 1) return 6;
             return 7;
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     string M(object i)
     {
-        [||]if (i == null || i as string == """") return null;
+        $$if (i == null || i as string == """") return null;
         if ((string)i == ""0"") return i as string;
         else return i.ToString();
     }
@@ -676,7 +676,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     int M(int i)
     {
-        [||]if (i == 10) return 5;
+        $$if (i == 10) return 5;
         if (i == 20) return 6;
         if (i == i) return 0;
         reuturn 7;
@@ -707,7 +707,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     int M(int i)
     {
-        [||]if (i == 10)
+        $$if (i == 10)
         {
             return 5;
         }
@@ -750,7 +750,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     int M(int i)
     {
-        [||]if (i == 5)
+        $$if (i == 5)
         {
             return 4;
         }
@@ -816,7 +816,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
         Console.WriteLine();
 #endif
 
-        [||]if (x == 1)
+        $$if (x == 1)
         {
             Console.WriteLine(x + z);
         }
@@ -856,7 +856,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     int M(int i)
     {
-        [||]if (/* t0 */args.Length /* t1*/ == /* t2 */ 2)
+        $$if (/* t0 */args.Length /* t1*/ == /* t2 */ 2)
             return /* t3 */ 0 /* t4 */; /* t5 */
         else /* t6 */
             return /* t7 */ 3 /* t8 */;
@@ -886,7 +886,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1 && i == 2)
+        $$if (i == 1 && i == 2)
             return;
         else if (i == 10)
             return;
@@ -916,7 +916,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1 && i == 2 && i == 3)
+        $$if (i == 1 && i == 2 && i == 3)
             return;
         else if (i == 10)
             return;
@@ -946,7 +946,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1 && i == 2 && (i == 3))
+        $$if (i == 1 && i == 2 && (i == 3))
             return;
         else if (i == 10)
             return;
@@ -976,7 +976,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1 && (i == 2) && i == 3)
+        $$if (i == 1 && (i == 2) && i == 3)
             return;
         else if (i == 10)
             return;
@@ -1006,7 +1006,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1 && (i == 2) && (i == 3))
+        $$if (i == 1 && (i == 2) && (i == 3))
             return;
         else if (i == 10)
             return;
@@ -1036,7 +1036,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if ((i == 1) && i == 2 && i == 3)
+        $$if ((i == 1) && i == 2 && i == 3)
             return;
         else if (i == 10)
             return;
@@ -1066,7 +1066,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if ((i == 1) && i == 2 && (i == 3))
+        $$if ((i == 1) && i == 2 && (i == 3))
             return;
         else if (i == 10)
             return;
@@ -1096,7 +1096,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if ((i == 1) && (i == 2) && i == 3)
+        $$if ((i == 1) && (i == 2) && i == 3)
             return;
         else if (i == 10)
             return;
@@ -1126,7 +1126,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if ((i == 1) && (i == 2) && (i == 3))
+        $$if ((i == 1) && (i == 2) && (i == 3))
             return;
         else if (i == 10)
             return;
@@ -1156,7 +1156,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (i == 1 && (i == 2 && i == 3))
+        $$if (i == 1 && (i == 2 && i == 3))
             return;
         else if (i == 10)
             return;
@@ -1186,7 +1186,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if ((i == 1 && i == 2) && i == 3)
+        $$if ((i == 1 && i == 2) && i == 3)
             return;
         else if (i == 10)
             return;
@@ -1216,7 +1216,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if (((i == 1) && i == 2) && i == 3)
+        $$if (((i == 1) && i == 2) && i == 3)
             return;
         else if (i == 10)
             return;
@@ -1246,7 +1246,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if ((i == 1 && (i == 2)) && i == 3)
+        $$if ((i == 1 && (i == 2)) && i == 3)
             return;
         else if (i == 10)
             return;
@@ -1276,7 +1276,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if ((i == 1 && (i == 2)) && (i == 3))
+        $$if ((i == 1 && (i == 2)) && (i == 3))
             return;
         else if (i == 10)
             return;
@@ -1306,7 +1306,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if ((i == 1) && ((i == 2) && i == 3))
+        $$if ((i == 1) && ((i == 2) && i == 3))
             return;
         else if (i == 10)
             return;
@@ -1336,7 +1336,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
 {
     void M(int i)
     {
-        [||]if ((i == 1) && (i == 2 && (i == 3)))
+        $$if ((i == 1) && (i == 2 && (i == 3)))
             return;
         else if (i == 10)
             return;

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertNumericLiteral/ConvertNumericLiteralTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertNumericLiteral/ConvertNumericLiteralTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -19,12 +19,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertNume
 
         private async Task TestMissingOneAsync(string initial)
         {
-            await TestMissingInRegularAndScriptAsync(CreateTreeText("[||]" + initial));
+            await TestMissingInRegularAndScriptAsync(CreateTreeText("$$" + initial));
         }
 
         private async Task TestFixOneAsync(string initial, string expected, Refactoring refactoring)
         {
-            await TestInRegularAndScriptAsync(CreateTreeText("[||]" + initial), CreateTreeText(expected), index: (int)refactoring);
+            await TestInRegularAndScriptAsync(CreateTreeText("$$" + initial), CreateTreeText(expected), index: (int)refactoring);
         }
 
         private static string CreateTreeText(string initial)
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertNume
     void M()
     {
         var numbers = new int[] {
-            [||]0x1, 0x2
+            $$0x1, 0x2
         };
     }
 }",
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertNume
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int a = 42[||];
+    int a = 42$$;
 }",
 @"class C
 {

--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Globalization;
@@ -728,7 +728,7 @@ class Program
             var text = @"
 class Program
 {
-    pri[||]vate int x;
+    pri$$vate int x;
 }
 ";
 
@@ -1050,7 +1050,7 @@ namespace ConsoleApplication1
     class Program
     {
         // Some random comment
-        public int myI[||]nt;
+        public int myI$$nt;
     }
 }
 ";

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -42,19 +42,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task NotWithNoInitializer1()
         {
-            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int [||]x; System.Console.WriteLine(x); }"));
+            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int $$x; System.Console.WriteLine(x); }"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task NotWithNoInitializer2()
         {
-            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int [||]x = ; System.Console.WriteLine(x); }"));
+            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int $$x = ; System.Console.WriteLine(x); }"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task NotOnSecondWithNoInitializer()
         {
-            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int x = 42, [||]y; System.Console.WriteLine(y); }"));
+            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int x = 42, $$y; System.Console.WriteLine(y); }"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    int [||]x = 42;
+    int $$x = 42;
 
     void M()
     {
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
     ref int M()
     {
         int[] arr = new[] { 1, 2, 3 };
-        ref int [||]x = ref arr[2];
+        ref int $$x = ref arr[2];
         return ref x;
     }
 }");
@@ -90,32 +90,32 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task SingleStatement()
         {
-            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int [||]x = 27; }"));
+            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int $$x = 27; }"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task MultipleDeclarators_First()
         {
-            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int [||]x = 0, y = 1, z = 2; }"));
+            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int $$x = 0, y = 1, z = 2; }"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task MultipleDeclarators_Second()
         {
-            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int x = 0, [||]y = 1, z = 2; }"));
+            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int x = 0, $$y = 1, z = 2; }"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task MultipleDeclarators_Last()
         {
-            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int x = 0, y = 1, [||]z = 2; }"));
+            await TestMissingInRegularAndScriptAsync(GetTreeText(@"{ int x = 0, y = 1, $$z = 2; }"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task Escaping1()
         {
             await TestFixOneAsync(
-@"{ int [||]x = 0;
+@"{ int $$x = 0;
 
 Console.WriteLine(x); }",
 @"{
@@ -126,7 +126,7 @@ Console.WriteLine(x); }",
         public async Task Escaping2()
         {
             await TestFixOneAsync(
-@"{ int [||]@x = 0;
+@"{ int $$@x = 0;
 
 Console.WriteLine(x); }",
 @"{
@@ -137,7 +137,7 @@ Console.WriteLine(x); }",
         public async Task Escaping3()
         {
             await TestFixOneAsync(
-@"{ int [||]@x = 0;
+@"{ int $$@x = 0;
 
 Console.WriteLine(@x); }",
 @"{
@@ -148,7 +148,7 @@ Console.WriteLine(@x); }",
         public async Task Escaping4()
         {
             await TestFixOneAsync(
-@"{ int [||]x = 0;
+@"{ int $$x = 0;
 
 Console.WriteLine(@x); }",
 @"{
@@ -164,7 +164,7 @@ class C
 {
     static void Main()
     {
-        var @where[||] = 0;
+        var @where$$ = 0;
         var q = from e in """" let a = new { @where } select a;
     }
 }";
@@ -191,7 +191,7 @@ class C
 {
     public void M()
     {
-        int [||]x = 1 + 1;
+        int $$x = 1 + 1;
         x.ToString();
     }
 }";
@@ -218,7 +218,7 @@ class C
 {
     public void M()
     {
-        double [||]x = 3;
+        double $$x = 3;
         x.ToString();
     }
 }";
@@ -240,7 +240,7 @@ class C
         public async Task Conversion_NoConversion()
         {
             await TestFixOneAsync(
-@"{ int [||]x = 3;
+@"{ int $$x = 3;
 
 x.ToString(); }",
                        @"{ 3.ToString(); }");
@@ -256,7 +256,7 @@ class C
 {
     void M()
     {
-        double [||]x = 3;
+        double $$x = 3;
         Console.WriteLine(x);
     }
 }",
@@ -289,7 +289,7 @@ class C
 {
     void F()
     {
-        Base [||]b = new Derived();
+        Base $$b = new Derived();
         b.M(""hi"");
     }
 }
@@ -331,7 +331,7 @@ class C
 {
     void F()
     {
-        Base [||]b = new Derived();
+        Base $$b = new Derived();
         b.M(3);
     }
 }
@@ -360,7 +360,7 @@ class C
         public async Task NoCastOnVar()
         {
             await TestFixOneAsync(
-@"{ var [||]x = 0;
+@"{ var $$x = 0;
 
 Console.WriteLine(x); }",
 @"{
@@ -375,7 +375,7 @@ class C
 {
     void M()
     {
-        int [||]x = x = 1;
+        int $$x = x = 1;
         int y = x;
     }
 }";
@@ -396,7 +396,7 @@ class C
         public async Task TestAnonymousType1()
         {
             await TestFixOneAsync(
-@"{ int [||]x = 42;
+@"{ int $$x = 42;
 var a = new { x }; }",
                        @"{ var a = new { x = 42 }; }");
         }
@@ -405,7 +405,7 @@ var a = new { x }; }",
         public async Task TestParenthesizedAtReference_Case3()
         {
             await TestFixOneAsync(
-@"{ int [||]x = 1 + 1;
+@"{ int $$x = 1 + 1;
 int y = x * 2; }",
                        @"{ int y = (1 + 1) * 2; }");
         }
@@ -421,7 +421,7 @@ class C
 
     void M()
     {
-        object [||]x = 1 + 1;
+        object $$x = 1 + 1;
         Goo(x);
     }
 }";
@@ -449,7 +449,7 @@ class C
 {
     void M()
     {
-        int [||]x = 1;
+        int $$x = 1;
         { Unrelated(); }
         Goo(x);
     }
@@ -476,7 +476,7 @@ class C
 {
     void M()
     {
-        System.Func<int> [||]x = () => 1;
+        System.Func<int> $$x = () => 1;
         int y = x();
     }
 }";
@@ -504,7 +504,7 @@ class C
     void F(object a, object b)
     {
         int x = 2;
-        bool [||]y = x > (f);
+        bool $$y = x > (f);
         F(x < x, y);
     }
     int f = 0;
@@ -532,7 +532,7 @@ class C
     void F(object a, object b)
     {
         int x = 2;
-        object [||]y = x > (f);
+        object $$y = x > (f);
         F(x < x, y);
     }
     int f = 0;
@@ -560,7 +560,7 @@ class C
     void F(object a, object b)
     {
         int x = 2;
-        bool [||]y = x > (int)1;
+        bool $$y = x > (int)1;
         F(x < x, y);
     }
     int f = 0;
@@ -588,7 +588,7 @@ class Program
     static void Main()
     {
         int x = 2;
-        int y[||] = (1+2);
+        int y$$ = (1+2);
         Bar(x < x, x > y);
     }
 
@@ -622,7 +622,7 @@ class Program
     static void Main()
     {
         int x = 2;
-        int y[||] = (1 + 2);
+        int y$$ = (1 + 2);
         var z = new[] { x < x, x > y };
     }
 }",
@@ -642,7 +642,7 @@ class Program
         public async Task TestArrayInitializer()
         {
             await TestFixOneAsync(
-@"{ int[] [||]x = {
+@"{ int[] $$x = {
     3,
     4,
     5
@@ -665,7 +665,7 @@ class Program
 { 
     static void Main()
     {
-        int[] [||]x = { 3, 4, 5 };
+        int[] $$x = { 3, 4, 5 };
         System.Array a = x;
     }
 }";
@@ -691,7 +691,7 @@ class Program
 { 
     static void Main()
     {
-        int[] [||]x = {
+        int[] $$x = {
                           3,
                           4,
                           5
@@ -725,7 +725,7 @@ class Program
 {
     void Main()
     {
-        int [||]x = 0;
+        int $$x = 0;
         Goo(ref x);
         Goo(x);
     }
@@ -771,7 +771,7 @@ class Program
 {
     void Main()
     {
-        int [||]x = 0;
+        int $$x = 0;
         Goo(x, ref x);
     }
 
@@ -807,7 +807,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i = 2;
         Console.WriteLine(i);
     }
@@ -837,7 +837,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i += 2;
         Console.WriteLine(i);
     }
@@ -869,7 +869,7 @@ class C
 
     static void M()
     {
-        int [||]x = (x = 0) + (x += 1);
+        int $$x = (x = 0) + (x += 1);
         int y = x;
     }
 }";
@@ -899,7 +899,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i -= 2;
         Console.WriteLine(i);
     }
@@ -929,7 +929,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i *= 2;
         Console.WriteLine(i);
     }
@@ -959,7 +959,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i /= 2;
         Console.WriteLine(i);
     }
@@ -989,7 +989,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i %= 2;
         Console.WriteLine(i);
     }
@@ -1019,7 +1019,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i &= 2;
         Console.WriteLine(i);
     }
@@ -1049,7 +1049,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i |= 2;
         Console.WriteLine(i);
     }
@@ -1079,7 +1079,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i ^= 2;
         Console.WriteLine(i);
     }
@@ -1109,7 +1109,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i <<= 2;
         Console.WriteLine(i);
     }
@@ -1139,7 +1139,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i >>= 2;
         Console.WriteLine(i);
     }
@@ -1169,7 +1169,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i++;
         Console.WriteLine(i);
     }
@@ -1199,7 +1199,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         ++i;
         Console.WriteLine(i);
     }
@@ -1229,7 +1229,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         i--;
         Console.WriteLine(i);
     }
@@ -1259,7 +1259,7 @@ class Program
 {
     void Main()
     {
-        int [||]i = 1;
+        int $$i = 1;
         --i;
         Console.WriteLine(i);
     }
@@ -1289,7 +1289,7 @@ class C
     unsafe void M()
     {
         int x = 0;
-        var y[||] = &x;
+        var y$$ = &x;
         var z = &y;
     }
 }";
@@ -1318,7 +1318,7 @@ class C
     static void Main(string[] args)
     {
         var x = y;
-        var y[||] = 45;
+        var y$$ = 45;
     }
 }";
 
@@ -1340,7 +1340,7 @@ class C
         {
             await TestFixOneAsync(@"
 {
-    int [||]x = 1,
+    int $$x = 1,
 #if true
         y,
 #endif
@@ -1367,7 +1367,7 @@ class C
 {
     int y,
 #if true
-        [||]x = 1,
+        $$x = 1,
 #endif
         z;
 
@@ -1394,7 +1394,7 @@ class C
 #if true
         z,
 #endif
-        [||]x = 1;
+        $$x = 1;
 
     int a = x;
 }",
@@ -1419,7 +1419,7 @@ class C
 {
     void M()
     {
-        int[] [||]a = /**/{ 1 };
+        int[] $$a = /**/{ 1 };
         Goo(a);
     }
 }";
@@ -1445,7 +1445,7 @@ class C
 {
     void M()
     {
-        int [||]i = 1, j = 2, k = 3;
+        int $$i = 1, j = 2, k = 3;
         System.Console.Write(i);
     }
 }";
@@ -1472,7 +1472,7 @@ class C
 {
     void M()
     {
-        int i = 1, [||]j = 2, k = 3;
+        int i = 1, $$j = 2, k = 3;
         System.Console.Write(j);
     }
 }";
@@ -1499,7 +1499,7 @@ class C
 {
     void M()
     {
-        int i = 1, j = 2, [||]k = 3;
+        int i = 1, j = 2, $$k = 3;
         System.Console.Write(k);
     }
 }";
@@ -1526,7 +1526,7 @@ class C
 {
     void M()
     {
-        var [||]x = 123;
+        var $$x = 123;
         var y = new { x };
     }
 }";
@@ -1552,7 +1552,7 @@ class C
 {
     void M()
     {
-        var [||]x = 123;
+        var $$x = 123;
         var y = new { x = x };
     }
 }";
@@ -1579,7 +1579,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Action<string[]> [||]del = Main;
+        Action<string[]> $$del = Main;
         del(null);
     }
 }";
@@ -1608,7 +1608,7 @@ class Program
 {
     static void Main()
     {
-        Action [||]x = delegate { };
+        Action $$x = delegate { };
         Action y = x ?? null;
     }
 }";
@@ -1638,7 +1638,7 @@ class Program
 {
     static void Main()
     {
-        Action [||]x = () => { };
+        Action $$x = () => { };
         Action y = x ?? null;
     }
 }";
@@ -1667,7 +1667,7 @@ class A
 {
     static void Main()
     {
-        long x[||] = 1;
+        long x$$ = 1;
         object z = x;
         Console.WriteLine((long)z);
     }
@@ -1698,7 +1698,7 @@ class A
     static void Main()
     {
         int y = 1;
-        long x[||] = y;
+        long x$$ = y;
         object z = x;
         Console.WriteLine((long)z);
     }
@@ -1729,7 +1729,7 @@ class A
 {
     static void Main()
     {
-        byte x[||] = 1;
+        byte x$$ = 1;
         object z = x;
         Console.WriteLine((byte)z);
     }
@@ -1759,7 +1759,7 @@ class A
 {
     static void Main()
     {
-        sbyte x[||] = 1;
+        sbyte x$$ = 1;
         object z = x;
         Console.WriteLine((sbyte)z);
     }
@@ -1789,7 +1789,7 @@ class A
 {
     static void Main()
     {
-        short x[||] = 1;
+        short x$$ = 1;
         object z = x;
         Console.WriteLine((short)z);
     }
@@ -1819,7 +1819,7 @@ class A
     static void Main(string[] args)
     {
         // Leading
-        int [||]i = 10;
+        int $$i = 10;
         //print
         Console.Write(i);
     }
@@ -1845,7 +1845,7 @@ class A
     static void Main(string[] args)
     {
         // Leading
-        int [||]i = 10; // Trailing
+        int $$i = 10; // Trailing
         //print
         Console.Write(i);
     }
@@ -1871,7 +1871,7 @@ class A
 {
     static void Main(string[] args)
     {
-        int [||]i = 10; // Trailing
+        int $$i = 10; // Trailing
         //print
         Console.Write(i);
     }
@@ -1897,7 +1897,7 @@ class A
     static void Main(string[] args)
     {
 #if true
-        int [||]i = 10; 
+        int $$i = 10; 
         //print
         Console.Write(i);
 #endif
@@ -1924,7 +1924,7 @@ class A
 {
     static void Main(string[] args)
     {
-        int [||]i = 5; int j = 110;
+        int $$i = 5; int j = 110;
         Console.Write(i + j);
     }
 }",
@@ -1951,7 +1951,7 @@ class C
         switch (10)
         {
             default:
-                int i[||] = 10;
+                int i$$ = 10;
                 Console.WriteLine(i);
                 break;
         }
@@ -1984,7 +1984,7 @@ class C
     static Action X;
     static void M()
     {
-        var [||]y = (X);
+        var $$y = (X);
         y();
     }
 }
@@ -2015,7 +2015,7 @@ class Program
     static void Main()
     {
         Action x = Console.WriteLine;
-        Action y[||] = x;
+        Action y$$ = x;
         y();
     }
 }
@@ -2047,7 +2047,7 @@ class A
 {
     static void Main()
     {
-        var [||]q = from x in """" select x;
+        var $$q = from x in """" select x;
         if (q is IEnumerable)
         {
         }
@@ -2079,7 +2079,7 @@ class C
 {
     static void Main()
     {
-        Action<string> f[||] = Goo<string>;
+        Action<string> f$$ = Goo<string>;
         Action<string> g = null;
         var h = f + g;
     }
@@ -2112,7 +2112,7 @@ unsafe class C
     static void M()
     {
         int x;
-        int* p[||] = &x;
+        int* p$$ = &x;
         var i = (Int32)p;
     }
 }",
@@ -2140,7 +2140,7 @@ unsafe class C
     static void M()
     {
         int x;
-        int* p[||] = &x;
+        int* p$$ = &x;
         var i = p->ToString();
     }
 }",
@@ -2168,7 +2168,7 @@ unsafe class C
     static void M()
     {
         int* x = null;
-        int p[||] = *x;
+        int p$$ = *x;
         var i = (Int64)p;
     }
 }",
@@ -2196,7 +2196,7 @@ unsafe class C
     static void M()
     {
         int** x = null;
-        int* p[||] = *x;
+        int* p$$ = *x;
         var i = p[1].ToString();
     }
 }",
@@ -2223,7 +2223,7 @@ unsafe class C
 {
     static void M()
     {
-        int* values[||] = stackalloc int[20];
+        int* values$$ = stackalloc int[20];
         int* copy = values;
         int* p = &values[1];
         int* q = &values[15];
@@ -2241,7 +2241,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<int?,int?> [||]lam = (int? s) => { return s; };
+        Func<int?,int?> $$lam = (int? s) => { return s; };
         Console.WriteLine(lam);
     }
 }",
@@ -2266,7 +2266,7 @@ class C
 {
     void M()
     {
-        string [||]x = null;
+        string $$x = null;
         Console.WriteLine(x);
     }
 }",
@@ -2291,7 +2291,7 @@ class C
 {
     void M()
     {
-        long x[||] = 1;
+        long x$$ = 1;
         System.IComparable<long> y = x;
     }
 }",
@@ -2317,7 +2317,7 @@ class C
 {
     static void Main()
     {
-        Goo(x => { int [||]y = x[0]; x[1] = y; });
+        Goo(x => { int $$y = x[0]; x[1] = y; });
     }
  
     static void Goo(Action<int[]> x) { }
@@ -2349,7 +2349,7 @@ class C
     void M()
     {
         var c = new C();
-        int x[||] = 1;
+        int x$$ = 1;
         c[x] = 2;
     }
 
@@ -2383,7 +2383,7 @@ class Program
 {
     static void Main()
     {
-        E x[||] = (global::E) -1;
+        E x$$ = (global::E) -1;
         object y = x;
     }
 }",
@@ -2414,7 +2414,7 @@ class Program
 {
     static void M()
     {
-        DayOfWeek x[||] = 0;
+        DayOfWeek x$$ = 0;
         object y = x;
         Console.WriteLine(y);
     }
@@ -2445,7 +2445,7 @@ class Program
 {
     static void M()
     {
-        Action a[||] = Console.WriteLine;
+        Action a$$ = Console.WriteLine;
         Action b = a + Console.WriteLine;
     }
 }",
@@ -2474,7 +2474,7 @@ class Program
 {
     static void Main()
     {
-        Action a[||] = Console.WriteLine;
+        Action a$$ = Console.WriteLine;
         object b = a;
     }
 }",
@@ -2504,7 +2504,7 @@ class A<T>
     {
         static void Goo()
         {
-            var y[||] = x;
+            var y$$ = x;
             var z = y;
         }
     }
@@ -2537,7 +2537,7 @@ class Program
 {
     static void Main()
     {
-        Predicate<object> x[||] = y => true;
+        Predicate<object> x$$ = y => true;
         var z = new Func<string, bool>(x);
     }
 }
@@ -2567,7 +2567,7 @@ class Program
 {
     static void Main()
     {
-        Exception e[||] = new ArgumentException();
+        Exception e$$ = new ArgumentException();
         Type b = e.GetType();
     }
 }
@@ -2597,7 +2597,7 @@ class Program
 {
     static void Main()
     {
-        IEnumerable<char> s[||] = ""abc"";
+        IEnumerable<char> s$$ = ""abc"";
         foreach (var x in s)
             Console.WriteLine(x);
     }
@@ -2631,7 +2631,7 @@ class Program
 {
     static void Main()
     {
-        IEnumerable s[||] = ""abc"";
+        IEnumerable s$$ = ""abc"";
         foreach (object x in s)
             Console.WriteLine(x);
     }
@@ -2665,7 +2665,7 @@ class Program
 {
     static void Main()
     {
-        IEnumerable s[||] = ""abc"";
+        IEnumerable s$$ = ""abc"";
         foreach (char x in s)
             Console.WriteLine(x);
     }
@@ -2700,7 +2700,7 @@ class C
 
     static void M()
     {
-        long [||]x = 1;
+        long $$x = 1;
         IComparable<long> c = Goo(x, x);
     }
 }
@@ -2730,7 +2730,7 @@ class C
 {
     static void M()
     {
-        object x[||] = null;
+        object x$$ = null;
         var a = new[] { x, x };
         Goo(a);
     }
@@ -2763,7 +2763,7 @@ class C
 {
     static void M()
     {
-        long x[||] = 42;
+        long x$$ = 42;
         Goo(x, x);
     }
 
@@ -2795,7 +2795,7 @@ class C
 {
     static void M()
     {
-        long x[||] = 42;
+        long x$$ = 42;
         Goo(() => { return x; }, () => { return x; });
     }
 
@@ -2830,7 +2830,7 @@ class C
 
     void M()
     {
-        C x[||] = 42;
+        C x$$ = 42;
         Console.WriteLine(x + x);
     }
 
@@ -2898,7 +2898,7 @@ class X
     const int Value = 1000;
     static void Main()
     {
-        var a[||] = Goo(X => (byte)X.Value, null);
+        var a$$ = Goo(X => (byte)X.Value, null);
         unchecked
         {
             Console.WriteLine(a);
@@ -2943,7 +2943,7 @@ static class C
 
     static void Main()
     {
-        var a[||] = Outer(x => Inner(x, null), null);
+        var a$$ = Outer(x => Inner(x, null), null);
         unsafe
         {
             Console.WriteLine(a);
@@ -2989,7 +2989,7 @@ class C
     {
         Goo(x =>
         {
-            string s[||] = x;
+            string s$$ = x;
             var y = s;
         });
     }
@@ -3022,7 +3022,7 @@ class C
 {
     static void M()
     {
-        int [||]a[10] = {
+        int $$a[10] = {
             0,
             0
         };
@@ -3105,7 +3105,7 @@ class Program
 {
     void Main()
     {
-        int [||]x = 0;
+        int $$x = 0;
 
         Goo(x);
 #line hidden
@@ -3137,7 +3137,7 @@ class Program
 {
     void Main()
     {
-        int [||]x = 0;
+        int $$x = 0;
         Goo(x);
 #line hidden
         Goo(x);
@@ -3160,7 +3160,7 @@ class Program
     static void Main()
     {
     label:
-        int [||]x = 1;
+        int $$x = 1;
         Console.WriteLine();
         int y = x;        
     }
@@ -3193,7 +3193,7 @@ class Program
     static void Main()
     {
         int x = 0;
-        int y[||] = x += 1;
+        int y$$ = x += 1;
         var z = new List<int> { y };
     }
 }",
@@ -3223,7 +3223,7 @@ class Program
 {
     static void Main()
     {
-        IList<dynamic> x[||] = new List<object>();
+        IList<dynamic> x$$ = new List<object>();
         IList<object> y = x;
     }
 }",
@@ -3252,7 +3252,7 @@ class Program
 {
     static void Main()
     {
-        IList<object> x[||] = new List<dynamic>();
+        IList<object> x$$ = new List<dynamic>();
         IList<dynamic> y = x;
     }
 }
@@ -3283,7 +3283,7 @@ class Program
 {
     static void Main()
     {
-        ValueType x[||] = 1;
+        ValueType x$$ = 1;
         object y = x;
     }
 }
@@ -3321,7 +3321,7 @@ static class C
 
     static void Main()
     {
-        Outer(y => Inner(x => { var z[||] = x; Action a = () => z.GetType(); }, y), null);
+        Outer(y => Inner(x => { var z$$ = x; Action a = () => z.GetType(); }, y), null);
     }
 }
 ",
@@ -3360,7 +3360,7 @@ class A<B>
         {
             void M()
             {
-                var x[||] = new C[0];
+                var x$$ = new C[0];
                 C[] y = x;
             }
         }
@@ -3397,7 +3397,7 @@ class A
 {
     static void Main()
     {
-        var a[||] = new A(); // Inline a
+        var a$$ = new A(); // Inline a
         Goo(a);
     }
  
@@ -3804,7 +3804,7 @@ class C
 
     static void N(int x, int y)
     {
-        FormattableString [||]s = $""{x}, {y}"";
+        FormattableString $$s = $""{x}, {y}"";
         M(s);
     }
 }";
@@ -3841,7 +3841,7 @@ class C
 
     static void N(int x, int y)
     {
-        FormattableString [||]s = $""{x}, {y}"";
+        FormattableString $$s = $""{x}, {y}"";
         M(s);
     }
 }";
@@ -3874,7 +3874,7 @@ class C
 
     static void N()
     {
-        var [||]x = 42;
+        var $$x = 42;
         M(() =>
         {
             Console.WriteLine(x);
@@ -3911,7 +3911,7 @@ class C
 {
     public void M()
     {
-        (int, string) [||]x = (1, ""hello"");
+        (int, string) $$x = (1, ""hello"");
         x.ToString();
     }
 }";
@@ -3928,7 +3928,7 @@ class C
 {
     public void M()
     {
-        (int, string) [||]x = (1, ""hello"");
+        (int, string) $$x = (1, ""hello"");
         x.ToString();
     }
 }";
@@ -3955,7 +3955,7 @@ class C
 {
     public void M()
     {
-        (int a, string b) [||]x = (a: 1, b: ""hello"");
+        (int a, string b) $$x = (a: 1, b: ""hello"");
         x.ToString();
     }
 }";
@@ -3982,7 +3982,7 @@ class C
 {
     public void M()
     {
-        (int a, string b) [||]x = (c: 1, d: ""hello"");
+        (int a, string b) $$x = (c: 1, d: ""hello"");
         x.a.ToString();
     }
 }";
@@ -4008,7 +4008,7 @@ class C
 {
     public void M()
     {
-        var [||]temp = new C();
+        var $$temp = new C();
         var (x1, x2) = temp;
         var x3 = temp;
     }
@@ -4037,7 +4037,7 @@ class Program
 {
     static void Main()
     {
-        var [||]kvp = KVP.Create(42, ""hello"");
+        var $$kvp = KVP.Create(42, ""hello"");
         var(x1, x2) = kvp;
     }
 }
@@ -4079,7 +4079,7 @@ class C
 {
     void M()
     {
-        int [||]i = 1 + 2;
+        int $$i = 1 + 2;
         string s = ""a"" + i;
     }
 }";
@@ -4104,7 +4104,7 @@ class C
 {
     void M()
     {
-        int [||]i = 1 + 2;
+        int $$i = 1 + 2;
         var t = (i, 3);
     }
 }";
@@ -4129,7 +4129,7 @@ class C
 {
     void M()
     {
-        int [||]i = 1 + 2;
+        int $$i = 1 + 2;
         var t = ( /*comment*/ i, 3);
     }
 }";
@@ -4154,7 +4154,7 @@ class C
 {
     void M()
     {
-        int [||]i = 1 + 2;
+        int $$i = 1 + 2;
         var t = (
             /*comment*/ i,
             /*comment*/ 3
@@ -4185,7 +4185,7 @@ class C
 {
     void M()
     {
-        int [||]i = 1 + 2;
+        int $$i = 1 + 2;
         var t = (i, i);
     }
 }";
@@ -4211,7 +4211,7 @@ class C
     static int y = 1;
     void M()
     {
-        int [||]i = C.y;
+        int $$i = C.y;
         var t = ((i, (i, _)) = (1, (i, 3)));
     }
 }";
@@ -4238,7 +4238,7 @@ class C
     static int y = 1;
     void M()
     {
-        int [||]i = C.y;
+        int $$i = C.y;
         var t = ((i, _) = (1, 2));
     }
 }";
@@ -4263,7 +4263,7 @@ class C
 {
     void M()
     {
-        int [||]Rest = 1 + 2;
+        int $$Rest = 1 + 2;
         var t = (Rest, 3);
     }
 }";
@@ -4287,7 +4287,7 @@ class C
 {
     void M()
     {
-        int [||]Item1 = 1 + 2;
+        int $$Item1 = 1 + 2;
         var t = (Item1, 3);
     }
 }";
@@ -4311,7 +4311,7 @@ class C
 {
     void M()
     {
-        int [||]@int = 1 + 2;
+        int $$@int = 1 + 2;
         var t = (@int, 3);
     }
 }";
@@ -4335,7 +4335,7 @@ class C
 {
     void M()
     {
-        int [||]@where = 1 + 2;
+        int $$@where = 1 + 2;
         var t = (@where, 3);
     }
 }";
@@ -4359,7 +4359,7 @@ class C
 {
     void M()
     {
-        int [||]i = 1 + 2;
+        int $$i = 1 + 2;
         var t = new { i, i }; // error already
     }
 }";
@@ -4384,7 +4384,7 @@ class C
     void M()
     {
         int j = 0;
-        int [||]i = j = 1;
+        int $$i = j = 1;
         var t = new { i, k = 3 };
     }
 }";
@@ -4409,7 +4409,7 @@ class C
 {
     void M()
     {
-        int [||]i = 1 + 2;
+        int $$i = 1 + 2;
         var t = new { /*comment*/ i, j = 3 };
     }
 }";
@@ -4433,7 +4433,7 @@ class C
 {
     void M()
     {
-        int [||]i = 1 + 2;
+        int $$i = 1 + 2;
         var t = new {
             /*comment*/ i,
             /*comment*/ j = 3
@@ -4502,7 +4502,7 @@ class C
 {
     bool M<T>(ref T x) 
     {
-        var [||]b = M(ref x);
+        var $$b = M(ref x);
         return b || b;
     }
 }",
@@ -4527,7 +4527,7 @@ class C
 {
     bool M<T>(out T x) 
     {
-        var [||]b = M(out x);
+        var $$b = M(out x);
         return b || b;
     }
 }",
@@ -4551,7 +4551,7 @@ class C
 {
     bool M()
     {
-        var [||]o = M();
+        var $$o = M();
         if (!o) throw null;
         throw null;
     }
@@ -4577,7 +4577,7 @@ class C
 {
     void M()
     {
-        var [||]o = (Exception)null;
+        var $$o = (Exception)null;
         Console.Write(o == new Exception());
     }
 }",

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -45,7 +45,7 @@ class C
 {
     void M(Action action)
     {
-        M(() [||]=> { });
+        M(() $$=> { });
     }
 }",
 @"using System;
@@ -68,7 +68,7 @@ class C
 {
     void M(int a, int b)
     {
-        var x = a [||]+ b + 3;
+        var x = a $$+ b + 3;
     }
 }",
 @"using System;
@@ -91,7 +91,7 @@ class C
 {
     void M(int a)
     {
-        var x = [||]a;
+        var x = $$a;
     }
 }");
         }
@@ -105,7 +105,7 @@ class C
 {
     void M(Action action)
     {
-        M(() => { var x [||]= y; });
+        M(() => { var x $$= y; });
     }
 }");
         }
@@ -4649,7 +4649,7 @@ class C
 {
     void M(int a)
     {
-        System.Console.Write([||]a);
+        System.Console.Write($$a);
     }
 }");
         }
@@ -4778,7 +4778,7 @@ class C
     static int a;
     void M()
     {
-        System.Console.Write(C.[||]a);
+        System.Console.Write(C.$$a);
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/LambdaSimplifier/LambdaSimplifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/LambdaSimplifier/LambdaSimplifierTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -24,7 +24,7 @@ class C
 {
     void Goo()
     {
-        Bar(s [||]=> Quux(s));
+        Bar(s $$=> Quux(s));
     }
 
     void Bar(Func<int, string> f);
@@ -55,7 +55,7 @@ class C
 {
     void Goo()
     {
-        Bar(s [||]=> Quux(s));
+        Bar(s $$=> Quux(s));
     }
 
     void Bar(Func<object, string> f);
@@ -86,7 +86,7 @@ class C
 {
     void Goo()
     {
-        Bar(s [||]=> Quux(s));
+        Bar(s $$=> Quux(s));
     }
 
     void Bar(Func<string, object> f);
@@ -117,7 +117,7 @@ class C
 {
     void Goo()
     {
-        Bar(s [||]=> Quux(s));
+        Bar(s $$=> Quux(s));
     }
 
     void Bar(Func<string, string> f);
@@ -135,7 +135,7 @@ class C
 {
     void Goo()
     {
-        Bar(s [||]=> Quux(s));
+        Bar(s $$=> Quux(s));
     }
 
     void Bar(Func<object, object> f);
@@ -153,7 +153,7 @@ class C
 {
     void Goo()
     {
-        Bar(s [||]=> Quux(s));
+        Bar(s $$=> Quux(s));
     }
 
     void Bar(Func<object, string> f);
@@ -171,7 +171,7 @@ class C
 {
     void Goo()
     {
-        Bar((s1, s2) [||]=> Quux(s1, s2));
+        Bar((s1, s2) $$=> Quux(s1, s2));
     }
 
     void Bar(Func<int, bool, string> f);
@@ -202,7 +202,7 @@ class C
 {
     void Goo()
     {
-        Bar((s1, s2) [||]=> {
+        Bar((s1, s2) $$=> {
             return Quux(s1, s2);
         });
     }
@@ -235,7 +235,7 @@ class C
 {
     void Goo()
     {
-        Bar((s1, s2) [||]=> {
+        Bar((s1, s2) $$=> {
             return this.Quux(s1, s2);
         });
     }
@@ -268,7 +268,7 @@ class C
 {
     void Goo()
     {
-        Bar(s [||]=> Quux(s));
+        Bar(s $$=> Quux(s));
         Bar(s => Quux(s));
     }
 
@@ -297,7 +297,7 @@ class C
 {
     void Goo()
     {
-        Bar(s [||]=> Quux(s));
+        Bar(s $$=> Quux(s));
         Bar(s => Quux(s));
     }
 
@@ -343,7 +343,7 @@ class A
 
     static void Main()
     {
-        Bar(x => [||]Goo(x));
+        Bar(x => $$Goo(x));
     }
 }");
         }
@@ -367,7 +367,7 @@ class C<T>
 {
     public static void InvokeGoo()
     {
-        Action<dynamic, string> goo = (x, y) => [||]C<T>.Goo(x, y); // Simplify lambda expression
+        Action<dynamic, string> goo = (x, y) => $$C<T>.Goo(x, y); // Simplify lambda expression
         goo(1, "");
     }
 
@@ -402,7 +402,7 @@ class Casd<T>
 {
     public static void InvokeGoo()
     {
-        Action<dynamic> goo = x => [||]Casd<T>.Goo(x); // Simplify lambda expression
+        Action<dynamic> goo = x => $$Casd<T>.Goo(x); // Simplify lambda expression
         goo(1, "");
     }
 
@@ -435,7 +435,7 @@ class C
     {
         C x = new C();
         int y = 1;
-        Bar(() [||]=> { return Console.ReadLine(); } < x, y > (1 + 2));
+        Bar(() $$=> { return Console.ReadLine(); } < x, y > (1 + 2));
     }
 
     static void Bar(object a, object b) { }
@@ -473,7 +473,7 @@ class C
 {
     void Main()
     {
-        Func<string> a = () [||]=> new C().ToString();
+        Func<string> a = () $$=> new C().ToString();
     }
 }",
 @"using System;
@@ -498,7 +498,7 @@ class Program
 {
     static void Main()
     {
-        Action a = [||]() => {
+        Action a = $$() => {
             Console.WriteLine();
         };
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             var code =
 @"namespace N1
 {
-    class Class1[||]
+    class Class1$$
     {
     }
 }";
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             var code =
 @"namespace N1
 {
-    [||]
+    $$
     class Class1
     {
     }
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             var code =
 @"namespace N1
 {
-    [||][X]
+    $$[X]
     class Class1
     {
     }
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
 @"namespace N1
 {
     class Class1
-    [||]{
+    $${
     }
 }";
             await TestMissingInRegularAndScriptAsync(code);
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             var code =
 @"namespace N1
 {
-    class Class1[||]
+    class Class1$$
     {
     }
 
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             var code =
 @"namespace N1
 {
-    class Class1[||]
+    class Class1$$
     {
     }
 
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
 {
     class OuterType
     {
-        class InnerType[||]
+        class InnerType$$
         {
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         public async Task TestMissing_OnMatchingFileName()
         {
             var code =
-@"[||]class test1 { }";
+@"$$class test1 { }";
 
             await TestMissingInRegularAndScriptAsync(code);
         }
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             var code =
 @"class outer
 { 
-    [||]class test1 { }
+    $$class test1 { }
 }";
 
             await TestMissingInRegularAndScriptAsync(code);
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         public async Task TestMatchingFileName_CaseSensitive()
         {
             var code =
-@"[||]class Test1 { }";
+@"$$class Test1 { }";
 
             await TestActionCountAsync(code, count: 2);
         }
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         public async Task TestForSpans2()
         {
             var code =
-@"[||]class Class1 { }
+@"$$class Class1 { }
  class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document Folders=""A\B""> 
-[||]class Class1 { }
+$$class Class1 { }
 class Class2 { }
         </Document>
     </Project>
@@ -106,7 +106,7 @@ class Class2 { }";
         public async Task TestForSpans4()
         {
             var code =
-@"class Class1[||] { }
+@"class Class1$$ { }
 class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
@@ -121,7 +121,7 @@ class Class2 { }";
         public async Task MoveTypeWithNoContainerNamespace()
         {
             var code =
-@"[||]class Class1 { }
+@"$$class Class1 { }
 class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
@@ -139,7 +139,7 @@ class Class2 { }";
 @"// Banner Text
 using System;
 
-[||]class Class1 { }
+$$class Class1 { }
 class Class2 { }";
 
             var codeAfterMove =
@@ -163,7 +163,7 @@ class Class1 { }
 @"// Banner Text
 using System;
 
-[||]class Class1 
+$$class Class1 
 { 
     void Print(int x)
     {
@@ -200,7 +200,7 @@ class Class1
 @"// Banner Text
 using System;
 
-[||]class Class1 
+$$class Class1 
 { 
     void Print(int x)
     {
@@ -249,7 +249,7 @@ class Class1
         public async Task MoveAnInterface()
         {
             var code =
-@"[||]interface IMoveType { }
+@"$$interface IMoveType { }
 class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
@@ -264,7 +264,7 @@ class Class2 { }";
         public async Task MoveAStruct()
         {
             var code =
-@"[||]struct MyStruct { }
+@"$$struct MyStruct { }
 class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
@@ -279,7 +279,7 @@ class Class2 { }";
         public async Task MoveAnEnum()
         {
             var code =
-@"[||]enum MyEnum { }
+@"$$enum MyEnum { }
 class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
@@ -296,7 +296,7 @@ class Class2 { }";
             var code =
 @"namespace N1
 {
-    [||]class Class1 { }
+    $$class Class1 { }
         class Class2 { }
 }";
 
@@ -324,7 +324,7 @@ class Class2 { }";
 {
     class Class1 
     {
-        [||]class Class2 { }
+        $$class Class2 { }
     }
     
 }";
@@ -360,7 +360,7 @@ class Class2 { }";
 {
     abstract class Class1 
     {
-        [||]class Class2 { }
+        $$class Class2 { }
     }
     
 }";
@@ -399,7 +399,7 @@ class Class2 { }";
     class Class1 
     {
         [Inner]
-        [||]class Class2 { }
+        $$class Class2 { }
     }
     
 }";
@@ -440,7 +440,7 @@ class Class2 { }";
     class Class1
     {
         /// Inner doc comment
-        [||]class Class2
+        $$class Class2
         {
         }
     }
@@ -480,7 +480,7 @@ class Class2 { }";
 {
     class Class1 
     {
-        [||]class Class2 { }
+        $$class Class2 { }
     }
     
 }";
@@ -518,7 +518,7 @@ class Class2 { }";
     {
         private int _field1;
 
-        [||]class Class2 { }
+        $$class Class2 { }
 
         public void Method1() { }
     }
@@ -561,7 +561,7 @@ class Class2 { }";
     {
         private int _field1;
 
-        [||]class Class2 { }
+        $$class Class2 { }
 
         public void Method1() { }
     }
@@ -611,7 +611,7 @@ class Class2 { }";
     {
         private int _field1;
 
-        [||]class Class2 
+        $$class Class2 
         {
             private string _field1;
             public void InnerMethod() { }
@@ -670,7 +670,7 @@ class Class2 { }";
     {
         class OuterClass2
         {
-            [||]class InnerClass2 
+            $$class InnerClass2 
             {
                 class InnerClass3
                 {
@@ -776,7 +776,7 @@ using System;
 using System.Collections;
 
 class Outer { 
-    [||]class Inner {
+    $$class Inner {
         DateTime d;
     }
 }";
@@ -818,7 +818,7 @@ class Outer
     {
     }
 
-    [||]class Inner2
+    $$class Inner2
     {
     }
 }";
@@ -855,7 +855,7 @@ class Outer
     {
     }
 
-    [||]class Inner2
+    $$class Inner2
     {
     }
 }";
@@ -897,7 +897,7 @@ class Outer
     {
     }
 
-    [||]class Inner2
+    $$class Inner2
     {
     }
 }";
@@ -933,7 +933,7 @@ partial class Outer
             var code =
 @"
 class Outer : IComparable { 
-    [||]class Inner : IWhatever {
+    $$class Inner : IWhatever {
         DateTime d;
     }
 }";
@@ -974,7 +974,7 @@ namespace N
 }
 
 #if true
-public class [||]Inner
+public class $$Inner
 {
 
 }
@@ -1025,7 +1025,7 @@ namespace N
         }
 
 #if true
-        public class [||]Inner
+        public class $$Inner
         {
 
         }
@@ -1075,7 +1075,7 @@ namespace N
 @"// Banner Text
 using System;
 
-[||]class Class1
+$$class Class1
 {
     void Foo()
     {
@@ -1136,7 +1136,7 @@ class Class1
     }
 }
 
-[||]class Class2
+$$class Class2
 {
     void Foo()
     {

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         public async Task SingleClassInFile_RenameFile()
         {
             var code =
-@"[||]class Class1 { }";
+@"$$class Class1 { }";
 
             var expectedDocumentName = "Class1.cs";
 
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         public async Task MoreThanOneTypeInFile_RenameFile()
         {
             var code =
-@"[||]class Class1
+@"$$class Class1
 { 
     class Inner { }
 }";
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             var code =
 @"class Class1
 { 
-    [||]class Inner { }
+    $$class Inner { }
 }";
 
             var expectedDocumentName = "Class1.Inner.cs";
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document Folders=""A\B""> 
-[||]class Class1
+$$class Class1
 { 
     class Inner { }
 }
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             // testworkspace creates files like test1.cs, test2.cs and so on.. 
             // so type name matches filename here and rename file action should not be offered.
             var code =
-@"[||]class test1 { }";
+@"$$class test1 { }";
 
             await TestRenameFileToMatchTypeAsync(code, expectedCodeAction: false);
         }
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         public async Task TestMissing_MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameFile()
         {
             var code =
-@"[||]class Class1 { }
+@"$$class Class1 { }
 class test1 { }";
 
             await TestRenameFileToMatchTypeAsync(code, expectedCodeAction: false);
@@ -96,7 +96,7 @@ class test1 { }";
         public async Task MultipleTopLevelTypesInFileAndNoneMatchFileName_RenameFile()
         {
             var code =
-@"[||]class Class1 { }
+@"$$class Class1 { }
 class Class2 { }";
 
             var expectedDocumentName = "Class1.cs";
@@ -109,7 +109,7 @@ class Class2 { }";
         {
             var code =
 @"class Class1 { }
-[||]class Class2 { }";
+$$class Class2 { }";
 
             var expectedDocumentName = "Class2.cs";
 
@@ -122,7 +122,7 @@ class Class2 { }";
             var code =
 @"class OuterType
 {
-    [||]class InnerType { }
+    $$class InnerType { }
 }";
 
             var expectedDocumentName = "InnerType.cs";
@@ -136,7 +136,7 @@ class Class2 { }";
             var code =
 @"class OuterType
 {
-    [||]class InnerType { }
+    $$class InnerType { }
 }";
 
             var expectedDocumentName = "OuterType.InnerType.cs";

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameType.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         public async Task SingleClassInFile_RenameType()
         {
             var code =
-@"[||]class Class1 { }";
+@"$$class Class1 { }";
 
             var codeWithTypeRenamedToMatchFileName =
 @"class [|test1|] { }";
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         public async Task MoreThanOneTypeInFile_RenameType()
         {
             var code =
-@"[||]class Class1
+@"$$class Class1
 { 
     class Inner { }
 }";
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             // testworkspace creates files like test1.cs, test2.cs and so on.. 
             // so type name matches filename here and rename file action should not be offered.
             var code =
-@"[||]class test1 { }";
+@"$$class test1 { }";
 
             await TestRenameTypeToMatchFileAsync(code, expectedCodeAction: false);
         }
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         public async Task TestMissing_MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameType()
         {
             var code =
-@"[||]class Class1 { }
+@"$$class Class1 { }
 class test1 { }";
 
             await TestRenameTypeToMatchFileAsync(code, expectedCodeAction: false);
@@ -64,7 +64,7 @@ class test1 { }";
         public async Task MultipleTopLevelTypesInFileAndNoneMatchFileName1_RenameType()
         {
             var code =
-@"[||]class Class1 { }
+@"$$class Class1 { }
 class Class2 { }";
 
             var codeWithTypeRenamedToMatchFileName =
@@ -79,7 +79,7 @@ class Class2 { }";
         {
             var code =
 @"class Class1 { }
-[||]class Class2 { }";
+$$class Class2 { }";
 
             var codeWithTypeRenamedToMatchFileName =
 @"class Class1 { }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 }",
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]Goo()
+    int $$Goo()
     {
     }
 }",
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]GetGoo() => 0;
+    int $$GetGoo() => 0;
 }",
 @"class C
 {
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]GetGoo();
+    int $$GetGoo();
 }",
 @"class C
 {
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    public static int [||]GetGoo()
+    public static int $$GetGoo()
     {
     }
 }",
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
 @"class C
 {
     [A]
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 }",
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
 @"class C
 {
     // Goo
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 }",
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
         int count;
         foreach (var x in y)
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
 @"class C
 {
 #if true
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 #endif
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
 @"class C
 {
 #if true
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
 @"class C
 {
 #if true
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -301,7 +301,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
     {
     }
 
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 #endif
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
     {
     }
 
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 #endif
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
 @"class C
 {
     // Goo
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
     // SetGoo
@@ -398,7 +398,7 @@ index: 1);
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]I.GetGoo()
+    int $$I.GetGoo()
     {
     }
 }",
@@ -424,7 +424,7 @@ index: 1);
 
 class C : I
 {
-    int [||]I.GetGoo()
+    int $$I.GetGoo()
     {
     }
 }",
@@ -450,7 +450,7 @@ class C : I
             await TestWithAllCodeStyleOff(
 @"interface I
 {
-    int [||]GetGoo();
+    int $$GetGoo();
 }
 
 class C : I
@@ -481,7 +481,7 @@ class C : I
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    [At[||]tr]
+    [At$$tr]
     int GetGoo()
     {
     }
@@ -496,7 +496,7 @@ class C : I
 {
     int GetGoo()
     {
-[||]
+$$
     }
 }");
         }
@@ -507,7 +507,7 @@ class C : I
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    void [||]GetGoo()
+    void $$GetGoo()
     {
     }
 }");
@@ -519,7 +519,7 @@ class C : I
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    async Task [||]GetGoo()
+    async Task $$GetGoo()
     {
     }
 }");
@@ -531,7 +531,7 @@ class C : I
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo<T>()
+    int $$GetGoo<T>()
     {
     }
 }");
@@ -543,7 +543,7 @@ class C : I
             await TestMissingInRegularAndScriptAsync(
 @"static class C
 {
-    int [||]GetGoo(this int i)
+    int $$GetGoo(this int i)
     {
     }
 }");
@@ -555,7 +555,7 @@ class C : I
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo(int i)
+    int $$GetGoo(int i)
     {
     }
 }");
@@ -567,7 +567,7 @@ class C : I
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo(int i = 0)
+    int $$GetGoo(int i = 0)
     {
     }
 }");
@@ -579,7 +579,7 @@ class C : I
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    [At[||]tr]
+    [At$$tr]
     int GetGoo()
     {
     }
@@ -594,7 +594,7 @@ class C : I
 {
     int GetGoo()
     {
-[||]
+$$
     }
 }");
         }
@@ -605,7 +605,7 @@ class C : I
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -636,7 +636,7 @@ class C : I
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -667,7 +667,7 @@ class C : I
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -698,7 +698,7 @@ class C : I
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -731,7 +731,7 @@ class C : I
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
         return GetGoo();
     }
@@ -754,7 +754,7 @@ class C : I
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    public virtual int [||]GetGoo()
+    public virtual int $$GetGoo()
     {
     }
 }
@@ -794,7 +794,7 @@ class D : C
 
 class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -829,7 +829,7 @@ class C
 
 class C
 {
-    public IEnumerator [||]GetEnumerator()
+    public IEnumerator $$GetEnumerator()
     {
     }
 
@@ -868,7 +868,7 @@ class C
 
 class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -902,7 +902,7 @@ index: 1);
 
 class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -946,7 +946,7 @@ index: 1);
 
 class C
 {
-    public int [||]GetGoo()
+    public int $$GetGoo()
     {
     }
 
@@ -980,7 +980,7 @@ index: 1);
 
 class C
 {
-    int [||]GetGoo() => 0;
+    int $$GetGoo() => 0;
     void SetGoo(int i) => Bar();
 }",
 @"using System;
@@ -1011,7 +1011,7 @@ index: 1);
 
 class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -1055,7 +1055,7 @@ index: 1);
 
 class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -1091,7 +1091,7 @@ index: 1);
 
 class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -1127,7 +1127,7 @@ index: 1);
 
 class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 
@@ -1161,7 +1161,7 @@ index: 1);
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    protected virtual int [||]GetGoo()
+    protected virtual int $$GetGoo()
     {
     }
 }
@@ -1200,7 +1200,7 @@ index: 0);
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    protected virtual int [||]GetGoo()
+    protected virtual int $$GetGoo()
     {
     }
 }
@@ -1241,7 +1241,7 @@ index: 0);
             await TestWithAllCodeStyleOff(
 @"interface I
 {
-    int [||]GetGoo();
+    int $$GetGoo();
 }
 
 class C : I
@@ -1273,7 +1273,7 @@ index: 0);
             await TestWithAllCodeStyleOff(
 @"partial class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
 }
@@ -1312,7 +1312,7 @@ index: 1);
 
 class C
 {
-    int [||]getGoo()
+    int $$getGoo()
     {
     }
 
@@ -1344,7 +1344,7 @@ index: 1);
             await TestWithAllCodeStyleOff(
 @"class C
 {
-    (int, string) [||]GetGoo()
+    (int, string) $$GetGoo()
     {
     }
 }",
@@ -1367,7 +1367,7 @@ index: 1);
 
 class C
 {
-    (int, string) [||]getGoo()
+    (int, string) $$getGoo()
     {
     }
 
@@ -1401,7 +1401,7 @@ index: 1);
 
 class C
 {
-    (int a, string b) [||]getGoo()
+    (int a, string b) $$getGoo()
     {
     }
 
@@ -1437,7 +1437,7 @@ index: 1);
 
 class C
 {
-    (int a, string b) [||]getGoo()
+    (int a, string b) $$getGoo()
     {
     }
 
@@ -1456,7 +1456,7 @@ index: 1));
 @"class C
 {
     // Goo
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
     // SetGoo
@@ -1499,7 +1499,7 @@ index: 0);
 @"class C
 {
     // Goo
-    int [||]GetGoo()
+    int $$GetGoo()
     {
     }
     // SetGoo
@@ -1547,7 +1547,7 @@ index: 1);
     }
 
     // SetGoo
-    void [||]SetGoo(out int i)
+    void $$SetGoo(out int i)
     {
     }
 
@@ -1565,7 +1565,7 @@ index: 1);
 @"class C
 {
     // Goo
-    int [||]GetGoo(out int i)
+    int $$GetGoo(out int i)
     {
     }
 
@@ -1593,7 +1593,7 @@ index: 1);
         Goo value = GetValue().GetValue();
     }
 
-    public Goo [||]GetValue()
+    public Goo $$GetValue()
     {
         return this;
     }
@@ -1622,7 +1622,7 @@ index: 1);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
         return 1;
     }
@@ -1640,7 +1640,7 @@ index: 1);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
         return 1;
     }
@@ -1658,7 +1658,7 @@ index: 1);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
         return 1;
     }
@@ -1676,7 +1676,7 @@ index: 1);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
         return 1;
     }
@@ -1701,7 +1701,7 @@ options: PreferExpressionBodiedAccessors);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
         return 1;
     }
@@ -1737,7 +1737,7 @@ options: PreferExpressionBodiedProperties);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo()
+    int $$GetGoo()
     {
         return 1;
     }
@@ -1762,7 +1762,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo() => 0;
+    int $$GetGoo() => 0;
 }",
 @"class C
 {
@@ -1777,7 +1777,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo() => 0;
+    int $$GetGoo() => 0;
 }",
 @"class C
 {
@@ -1792,7 +1792,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo() => throw e;
+    int $$GetGoo() => throw e;
 }",
 @"class C
 {
@@ -1807,7 +1807,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo() { throw e; }
+    int $$GetGoo() { throw e; }
 }",
 @"class C
 {
@@ -1821,7 +1821,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo() { throw e; }
+    int $$GetGoo() { throw e; }
 }",
 @"class C
 {
@@ -1835,7 +1835,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]GetGoo() { throw e +
+    int $$GetGoo() { throw e +
         e; }
 }",
 @"class C
@@ -1859,7 +1859,7 @@ options: PreferExpressionBodiedAccessorsAndProperties);
             await TestWithAllCodeStyleOff(
 @"interface IGoo
 {
-    int [||]GetGoo();
+    int $$GetGoo();
 }
 
 class C : IGoo
@@ -1893,7 +1893,7 @@ class C : IGoo
             await TestMissingAsync(
 @"class C
 {
-    public override string [||]ToString()
+    public override string $$ToString()
     {
     }
 }");
@@ -1906,7 +1906,7 @@ class C : IGoo
             await TestWithAllCodeStyleOff(
 @"class C : System.Type
 {
-    public override int [||]GetArrayRank()
+    public override int $$GetArrayRank()
     {
     }
 }",

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceProp
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceProp
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop
+    public int $$Prop
     {
         get
         {
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceProp
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop
+    public int $$Prop
     {
         get
         {
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceProp
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop
+    public int $$Prop
     {
         get
         {
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceProp
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop
+    public int $$Prop
     {
         get
         {
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceProp
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop
+    public int $$Prop
     {
         get
         {
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceProp
 
 class CAttribute : Attribute
 {
-    public int [||]Prop
+    public int $$Prop
     {
         get
         {
@@ -249,7 +249,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         set
         {
@@ -272,7 +272,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         set
         {
@@ -305,7 +305,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -337,7 +337,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop
+    public int $$Prop
     {
         get
         {
@@ -369,7 +369,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -411,7 +411,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -453,7 +453,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -476,7 +476,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         set
         {
@@ -499,7 +499,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -541,7 +541,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -583,7 +583,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop { }
+    int $$Prop { }
 
     void M()
     {
@@ -605,7 +605,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop => 1;
+    int $$Prop => 1;
 }",
 @"class C
 {
@@ -622,7 +622,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop => 1; // Comment
+    int $$Prop => 1; // Comment
 }",
 @"class C
 {
@@ -639,7 +639,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Goo
+    int $$Goo
     {
         get
         {
@@ -672,7 +672,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop => /* return 42 */ 42;
+    public int $$Prop => /* return 42 */ 42;
 }",
 @"class C
 {
@@ -690,7 +690,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public abstract int [||]Prop { get; }
+    public abstract int $$Prop { get; }
 
     public void M()
     {
@@ -712,7 +712,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public virtual int [||]Prop
+    public virtual int $$Prop
     {
         get
         {
@@ -743,7 +743,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"interface I
 {
-    int [||]Prop { get; }
+    int $$Prop { get; }
 }",
 @"interface I
 {
@@ -757,7 +757,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop { get; }
+    public int $$Prop { get; }
 }",
 @"class C
 {
@@ -776,7 +776,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop { get; }
+    public int $$Prop { get; }
 
     public C()
     {
@@ -805,7 +805,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop { get; }
+    public int $$Prop { get; }
 
     public C()
     {
@@ -834,7 +834,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop { get; } = 1;
+    public int $$Prop { get; } = 1;
 }",
 @"class C
 {
@@ -855,7 +855,7 @@ class D
 {
     private int prop;
 
-    public int [||]Prop { get; } = 1;
+    public int $$Prop { get; } = 1;
 }",
 @"class C
 {
@@ -875,7 +875,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]PascalCase { get; }
+    public int $$PascalCase { get; }
 }",
 @"class C
 {
@@ -894,7 +894,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop
+    public int $$Prop
     {
         get
         {
@@ -921,7 +921,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public int [||]Prop
+    public int $$Prop
     {
         set
         {
@@ -946,7 +946,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    public object [||]Prop
+    public object $$Prop
     {
         set
         {
@@ -971,7 +971,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop { get; set; }
+    int $$Prop { get; set; }
 
     void M()
     {
@@ -1007,7 +1007,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop { get; set; }
+    int $$Prop { get; set; }
 
     void M()
     {
@@ -1043,7 +1043,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop { get; set; }
+    int $$Prop { get; set; }
 
     void M()
     {
@@ -1079,7 +1079,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop { get; set; }
+    int $$Prop { get; set; }
 
     void M()
     {
@@ -1113,7 +1113,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop { get; set; }
+    int $$Prop { get; set; }
 
     void M()
     {
@@ -1148,7 +1148,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"public class Goo
 {
-    public bool [||]Any { get; } // Replace 'Any' with method
+    public bool $$Any { get; } // Replace 'Any' with method
 
     public static void Bar()
     {
@@ -1180,7 +1180,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -1201,7 +1201,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -1228,7 +1228,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get => 0;
 
@@ -1249,7 +1249,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop => 0;
+    int $$Prop => 0;
 }",
 @"class C
 {
@@ -1264,7 +1264,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop { get; }
+    int $$Prop { get; }
 }",
 @"class C
 {
@@ -1281,7 +1281,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop { get; set; }
+    int $$Prop { get; set; }
 }",
 @"class C
 {
@@ -1299,7 +1299,7 @@ class D
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -1331,7 +1331,7 @@ class D
     /// <value>
     ///     An value that provides access to the language service for the active configured project.
     /// </value>
-    object [||]ActiveProjectContext
+    object $$ActiveProjectContext
     {
         get;
     }
@@ -1361,7 +1361,7 @@ class D
     /// <value>
     ///     An value that provides access to the language service for the active configured project.
     /// </value>
-    object [||]ActiveProjectContext
+    object $$ActiveProjectContext
     {
         set;
     }
@@ -1391,7 +1391,7 @@ class D
     /// <value>
     ///     An value that provides access to the language service for the active configured project.
     /// </value>
-    object [||]ActiveProjectContext
+    object $$ActiveProjectContext
     {
         get; set;
     }
@@ -1427,7 +1427,7 @@ class D
     ///     Sets <see cref=""ActiveProjectContext""/>.
     /// </summary>
     /// <seealso cref=""ActiveProjectContext""/>
-    object [||]ActiveProjectContext
+    object $$ActiveProjectContext
     {
         set;
     }
@@ -1463,7 +1463,7 @@ internal struct AStruct
     ///     Gets or sets <see cref=""ActiveProjectContext""/>.
     /// </summary>
     /// <seealso cref=""ActiveProjectContext""/>
-    object [||]ActiveProjectContext
+    object $$ActiveProjectContext
     {
         get; set;
     }
@@ -1502,7 +1502,7 @@ internal struct AStruct
 @"internal interface ISomeInterface<T>
 {
     /// <seealso cref=""Context""/>
-    ISomeInterface<T> [||]Context
+    ISomeInterface<T> $$Context
     {
         set;
     }
@@ -1531,7 +1531,7 @@ internal struct AStruct
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -1563,7 +1563,7 @@ internal struct AStruct
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop
+    int $$Prop
     {
         get
         {
@@ -1594,7 +1594,7 @@ internal struct AStruct
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop =>
+    int $$Prop =>
 #if true
         0;
 #else
@@ -1619,7 +1619,7 @@ internal struct AStruct
             await TestInRegularAndScriptAsync(
 @"class C
 {
-    int [||]Prop =>
+    int $$Prop =>
 #if true
         0;
 #else
@@ -1645,7 +1645,7 @@ internal struct AStruct
             await TestInRegularAndScriptAsync(
 @"interface IGoo
 {
-    int [||]Goo { get; set; }
+    int $$Goo { get; set; }
 }
 
 class C : IGoo

--- a/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -47,7 +47,7 @@ class C
 {
     static void Main()
     {
-        var[||] i = 0;
+        var$$ i = 0;
     }
 }";
 
@@ -73,7 +73,7 @@ class C
 {
     static void Main()
     {
-        System.Action notThisLocal = () => { foreach (var[||] i in new int[0]) { } };
+        System.Action notThisLocal = () => { foreach (var$$ i in new int[0]) { } };
     }
 }";
 
@@ -82,7 +82,7 @@ class C
 {
     static void Main()
     {
-        System.Action notThisLocal = () => { foreach (int[||] i in new int[0]) { } };
+        System.Action notThisLocal = () => { foreach (int$$ i in new int[0]) { } };
     }
 }";
 
@@ -97,7 +97,7 @@ class C
 {
     static void Main()
     {
-        _ = 0 is var[||] i;
+        _ = 0 is var$$ i;
     }
 }";
 
@@ -114,7 +114,7 @@ class C
 {
     static void Main()
     {
-        var[||] i = 0, j = j;
+        var$$ i = 0, j = j;
     }
 }";
 
@@ -132,7 +132,7 @@ class C
 {
     static void Main()
     {
-        var[||] i;
+        var$$ i;
     }
 }";
 
@@ -147,7 +147,7 @@ class C
 {
     static void Main()
     {
-        for (var[||] i = 0;;) { }
+        for (var$$ i = 0;;) { }
     }
 }";
 
@@ -171,7 +171,7 @@ class C : System.IDisposable
 {
     static void Main()
     {
-        using (var[||] c = new C()) { }
+        using (var$$ c = new C()) { }
     }
 }";
 
@@ -195,7 +195,7 @@ class var
 {
     static void Main()
     {
-        var[||] i = null;
+        var$$ i = null;
     }
 }";
             await TestMissingInRegularAndScriptAsync(code, options: PreferImplicitTypeWithNone());
@@ -209,7 +209,7 @@ class C
 {
     static void Main()
     {
-        foreach (var[||] i in new[] { 0 }) { }
+        foreach (var$$ i in new[] { 0 }) { }
     }
 }";
 
@@ -233,7 +233,7 @@ class C
 {
     static void Main()
     {
-        var[||] (i, j) = (0, 1);
+        var$$ (i, j) = (0, 1);
     }
 }";
 
@@ -257,7 +257,7 @@ class C
 {
     static void Main()
     {
-        (var[||] i, var j) = (0, 1);
+        (var$$ i, var j) = (0, 1);
     }
 }";
 

--- a/src/EditorFeatures/CSharpTest/ConvertAutoPropertyToFullProperty/ConvertAutoPropertyToFullPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertAutoPropertyToFullProperty/ConvertAutoPropertyToFullPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertAutoPropertyToFu
             var text = @"
 class goo
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -54,7 +54,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 
 }
 ";
@@ -86,7 +86,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get; set; } = 2
+    public int G$$oo { get; set; } = 2
 }
 ";
             var expected = @"
@@ -117,7 +117,7 @@ class goo
 class goo
 {
     const int num = 345;
-    public int G[||]oo { get; set; } = 2*num
+    public int G$$oo { get; set; } = 2*num
 }
 ";
             var expected = @"
@@ -148,7 +148,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get; private set; }
+    public int G$$oo { get; private set; }
 }
 ";
             var expected = @"
@@ -180,7 +180,7 @@ class goo
 {
     private int _goo;
 
-    public int G[||]oo { get; private set; }
+    public int G$$oo { get; private set; }
 }
 ";
             var expected = @"
@@ -212,7 +212,7 @@ class goo
 class goo
 {
     // Comments before
-    public int G[||]oo { get; private set; } //Comments during
+    public int G$$oo { get; private set; } //Comments during
     //Comments after
 }
 ";
@@ -245,7 +245,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -265,7 +265,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -285,7 +285,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo
+    public int G$$oo
     {
         get;
         set;
@@ -313,7 +313,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get /* test */ ; set /* test2 */ ; }
+    public int G$$oo { get /* test */ ; set /* test2 */ ; }
 }
 ";
             var expected = @"
@@ -333,7 +333,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -362,7 +362,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -390,7 +390,7 @@ class goo
             var text = @"
 class goo
 {
-    public static int G[||]oo { get; set; }
+    public static int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -420,7 +420,7 @@ class goo
             var text = @"
 class goo
 {
-    protected int G[||]oo { get; set; }
+    protected int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -450,7 +450,7 @@ class goo
             var text = @"
 class goo
 {
-    internal int G[||]oo { get; set; }
+    internal int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -481,7 +481,7 @@ class goo
 class goo
 {
     [A]
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -515,7 +515,7 @@ class goo
     /// <summary>
     /// test stuff here
     /// </summary>
-    public int testg[||]oo { /* test1 */ get /* test2 */; /* test3 */ set /* test4 */; /* test5 */ } /* test6 */
+    public int testg$$oo { /* test1 */ get /* test2 */; /* test3 */ set /* test4 */; /* test5 */ } /* test6 */
 }
 ";
             var expected = @"
@@ -553,7 +553,7 @@ class MyBaseClass
 
 class MyDerivedClass : MyBaseClass
 {
-    public override string N[||]ame {get; set;}
+    public override string N$$ame {get; set;}
 }
 ";
             var expected = @"
@@ -588,7 +588,7 @@ class MyDerivedClass : MyBaseClass
             var text = @"
 class MyClass
 {
-    public sealed string N[||]ame {get; set;}
+    public sealed string N$$ame {get; set;}
 }
 ";
             var expected = @"
@@ -618,7 +618,7 @@ class MyClass
             var text = @"
 class MyBaseClass
 {
-    public virtual string N[||]ame { get; set; }
+    public virtual string N$$ame { get; set; }
 }
 
 class MyDerivedClass : MyBaseClass
@@ -658,7 +658,7 @@ class MyDerivedClass : MyBaseClass
             var text = @"
 class MyClass
 {
-    private string N[||]ame { get; set; }
+    private string N$$ame { get; set; }
 }
 ";
             var expected = @"
@@ -688,7 +688,7 @@ class MyClass
             var text = @"
 class MyBaseClass
 {
-    public abstract string N[||]ame { get; set; }
+    public abstract string N$$ame { get; set; }
 }
 
 class MyDerivedClass : MyBaseClass
@@ -705,7 +705,7 @@ class MyDerivedClass : MyBaseClass
             var text = @"
 class MyBaseClass
 {
-    extern string N[||]ame { get; set; }
+    extern string N$$ame { get; set; }
 }
 ";
             await TestMissingAsync(text);
@@ -717,7 +717,7 @@ class MyBaseClass
             var text = @"
 class goo
 {
-    public int G[||]oo { get;}
+    public int G$$oo { get;}
 }
 ";
             var expected = @"
@@ -743,7 +743,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get;}
+    public int G$$oo { get;}
 }
 ";
             var expected = @"
@@ -763,7 +763,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo
+    public int G$$oo
     {
         set {}
     }
@@ -780,7 +780,7 @@ class goo
 {
    private int _testgoo;
 
-   public int testg[||]oo {get => _testgoo; set => _testgoo = value; }
+   public int testg$$oo {get => _testgoo; set => _testgoo = value; }
 }
 ";
             await TestMissingAsync(text);
@@ -792,7 +792,7 @@ class goo
             var text = @"
 class goo
 {
-    [||]public int Goo { get; set; }
+    $$public int Goo { get; set; }
 }
 ";
             var expected = @"
@@ -822,7 +822,7 @@ class goo
             var text = @"
 class goo
 {
-    public int Goo[||] { get; set; }
+    public int Goo$$ { get; set; }
 }
 ";
             var expected = @"
@@ -852,7 +852,7 @@ class goo
             var text = @"
 class goo
 {
-    public int Goo { g[||]et; set; }
+    public int Goo { g$$et; set; }
 }
 ";
             await TestMissingAsync(text);
@@ -864,7 +864,7 @@ class goo
             var text = @"
 class goo
 {
-    public int Goo { g[||]et; get; }
+    public int Goo { g$$et; get; }
 }
 ";
             await TestMissingAsync(text);
@@ -876,7 +876,7 @@ class goo
             var text = @"
 class goo
 {
-    public int Goo { get; s[||]et; set; }
+    public int Goo { get; s$$et; set; }
 }
 ";
             await TestMissingAsync(text);
@@ -888,7 +888,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -918,7 +918,7 @@ class goo
             var text = @"
 class goo
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -948,7 +948,7 @@ class goo
             var text = @"
 class goo
 {
-    public static int G[||]oo { get; set; }
+    public static int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -978,7 +978,7 @@ class goo
             var text = @"
 interface IGoo
 {
-    public int Goo { get; s[||]et; }
+    public int Goo { get; s$$et; }
 }
 ";
             await TestMissingAsync(text);
@@ -990,7 +990,7 @@ interface IGoo
             var text = @"
 struct goo
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }
 ";
             var expected = @"
@@ -1026,7 +1026,7 @@ partial class Program
 
 partial class Program
 {
-    int [||]Q { get; set; }
+    int $$Q { get; set; }
 }
 ";
             var expected = @"
@@ -1052,7 +1052,7 @@ partial class Program
             var file1 = @"
 partial class Program
 {
-    int [||]P { get; set; }
+    int $$P { get; set; }
 }";
             var file2 = @"
 partial class Program
@@ -1103,7 +1103,7 @@ partial class Program
             var file2 = @"
 partial class Program
 {
-    int Q[||] { get; set; }
+    int Q$$ { get; set; }
 }";
             var file2AfterRefactor = @"
 partial class Program
@@ -1142,10 +1142,10 @@ partial class Program
         {
             await TestMissingAsync(@"namespace NS
 {
-    public int G[||]oo { get; set; }
+    public int G$$oo { get; set; }
 }");
 
-            await TestMissingAsync("public int G[||]oo { get; set; }");
+            await TestMissingAsync("public int G$$oo { get; set; }");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -36,7 +36,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach[||](var a in array)
+        foreach$$(var a in array)
         {
         }
     }
@@ -66,7 +66,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach[||](var a in array) ;
+        foreach$$(var a in array) ;
     }
 }
 ";
@@ -92,7 +92,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach[||](var a in array) Console.WriteLine(a);
+        foreach$$(var a in array) Console.WriteLine(a);
     }
 }
 ";
@@ -122,7 +122,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach[||](var a in array)
+        foreach$$(var a in array)
         {
             Console.WriteLine(a);
         }
@@ -156,7 +156,7 @@ class Test
     {
         var array = new int[] { 1, 3, 4 };
         /* comment */
-        foreach[||](var a in array) /* comment */
+        foreach$$(var a in array) /* comment */
         {
         }
     }
@@ -187,7 +187,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach[||](var a in array)
+        foreach$$(var a in array)
         /* comment */
         {
         }/* comment */
@@ -219,7 +219,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach[||](var a in array) /* comment */;
+        foreach$$(var a in array) /* comment */;
     }
 }
 ";
@@ -245,7 +245,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach[||](var a in array) Console.WriteLine(a); // test
+        foreach$$(var a in array) Console.WriteLine(a); // test
     }
 }
 ";
@@ -275,7 +275,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach [||] (var a in array) /* test */ Console.WriteLine(a); 
+        foreach $$ (var a in array) /* test */ Console.WriteLine(a); 
     }
 }
 ";
@@ -305,7 +305,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach [||] (var a in array) 
+        foreach $$ (var a in array) 
             /* test */ Console.WriteLine(a); 
     }
 }
@@ -337,7 +337,7 @@ class Test
     void Method()
     {
         // test
-        foreach[||](var a in new int[] { 1, 3, 4 })
+        foreach$$(var a in new int[] { 1, 3, 4 })
         {
         }
     }
@@ -368,7 +368,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach [||] (var a /* test */ in array) ;
+        foreach $$ (var a /* test */ in array) ;
     }
 }
 ";
@@ -384,7 +384,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach [||] (/* test */ var a in array) ;
+        foreach $$ (/* test */ var a in array) ;
     }
 }
 ";
@@ -400,7 +400,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach [||] (var a in array /* test */) ;
+        foreach $$ (var a in array /* test */) ;
     }
 }
 ";
@@ -415,7 +415,7 @@ class Test
 {
     void Method()
     {
-        foreach[||](var a in new int[] { 1, 3, 4 })
+        foreach$$(var a in new int[] { 1, 3, 4 })
         {
             Console.WriteLine(a);
         }
@@ -449,7 +449,7 @@ class Test
     {
         var array = 1;
 
-        foreach[||](var a in new int[] { 1, 3, 4 })
+        foreach$$(var a in new int[] { 1, 3, 4 })
         {
             Console.WriteLine(a);
         }
@@ -484,7 +484,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach [||] (var a in array)
+        foreach $$ (var a in array)
         {
             int i = 0;
         }
@@ -517,7 +517,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach [||] (var a in array)
+        foreach $$ (var a in array)
         {
             a = 1;
         }
@@ -538,7 +538,7 @@ class Test
         var array = new int[] { 1, 3, 4 };
         foreach (var a in array)
         {
-            [||] 
+            $$ 
         }
     }
 }
@@ -555,7 +555,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        [||] foreach (var a in array)
+        $$ foreach (var a in array)
         {
         }
     }
@@ -573,7 +573,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach (var a in array) [||] 
+        foreach (var a in array) $$ 
         {
         }
     }
@@ -592,7 +592,7 @@ class Test
 
     void Method()
     {
-        foreach [||] (var a in array)
+        foreach $$ (var a in array)
         {
         }
     }
@@ -623,7 +623,7 @@ class Test
     void Method()
     {
         var array = new int[][] { new int[] { 1, 3, 4 } };
-        foreach [||] (var a in array[0])
+        foreach $$ (var a in array[0])
         {
             Console.WriteLine(a);
         }
@@ -655,7 +655,7 @@ class Test
 {
     void Method(int[] array)
     {
-        foreach [||] (var a in array)
+        foreach $$ (var a in array)
         {
         }
     }
@@ -685,7 +685,7 @@ class Test
 
     void Method()
     {
-        foreach [||] (var a in Prop)
+        foreach $$ (var a in Prop)
         {
         }
     }
@@ -718,7 +718,7 @@ class Test
     void Method()
     {
         var array = (IList<int>)(new int[] { 1, 3, 4 });
-        foreach[||] (var a in array)
+        foreach$$ (var a in array)
         {
             Console.WriteLine(a);
         }
@@ -755,7 +755,7 @@ class Test
     void Method()
     {
         var list = new List<int>();
-        foreach [||](var a in list)
+        foreach $$(var a in list)
         {
             Console.WriteLine(a);
         }
@@ -793,7 +793,7 @@ class Test
     void Method()
     {
         var list = new ReadOnly<int>();
-        foreach [||](var a in list)
+        foreach $$(var a in list)
         {
             Console.WriteLine(a);
         }
@@ -850,7 +850,7 @@ class Test
     void Method()
     {
         var list = new List();
-        foreach [||](var a in list)
+        foreach $$(var a in list)
         {
             Console.WriteLine(a);
         }
@@ -933,7 +933,7 @@ class Test
     void Method()
     {
         var list = ImmutableArray.Create(1);
-        foreach [||](var a in list)
+        foreach $$(var a in list)
         {
             Console.WriteLine(a);
         }
@@ -974,7 +974,7 @@ class Test
     void Method()
     {
         var list = new Explicit();
-        foreach [||] (var a in list)
+        foreach $$ (var a in list)
         {
             Console.WriteLine(a);
         }
@@ -1033,7 +1033,7 @@ class Test
     void Method()
     {
         var list = new Explicit();
-        foreach [||] (var a in list)
+        foreach $$ (var a in list)
         {
             Console.WriteLine(a);
         }
@@ -1068,7 +1068,7 @@ class Test
     void Method()
     {
         var list = new Explicit();
-        foreach [||] (int a in list)
+        foreach $$ (int a in list)
         {
             Console.WriteLine(a);
         }
@@ -1135,7 +1135,7 @@ class Test
     void Method()
     {
         var list = new Mixed();
-        foreach [||] (var a in list)
+        foreach $$ (var a in list)
         {
             Console.WriteLine(a);
         }
@@ -1201,7 +1201,7 @@ class Test
     void Method()
     {
         var list = new Mixed();
-        foreach [||] (string a in list)
+        foreach $$ (string a in list)
         {
             Console.WriteLine(a);
         }
@@ -1269,7 +1269,7 @@ namespace NS
     {
         void Method()
         {
-            foreach [||] (string a in new NS.Mixed())
+            foreach $$ (string a in new NS.Mixed())
             {
                 Console.WriteLine(a);
             }
@@ -1335,7 +1335,7 @@ class Test
     void Method()
     {
         if (true)
-            foreach [||] (var a in new int[] {});
+            foreach $$ (var a in new int[] {});
     }
 }
 ";
@@ -1352,7 +1352,7 @@ class Test
     {
         var array = new int[] { 1, 3, 4 };
         if (true)
-            foreach [||] (var a in array) Console.WriteLine(a);
+            foreach $$ (var a in array) Console.WriteLine(a);
     }
 }
 ";
@@ -1383,7 +1383,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach [||] (var i in array)
+        foreach $$ (var i in array)
         {
             Console.WriteLine(i);
         }
@@ -1416,7 +1416,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 3, 4 };
-        foreach [||] (int a in array)
+        foreach $$ (int a in array)
         {
             Console.WriteLine(i);
         }
@@ -1448,7 +1448,7 @@ class Test
 {
     void Method()
     {
-        foreach [||] (var a in ""test"")
+        foreach $$ (var a in ""test"")
         {
             Console.WriteLine(a);
         }
@@ -1482,7 +1482,7 @@ class Test
     void Method()
     {
         const string test = ""test"";
-        foreach [||] (var a in test)
+        foreach $$ (var a in test)
         {
             Console.WriteLine(a);
         }
@@ -1516,7 +1516,7 @@ class Test
 
     void Method()
     {
-        foreach [||] (var a in test)
+        foreach $$ (var a in test)
         {
             Console.WriteLine(a);
         }
@@ -1550,7 +1550,7 @@ class Test
     void Method()
     {
         var array = new object[] { 1, 2, 3 };
-        foreach [||] (string a in array)
+        foreach $$ (string a in array)
         {
             Console.WriteLine(a);
         }
@@ -1583,7 +1583,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 2, 3 };
-        foreach [||] (string a in array)
+        foreach $$ (string a in array)
         {
             Console.WriteLine(a);
         }
@@ -1602,7 +1602,7 @@ class Test
     void Method()
     {
         var array = new int[] { 1, 2, 3 };
-        foreach [||] (in array)
+        foreach $$ (in array)
         {
             Console.WriteLine(a);
         }
@@ -1620,7 +1620,7 @@ class Test
 {
     void Method()
     {
-        foreach [||] (string a in )
+        foreach $$ (string a in )
         {
             Console.WriteLine(a);
         }
@@ -1638,7 +1638,7 @@ class Test
 {
     void Method()
     {
-        foreach [||] (int a in ""test"")
+        foreach $$ (int a in ""test"")
         {
             Console.WriteLine(a);
         }
@@ -1676,7 +1676,7 @@ class Test
     void Method()
     {
         var list = new Explicit();
-        foreach [||] (var a in list)
+        foreach $$ (var a in list)
         {
             Console.WriteLine(a);
         }

--- a/src/EditorFeatures/CSharpTest/ConvertForToForEach/ConvertForToForEachTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertForToForEach/ConvertForToForEachTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -35,7 +35,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -65,7 +65,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Action a = () =>
             {
@@ -102,7 +102,7 @@ class C
 {
     void Test(IList<string> list)
     {
-        [||]for (int i = 0; i < list.Count; i++)
+        $$for (int i = 0; i < list.Count; i++)
         {
             Console.WriteLine(list[i]);
             list.Add(null);
@@ -136,7 +136,7 @@ class C
 {
     void Test(IList<string> list)
     {
-        [||]for (int i = 0; i < list.Count; i++)
+        $$for (int i = 0; i < list.Count; i++)
         {
             Console.WriteLine(list[i]);
             list = null;
@@ -170,7 +170,7 @@ class C
 {
     void Test(IList<string> list)
     {
-        [||]for (int i = 0; i < list.Count; i++)
+        $$for (int i = 0; i < list.Count; i++)
         {
             Console.WriteLine(list[i]);
             Console.WriteLine(list.Count);
@@ -205,7 +205,7 @@ class C
     {
         Action a = () =>
         {
-            [||]for (int i = 0; i < array.Length; i++)
+            $$for (int i = 0; i < array.Length; i++)
             {
                 Console.WriteLine(array[i]);
             }
@@ -239,7 +239,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
             Console.WriteLine(array[i]);
@@ -271,7 +271,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
             Console.WriteLine(array[i]);
     }
 }",
@@ -297,7 +297,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; ++i)
+        $$for (int i = 0; i < array.Length; ++i)
         {
             Console.WriteLine(array[i]);
         }
@@ -327,7 +327,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i += 1)
+        $$for (int i = 0; i < array.Length; i += 1)
         {
             Console.WriteLine(array[i]);
         }
@@ -357,7 +357,7 @@ class C
 {
     void Test(string[] array)
     {
-       [||] for (int i = 0; i < array.Length; i++)
+       $$ for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -375,7 +375,7 @@ class C
 {
     void Test(string[] array)
     {
-        for ([||] int i = 0; i < array.Length; i++)
+        for ($$ int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -393,7 +393,7 @@ class C
 {
     void Test(string[] array)
     {
-        for (int i = 0; i < array.Length; i++ [||])
+        for (int i = 0; i < array.Length; i++ $$)
         {
             Console.WriteLine(array[i]);
         }
@@ -411,7 +411,7 @@ class C
 {
     void Test(string[] array)
     {
-        for[||] (int i = 0; i < array.Length; i++)
+        for$$ (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -471,7 +471,7 @@ class C
 {
     void Test(string[] array)
     {
-        for [||](int i = 0; i < array.Length; i++)
+        for $$(int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -501,7 +501,7 @@ class C
 {
     void Test(string[] array)
     {
-        for (int i = 0; i < array.Length; i++)[||]
+        for (int i = 0; i < array.Length; i++)$$
         {
             Console.WriteLine(array[i]);
         }
@@ -531,7 +531,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; )
+        $$for (int i = 0; i < array.Length; )
         {
             Console.WriteLine(array[i]);
         }
@@ -549,7 +549,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i += 2)
+        $$for (int i = 0; i < array.Length; i += 2)
         {
             Console.WriteLine(array[i]);
         }
@@ -567,7 +567,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; j += 2)
+        $$for (int i = 0; i < array.Length; j += 2)
         {
             Console.WriteLine(array[i]);
         }
@@ -585,7 +585,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; ; i++)
+        $$for (int i = 0; ; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -603,7 +603,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; j < array.Length; i++)
+        $$for (int i = 0; j < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -621,7 +621,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < GetLength(array); i++)
+        $$for (int i = 0; i < GetLength(array); i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -639,7 +639,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (; i < array.Length; i++)
+        $$for (; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -658,7 +658,7 @@ class C
     void Test(string[] array)
     {
         int i;
-        [||]for (i = 0; i < array.Length; i++)
+        $$for (i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -676,7 +676,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i; i < array.Length; i++)
+        $$for (int i; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -694,7 +694,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 1; i < array.Length; i++)
+        $$for (int i = 1; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -712,7 +712,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0, j = 0; i < array.Length; i++)
+        $$for (int i = 0, j = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -731,7 +731,7 @@ class C
 {
     void Test(IList<string> list)
     {
-        [||]for (int i = 0; i < list.Count; i++)
+        $$for (int i = 0; i < list.Count; i++)
         {
             Console.WriteLine(list[i]);
         }
@@ -763,7 +763,7 @@ class C
 {
     void Test(IList<string> list)
     {
-        [||]for (int i = 0; i < list.Count; i++)
+        $$for (int i = 0; i < list.Count; i++)
         {
             var val = list[i];
             Console.WriteLine(list[i]);
@@ -796,7 +796,7 @@ class C
 {
     void Test(IList<string> list)
     {
-        [||]for (int i = 0; i < list.Count; i++)
+        $$for (int i = 0; i < list.Count; i++)
         {
             var val = list [ i ];
             Console.WriteLine(list [ /*find me*/ i ]);
@@ -829,7 +829,7 @@ class C
 {
     void Test(IList<string> list)
     {
-        [||]for (int i = 0; i < list.Count; i++)
+        $$for (int i = 0; i < list.Count; i++)
         {
             // loop comment
 
@@ -866,7 +866,7 @@ class C
 {
     void Test(IList<string> list)
     {
-        [||]for (int i = 0; i < list.Count; i++)
+        $$for (int i = 0; i < list.Count; i++)
         {
 #if true
 
@@ -906,7 +906,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(i);
         }
@@ -924,7 +924,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(other[i]);
         }
@@ -942,7 +942,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             array[i] = 1;
         }
@@ -972,7 +972,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -1012,7 +1012,7 @@ class C
     void Test(MyList list)
     {
         // need to use 'string' here to preserve original index semantics.
-        [||]for (int i = 0; i < list.Length; i++)
+        $$for (int i = 0; i < list.Length; i++)
         {
             Console.WriteLine(list[i]);
         }
@@ -1062,7 +1062,7 @@ class C
     void Test(MyList list)
     {
         // can use 'var' here since hte type stayed the same.
-        [||]for (int i = 0; i < list.Length; i++)
+        $$for (int i = 0; i < list.Length; i++)
         {
             Console.WriteLine(list[i]);
         }
@@ -1103,7 +1103,7 @@ class C
     void Test(string[] array)
     {
         // trivia 1
-        [||]for /*trivia 2*/ ( /*trivia 3*/ int i = 0; i < array.Length; i++) /*trivia 4*/
+        $$for /*trivia 2*/ ( /*trivia 3*/ int i = 0; i < array.Length; i++) /*trivia 4*/
         // trivia 5
         {
             Console.WriteLine(array[i]);
@@ -1136,7 +1136,7 @@ class C
 {
     void Test(string[] array)
     {
-        [||]for (var (i, j) = (0, 0); i < array.Length; i++)
+        $$for (var (i, j) = (0, 0); i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -1154,7 +1154,7 @@ class C
 {
     void Test(string[,] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i, 0]);
         }
@@ -1172,7 +1172,7 @@ class C
 {
     void Test(string[,] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i, i]);
         }
@@ -1190,7 +1190,7 @@ class C
 {
     void Test(string[][] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i]);
         }
@@ -1220,7 +1220,7 @@ class C
 {
     void Test(string[][] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i][0]);
         }
@@ -1250,7 +1250,7 @@ class C
 {
     void Test(string[][] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             var subArray = array[i];
             for (int j = 0; j < subArray.Length; j++)
@@ -1287,7 +1287,7 @@ class C
 {
     void Test(string[][] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             for (int j = 0; j < array[i].Length; j++)
             {
@@ -1325,7 +1325,7 @@ class C
     {
         for (int i = 0; i < array.Length; i++)
         {
-            [||]for (int j = 0; j < array[i].Length; j++)
+            $$for (int j = 0; j < array[i].Length; j++)
             {
                 Console.WriteLine(array[i][j]);
             }
@@ -1359,7 +1359,7 @@ class C
 {
     void Test(string[][] array)
     {
-        [||]for (int i = 0; i < array.Length; i++)
+        $$for (int i = 0; i < array.Length; i++)
         {
             Console.WriteLine(array[i][i]);
         }

--- a/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToInterpolatedSt
 {
     void M()
     {
-        var v = [||]""string"";
+        var v = $$""string"";
     }
 }");
         }
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToInterpolatedSt
 {
     void M()
     {
-        var v = [||]""string"" + ""string"";
+        var v = $$""string"" + ""string"";
     }
 }");
         }
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToInterpolatedSt
 {
     void M()
     {
-        var v = ""string"" + [||]""string"";
+        var v = ""string"" + $$""string"";
     }
 }");
         }
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToInterpolatedSt
 {
     void M()
     {
-        var v = [||]""string"" + 1;
+        var v = $$""string"" + 1;
     }
 }",
 @"public class C
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToInterpolatedSt
 {
     void M()
     {
-        var v = ""string""[||] + 1;
+        var v = ""string""$$ + 1;
     }
 }",
 @"public class C
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToInterpolatedSt
 {
     void M()
     {
-        var v = 1 + [||]""string"";
+        var v = 1 + $$""string"";
     }
 }",
 @"public class C
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToInterpolatedSt
 {
     void M()
     {
-        var v = 1 + 2 + [||]""string"";
+        var v = 1 + 2 + $$""string"";
     }
 }",
 @"public class C
@@ -145,7 +145,7 @@ public class C
     {
         var v =
             // Leading trivia
-            1 + 2 + [||]""string"" /* trailing trivia */;
+            1 + 2 + $$""string"" /* trailing trivia */;
     }
 }",
 @"
@@ -168,7 +168,7 @@ public class C
 {
     void M()
     {
-        var v = 1 + 2 + [||]""string"" + 3 + 4;
+        var v = 1 + 2 + $$""string"" + 3 + 4;
     }
 }",
 @"public class C
@@ -189,7 +189,7 @@ public class C
 {
     void M()
     {
-        var v = ""\r"" + 2 + [||]""string"" + 3 + ""\n"";
+        var v = ""\r"" + 2 + $$""string"" + 3 + ""\n"";
     }
 }",
 @"
@@ -211,7 +211,7 @@ public class C
 {
     void M()
     {
-        var v = ""\\r"" + 2 + [||]""string"" + 3 + ""\\n"";
+        var v = ""\\r"" + 2 + $$""string"" + 3 + ""\\n"";
     }
 }",
 @"
@@ -232,7 +232,7 @@ public class C
 {
     void M()
     {
-        var v = 1 + [||]@""string"";
+        var v = 1 + $$@""string"";
     }
 }",
 @"public class C
@@ -252,7 +252,7 @@ public class C
 {
     void M()
     {
-        var v = 1 + [||]@""string"" + 2 + ""string"";
+        var v = 1 + $$@""string"" + 2 + ""string"";
     }
 }");
         }
@@ -265,7 +265,7 @@ public class C
 {
     void M()
     {
-        var v = 1 + @""string"" + 2 + [||]""string"";
+        var v = 1 + @""string"" + 2 + $$""string"";
     }
 }");
         }
@@ -285,7 +285,7 @@ public class C
     void M()
     {
         D d = null;
-        var v = 1 + [||]""string"" + d;
+        var v = 1 + $$""string"" + d;
     }
 }",
 @"public class D
@@ -319,7 +319,7 @@ public class C
     void M()
     {
         D d = null;
-        var v = d + [||]""string"" + 1;
+        var v = d + $$""string"" + 1;
     }
 }");
         }
@@ -333,7 +333,7 @@ public class C
 {
     void M()
     {
-        var v = ""A"" + 1 + [||]""B"" + ""C"";
+        var v = ""A"" + 1 + $$""B"" + ""C"";
     }
 }",
 @"public class C
@@ -354,7 +354,7 @@ public class C
 {
     void M()
     {
-        var v = ""A"" + [||]""B"" + ""C"" + 1;
+        var v = ""A"" + $$""B"" + ""C"" + 1;
     }
 }",
 @"public class C
@@ -375,7 +375,7 @@ public class C
 {
     void M()
     {
-        var v = ""A"" + 1 + [||]""B"" + ""C"" + 2 +""D""+ ""E""+ ""F"" + 3;
+        var v = ""A"" + 1 + $$""B"" + ""C"" + 2 +""D""+ ""E""+ ""F"" + 3;
     }
 }",
 @"public class C
@@ -396,7 +396,7 @@ public class C
 {
     void M()
     {
-        var v = ""A"" + 1 + [||]""B"" + @""C"";
+        var v = ""A"" + 1 + $$""B"" + @""C"";
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAwaitTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAwaitTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -690,7 +690,7 @@ class TestClass
     private async Task MyTestMethod1Async()
     {
         Func<Task> lambda = () => {
-            int myInt = MyInt [||] MethodAsync();
+            int myInt = MyInt $$ MethodAsync();
         };
     }
 
@@ -713,7 +713,7 @@ class TestClass
     private async Task MyTestMethod1Async()
     {
         Action lambda = () => {
-            int myInt = MyIntM [||] ethodAsync();
+            int myInt = MyIntM $$ ethodAsync();
         };
     }
 
@@ -816,7 +816,7 @@ class TestClass
     private async Task MyTestMethod1Async()
     {
         Action @delegate = delegate {
-            int myInt = MyInt [||] MethodAsync();
+            int myInt = MyInt $$ MethodAsync();
         };
     }
 
@@ -839,7 +839,7 @@ class TestClass
     private async Task MyTestMethod1Async()
     {
         Func<Task> @delegate = delegate {
-            int myInt = MyIntM [||] ethodAsync();
+            int myInt = MyIntM $$ ethodAsync();
         };
     }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
 
     void Goo()
     {
-        [||]var v = a;
+        $$var v = a;
         if (v != null)
         {
             v();
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         var v = a;
-        [||]if (v != null)
+        $$if (v != null)
         {
             v();
         }
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
         var v = a;
         if (v != null)
         {
-            [||]v();
+            $$v();
         }
     }
 }",
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
 
     void Goo()
     {
-        [||]var v = a;
+        $$var v = a;
         if (v != null)
         {
             v();
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
 
     void Goo()
     {
-        [||]var v = a;
+        $$var v = a;
         if (null != v)
         {
             v();
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
 
     void Goo()
     {
-        [||]var v = a;
+        $$var v = a;
         if (null != v)
             v();
     }
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         bool b = true;
-        [||]var v = b ? a : null;
+        $$var v = b ? a : null;
         if (v != null)
         {
             v();
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
 
     void Goo()
     {
-        [||]var v = a;
+        $$var v = a;
         if (v != null)
         {
             v();
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
 
     void Goo()
     {
-        [||]var v = a, x = a;
+        $$var v = a, x = a;
         if (v != null)
         {
             v();
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         var v = a, x = a;
-        [||]if (v != null)
+        $$if (v != null)
         {
             v();
         }
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
 
     void Goo()
     {
-        [||]var v = a;
+        $$var v = a;
         if (v != null)
         {
             v();
@@ -319,7 +319,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         var v = a;
-        [||]if (v != null)
+        $$if (v != null)
         {
             v();
         }
@@ -353,7 +353,7 @@ class C
 
     void M()
     {
-        [||]if (this.E != null)
+        $$if (this.E != null)
         {
             this.E(this, EventArgs.Empty);
         }
@@ -386,7 +386,7 @@ class C
     {
         if (this.E != null)
         {
-            [||]this.E(this, EventArgs.Empty);
+            $$this.E(this, EventArgs.Empty);
         }
     }
 }",
@@ -418,7 +418,7 @@ class C
         if (true != true)
         {
         }
-        else [||]if (this.E != null)
+        else $$if (this.E != null)
         {
             this.E(this, EventArgs.Empty);
         }
@@ -458,7 +458,7 @@ class C
         if (true != true)
         {
         }
-        else [||]if (this.E != null)
+        else $$if (this.E != null)
             this.E(this, EventArgs.Empty);
     }
 }",
@@ -488,7 +488,7 @@ class C
     void Goo()
     {
         // Comment
-        [||]var v = a;
+        $$var v = a;
         if (v != null)
         {
             v();
@@ -516,7 +516,7 @@ class C
     void Goo()
     {
         // Comment
-        [||]if (a != null)
+        $$if (a != null)
         {
             a();
         }
@@ -547,7 +547,7 @@ class C
     void Goo()
     {
         var v = a;
-        [||]if (v != null)
+        $$if (v != null)
         {
             v();
         }
@@ -580,7 +580,7 @@ class C
         var v = a;
         if (v != null)
         {
-            [||]v();
+            $$v();
         }
     }
 }",
@@ -605,7 +605,7 @@ class C
 
     void Goo()
     {
-        [||]var v = a;
+        $$var v = a;
         v?.Invoke();
     }
 }");
@@ -622,7 +622,7 @@ class C
     void Goo()
     {
         var v = a;
-        [||]v?.Invoke();
+        $$v?.Invoke();
     }
 }");
         }
@@ -637,7 +637,7 @@ class C
 
     void Goo()
     {
-        [||]a?.Invoke();
+        $$a?.Invoke();
     }
 }");
         }
@@ -655,7 +655,7 @@ class C
         var v = a;
         if (v == a)
         {
-            [||]v();
+            $$v();
         }
     }
 }");
@@ -674,7 +674,7 @@ class C
         var v = a;
         if (v == null)
         {
-            [||]v();
+            $$v();
         }
     }
 }");
@@ -694,7 +694,7 @@ class C
 
     void Goo()
     {
-        [||]var v = a;
+        $$var v = a;
         int x;
         if (v != null)
         {
@@ -720,7 +720,7 @@ class C
     {
         var v = a;
         int x;
-        [||]if (v != null)
+        $$if (v != null)
         {
             v();
         }
@@ -750,7 +750,7 @@ class C
     int Goo()
     {
         var v = a;
-        [||]if (v != null)
+        $$if (v != null)
         {
             return v();
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -619,15 +619,15 @@ namespace Root
             var content =
 @"class A
 {
-    [|[||]|] i;
+    [|$$|] i;
 }
 ";
 
             foreach (var pair in builtInTypeMap)
             {
-                int position = content.IndexOf(@"[||]", StringComparison.Ordinal);
-                var newContent = content.Replace(@"[||]", pair.Key);
-                var expected = content.Replace(@"[||]", pair.Value);
+                int position = content.IndexOf(@"$$", StringComparison.Ordinal);
+                var newContent = content.Replace(@"$$", pair.Key);
+                var expected = content.Replace(@"$$", pair.Value);
                 await TestWithPredefinedTypeOptionsAsync(newContent, expected);
             }
         }
@@ -2727,7 +2727,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Console.[||]
+        Console.$$
     }
 }";
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Immutable;
@@ -448,7 +448,7 @@ class C
         public async Task TestTestMissingName()
         {
             await TestMissingInRegularAndScriptAsync(
-@"[assembly: Microsoft.CodeAnalysis.[||]]");
+@"[assembly: Microsoft.CodeAnalysis.$$]");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Immutable;
@@ -1564,7 +1564,7 @@ class Class { }
             public async Task TestDiagnosticWithoutLocationCanBeSuppressed()
             {
                 await TestAsync(
-        @"[||]
+        @"$$
 using System;
 
 class Class

--- a/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateDefaultConstruc
         public async Task TestProtectedBase()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -48,7 +48,7 @@ class B
         public async Task TestPublicBase()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -77,7 +77,7 @@ class B
         public async Task TestInternalBase()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -106,7 +106,7 @@ class B
         public async Task TestPrivateBase()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -122,7 +122,7 @@ class B
         public async Task TestRefOutParams()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -151,7 +151,7 @@ class B
         public async Task TestFix1()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -196,7 +196,7 @@ class B
         public async Task TestFix2()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -242,7 +242,7 @@ index: 1);
         public async Task TestRefactoring1()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -288,7 +288,7 @@ index: 2);
         public async Task TestFixAll1()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -342,7 +342,7 @@ index: 3);
         public async Task TestFixAll2()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
     public C(bool x)
     {
@@ -399,7 +399,7 @@ index: 2);
         public async Task TestFixAll_WithTuples()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
     public C((bool, bool) x)
     {
@@ -456,7 +456,7 @@ index: 2);
         public async Task TestMissing1()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
     public C(int x)
     {
@@ -476,7 +476,7 @@ class B
         public async Task TestDefaultConstructorGeneration_1()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
     public C(int y)
     {
@@ -513,7 +513,7 @@ class B
         public async Task TestDefaultConstructorGeneration_2()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
     private C(int y)
     {
@@ -549,7 +549,7 @@ class B
         public async Task TestFixCount1()
         {
             await TestActionCountAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -568,7 +568,7 @@ count: 1);
         {
             await TestInRegularAndScriptAsync(
 @"using System;
-class Program : Excep[||]tion
+class Program : Excep$$tion
 {
 }",
 @"using System;
@@ -603,7 +603,7 @@ index: 4);
 using System.Collections.Generic;
 using System.Linq;
 
-class Program : [||]Exception
+class Program : $$Exception
 {
     public Program()
     {
@@ -651,7 +651,7 @@ index: 3);
 using System.Collections.Generic;
 using System.Linq;
 
-class Program : [||]Exception
+class Program : $$Exception
 {
     public Program(string message) : base(message)
     {
@@ -705,7 +705,7 @@ class Program : Exception
 using System.Collections.Generic;
 using System.Linq;
 
-class Program : [||]Exception
+class Program : $$Exception
 {
     public Program(string message, Exception innerException) : base(message, innerException)
     {
@@ -752,7 +752,7 @@ index: 2);
         public async Task Tuple()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -781,7 +781,7 @@ class B
         public async Task TupleWithNames()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -818,7 +818,7 @@ class B
     }
 }
 
-class [||]Derived : Base
+class $$Derived : Base
 {
 }",
 @"class Base
@@ -848,7 +848,7 @@ class Derived : Base
     }
 }
 
-class [||]Derived : Base
+class $$Derived : Base
 {
 }",
 @"class Base
@@ -871,7 +871,7 @@ class Derived : Base
         public async Task TestNotOnEnum()
         {
             await TestMissingInRegularAndScriptAsync(
-@"enum [||]E
+@"enum $$E
 {
 }");
         }
@@ -881,7 +881,7 @@ class Derived : Base
         public async Task TestGenerateConstructorFromProtectedConstructor()
         {
             await TestInRegularAndScriptAsync(
-@"abstract class C : [||]B
+@"abstract class C : $$B
 {
 }
 
@@ -911,7 +911,7 @@ abstract class B
         public async Task TestGenerateConstructorFromProtectedConstructor2()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -941,7 +941,7 @@ abstract class B
         public async Task TestGenerateConstructorFromPublicConstructor()
         {
             await TestInRegularAndScriptAsync(
-@"abstract class C : [||]B
+@"abstract class C : $$B
 {
 }
 
@@ -971,7 +971,7 @@ abstract class B
         public async Task TestGenerateConstructorFromPublicConstructor2()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -1001,7 +1001,7 @@ abstract class B
         public async Task TestGenerateConstructorFromInternalConstructor()
         {
             await TestInRegularAndScriptAsync(
-@"abstract class C : [||]B
+@"abstract class C : $$B
 {
 }
 
@@ -1031,7 +1031,7 @@ abstract class B
         public async Task TestGenerateConstructorFromInternalConstructor2()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -1061,7 +1061,7 @@ abstract class B
         public async Task TestGenerateConstructorFromProtectedInternalConstructor()
         {
             await TestInRegularAndScriptAsync(
-@"abstract class C : [||]B
+@"abstract class C : $$B
 {
 }
 
@@ -1091,7 +1091,7 @@ abstract class B
         public async Task TestGenerateConstructorFromProtectedInternalConstructor2()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 
@@ -1121,7 +1121,7 @@ abstract class B
         public async Task TestGenerateConstructorFromPrivateProtectedConstructor()
         {
             await TestInRegularAndScriptAsync(
-@"abstract class C : [||]B
+@"abstract class C : $$B
 {
 }
 
@@ -1151,7 +1151,7 @@ abstract class B
         public async Task TestGenerateConstructorFromPrivateProtectedConstructor2()
         {
             await TestInRegularAndScriptAsync(
-@"class C : [||]B
+@"class C : $$B
 {
 }
 

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -672,7 +672,7 @@ new TestParameters(options: Option(CodeStyleOptions.QualifyFieldAccess, CodeStyl
 class Z
 {
     int a;
-    [||]
+    $$
 }",
 @"using System.Collections.Generic;
 
@@ -694,7 +694,7 @@ chosenSymbols: new[] { "a" });
             await TestWithPickMembersDialogAsync(
 @"using System.Collections.Generic;
 
-class [||]Z
+class $$Z
 {
     int a;
 }",
@@ -718,7 +718,7 @@ chosenSymbols: new[] { "a" });
             await TestMissingInRegularAndScriptAsync(
 @"using System.Collections.Generic;
 
-[X][||]
+[X]$$
 class Z
 {
     int a;
@@ -734,7 +734,7 @@ class Z
 class Z
 {
     int a;
-    [||]
+    $$
 }",
 @"using System.Collections.Generic;
 
@@ -759,7 +759,7 @@ class Z
 {
     int a;
     string b;
-    [||]
+    $$
 }",
 @"using System.Collections.Generic;
 
@@ -789,7 +789,7 @@ class Z
 {
     int a;
     string b;
-    [||]
+    $$
 }",
 @"
 using System;
@@ -822,7 +822,7 @@ class Z
 {
     int a;
     string b;
-    [||]
+    $$
 }",
 @"
 using System;
@@ -860,7 +860,7 @@ class Z
 {
     int a;
     string b;
-    [||]public void M() { }
+    $$public void M() { }
 }");
         }
 
@@ -876,7 +876,7 @@ class Z
     string b;
     public void M()
     {
-    }[||]
+    }$$
 
     public void N() { }
 }");
@@ -894,7 +894,7 @@ class Z
     string b;
     public void M()
     {
- [||] 
+ $$ 
     }
 
     public void N() { }

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using System.Threading.Tasks;
@@ -502,7 +502,7 @@ class Base {
 class Program : Base
 {
     int j;
-    [||]
+    $$
 }",
 @"using System.Collections.Generic;
 
@@ -867,7 +867,7 @@ class Program
 {
     int a;
     string b;
-    [||]
+    $$
 }",
 @"using System.Collections.Generic;
 
@@ -898,7 +898,7 @@ class Program
     int a;
     string b;
     bool c;
-    [||]
+    $$
 }",
 @"using System.Collections.Generic;
 
@@ -930,7 +930,7 @@ class Program
     int a;
     string b;
     bool c;
-    [||]
+    $$
 }",
 @"using System.Collections.Generic;
 
@@ -958,7 +958,7 @@ chosenSymbols: new string[] { });
 class Program
 {
     public int F { get; set; }
-    [||]
+    $$
 }",
 @"
 class Program
@@ -985,7 +985,7 @@ using System.Collections.Generic;
 class Program
 {
     public string s;
-    [||]
+    $$
 }",
 @"
 using System.Collections.Generic;
@@ -1025,7 +1025,7 @@ using System.Collections.Generic;
 class Program
 {
     public string s;
-    [||]
+    $$
 }",
 @"
 using System.Collections.Generic;
@@ -1060,7 +1060,7 @@ using System.Collections.Generic;
 class Program
 {
     public string s;
-    [||]
+    $$
 
     public static bool operator ==(Program program1, Program program2) => true;
 }",
@@ -1094,7 +1094,7 @@ using System.Collections.Generic;
 struct Program
 {
     public string s;
-    [||]
+    $$
 }",
 @"
 using System.Collections.Generic;
@@ -1138,7 +1138,7 @@ using System.Collections.Generic;
 struct Program
 {
     public string s;
-    [||]
+    $$
 }",
 @"
 using System;
@@ -1172,7 +1172,7 @@ using System.Collections.Generic;
 class Program
 {
     public string s;
-    [||]
+    $$
 }",
 @"
 using System;
@@ -1207,7 +1207,7 @@ using System.Collections.Generic;
 class Program : System.IEquatable<Program>
 {
     public string s;
-    [||]
+    $$
 }",
 @"
 using System.Collections.Generic;
@@ -1238,7 +1238,7 @@ optionsCallback: options => Assert.Null(options.FirstOrDefault(i => i.Id == Impl
 public class Class1
 {
     int i;
-    [||]
+    $$
 
     public void F()
     {

--- a/src/EditorFeatures/CSharpTest/GenerateOverrides/GenerateOverridesTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateOverrides/GenerateOverridesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateOverrides
 @"
 class C
 {
-    [||]
+    $$
 }",
 @"
 class C
@@ -64,7 +64,7 @@ class Base
 
 class Derived : Base
 {
-     [||]
+     $$
 }",
 @"
 using System;
@@ -99,7 +99,7 @@ class Derived : Base
 @"
 static class C
 {
-    [||]
+    $$
 }");
         }
 
@@ -109,7 +109,7 @@ static class C
         {
             await TestMissingAsync(
 @"
-static class [||]C
+static class $$C
 {
     
 }");

--- a/src/EditorFeatures/CSharpTest/GoToAdjacentMember/CSharpGoToAdjacentMemberTests.cs
+++ b/src/EditorFeatures/CSharpTest/GoToAdjacentMember/CSharpGoToAdjacentMemberTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
@@ -40,7 +40,7 @@ $$
             var code = @"$$
 class C
 {
-    [||]void M() { }
+    $$void M() { }
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -53,7 +53,7 @@ class C
             var code = @"
 class C
 {
-    [||]void M() { }
+    $$void M() { }
 }
 
 $$";
@@ -75,7 +75,7 @@ $$
 
 class C2
 {
-    [||]void M() { }
+    $$void M() { }
 } ";
 
             await AssertNavigatedAsync(code, next: true);
@@ -88,7 +88,7 @@ class C2
             var code = @"
 class C1
 {
-    [||]void M() { }
+    $$void M() { }
 }
 
 $$
@@ -109,7 +109,7 @@ class C2
 class C
 {
     $$void M1() { }
-    [||]void M2() { }
+    $$void M2() { }
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -122,7 +122,7 @@ class C
             var code = @"
 class C
 {
-    [||]void M1() { }
+    $$void M1() { }
     $$void M2() { }
 }";
 
@@ -136,7 +136,7 @@ class C
             var code = @"
 class C
 {
-    [||]void M1() { }
+    $$void M1() { }
     $$void M2() { }
 }";
 
@@ -151,7 +151,7 @@ class C
 class C
 {
     $$void M1() { }
-    [||]void M2() { }
+    $$void M2() { }
 }";
 
             await AssertNavigatedAsync(code, next: false);
@@ -168,7 +168,7 @@ class C
 
     class N
     {
-        [||]void M2() { }
+        $$void M2() { }
     }
 }";
 
@@ -183,7 +183,7 @@ class C
 class C
 {
     $$void M1() { }
-    [||]public C() { }
+    $$public C() { }
 }";
             await AssertNavigatedAsync(code, next: true);
         }
@@ -196,7 +196,7 @@ class C
 class C
 {
     $$void M1() { }
-    [||]~C() { }
+    $$~C() { }
 }";
             await AssertNavigatedAsync(code, next: true);
         }
@@ -209,7 +209,7 @@ class C
 class C
 {
     $$void M1() { }
-    [||]static C operator+(C left, C right) { throw new System.NotImplementedException(); }
+    $$static C operator+(C left, C right) { throw new System.NotImplementedException(); }
 }";
             await AssertNavigatedAsync(code, next: true);
         }
@@ -221,7 +221,7 @@ class C
 class C
 {
     $$void M1() { }
-    [||]int F;
+    $$int F;
 }";
             await AssertNavigatedAsync(code, next: true);
         }
@@ -234,7 +234,7 @@ class C
 class C
 {
     $$void M1() { }
-    [||]event System.EventHandler E;
+    $$event System.EventHandler E;
 }";
             await AssertNavigatedAsync(code, next: true);
         }
@@ -247,7 +247,7 @@ class C
 class C
 {
     $$void M1() { }
-    [||]int P { get; set ; }
+    $$int P { get; set ; }
 }";
             await AssertNavigatedAsync(code, next: true);
         }
@@ -261,7 +261,7 @@ class C
 {
     $$void M1() { }
 
-    [||]int P
+    $$int P
     {
         get { return 42; }
         set { }
@@ -286,7 +286,7 @@ class C
         set { }
     }
 
-    [||]void M2() { }
+    $$void M2() { }
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -307,7 +307,7 @@ class C
         set { }
     }
 
-    [||]void M2() { }
+    $$void M2() { }
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -322,7 +322,7 @@ class C
 {
     $$void M1() { }
 
-    [||]int this[int i]
+    $$int this[int i]
     {
         get { return 42; }
         set { }
@@ -347,7 +347,7 @@ class C
         set { }
     }
 
-    [||]void M2() { }
+    $$void M2() { }
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -362,7 +362,7 @@ class C
 {
     $$void M1() { }
 
-    [||]event EventHandler E
+    $$event EventHandler E
     {
         add { }
         remove { }
@@ -387,7 +387,7 @@ class C
         remove { }
     }
 
-    [||]void M2() { }
+    $$void M2() { }
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -405,7 +405,7 @@ class C
         $$System.Console.WriteLine();
     }
 
-    [||]void M2() { }
+    $$void M2() { }
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -422,7 +422,7 @@ class C
 
     $$
 
-    [||]void M2() { }
+    $$void M2() { }
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -435,7 +435,7 @@ class C
             var code = @"
 class C
 {
-    [||]void M1() { }
+    $$void M1() { }
 
     $$
 
@@ -456,7 +456,7 @@ class C
     {
     } $$
 
-    [||]void M2() { }
+    $$void M2() { }
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -469,7 +469,7 @@ class C
             var code = @"
 class C
 {
-    [||]void M1()
+    $$void M1()
     {
     } $$
 
@@ -488,7 +488,7 @@ class C
 {
     int M1() => $$42;
 
-    [||]int M2() => 42;
+    $$int M2() => 42;
 }";
 
             await AssertNavigatedAsync(code, next: true);
@@ -502,7 +502,7 @@ class C
             var code = @"
 class C
 {
-    [||]void M1()
+    $$void M1()
     {
         Console.WriteLine($$);
     }
@@ -522,7 +522,7 @@ class C
             var code = @"
 $$void M1() { }
 
-[||]void M2() { }";
+$$void M2() { }";
 
             await AssertNavigatedAsync(code, next: true, sourceCodeKind: SourceCodeKind.Script);
         }
@@ -532,7 +532,7 @@ $$void M1() { }
         public async Task PrevInScript()
         {
             var code = @"
-[||]void M1() { }
+$$void M1() { }
 
 $$void M2() { }";
 

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
         public async Task TestEmptyFile()
         {
             await TestMissingInRegularAndScriptAsync(
-@"[||]");
+@"$$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
@@ -34,7 +34,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -62,7 +62,7 @@ using System;
 
 class C
 {
-    public C([||]int? i)
+    public C($$int? i)
     {
     }
 }",
@@ -90,7 +90,7 @@ using System;
 
 class C
 {
-    public C([||]int i)
+    public C($$int i)
     {
     }
 }");
@@ -105,7 +105,7 @@ using System;
 
 interface I
 {
-    void M([||]string s);
+    void M($$string s);
 }");
         }
 
@@ -118,7 +118,7 @@ using System;
 
 class C
 {
-    abstract void M([||]string s);
+    abstract void M($$string s);
 }");
         }
 
@@ -131,7 +131,7 @@ using System;
 
 class C
 {
-    extern void M([||]string s);
+    extern void M($$string s);
 }");
         }
 
@@ -144,7 +144,7 @@ using System;
 
 class C
 {
-    partial void M([||]string s);
+    partial void M($$string s);
 
     partial void M(string s)
     {
@@ -165,7 +165,7 @@ class C
     {
     }
 
-    partial void M([||]string s);
+    partial void M($$string s);
 }");
         }
 
@@ -180,7 +180,7 @@ class C
 {
     partial void M(string s);
 
-    partial void M([||]string s)
+    partial void M($$string s)
     {
     }
 }",
@@ -210,7 +210,7 @@ using System;
 
 class C
 {
-    partial void M([||]string s)
+    partial void M($$string s)
     {
     }
 
@@ -242,7 +242,7 @@ using System;
 
 class C
 {
-    extern void M([||]string s);
+    extern void M($$string s);
 }");
         }
 
@@ -257,7 +257,7 @@ class C
 {
     private string _s;
 
-    public C([||]string s)
+    public C($$string s)
     {
         _s = s;
     }
@@ -287,7 +287,7 @@ class C
 {
     private string S;
 
-    public C([||]string s)
+    public C($$string s)
     {
         S = s;
     }
@@ -317,7 +317,7 @@ class C
 {
     private string S;
 
-    public C([||]string s)
+    public C($$string s)
     {
         S = s;
     }
@@ -352,7 +352,7 @@ class C
 {
     private string S;
 
-    public C([||]string s)
+    public C($$string s)
     {
         S = s;
     }
@@ -388,7 +388,7 @@ class C
 {
     private string S;
 
-    public C([||]string s)
+    public C($$string s)
         => S = s;
 }",
 @"
@@ -412,7 +412,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
         => Init();
 }",
 @"
@@ -441,7 +441,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
         => Init();
 }",
 @"
@@ -471,7 +471,7 @@ using System;
 
 class C
 {
-    public C(string a, [||]string s)
+    public C(string a, $$string s)
     {
         if (a == null)
         {
@@ -506,7 +506,7 @@ using System;
 
 class C
 {
-    public C(string [||]a, string s)
+    public C(string $$a, string s)
     {
         if (s == null)
         {
@@ -541,7 +541,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
         if (s == null)
         {
@@ -560,7 +560,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
         _s = s ?? throw new ArgumentNullException();
     }
@@ -576,7 +576,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
         if (string.IsNullOrEmpty(s))
         {
@@ -594,7 +594,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
         if (string.IsNullOrWhiteSpace(s))
         {
@@ -612,7 +612,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
         if (null == s)
         {
@@ -631,7 +631,7 @@ using System;
 
 class C
 {
-    public C([||]string)
+    public C($$string)
     {
     }
 }");
@@ -646,7 +646,7 @@ using System;
 
 class C
 {
-    void F([||]string s)
+    void F($$string s)
     {
     }
 }",
@@ -674,7 +674,7 @@ using System;
 
 class C
 {
-    public static C operator +(C c1, [||]string s)
+    public static C operator +(C c1, $$string s)
     {
     }
 }",
@@ -683,7 +683,7 @@ using System;
 
 class C
 {
-    public static C operator +(C c1, [||]string s)
+    public static C operator +(C c1, $$string s)
     {
         if (s == null)
         {
@@ -704,7 +704,7 @@ class C
 {
     public C()
     {
-        Func<string, int> f = ([||]string s) => { return 0; }
+        Func<string, int> f = ($$string s) => { return 0; }
     }
 }");
         }
@@ -720,7 +720,7 @@ class C
 {
     public C()
     {
-        void Goo([||]string s)
+        void Goo($$string s)
         {
         }
     }
@@ -736,7 +736,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -764,7 +764,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -791,7 +791,7 @@ class C
 @"
 class C
 {
-    public C(String [||]s)
+    public C(String $$s)
     {
         if (s == null)
         {
@@ -811,7 +811,7 @@ using System;
 
 class Program
 {
-    static void Main([||]String bar)
+    static void Main($$String bar)
     {
     }
 }",
@@ -844,7 +844,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -873,7 +873,7 @@ using System;
 
 class C
 {
-    public C(string s[||])
+    public C(string s$$)
 }",
 @"
 using System;
@@ -901,7 +901,7 @@ using System.Linq;
 
 class C
 {
-    public int Foo(int[] array[||]) =>
+    public int Foo(int[] array$$) =>
         array.Where(x => x > 3)
             .OrderBy(x => x)
             .Count();
@@ -937,7 +937,7 @@ using System.Linq;
 
 class C
 {
-    public int Foo(int[] array[||]) /* Bar */ => /* Bar */
+    public int Foo(int[] array$$) /* Bar */ => /* Bar */
         array.Where(x => x > 3)
             .OrderBy(x => x)
             .Count(); /* Bar */
@@ -973,7 +973,7 @@ using System.Linq;
 
 class C
 {
-    public void Foo(string bar[||]) =>
+    public void Foo(string bar$$) =>
 #if DEBUG
         Console.WriteLine(""debug"" + bar);
 #else
@@ -993,7 +993,7 @@ using System.Linq;
 
 class C
 {
-    public int Foo(int[] array[||]) =>
+    public int Foo(int[] array$$) =>
 #if DEBUG
         array.Where(x => x > 3)
             .OrderBy(x => x)
@@ -1017,7 +1017,7 @@ using System.Linq;
 
 class C
 {
-    public void Foo(int[] array[||]) =>
+    public void Foo(int[] array$$) =>
         array.Where(x => x > 3)
             .OrderBy(x => x)
             .Count();

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -24,7 +24,7 @@ class C
 {
     private string s;
 
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -49,7 +49,7 @@ class C
 {
     private string s;
 
-    public C(string s[||])
+    public C(string s$$)
     {
     }
 }",
@@ -74,7 +74,7 @@ class C
 {
     private string s;
 
-    public C(string s[||], string t)
+    public C(string s$$, string t)
     {
     }
 }",
@@ -99,7 +99,7 @@ class C
 {
     private string _s;
 
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -124,7 +124,7 @@ class C
 {
     private string S { get; }
 
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -149,7 +149,7 @@ class C
 {
     private string t;
 
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -176,7 +176,7 @@ class C
 {
     private string S => null;
 
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -203,7 +203,7 @@ class C
 {
     private string T { get; }
 
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -229,7 +229,7 @@ class C
 {
     private int s;
 
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -256,7 +256,7 @@ class C
 {
     private int s;
 
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -282,7 +282,7 @@ class C
 {
     private object s;
 
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -308,7 +308,7 @@ class C
     private int s;
     private int x;
 
-    public C([||]string s)
+    public C($$string s)
     {
         x = s;
     }
@@ -325,7 +325,7 @@ class C
     private int s;
     private int x;
 
-    public C([||]string s)
+    public C($$string s)
     {
         x = s ?? throw new Exception();
     }
@@ -341,7 +341,7 @@ class C
 {
     private int s;
 
-    public C([||]string s)
+    public C($$string s)
     {
         s = 0;
     }
@@ -352,7 +352,7 @@ class C
 {
     private int s;
 
-    public C([||]string s)
+    public C($$string s)
     {
         s = 0;
         S = s;
@@ -372,7 +372,7 @@ class C
     private string s;
     private string t;
 
-    public C([||]string s, string t)
+    public C($$string s, string t)
     {
         this.t = t;   
     }
@@ -401,7 +401,7 @@ class C
     private string s;
     private string t;
 
-    public C(string s, [||]string t)
+    public C(string s, $$string t)
     {
         this.s = s;   
     }
@@ -429,7 +429,7 @@ class C
 {
     private string s;
 
-    public C([||]string s)
+    public C($$string s)
     {
         if (true) { } 
     }
@@ -457,7 +457,7 @@ class C
 {
     private string s;
 
-    public void M([||]string s)
+    public void M($$string s)
     {
     }
 }");
@@ -473,7 +473,7 @@ class C
     private string s;
     private string t;
 
-    public C(string s, [||]string t)
+    public C(string s, $$string t)
         => this.s = s;   
 }",
 @"
@@ -500,7 +500,7 @@ class C
     private string s;
     private string t;
 
-    public C([||]string s, string t)
+    public C($$string s, string t)
         => this.t = t;   
 }",
 @"
@@ -524,7 +524,7 @@ class C
 @"
 class C
 {
-    public C(string s, [||]string t)
+    public C(string s, $$string t)
     {
         S = s;   
     }
@@ -552,7 +552,7 @@ class C
 @"
 class C
 {
-    public C([||]string s, string t)
+    public C($$string s, string t)
     {
         T = t;   
     }
@@ -583,7 +583,7 @@ class C
 {
     private string s;
 
-    public C(string s[||])
+    public C(string s$$)
 }",
 @"
 class C

--- a/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     void M()
     {
-        int [||]x;
+        int $$x;
         {
             Console.WriteLine(x);
         }
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     void M()
     {
-        int [||]x;
+        int $$x;
         Console.WriteLine();
         Console.WriteLine(x);
     }
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     void M()
     {
-        int [||]x;
+        int $$x;
         Console.WriteLine();
         {
             Console.WriteLine(x);
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     void M()
     {
-        int [||]x;
+        int $$x;
         Console.WriteLine();
         {
             Console.WriteLine(x);
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     void M()
     {
-        int [||]x;
+        int $$x;
         {
             x = 5;
             Console.WriteLine(x);
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     void M()
     {
-        int [||]x = 0;
+        int $$x = 0;
         {
             x = 5;
             Console.WriteLine(x);
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     void M()
     {
-        var [||]x = (short)0;
+        var $$x = (short)0;
         {
             x = 5;
             Console.WriteLine(x);
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     void M()
     {
-        int [||]x;
+        int $$x;
         Console.WriteLine(x);
     }
 }");
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     static void Main()
     {
-        object[] [||]x = {
+        object[] $$x = {
             x = null
         };
         x.ToString();
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     static void Main()
     {
-        int [||]i = 5;
+        int $$i = 5;
         int j = 10;
         Console.WriteLine(i);
     }
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveDeclarationNearRefe
 {
     static void Main(string[] args)
     {
-        int [||]i = 5; Console.WriteLine();
+        int $$i = 5; Console.WriteLine();
         Console.Write(i);
     }
 }",
@@ -335,7 +335,7 @@ class Program
 {
     void Main()
     {
-        int [||]x = 0;
+        int $$x = 0;
         Goo();
         Bar(x);
 #line hidden
@@ -364,7 +364,7 @@ class Program
 {
     void Main()
     {
-        int [||]x = 0;
+        int $$x = 0;
         Goo();
 #line hidden
         Goo();
@@ -399,7 +399,7 @@ class Program
 {
     void Main()
     {
-        var [||]@lock = new object();
+        var $$@lock = new object();
         new[] { 1 }.AsParallel().ForAll((i) => {
             lock (@lock)
             {
@@ -436,7 +436,7 @@ class Program
 {
     void Main()
     {
-        var [||]i = 0;
+        var $$i = 0;
         foreach (var v in new[] { 1 })
         {
             Console.Write(i);
@@ -478,7 +478,7 @@ static class C
 
     static void Main()
     {
-        var [||]a = Outer(x => Inner(x, null), null);
+        var $$a = Outer(x => Inner(x, null), null);
         unsafe
         {
             Console.WriteLine(a);
@@ -522,7 +522,7 @@ class X
     const int Value = 1000;
     static void Main()
     {
-        var [||]a = Goo(X => (byte)X.Value, null);
+        var $$a = Goo(X => (byte)X.Value, null);
         unchecked
         {
             Console.WriteLine(a);
@@ -562,7 +562,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        // Comment [||]about goo!
+        // Comment $$about goo!
         // Comment about goo!
         // Comment about goo!
         // Comment about goo!
@@ -584,7 +584,7 @@ class Program
 {
     void M()
     {
-        (int, string) [||]x;
+        (int, string) $$x;
         {
             Console.WriteLine(x);
         }
@@ -610,7 +610,7 @@ class Program
 {
     void M()
     {
-        (int a, string b) [||]x;
+        (int a, string b) $$x;
         {
             Console.WriteLine(x);
         }
@@ -637,7 +637,7 @@ class Program
     static void Main(string[] args)
     {
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         Console.Write(i);
@@ -665,7 +665,7 @@ class Program
     static void Main(string[] args)
     {
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         {
@@ -697,7 +697,7 @@ class Program
     static void Main(string[] args)
     {
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         // Existing trivia
@@ -727,7 +727,7 @@ class Program
     static void Main(string[] args)
     {
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         {
@@ -765,7 +765,7 @@ class Program
         }
 
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         i = 0;
@@ -802,7 +802,7 @@ class Program
         }
 
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         {
@@ -843,7 +843,7 @@ class Program
         }
 
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         // Existing trivia
@@ -882,7 +882,7 @@ class Program
         }
 
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         {
@@ -921,7 +921,7 @@ class Program
     static void Main(string[] args)
     {
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         i = 0;
@@ -950,7 +950,7 @@ class Program
     static void Main(string[] args)
     {
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         {
@@ -983,7 +983,7 @@ class Program
     static void Main(string[] args)
     {
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         // Existing trivia
@@ -1014,7 +1014,7 @@ class Program
     static void Main(string[] args)
     {
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         {
@@ -1053,7 +1053,7 @@ class Program
         }
 
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         i = 0;
@@ -1090,7 +1090,7 @@ class Program
         }
 
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         {
@@ -1131,7 +1131,7 @@ class Program
         }
 
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         // Existing trivia
@@ -1170,7 +1170,7 @@ class Program
         }
 
         // leading trivia
-        int [||]i = 5;
+        int $$i = 5;
         Console.WriteLine();
 
         {

--- a/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([||]e)
+            switch ($$e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
                 default:
                     break;
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
             }
         }
@@ -486,7 +486,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
             }
         }
@@ -534,7 +534,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
             }
         }
@@ -583,7 +583,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = Append;
-            [||]switch (e)
+            $$switch (e)
             {
                 case CreateNew:
                     break;
@@ -618,7 +618,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = Append;
-            [||]switch (e)
+            $$switch (e)
             {
                 case CreateNew:
                     break;
@@ -653,7 +653,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = Append;
-            [||]switch (e)
+            $$switch (e)
             {
                 case CreateNew:
                     break;
@@ -713,7 +713,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = Append;
-            [||]switch (e)
+            $$switch (e)
             {
             }
         }
@@ -769,7 +769,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -826,7 +826,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = MyEnum.Fizz;
-            [||]switch (e)
+            $$switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -877,7 +877,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = ""test"";
-            [||]switch (e)
+            $$switch (e)
             {
                 case ""test1"":
                 case ""test1"":
@@ -905,7 +905,7 @@ class MyClass
     void Method()
     {
         var e = MyEnum.Fizz;
-        [||]switch (e)
+        $$switch (e)
         {
             case (MyEnum)0:
             case (MyEnum)1:
@@ -954,7 +954,7 @@ class MyClass
     void Method()
     {
         var e = MyEnum.Fizz;
-        [||]switch (e)
+        $$switch (e)
     }
 }
 ",

--- a/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ReplaceDocCommentTextWi
         {
             await TestInRegularAndScriptAsync(
 @"
-/// Testing keyword [||]null.
+/// Testing keyword $$null.
 class C<TKey>
 {
 }",
@@ -37,7 +37,7 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// Testing keyword abstract[||].
+/// Testing keyword abstract$$.
 class C<TKey>
 {
 }",
@@ -54,7 +54,7 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// Testing keyword static[||]
+/// Testing keyword static$$
 class C<TKey>
 {
 }",
@@ -88,7 +88,7 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// Testing keyword asy[||]nc.
+/// Testing keyword asy$$nc.
 class C<TKey>
 {
 }",
@@ -116,7 +116,7 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// TKey must implement the [||]System.IDisposable interface.
+/// TKey must implement the $$System.IDisposable interface.
 class C<TKey>
 {
 }",
@@ -133,7 +133,7 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// TKey must implement the System[||].IDisposable interface.
+/// TKey must implement the System$$.IDisposable interface.
 class C<TKey>
 {
 }",
@@ -150,7 +150,7 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// TKey must implement the System.[||]IDisposable interface.
+/// TKey must implement the System.$$IDisposable interface.
 class C<TKey>
 {
 }",
@@ -167,7 +167,7 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// TKey must implement the System.IDisposable[||] interface.
+/// TKey must implement the System.IDisposable$$ interface.
 class C<TKey>
 {
 }",
@@ -201,7 +201,7 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// [||]TKey must implement the System.IDisposable interface.
+/// $$TKey must implement the System.IDisposable interface.
 class C<TKey>
 {
 }",
@@ -218,7 +218,7 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// [||]TKey must implement the System.IDisposable interface.
+/// $$TKey must implement the System.IDisposable interface.
 class C<TKey>{}",
 
 @"
@@ -231,7 +231,7 @@ class C<TKey>{}");
         {
             await TestInRegularAndScriptAsync(
 @"
-/// Use WriteLine[||] as a Console.WriteLine replacement
+/// Use WriteLine$$ as a Console.WriteLine replacement
 class C
 {
     void WriteLine<TKey>(TKey value) { }
@@ -250,7 +250,7 @@ class C
         {
             await TestMissingAsync(
 @"
-/// Use WriteLine1[||] as a Console.WriteLine replacement
+/// Use WriteLine1$$ as a Console.WriteLine replacement
 class C
 {
     void WriteLine<TKey>(TKey value) { }
@@ -264,7 +264,7 @@ class C
 @"
 class C
 {
-    /// value has type TKey[||] so we don't box primitives.
+    /// value has type TKey$$ so we don't box primitives.
     void WriteLine<TKey>(TKey value) { }
 }",
 
@@ -283,7 +283,7 @@ class C
 @"
 class C
 {
-    /// value has type TKey[||] so we don't box primitives.
+    /// value has type TKey$$ so we don't box primitives.
     void WriteLine<TKey>(TKey value){}
 }",
 
@@ -302,7 +302,7 @@ class C
 @"
 class C
 {
-    /// value has type TKey[||] so we don't box primitives.
+    /// value has type TKey$$ so we don't box primitives.
     object WriteLine<TKey>(TKey value) => null;
 }",
 
@@ -321,7 +321,7 @@ class C
 @"
 class C
 {
-    /// value has type TKey[||] so we don't box primitives.
+    /// value has type TKey$$ so we don't box primitives.
     void WriteLine<TKey>(TKey value);
 }",
 
@@ -340,7 +340,7 @@ class C
 @"
 class C
 {
-    /// value[||] has type TKey so we don't box primitives.
+    /// value$$ has type TKey so we don't box primitives.
     void WriteLine<TKey>(TKey value) { }
 }",
 
@@ -359,7 +359,7 @@ class C
 @"
 class C
 {
-    /// value[||] has type TKey so we don't box primitives.
+    /// value$$ has type TKey so we don't box primitives.
     void WriteLine<TKey>(TKey value){}
 }",
 
@@ -378,7 +378,7 @@ class C
 @"
 class C
 {
-    /// value[||] has type TKey so we don't box primitives.
+    /// value$$ has type TKey so we don't box primitives.
     object WriteLine<TKey>(TKey value) => null;
 }",
 
@@ -397,7 +397,7 @@ class C
 @"
 class C
 {
-    /// value[||] has type TKey so we don't box primitives.
+    /// value$$ has type TKey so we don't box primitives.
     void WriteLine<TKey>(TKey value);
 }",
 
@@ -415,7 +415,7 @@ class C
         {
             await TestMissingAsync(
 @"
-/// Testing keyword interfa[||]ce.
+/// Testing keyword interfa$$ce.
 class C<TKey>
 {
 }");
@@ -427,7 +427,7 @@ class C<TKey>
         {
             await TestMissingAsync(
 @"
-/// Testing keyword inside <see langword =""nu[||]ll""/>
+/// Testing keyword inside <see langword =""nu$$ll""/>
 class C
 {
     void WriteLine<TKey>(TKey value) { }
@@ -440,7 +440,7 @@ class C
         {
             await TestMissingAsync(
 @"
-/// Testing keyword inside <see langword =""nu[||]ll""
+/// Testing keyword inside <see langword =""nu$$ll""
 class C
 {
     void WriteLine<TKey>(TKey value) { }

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral;
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = [||]"""";
+        var v = $$"""";
     }
 }");
         }
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = """"[||];
+        var v = """"$$;
     }
 }");
         }
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = """" [||];
+        var v = """" $$;
     }
 }");
         }
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = """"[||]
+        var v = """"$$
     }
 }");
         }
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = """" [||]
+        var v = """" $$
     }
 }");
         }
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $""""[||];
+        var v = $""""$$;
     }
 }");
         }
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $"""" [||];
+        var v = $"""" $$;
     }
 }");
         }
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $""""[||]
+        var v = $""""$$
     }
 }");
         }
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $"""" [||]
+        var v = $"""" $$
     }
 }");
         }
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = @""a[||]b"";
+        var v = @""a$$b"";
     }
 }");
         }
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $@""a[||]b"";
+        var v = $@""a$$b"";
     }
 }");
         }
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = ""[||]"";
+        var v = ""$$"";
     }
 }",
 @"class C
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     void M()
     {
         var v = """" +
-            ""[||]"";
+            ""$$"";
     }
 }");
         }
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $""[||]"";
+        var v = $""$$"";
     }
 }",
 @"class C
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     void M()
     {
         var v = $"""" +
-            $""[||]"";
+            $""$$"";
     }
 }");
         }
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = ""now is [||]the time"";
+        var v = ""now is $$the time"";
     }
 }",
 @"class C
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     void M()
     {
         var v = ""now is "" +
-            ""[||]the time"";
+            ""$$the time"";
     }
 }");
         }
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $""now is [||]the { 1 + 2 } time for { 3 + 4 } all good men"";
+        var v = $""now is $$the { 1 + 2 } time for { 3 + 4 } all good men"";
     }
 }",
 @"class C
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     void M()
     {
         var v = $""now is "" +
-            $""[||]the { 1 + 2 } time for { 3 + 4 } all good men"";
+            $""$$the { 1 + 2 } time for { 3 + 4 } all good men"";
     }
 }");
         }
@@ -330,7 +330,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $""now is the [||]{ 1 + 2 } time for { 3 + 4 } all good men"";
+        var v = $""now is the $${ 1 + 2 } time for { 3 + 4 } all good men"";
     }
 }",
 @"class C
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     void M()
     {
         var v = $""now is the "" +
-            $""[||]{ 1 + 2 } time for { 3 + 4 } all good men"";
+            $""$${ 1 + 2 } time for { 3 + 4 } all good men"";
     }
 }");
         }
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $""now is the { 1 + 2 }[||] time for { 3 + 4 } all good men"";
+        var v = $""now is the { 1 + 2 }$$ time for { 3 + 4 } all good men"";
     }
 }",
 @"class C
@@ -359,7 +359,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     void M()
     {
         var v = $""now is the { 1 + 2 }"" +
-            $""[||] time for { 3 + 4 } all good men"";
+            $""$$ time for { 3 + 4 } all good men"";
     }
 }");
         }
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $""now is the {[||] 1 + 2 } time for { 3 + 4 } all good men"";
+        var v = $""now is the {$$ 1 + 2 } time for { 3 + 4 } all good men"";
     }
 }");
         }
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     void M()
     {
-        var v = $""now is the { 1 + 2 [||]} time for { 3 + 4 } all good men"";
+        var v = $""now is the { 1 + 2 $$} time for { 3 + 4 } all good men"";
     }
 }");
         }
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
     static void Main(string[] args)
     {
-        var str = $""somestring { args[0]}[||]"" +
+        var str = $""somestring { args[0]}$$"" +
             $""{args[1]}"" +
             $""{args[2]}"";
 
@@ -426,7 +426,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     static void Main(string[] args)
     {
         var str = $""somestring { args[0]}"" +
-            $""[||]"" +
+            $""$$"" +
             $""{args[1]}"" +
             $""{args[2]}"";
 
@@ -447,7 +447,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     static void Main(string[] args)
     {
         var str = $""somestring { args[0]}"" +
-            $""{args[1]}[||]"" +
+            $""{args[1]}$$"" +
             $""{args[2]}"";
 
         var str2 = ""string1"" +
@@ -461,7 +461,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     {
         var str = $""somestring { args[0]}"" +
             $""{args[1]}"" +
-            $""[||]"" +
+            $""$$"" +
             $""{args[2]}"";
 
         var str2 = ""string1"" +
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     {
         var str = $""somestring { args[0]}"" +
             $""{args[1]}"" +
-            $""{args[2]}[||]"";
+            $""{args[2]}$$"";
 
         var str2 = ""string1"" +
             ""string2"" +
@@ -496,7 +496,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         var str = $""somestring { args[0]}"" +
             $""{args[1]}"" +
             $""{args[2]}"" +
-            $""[||]"";
+            $""$$"";
 
         var str2 = ""string1"" +
             ""string2"" +
@@ -518,7 +518,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
             $""{args[1]}"" +
             $""{args[2]}"";
 
-        var str2 = ""string1[||]"" +
+        var str2 = ""string1$$"" +
             ""string2"" +
             ""string3"";
     }
@@ -532,7 +532,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
             $""{args[2]}"";
 
         var str2 = ""string1"" +
-            ""[||]"" +
+            ""$$"" +
             ""string2"" +
             ""string3"";
     }
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
             $""{args[2]}"";
 
         var str2 = ""string1"" +
-            ""string2[||]"" +
+            ""string2$$"" +
             ""string3"";
     }
 }",
@@ -567,7 +567,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 
         var str2 = ""string1"" +
             ""string2"" +
-            ""[||]"" +
+            ""$$"" +
             ""string3"";
     }
 }");
@@ -588,7 +588,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 
         var str2 = ""string1"" +
             ""string2"" +
-            ""string3[||]"";
+            ""string3$$"";
     }
 }",
 @"class Program
@@ -602,7 +602,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         var str2 = ""string1"" +
             ""string2"" +
             ""string3"" +
-            ""[||]"";
+            ""$$"";
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral;
@@ -23,11 +23,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         {
             using (var workspace = TestWorkspace.CreateCSharp(inputMarkup))
             {
-                var document = workspace.Documents.Single();
+                Assert.True(workspace.TryGetDocumentWithSelectedSpan(out var doc, out var originalSelection));
+                var document = workspace.Documents.Single(d => d.Id == doc.Id);
                 var view = document.GetTextView();
 
                 var originalSnapshot = view.TextBuffer.CurrentSnapshot;
-                var originalSelection = document.SelectedSpans.Single();
                 view.SetSelection(originalSelection.ToSnapshotSpan(originalSnapshot));
 
                 var undoHistoryRegistry = workspace.GetService<ITextUndoHistoryRegistry>();

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading;
 using System.Threading.Tasks;
@@ -1858,7 +1858,7 @@ class C
 {
     void M(IEnumerable<string> args)
     {
-        args = args.Select(a =>[||])
+        args = args.Select(a =>$$)
     }
 }";
             await TestAsync(text, "global::System.Object", testPosition: false);
@@ -1949,7 +1949,7 @@ public class C
 {
     static void Main(string[] args)
     {
-        System.ConsoleModifiers c = default([||])
+        System.ConsoleModifiers c = default($$)
     }
 }";
             await TestAsync(text, "global::System.ConsoleModifiers", testNode: false);
@@ -1964,7 +1964,7 @@ public class C
 {
     static void Goo(System.ConsoleModifiers arg)
     {
-        Goo(default([||])
+        Goo(default($$)
     }
 }";
             await TestAsync(text, "global::System.ConsoleModifiers", testNode: false);
@@ -2013,7 +2013,7 @@ class C
   void M()
   {
         int[] array;
-        C p = new [||]
+        C p = new $$
         array[4] = 4;
   }
 }";
@@ -2036,7 +2036,7 @@ class C
         public async Task TestDeconstruction2()
         {
             await TestInMethodAsync(
-@"(int i, _) =  [||]", "(global::System.Int32 i, global::System.Object _)", testNode: false);
+@"(int i, _) =  $$", "(global::System.Int32 i, global::System.Object _)", testNode: false);
         }
 
         [WorkItem(13402, "https://github.com/dotnet/roslyn/issues/13402")]
@@ -2048,7 +2048,7 @@ class C
 {
     static void Main(string[] args)
     {
-        Program p = new [||] 
+        Program p = new $$ 
         { }
     }
 }";

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading;
 using System.Threading.Tasks;
@@ -1858,7 +1858,7 @@ class C
 {
     void M(IEnumerable<string> args)
     {
-        args = args.Select(a =>$$)
+        args = args.Select(a =>[||])
     }
 }";
             await TestAsync(text, "global::System.Object", testPosition: false);
@@ -1949,7 +1949,7 @@ public class C
 {
     static void Main(string[] args)
     {
-        System.ConsoleModifiers c = default($$)
+        System.ConsoleModifiers c = default([||])
     }
 }";
             await TestAsync(text, "global::System.ConsoleModifiers", testNode: false);
@@ -1964,7 +1964,7 @@ public class C
 {
     static void Goo(System.ConsoleModifiers arg)
     {
-        Goo(default($$)
+        Goo(default([||])
     }
 }";
             await TestAsync(text, "global::System.ConsoleModifiers", testNode: false);
@@ -2013,7 +2013,7 @@ class C
   void M()
   {
         int[] array;
-        C p = new $$
+        C p = new [||]
         array[4] = 4;
   }
 }";
@@ -2036,7 +2036,7 @@ class C
         public async Task TestDeconstruction2()
         {
             await TestInMethodAsync(
-@"(int i, _) =  $$", "(global::System.Int32 i, global::System.Object _)", testNode: false);
+@"(int i, _) =  [||]", "(global::System.Int32 i, global::System.Object _)", testNode: false);
         }
 
         [WorkItem(13402, "https://github.com/dotnet/roslyn/issues/13402")]
@@ -2048,7 +2048,7 @@ class C
 {
     static void Main(string[] args)
     {
-        Program p = new $$ 
+        Program p = new [||] 
         { }
     }
 }";

--- a/src/EditorFeatures/CSharpTest/UseCoalesceExpression/UseCoalesceExpressionForNullableTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCoalesceExpression/UseCoalesceExpressionForNullableTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -28,7 +28,7 @@ class C
 {
     void M(int? x, int? y)
     {
-        var z = [||]!x.HasValue ? y : x.Value;
+        var z = $$!x.HasValue ? y : x.Value;
     }
 }",
 @"using System;
@@ -52,7 +52,7 @@ class C
 {
     void M(int? x, int? y)
     {
-        var z = [||]x.HasValue ? x.Value : y;
+        var z = $$x.HasValue ? x.Value : y;
     }
 }",
 @"using System;
@@ -76,7 +76,7 @@ class C
 {
     void M(int? x, int? y)
     {
-        var z = [||]!(x + y).HasValue ? y : (x + y).Value;
+        var z = $$!(x + y).HasValue ? y : (x + y).Value;
     }
 }",
 @"using System;
@@ -100,7 +100,7 @@ class C
 {
     void M(int? x, int? y)
     {
-        var z = [||](x.HasValue) ? x.Value : y;
+        var z = $$(x.HasValue) ? x.Value : y;
     }
 }",
 @"using System;
@@ -200,7 +200,7 @@ class C
 {
     void M(int? x, int? y)
     {
-        Expression<Func<int>> e = () => [||]!x.HasValue ? y : x.Value;
+        Expression<Func<int>> e = () => $$!x.HasValue ? y : x.Value;
     }
 }",
 @"using System;

--- a/src/EditorFeatures/CSharpTest/UseCoalesceExpression/UseCoalesceExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCoalesceExpression/UseCoalesceExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -27,7 +27,7 @@ class C
 {
     void M(string x, string y)
     {
-        var z = [||]x == null ? y : x;
+        var z = $$x == null ? y : x;
     }
 }",
 @"using System;
@@ -51,7 +51,7 @@ class C
 {
     void M(string x, string y)
     {
-        var z = [||]x != null ? x : y;
+        var z = $$x != null ? x : y;
     }
 }",
 @"using System;
@@ -75,7 +75,7 @@ class C
 {
     void M(string x, string y)
     {
-        var z = [||]null == x ? y : x;
+        var z = $$null == x ? y : x;
     }
 }",
 @"using System;
@@ -99,7 +99,7 @@ class C
 {
     void M(string x, string y)
     {
-        var z = [||]null != x ? x : y;
+        var z = $$null != x ? x : y;
     }
 }",
 @"using System;
@@ -123,7 +123,7 @@ class C
 {
     void M(string x, string y)
     {
-        var z = [||]x.ToString() == null ? y : x.ToString();
+        var z = $$x.ToString() == null ? y : x.ToString();
     }
 }",
 @"using System;
@@ -147,7 +147,7 @@ class C
 {
     void M(string x, string y)
     {
-        var z = [||](x == null) ? y : x;
+        var z = $$(x == null) ? y : x;
     }
 }",
 @"using System;
@@ -171,7 +171,7 @@ class C
 {
     void M(string x, string y)
     {
-        var z = [||](x) == null ? y : x;
+        var z = $$(x) == null ? y : x;
     }
 }",
 @"using System;
@@ -195,7 +195,7 @@ class C
 {
     void M(string x, string y)
     {
-        var z = [||]x == null ? y : (x);
+        var z = $$x == null ? y : (x);
     }
 }",
 @"using System;
@@ -219,7 +219,7 @@ class C
 {
     void M(string x, string y)
     {
-        var z = [||]x == null ? (y) : x;
+        var z = $$x == null ? (y) : x;
     }
 }",
 @"using System;
@@ -348,7 +348,7 @@ class C
 {
     void Main(string s, string y)
     {
-        Expression<Func<string>> e = () => [||]s != null ? s : y;
+        Expression<Func<string>> e = () => $$s != null ? s : y;
     }
 }",
 @"using System;
@@ -372,7 +372,7 @@ class C<T>
 {
     void Main(T t)
     {
-        var v = [||]t == null ? throw new Exception() : t;
+        var v = $$t == null ? throw new Exception() : t;
     }
 }");
         }
@@ -386,7 +386,7 @@ class C<T> where T : struct
 {
     void Main(T t)
     {
-        var v = [||]t == null ? throw new Exception() : t;
+        var v = $$t == null ? throw new Exception() : t;
     }
 }");
         }
@@ -400,7 +400,7 @@ class C<T> where T : class
 {
     void Main(T t)
     {
-        var v = [||]t == null ? throw new Exception() : t;
+        var v = $$t == null ? throw new Exception() : t;
     }
 }",
 @"
@@ -422,7 +422,7 @@ class C
 {
     void Main(int? t)
     {
-        var v = [||]t == null ? throw new Exception() : t;
+        var v = $$t == null ? throw new Exception() : t;
     }
 }");
         }
@@ -436,7 +436,7 @@ class C
 {
     void Main(int[] t)
     {
-        var v = [||]t == null ? throw new Exception() : t;
+        var v = $$t == null ? throw new Exception() : t;
     }
 }",
 @"
@@ -458,7 +458,7 @@ class C
 {
     void Main(System.ICloneable t)
     {
-        var v = [||]t == null ? throw new Exception() : t;
+        var v = $$t == null ? throw new Exception() : t;
     }
 }",
 @"
@@ -480,7 +480,7 @@ class C
 {
     void Main(dynamic t)
     {
-        var v = [||]t == null ? throw new Exception() : t;
+        var v = $$t == null ? throw new Exception() : t;
     }
 }",
 @"

--- a/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -28,7 +28,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c.Add(1);
     }
 }",
@@ -56,7 +56,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c[1] = 2;
     }
 }",
@@ -84,7 +84,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c[1] = 2;
     }
 }", new TestParameters(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5)));
@@ -100,7 +100,7 @@ class C
 {
     void M()
     {
-        a.b.c = [||]new List<int>();
+        a.b.c = $$new List<int>();
         a.b.c[1] = 2;
     }
 }",
@@ -128,7 +128,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c[1] = 2;
         c[2] = """";
     }
@@ -158,7 +158,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c[1] = 2;
         c[2] = """";
         c[3, 4] = 5;
@@ -190,7 +190,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c[1] = 2;
         c.Add(0);
     }
@@ -220,7 +220,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c.Add(0);
         c[1] = 2;
     }
@@ -250,7 +250,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c.Add(1);
         c.Add(2);
         throw new Exception();
@@ -287,7 +287,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c.Add(1);
     }
 }", new TestParameters(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp2)));
@@ -303,7 +303,7 @@ class C
 {
     void M()
     {
-        var c = [||]new C();
+        var c = $$new C();
         c.Add(1);
     }
 }");
@@ -319,7 +319,7 @@ class C
 {
     void M()
     {
-        var c = [||]new C();
+        var c = $$new C();
         c.Add(1);
     }
 
@@ -339,7 +339,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>(1);
+        var c = $$new List<int>(1);
         c.Add(1);
     }
 }",
@@ -368,7 +368,7 @@ class C
     void M()
     {
         List<int> c = null;
-        c = [||]new List<int>();
+        c = $$new List<int>();
         c.Add(1);
     }
 }",
@@ -397,7 +397,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c.Add(ref i);
     }
 }");
@@ -414,7 +414,7 @@ class C
     void M()
     {
         List<int>[] array;
-        array[0] = [||]new List<int>();
+        array[0] = $$new List<int>();
         array[0].Add(1);
         array[0].Add(2);
     }
@@ -445,7 +445,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c.Add(arg: 1);
     }
 }");
@@ -461,7 +461,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>() { 1 };
+        var c = $$new List<int>() { 1 };
         c.Add(1);
     }
 }");
@@ -591,7 +591,7 @@ class C
 {
     void M()
     {
-        var c = [||]new List<int>();
+        var c = $$new List<int>();
         c.Add(1); // Goo
         c.Add(2); // Bar
     }
@@ -621,7 +621,7 @@ class C
 {
     void M()
     {
-        var c = new [||]Dictionary<int, string>();
+        var c = new $$Dictionary<int, string>();
         c.Add(1, ""x"");
         c.Add(2, ""y"");
     }
@@ -655,7 +655,7 @@ public class Goo
         string item = null;
         var items = new List<string>();
 
-        var values = new [||]List<string>(); // Collection initialization can be simplified
+        var values = new $$List<string>(); // Collection initialization can be simplified
         values.Add(item);
         values.AddRange(items);
     }
@@ -692,7 +692,7 @@ class Program
     static void Main(string[] args)
     {
         var myStringArray = new string[] { ""Test"", ""123"", ""ABC"" };
-        var myStringList = myStringArray?.ToList() ?? new [||]List<string>();
+        var myStringList = myStringArray?.ToList() ?? new $$List<string>();
         myStringList.Add(""Done"");
     }
 }");
@@ -710,7 +710,7 @@ class C
 {
     static void M()
     {
-        var items = new [||]List<object>();
+        var items = new $$List<object>();
         items[0] = items[0];
     }
 }");
@@ -728,7 +728,7 @@ class C
 {
     static void M()
     {
-        var items = new [||]List<object>();
+        var items = new $$List<object>();
         items[0] = 1;
         items[1] = items[0];
     }
@@ -740,7 +740,7 @@ class C
 {
     static void M()
     {
-        var items = new [||]List<object>
+        var items = new $$List<object>
         {
             [0] = 1
         };
@@ -762,7 +762,7 @@ class C
 {
     void M()
     {
-        var t = [||]new List<int>(new int[] { 1, 2, 3 });
+        var t = $$new List<int>(new int[] { 1, 2, 3 });
         t.Add(t.Min() - 1);
     }
 }");
@@ -781,7 +781,7 @@ class C
     static void M()
     {
         List<object> items = null;
-        items = new [||]List<object>();
+        items = new $$List<object>();
         items[0] = 1;
         items[1] = items[0];
     }
@@ -794,7 +794,7 @@ class C
     static void M()
     {
         List<object> items = null;
-        items = new [||]List<object>
+        items = new $$List<object>
         {
             [0] = 1
         };
@@ -816,7 +816,7 @@ class C
     void M()
     {
         List<int> t = null;
-        t = [||]new List<int>(new int[] { 1, 2, 3 });
+        t = $$new List<int>(new int[] { 1, 2, 3 });
         t.Add(t.Min() - 1);
     }
 }");
@@ -834,7 +834,7 @@ class C
     private List<int> myField;
     void M()
     {
-        myField = [||]new List<int>();
+        myField = $$new List<int>();
         myField.Add(this.myField.Count);
     }
 }");
@@ -851,7 +851,7 @@ class C
 {
     void Goo()
     {
-        dynamic body = [||]new ExpandoObject();
+        dynamic body = $$new ExpandoObject();
         body[0] = new ExpandoObject();
     }
 }");
@@ -869,7 +869,7 @@ public class Goo
 {
     public void M()
     {
-        var items = new [||]List<object>();
+        var items = new $$List<object>();
 #if true
         items.Add(1);
 #endif
@@ -890,7 +890,7 @@ public class Goo
     public void M()
     {
 #if true
-        var items = new [||]List<object>();
+        var items = new $$List<object>();
         items.Add(1);
 #endif
     }
@@ -925,7 +925,7 @@ public class Goo
     public void M()
     {
         int lastItem;
-        var list = [||]new List<int>();
+        var list = $$new List<int>();
         list.Add(lastItem = 5);
     }
 }",
@@ -958,7 +958,7 @@ public class Goo
     public void M()
     {
         int lastItem = 0;
-        var list = [||]new List<int>();
+        var list = $$new List<int>();
         list.Add(lastItem += 5);
     }
 }",
@@ -990,7 +990,7 @@ class MyClass
 {
     public void Main()
     {
-        var list = [||]new List<int>();
+        var list = $$new List<int>();
         list.Add(1);
 
         int horse = 1;

--- a/src/EditorFeatures/CSharpTest/UseDefaultLiteral/UseDefaultLiteralTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseDefaultLiteral/UseDefaultLiteralTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseDefaultLiteral
 @"
 class C
 {
-    void Goo(string s = [||]default(string))
+    void Goo(string s = $$default(string))
     {
     }
 }", parameters: new TestParameters(
@@ -44,7 +44,7 @@ class C
 @"
 class C
 {
-    void Goo(string s = [||]default(string))
+    void Goo(string s = $$default(string))
     {
     }
 }",
@@ -66,7 +66,7 @@ class C
 {
     void Goo(string s)
     {
-        if (s == [||]default(string)) { }
+        if (s == $$default(string)) { }
     }
 }",
 @"
@@ -88,7 +88,7 @@ class C
 {
     string Goo()
     {
-        return [||]default(string);
+        return $$default(string);
     }
 }",
 @"
@@ -110,7 +110,7 @@ class C
 {
     string Goo()
     {
-        return [||]default(int);
+        return $$default(int);
     }
 }", parameters: s_testParameters);
         }
@@ -126,7 +126,7 @@ class C
 {
     void Goo()
     {
-        Func<string> f = () => [||]default(string);
+        Func<string> f = () => $$default(string);
     }
 }",
 @"
@@ -136,7 +136,7 @@ class C
 {
     void Goo()
     {
-        Func<string> f = () => [||]default;
+        Func<string> f = () => $$default;
     }
 }", parseOptions: s_parseOptions);
         }
@@ -152,7 +152,7 @@ class C
 {
     void Goo()
     {
-        Func<string> f = () => [||]default(int);
+        Func<string> f = () => $$default(int);
     }
 }", parameters: s_testParameters);
         }
@@ -166,7 +166,7 @@ class C
 {
     void Goo()
     {
-        string s = [||]default(string);
+        string s = $$default(string);
     }
 }",
 @"
@@ -188,7 +188,7 @@ class C
 {
     void Goo()
     {
-        string s = [||]default(int);
+        string s = $$default(int);
     }
 }", parameters: s_testParameters);
         }
@@ -202,7 +202,7 @@ class C
 {
     void Goo()
     {
-        var s = [||]default(string);
+        var s = $$default(string);
     }
 }",  parameters: s_testParameters);
         }
@@ -216,7 +216,7 @@ class C
 {
     void Goo()
     {
-        Bar([||]default(string));
+        Bar($$default(string));
     }
 
     void Bar(string s) { }
@@ -242,7 +242,7 @@ class C
 {
     void Goo()
     {
-        Bar([||]default(string));
+        Bar($$default(string));
     }
 
     void Bar(string s) { }
@@ -259,7 +259,7 @@ class C
 {
     void Goo(bool b)
     {
-        var v = b ? [||]default(string) : default(string);
+        var v = b ? $$default(string) : default(string);
     }
 }",
 @"
@@ -281,7 +281,7 @@ class C
 {
     void Goo(bool b)
     {
-        var v = b ? default(string) : [||]default(string);
+        var v = b ? default(string) : $$default(string);
     }
 }",
 @"
@@ -374,7 +374,7 @@ struct S
     void M()
     {
         var s = new S();
-        s.Equals([||]default(S));
+        s.Equals($$default(S));
     }
 
     public override bool Equals(object obj)
@@ -394,7 +394,7 @@ struct S<T>
     void M()
     {
         var s = new S<int>();
-        s.Equals([||]default(S<int>));
+        s.Equals($$default(S<int>));
     }
 
     public override bool Equals(object obj)
@@ -414,7 +414,7 @@ struct S
     void M()
     {
         var s = new S();
-        s.Equals([||]default(S));
+        s.Equals($$default(S));
     }
 
     public new bool Equals(S s) => true;
@@ -445,7 +445,7 @@ class C
     {
         switch (true)
         {
-            case [||]default(bool):
+            case $$default(bool):
         }
     }
 }", s_testParameters);
@@ -462,7 +462,7 @@ class C
     {
         switch (true)
         {
-            case ([||]default(bool)):
+            case ($$default(bool)):
         }
     }
 }", s_testParameters);
@@ -479,7 +479,7 @@ class C
     {
         switch (true)
         {
-            case (bool)[||]default(bool):
+            case (bool)$$default(bool):
         }
     }
 }",
@@ -490,7 +490,7 @@ class C
     {
         switch (true)
         {
-            case (bool)[||]default:
+            case (bool)$$default:
         }
     }
 }", parameters: s_testParameters);
@@ -507,7 +507,7 @@ class C
     {
         switch (true)
         {
-            case [||]default(bool) when true:
+            case $$default(bool) when true:
         }
     }
 }", s_testParameters);
@@ -524,7 +524,7 @@ class C
     {
         switch (true)
         {
-            case ([||]default(bool)) when true:
+            case ($$default(bool)) when true:
         }
     }
 }", s_testParameters);
@@ -541,7 +541,7 @@ class C
     {
         switch (true)
         {
-            case (bool)[||]default(bool) when true:
+            case (bool)$$default(bool) when true:
         }
     }
 }",
@@ -552,7 +552,7 @@ class C
     {
         switch (true)
         {
-            case (bool)[||]default when true:
+            case (bool)$$default when true:
         }
     }
 }", parameters: s_testParameters);
@@ -569,7 +569,7 @@ class C
     {
         switch (true)
         {
-            case default(bool) when [||]default(bool):
+            case default(bool) when $$default(bool):
         }
     }
 }",
@@ -595,7 +595,7 @@ class C
 {
     void M()
     {
-        if (true is [||]default(bool));
+        if (true is $$default(bool));
     }
 }", s_testParameters);
         }
@@ -609,7 +609,7 @@ class C
 {
     void M()
     {
-        if (true is ([||]default(bool)));
+        if (true is ($$default(bool)));
     }
 }", s_testParameters);
         }
@@ -623,7 +623,7 @@ class C
 {
     void M()
     {
-        if (true is (bool)[||]default(bool));
+        if (true is (bool)$$default(bool));
     }
 }",
 @"

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get
         {
-            [||]return Bar();
+            $$return Bar();
         }
     }
 }",
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get
         {
-            [||]return Bar();
+            $$return Bar();
         }
     }
 }", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get
         {
-            return [||]Bar();
+            return $$Bar();
         }
     }
 }",
@@ -107,13 +107,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get
         {
-            return [||]Bar();
+            return $$Bar();
         }
     }
 }",
 @"class C
 {
-    int Goo => [||]Bar();
+    int Goo => $$Bar();
 }", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestMissingAsync(
 @"class C
 {
-    int Goo { get => [||]Bar(); }
+    int Goo { get => $$Bar(); }
 }", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
         }
 
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    int Goo { get => [||]Bar(); }
+    int Goo { get => $$Bar(); }
 }",
 
 @"class C
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    int Goo { get => [||]Bar(); }
+    int Goo { get => $$Bar(); }
 }",
 @"class C
 {
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    int Goo { get => [||]Bar(); }
+    int Goo { get => $$Bar(); }
 }",
 @"class C
 {

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public C()
     {
-        [||]Bar();
+        $$Bar();
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public C()
     {
-        [||]Bar();
+        $$Bar();
     }
 }",
 @"class C
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public C()
     {
-        return () => { [||] };
+        return () => { $$ };
     }
 }", parameters: new TestParameters(options: UseBlockBody));
         }
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestMissingAsync(
 @"class C
 {
-    public C() => [||]Bar();
+    public C() => $$Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    public C() => [||]Bar();
+    public C() => $$Bar();
 }",
 @"class C
 {

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public static implicit operator bool(C c1)
     {
-        [||]Bar();
+        $$Bar();
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public static implicit operator bool(C c1)
     {
-        [||]Bar();
+        $$Bar();
     }
 }",
 @"class C
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public static implicit operator bool(C c1)
     {
-        return () => { [||] };
+        return () => { $$ };
     }
 }", parameters: new TestParameters(options: UseBlockBody));
         }
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestMissingAsync(
 @"class C
 {
-    public static implicit operator bool(C c1) => [||]Bar();
+    public static implicit operator bool(C c1) => $$Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    public static implicit operator bool(C c1) => [||]Bar();
+    public static implicit operator bool(C c1) => $$Bar();
 }",
 @"class C
 {

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get 
         {
-            [||]return Bar();
+            $$return Bar();
         }
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get
         {
-            [||]return Bar();
+            $$return Bar();
         }
     }
 }",
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get 
         {
-            return () => { [||] };
+            return () => { $$ };
         }
     }
 }", parameters: new TestParameters(options: UseBlockBody));
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestMissingAsync(
 @"class C
 {
-    int this[int i] => [||]Bar();
+    int this[int i] => $$Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    int this[int i] => [||]Bar();
+    int this[int i] => $$Bar();
 }",
 @"class C
 {

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     void Goo()
     {
-        [||]Bar();
+        $$Bar();
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     void Goo()
     {
-        [||]Bar();
+        $$Bar();
     }
 }",
 @"class C
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     Action Goo()
     {
-        return () => { [||] };
+        return () => { $$ };
     }
 }", parameters: new TestParameters(options: UseBlockBody));
         }
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestMissingAsync(
 @"class C
 {
-    void Goo() => [||]Bar();
+    void Goo() => $$Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    void Goo() => [||]Bar();
+    void Goo() => $$Bar();
 }",
 @"class C
 {

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public static bool operator +(C c1, C c2)
     {
-        [||]Bar();
+        $$Bar();
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public static bool operator +(C c1, C c2)
     {
-        [||]Bar();
+        $$Bar();
     }
 }",
 @"class C
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public static bool operator +(C c1, C c2)
     {
-        return () => { [||] };
+        return () => { $$ };
     }
 }", parameters: new TestParameters(options: UseBlockBody));
         }
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestMissingAsync(
 @"class C
 {
-    public static bool operator +(C c1, C c2) => [||]Bar();
+    public static bool operator +(C c1, C c2) => $$Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    public static bool operator +(C c1, C c2) => [||]Bar();
+    public static bool operator +(C c1, C c2) => $$Bar();
 }",
 @"class C
 {

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get 
         {
-            [||]return Bar();
+            $$return Bar();
         }
     }
 }", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get 
         {
-            [||]return Bar();
+            $$return Bar();
         }
     }
 }",
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get
         {
-            [||]return Bar();
+            $$return Bar();
         }
     }
 }",
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get
         {
-            [||]return Bar();
+            $$return Bar();
         }
     }
 }",
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     {
         get 
         {
-            return () => { [||] };
+            return () => { $$ };
         }
     }
 }", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestMissingAsync(
 @"class C
 {
-    int Goo => [||]Bar();
+    int Goo => $$Bar();
 }", parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
         }
 
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestMissingAsync(
 @"class C
 {
-    int Goo => [||]Bar();
+    int Goo => $$Bar();
 }", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
         }
 
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    int Goo => [||]Bar();
+    int Goo => $$Bar();
 }",
 @"class C
 {
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestInRegularAndScript1Async(
 @"class C
 {
-    int Goo => [||]Bar();
+    int Goo => $$Bar();
 }",
 @"class C
 {
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestAsync(
 @"class C
 {
-    int Goo => [||]Bar();
+    int Goo => $$Bar();
 }",
 @"class C
 {

--- a/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -31,7 +31,7 @@ class C
     void M()
     {
         int a = 1;
-        var t = ([||]a: a, 2);
+        var t = ($$a: a, 2);
     }
 }",
 @"
@@ -56,7 +56,7 @@ class C
     void M()
     {
         int alice = 1;
-        (int, int, string) t = ([||]alice: alice, alice, null);
+        (int, int, string) t = ($$alice: alice, alice, null);
     }
 }", parameters: new TestParameters(parseOptions: s_parseOptions));
         }
@@ -71,7 +71,7 @@ class C
     void M()
     {
         int a = 2;
-        var t = (1, [||]a: a);
+        var t = (1, $$a: a);
     }
 }", count: 0, parameters: new TestParameters(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6)));
         }
@@ -86,7 +86,7 @@ class C
     void M()
     {
         int a = 2;
-        var t = (1, [||]a: a);
+        var t = (1, $$a: a);
     }
 }", count: 0, parameters: new TestParameters(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7)));
         }
@@ -127,7 +127,7 @@ class C
     void M()
     {
         int a = 1;
-        var t = new { [||]a= a, 2 };
+        var t = new { $$a= a, 2 };
     }
 }",
 @"
@@ -152,7 +152,7 @@ class C
     void M()
     {
         int alice = 1;
-        var t = new { [||]alice=alice, alice };
+        var t = new { $$alice=alice, alice };
     }
 }", parameters: new TestParameters(parseOptions: s_parseOptions));
         }

--- a/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -27,7 +27,7 @@ class C
 {
     void M(string s)
     {
-        if ([||]ReferenceEquals(s, null))
+        if ($$ReferenceEquals(s, null))
             return;
     }
 }",
@@ -53,7 +53,7 @@ class C
 {
     void M(string s)
     {
-        if (object.[||]ReferenceEquals(s, null))
+        if (object.$$ReferenceEquals(s, null))
             return;
     }
 }",
@@ -79,7 +79,7 @@ class C
 {
     void M(string s)
     {
-        if (Object.[||]ReferenceEquals(s, null))
+        if (Object.$$ReferenceEquals(s, null))
             return;
     }
 }",
@@ -105,7 +105,7 @@ class C
 {
     void M(string s)
     {
-        if ([||]ReferenceEquals(null, s))
+        if ($$ReferenceEquals(null, s))
             return;
     }
 }",
@@ -131,7 +131,7 @@ class C
 {
     void M(string s)
     {
-        if (![||]ReferenceEquals(null, s))
+        if (!$$ReferenceEquals(null, s))
             return;
     }
 }",
@@ -157,7 +157,7 @@ class C
 {
     void M(string s)
     {
-        if ([||]ReferenceEquals(null, s))
+        if ($$ReferenceEquals(null, s))
             return;
     }
 }", parameters: new TestParameters(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6)));
@@ -229,7 +229,7 @@ class C
 {
     public static void NotNull<T>(T value)
     {
-        if ([||]ReferenceEquals(value, null))
+        if ($$ReferenceEquals(value, null))
         {
             return;
         }
@@ -259,7 +259,7 @@ class C
 {
     public static void NotNull<T>(T value) where T:class
     {
-        if ([||]ReferenceEquals(value, null))
+        if ($$ReferenceEquals(value, null))
         {
             return;
         }
@@ -290,7 +290,7 @@ class C
 {
     public static void NotNull<T>(T value) where T:struct
     {
-        if ([||]ReferenceEquals(value, null))
+        if ($$ReferenceEquals(value, null))
         {
             return;
         }

--- a/src/EditorFeatures/CSharpTest/UseLocalFunction/UseLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseLocalFunction/UseLocalFunctionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -27,7 +27,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = v =>
+        Func<int, int> $$fibonacci = v =>
         {
             if (v <= 1)
             {
@@ -50,7 +50,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = v =>
+        Func<int, int> $$fibonacci = v =>
         {
             if (v <= 1)
             {
@@ -75,7 +75,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = v =>
+        Func<int, int> $$fibonacci = v =>
         {
             fibonacci = null;
             if (v <= 1)
@@ -98,7 +98,7 @@ class C
     void M()
     {
         // Func can't be bound.
-        Func<int, int> [||]fibonacci = v =>
+        Func<int, int> $$fibonacci = v =>
         {
             if (v <= 1)
             {
@@ -121,7 +121,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = v =>
+        Func<int, int> $$fibonacci = v =>
         {
             if (v <= 1)
             {
@@ -142,7 +142,7 @@ class C
 
 class C
 {
-    Func<int, int> [||]fibonacci = v =>
+    Func<int, int> $$fibonacci = v =>
         {
             if (v <= 1)
             {
@@ -164,7 +164,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = v =>
+        Func<int, int> $$fibonacci = v =>
         {
             if (v <= 1)
             {
@@ -204,7 +204,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = (v) =>
+        Func<int, int> $$fibonacci = (v) =>
         {
             if (v <= 1)
             {
@@ -244,7 +244,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = (int v) =>
+        Func<int, int> $$fibonacci = (int v) =>
         {
             if (v <= 1)
             {
@@ -284,7 +284,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = v =>
+        Func<int, int> $$fibonacci = v =>
             v <= 1
                 ? 1
                 : fibonacci(v - 1, v - 2);
@@ -314,7 +314,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = (v) =>
+        Func<int, int> $$fibonacci = (v) =>
             v <= 1
                 ? 1
                 : fibonacci(v - 1, v - 2);
@@ -344,7 +344,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = (int v) =>
+        Func<int, int> $$fibonacci = (int v) =>
             v <= 1
                 ? 1
                 : fibonacci(v - 1, v - 2);
@@ -374,7 +374,7 @@ class C
 {
     void M()
     {
-        var [||]fibonacci = (Func<int, int>)(v =>
+        var $$fibonacci = (Func<int, int>)(v =>
         {
             if (v <= 1)
             {
@@ -414,7 +414,7 @@ class C
 {
     void M()
     {
-        var [||]fibonacci = ((Func<int, int>)(v =>
+        var $$fibonacci = ((Func<int, int>)(v =>
         {
             if (v <= 1)
             {
@@ -454,7 +454,7 @@ class C
 {
     void M()
     {
-        var [||]fibonacci = (Func<int, int>)((v) =>
+        var $$fibonacci = (Func<int, int>)((v) =>
         {
             if (v <= 1)
             {
@@ -494,7 +494,7 @@ class C
 {
     void M()
     {
-        var [||]fibonacci = (Func<int, int>)((int v) =>
+        var $$fibonacci = (Func<int, int>)((int v) =>
         {
             if (v <= 1)
             {
@@ -534,7 +534,7 @@ class C
 {
     void M()
     {
-        var [||]fibonacci = (Func<int, int>)(v =>
+        var $$fibonacci = (Func<int, int>)(v =>
             v <= 1
                 ? 1
                 : fibonacci(v - 1, v - 2));
@@ -564,7 +564,7 @@ class C
 {
     void M()
     {
-        var [||]fibonacci = (Func<int, int>)((v) =>
+        var $$fibonacci = (Func<int, int>)((v) =>
             v <= 1
                 ? 1
                 : fibonacci(v - 1, v - 2));
@@ -594,7 +594,7 @@ class C
 {
     void M()
     {
-        var [||]fibonacci = (Func<int, int>)((int v) =>
+        var $$fibonacci = (Func<int, int>)((int v) =>
             v <= 1
                 ? 1
                 : fibonacci(v - 1, v - 2));
@@ -624,7 +624,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fib = null;
+        Func<int, int> $$fib = null;
         fibonacci = v =>
         {
             if (v <= 1)
@@ -648,7 +648,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = GetCallback();
+        Func<int, int> $$fibonacci = GetCallback();
         fibonacci = v =>
         {
             if (v <= 1)
@@ -672,7 +672,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = null;
+        Func<int, int> $$fibonacci = null;
         fibonacci = v =>
         {
             if (v <= 1)
@@ -713,7 +713,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = default;
+        Func<int, int> $$fibonacci = default;
         fibonacci = v =>
         {
             if (v <= 1)
@@ -754,7 +754,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = default(Func<int, int>);
+        Func<int, int> $$fibonacci = default(Func<int, int>);
         fibonacci = v =>
         {
             if (v <= 1)
@@ -795,7 +795,7 @@ class C
 {
     void M()
     {
-        var [||]fibonacci = default(Func<int, int>);
+        var $$fibonacci = default(Func<int, int>);
         fibonacci = v =>
         {
             if (v <= 1)
@@ -836,7 +836,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = null;
+        Func<int, int> $$fibonacci = null;
         fibonacci = (v) =>
         {
             if (v <= 1)
@@ -877,7 +877,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = null;
+        Func<int, int> $$fibonacci = null;
         fibonacci = (int v) =>
         {
             if (v <= 1)
@@ -918,7 +918,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = null;
+        Func<int, int> $$fibonacci = null;
         fibonacci = v =>
             v <= 1
                 ? 1
@@ -949,7 +949,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = null;
+        Func<int, int> $$fibonacci = null;
         fibonacci = (v) =>
             v <= 1
                 ? 1
@@ -980,7 +980,7 @@ class C
 {
     void M()
     {
-        Func<int, int> [||]fibonacci = null;
+        Func<int, int> $$fibonacci = null;
         fibonacci = (int v) =>
             v <= 1
                 ? 1
@@ -1114,7 +1114,7 @@ class C
     void M()
     {
         // Leading trivia
-        Func<int, int> [||]fibonacci = v =>
+        Func<int, int> $$fibonacci = v =>
         {
             if (v <= 1)
             {
@@ -1155,7 +1155,7 @@ class C
 {
     void M()
     {
-        D [||]lambda = (in int p) => throw null;
+        D $$lambda = (in int p) => throw null;
     }
 }",
 @"
@@ -1179,7 +1179,7 @@ class C
 {
     void M()
     {
-        D [||]lambda = () => throw null;
+        D $$lambda = () => throw null;
     }
 }",
 @"
@@ -1205,7 +1205,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<string, Task> [||]f = x => { return Task.CompletedTask; };
+        Func<string, Task> $$f = x => { return Task.CompletedTask; };
         Func<string, Task> actual = null;
         AssertSame(f, actual);
     }
@@ -1226,7 +1226,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<string, Task> [||]f = x => { return Task.CompletedTask; };
+        Func<string, Task> $$f = x => { return Task.CompletedTask; };
         Func<string, Task> actual = null;
         AssertSame(f, actual);
     }
@@ -1260,7 +1260,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<object, string> [||]f = x => """";
+        Func<object, string> $$f = x => """";
         M(f);
     }
 
@@ -1279,7 +1279,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<object, string> [||]f = x => """";
+        Func<object, string> $$f = x => """";
         M(f);
     }
 
@@ -1298,7 +1298,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<object, string> [||]f = x => """";
+        Func<object, string> $$f = x => """";
         M(f);
     }
 
@@ -1329,7 +1329,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<object, string> [||]f = x => """";
+        Func<object, string> $$f = x => """";
         M(f);
     }
 
@@ -1360,7 +1360,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<string, string> [||]f = x => """";
+        Func<string, string> $$f = x => """";
         M(f);
     }
 
@@ -1391,7 +1391,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<object, object> [||]f = x => """";
+        Func<object, object> $$f = x => """";
         M(f);
     }
 
@@ -1427,7 +1427,7 @@ class Enclosing<T> where T : class
   {
     public void Caller()
     {
-      MyDelegate [||]local = x => x;
+      MyDelegate $$local = x => x;
 
       var doubleDelegate = local + local;
     }
@@ -1450,7 +1450,7 @@ class Enclosing<T> where T : class
     {
         public void Caller()
         {
-            MyDelegate [||]local = x => x;
+            MyDelegate $$local = x => x;
 
             var str = local.ToString();
         }
@@ -1473,7 +1473,7 @@ class Enclosing<T> where T : class
     {
         public void Caller(T t)
         {
-            MyDelegate[||]local = x => x;
+            MyDelegate$$local = x => x;
 
             Console.Write(local.Invoke(t));
 
@@ -1500,7 +1500,7 @@ class Enclosing<T> where T : class
   {
     public void Caller()
     {
-      MyDelegate [||]local = x => x;
+      MyDelegate $$local = x => x;
 
       Expression<Action> expression = () => local(null);
     }
@@ -1522,7 +1522,7 @@ public class C
 
     Expression<Action> Example()
     {
-        Action [||]action = () => Method(null);
+        Action $$action = () => Method(null);
         return () => Method(action);
     }
 }
@@ -1544,7 +1544,7 @@ class Enclosing<T> where T : class
     {
         public void Caller()
         {
-            MyDelegate [||]local = x => x;
+            MyDelegate $$local = x => x;
 
             local.Invoke();
         }
@@ -1583,7 +1583,7 @@ class Enclosing<T> where T : class
     {
         public void Caller(T t)
         {
-            MyDelegate [||]local = x => x;
+            MyDelegate $$local = x => x;
 
             Console.Write(local.Invoke(t));
         }
@@ -1622,7 +1622,7 @@ class Enclosing<T> where T : class
     {
         public void Caller(T t)
         {
-            MyDelegate [||]local = x => x;
+            MyDelegate $$local = x => x;
 
             Console.Write(local.Invoke(t));
 
@@ -1667,7 +1667,7 @@ class Enclosing<T> where T : class
     {
         public void Caller(T t)
         {
-            MyDelegate [||]local = x => x;
+            MyDelegate $$local = x => x;
 
             Console.Write(local.Invoke(t));
 
@@ -1709,7 +1709,7 @@ class C
     void Goo()
     {
         var buildCancelled = false;
-        Action [||]onUpdateSolutionCancel = () => { buildCancelled = true; };
+        Action $$onUpdateSolutionCancel = () => { buildCancelled = true; };
     }
 }",
 @"using System;
@@ -1736,7 +1736,7 @@ class C
     void Goo()
     {
         var buildCancelled = false;
-        Action<int> [||]onUpdateSolutionCancel = a => { buildCancelled = true; };
+        Action<int> $$onUpdateSolutionCancel = a => { buildCancelled = true; };
     }
 }",
 @"using System;
@@ -1763,7 +1763,7 @@ class C
     void Goo()
     {
         var buildCancelled = false;
-        Action<int> [||]onUpdateSolutionCancel = (int a) => { buildCancelled = true; };
+        Action<int> $$onUpdateSolutionCancel = (int a) => { buildCancelled = true; };
     }
 }",
 @"using System;
@@ -1789,7 +1789,7 @@ class C
 {
     void Goo()
     {
-        Func<int, int[]> [||]onUpdateSolutionCancel = x => { return null; };
+        Func<int, int[]> $$onUpdateSolutionCancel = x => { return null; };
     }
 }",
 @"using System;
@@ -1816,7 +1816,7 @@ class C
 {
     void Goo()
     {
-        Func<int, Task<int[]>> [||]onUpdateSolutionCancel = async x => { return null; };
+        Func<int, Task<int[]>> $$onUpdateSolutionCancel = async x => { return null; };
     }
 }",
 @"using System;
@@ -1843,7 +1843,7 @@ class C
     void Goo()
     {
         var buildCancelled = false;
-        var [||]onUpdateSolutionCancel = (Action)(() => { buildCancelled = true; });
+        var $$onUpdateSolutionCancel = (Action)(() => { buildCancelled = true; });
     }
 }",
 @"using System;
@@ -1870,7 +1870,7 @@ class C
     void Goo()
     {
         var buildCancelled = false;
-        var [||]onUpdateSolutionCancel = (Action<int>)(a => { buildCancelled = true; });
+        var $$onUpdateSolutionCancel = (Action<int>)(a => { buildCancelled = true; });
     }
 }",
 @"using System;
@@ -1897,7 +1897,7 @@ class C
     void Goo()
     {
         var buildCancelled = false;
-        var [||]onUpdateSolutionCancel = (Action<int>)((int a) => { buildCancelled = true; });
+        var $$onUpdateSolutionCancel = (Action<int>)((int a) => { buildCancelled = true; });
     }
 }",
 @"using System;
@@ -1924,7 +1924,7 @@ class C
     void Goo()
     {
         var buildCancelled = false;
-        Action [||]onUpdateSolutionCancel = null;
+        Action $$onUpdateSolutionCancel = null;
         onUpdateSolutionCancel = () => { buildCancelled = true; };
     }
 }",
@@ -1952,7 +1952,7 @@ class C
     void Goo()
     {
         var buildCancelled = false;
-        Action<int> [||]onUpdateSolutionCancel = null;
+        Action<int> $$onUpdateSolutionCancel = null;
         onUpdateSolutionCancel = a => { buildCancelled = true; };
     }
 }",
@@ -1980,7 +1980,7 @@ class C
     void Goo()
     {
         var buildCancelled = false;
-        Action<int> [||]onUpdateSolutionCancel = null;
+        Action<int> $$onUpdateSolutionCancel = null;
         onUpdateSolutionCancel = (int a) => { buildCancelled = true; };
     }
 }",

--- a/src/EditorFeatures/CSharpTest/UseNamedArguments/UseNamedArgumentsTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseNamedArguments/UseNamedArgumentsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseNamedArguments
         public async Task TestFirstArgument()
         {
             await TestWithCSharp7(
-@"class C { void M(int arg1, int arg2) => M([||]1, 2); }",
+@"class C { void M(int arg1, int arg2) => M($$1, 2); }",
 @"class C { void M(int arg1, int arg2) => M(arg1: 1, arg2: 2); }");
         }
 
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseNamedArguments
         {
             // First option only adds the named argument to the specific parameter you're on.
             await TestWithCSharp7_2(
-@"class C { void M(int arg1, int arg2) => M([||]1, 2); }",
+@"class C { void M(int arg1, int arg2) => M($$1, 2); }",
 @"class C { void M(int arg1, int arg2) => M(arg1: 1, 2); }");
         }
 
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseNamedArguments
         {
             // Second option only adds the named argument to parameter you're on and all trailing parameters.
             await TestWithCSharp7_2(
-@"class C { void M(int arg1, int arg2) => M([||]1, 2); }",
+@"class C { void M(int arg1, int arg2) => M($$1, 2); }",
 @"class C { void M(int arg1, int arg2) => M(arg1: 1, arg2: 2); }",
 index: 1);
         }
@@ -61,7 +61,7 @@ index: 1);
         public async Task TestNonFirstArgument()
         {
             await TestWithCSharp7(
-@"class C { void M(int arg1, int arg2) => M(1, [||]2); }",
+@"class C { void M(int arg1, int arg2) => M(1, $$2); }",
 @"class C { void M(int arg1, int arg2) => M(1, arg2: 2); }");
         }
 
@@ -69,7 +69,7 @@ index: 1);
         public async Task TestNonFirstArgument_CSharp_7_2()
         {
             // Because we're on the last argument, we should only offer one refactoring to the user.
-            var initialMarkup = @"class C { void M(int arg1, int arg2) => M(1, [||]2); }";
+            var initialMarkup = @"class C { void M(int arg1, int arg2) => M(1, $$2); }";
             await TestActionCountAsync(initialMarkup, count: 1, parameters: new TestParameters(parseOptions: CSharp72));
 
             await TestWithCSharp7_2(
@@ -81,7 +81,7 @@ initialMarkup,
         public async Task TestDelegate()
         {
             await TestWithCSharp7(
-@"class C { void M(System.Action<int> f) => f([||]1); }",
+@"class C { void M(System.Action<int> f) => f($$1); }",
 @"class C { void M(System.Action<int> f) => f(obj: 1); }");
         }
 
@@ -89,7 +89,7 @@ initialMarkup,
         public async Task TestConditionalMethod()
         {
             await TestWithCSharp7(
-@"class C { void M(int arg1, int arg2) => this?.M([||]1, 2); }",
+@"class C { void M(int arg1, int arg2) => this?.M($$1, 2); }",
 @"class C { void M(int arg1, int arg2) => this?.M(arg1: 1, arg2: 2); }");
         }
 
@@ -97,7 +97,7 @@ initialMarkup,
         public async Task TestConditionalIndexer()
         {
             await TestWithCSharp7(
-@"class C { int? this[int arg1, int arg2] => this?[[||]1, 2]; }",
+@"class C { int? this[int arg1, int arg2] => this?[$$1, 2]; }",
 @"class C { int? this[int arg1, int arg2] => this?[arg1: 1, arg2: 2]; }");
         }
 
@@ -105,7 +105,7 @@ initialMarkup,
         public async Task TestThisConstructorInitializer()
         {
             await TestWithCSharp7(
-@"class C { C(int arg1, int arg2) {} C() : this([||]1, 2) {} }",
+@"class C { C(int arg1, int arg2) {} C() : this($$1, 2) {} }",
 @"class C { C(int arg1, int arg2) {} C() : this(arg1: 1, arg2: 2) {} }");
         }
 
@@ -113,7 +113,7 @@ initialMarkup,
         public async Task TestBaseConstructorInitializer()
         {
             await TestWithCSharp7(
-@"class C { public C(int arg1, int arg2) {} } class D : C { D() : base([||]1, 2) {} }",
+@"class C { public C(int arg1, int arg2) {} } class D : C { D() : base($$1, 2) {} }",
 @"class C { public C(int arg1, int arg2) {} } class D : C { D() : base(arg1: 1, arg2: 2) {} }");
         }
 
@@ -121,7 +121,7 @@ initialMarkup,
         public async Task TestConstructor()
         {
             await TestWithCSharp7(
-@"class C { C(int arg1, int arg2) { new C([||]1, 2); } }",
+@"class C { C(int arg1, int arg2) { new C($$1, 2); } }",
 @"class C { C(int arg1, int arg2) { new C(arg1: 1, arg2: 2); } }");
         }
 
@@ -129,7 +129,7 @@ initialMarkup,
         public async Task TestIndexer()
         {
             await TestWithCSharp7(
-@"class C { char M(string arg1) => arg1[[||]0]; }",
+@"class C { char M(string arg1) => arg1[$$0]; }",
 @"class C { char M(string arg1) => arg1[index: 0]; }");
         }
 
@@ -137,35 +137,35 @@ initialMarkup,
         public async Task TestMissingOnArrayIndexer()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class C { int M(int[] arg1) => arg1[[||]0]; }");
+@"class C { int M(int[] arg1) => arg1[$$0]; }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNamedArguments)]
         public async Task TestMissingOnConditionalArrayIndexer()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class C { int? M(int[] arg1) => arg1?[[||]0]; }");
+@"class C { int? M(int[] arg1) => arg1?[$$0]; }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNamedArguments)]
         public async Task TestMissingOnEmptyArgumentList()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class C { void M() => M([||]); }");
+@"class C { void M() => M($$); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNamedArguments)]
         public async Task TestMissingOnExistingArgumentName()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class C { void M(int arg) => M([||]arg: 1); }");
+@"class C { void M(int arg) => M($$arg: 1); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNamedArguments)]
         public async Task TestEmptyParams()
         {
             await TestWithCSharp7(
-@"class C { void M(int arg1, params int[] arg2) => M([||]1); }",
+@"class C { void M(int arg1, params int[] arg2) => M($$1); }",
 @"class C { void M(int arg1, params int[] arg2) => M(arg1: 1); }");
         }
 
@@ -173,7 +173,7 @@ initialMarkup,
         public async Task TestSingleParams()
         {
             await TestWithCSharp7(
-@"class C { void M(int arg1, params int[] arg2) => M([||]1, 2); }",
+@"class C { void M(int arg1, params int[] arg2) => M($$1, 2); }",
 @"class C { void M(int arg1, params int[] arg2) => M(arg1: 1, arg2: 2); }");
         }
 
@@ -181,7 +181,7 @@ initialMarkup,
         public async Task TestNamedParams()
         {
             await TestWithCSharp7(
-@"class C { void M(int arg1, params int[] arg2) => M([||]1, arg2: new int[0]); }",
+@"class C { void M(int arg1, params int[] arg2) => M($$1, arg2: new int[0]); }",
 @"class C { void M(int arg1, params int[] arg2) => M(arg1: 1, arg2: new int[0]); }");
         }
 
@@ -189,7 +189,7 @@ initialMarkup,
         public async Task TestExistingArgumentNames()
         {
             await TestWithCSharp7(
-@"class C { void M(int arg1, int arg2) => M([||]1, arg2: 2); }",
+@"class C { void M(int arg1, int arg2) => M($$1, arg2: 2); }",
 @"class C { void M(int arg1, int arg2) => M(arg1: 1, arg2: 2); }");
         }
 
@@ -197,7 +197,7 @@ initialMarkup,
         public async Task TestExistingUnorderedArgumentNames()
         {
             await TestWithCSharp7(
-@"class C { void M(int arg1, int arg2, int arg3) => M([||]1, arg3: 3, arg2: 2); }",
+@"class C { void M(int arg1, int arg2, int arg3) => M($$1, arg3: 3, arg2: 2); }",
 @"class C { void M(int arg1, int arg2, int arg3) => M(arg1: 1, arg3: 3, arg2: 2); }");
         }
 
@@ -207,7 +207,7 @@ initialMarkup,
             await TestWithCSharp7(
 @"class C { void M(int arg1, ref int arg2) => M(
 
-    [||]1,
+    $$1,
 
     ref arg1
 
@@ -225,14 +225,14 @@ initialMarkup,
         public async Task TestMissingOnNameOf()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class C { string M() => nameof([||]M); }");
+@"class C { string M() => nameof($$M); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNamedArguments)]
         public async Task TestAttribute()
         {
             await TestWithCSharp7(
-@"[C([||]1, 2)]
+@"[C($$1, 2)]
 class C : System.Attribute { public C(int arg1, int arg2) {} }",
 @"[C(arg1: 1, arg2: 2)]
 class C : System.Attribute { public C(int arg1, int arg2) {} }");
@@ -242,7 +242,7 @@ class C : System.Attribute { public C(int arg1, int arg2) {} }");
         public async Task TestAttributeWithNamedProperties()
         {
             await TestWithCSharp7(
-@"[C([||]1, P = 2)]
+@"[C($$1, P = 2)]
 class C : System.Attribute { public C(int arg1) {} public int P { get; set; } }",
 @"[C(arg1: 1, P = 2)]
 class C : System.Attribute { public C(int arg1) {} public int P { get; set; } }");
@@ -256,7 +256,7 @@ class C : System.Attribute { public C(int arg1) {} public int P { get; set; } }"
 @"class C
 {
     void M(int arg1, int arg2) 
-        => M([||]1 + 2, 2);
+        => M($$1 + 2, 2);
 }",
 @"class C
 {
@@ -273,7 +273,7 @@ class C : System.Attribute { public C(int arg1) {} public int P { get; set; } }"
 @"class C
 {
     void M(int arg1, int arg2) 
-        => M(1[||] + 2, 2);
+        => M(1$$ + 2, 2);
 }",
 @"class C
 {
@@ -293,7 +293,7 @@ using System;
 class C
 {
     void M(Action arg1, int arg2) 
-        => M([||]() => { }, 2);
+        => M($$() => { }, 2);
 }",
 @"
 using System;
@@ -313,7 +313,7 @@ class C
 @"class C
 {
     void M(int arg1, int arg2) 
-        => M(1 [||]+ 2, 2);
+        => M(1 $$+ 2, 2);
 }",
 @"class C
 {
@@ -333,7 +333,7 @@ using System;
 class C
 {
     void M(Action arg1, int arg2) 
-        => M(() => { [||] }, 2);
+        => M(() => { $$ }, 2);
 }",
 @"
 using System;
@@ -357,7 +357,7 @@ class C
 {
     void M(Action arg1, int arg2) 
         => M(() => {
-             [||]
+             $$
            }, 2);
 }");
         }
@@ -384,7 +384,7 @@ class C
             await TestWithCSharp7(
 @"class C
 {
-    void M(int arg1) => M(arg1[||]);
+    void M(int arg1) => M(arg1$$);
 }",
 @"class C
 {
@@ -399,7 +399,7 @@ class C
             await TestWithCSharp7(
 @"class C
 {
-    void M(int arg1, int arg2) => M(arg1[||], arg2);
+    void M(int arg1, int arg2) => M(arg1$$, arg2);
 }",
 @"class C
 {
@@ -415,7 +415,7 @@ class C
 @"using System.Linq;
 class C
 {
-    void M(int[] arr) => arr.Zip(arr, (p1, p2) =>  ([||]p1, p2));
+    void M(int[] arr) => arr.Zip(arr, (p1, p2) =>  ($$p1, p2));
 }
 ");
         }
@@ -427,7 +427,7 @@ class C
             await TestWithCSharp7(
 @"class C
 {
-    void M(int @default, int @params) => M([||]1, 2);
+    void M(int @default, int @params) => M($$1, 2);
 }",
 @"class C
 {
@@ -440,7 +440,7 @@ class C
         public async Task TestCharacterEscape2()
         {
             await TestWithCSharp7(
-@"[C([||]1, 2)]
+@"[C($$1, 2)]
 class C : System.Attribute
 {
     public C(int @default, int @params) {}

--- a/src/EditorFeatures/CSharpTest/UseNullPropagation/UseNullPropagationTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseNullPropagation/UseNullPropagationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -27,7 +27,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]o == null ? null : o.ToString();
+        var v = $$o == null ? null : o.ToString();
     }
 }",
 @"using System;
@@ -51,7 +51,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]o == null ? null : o.ToString();
+        var v = $$o == null ? null : o.ToString();
     }
 }", new TestParameters(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5)));
         }
@@ -66,7 +66,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]null == o ? null : o.ToString();
+        var v = $$null == o ? null : o.ToString();
     }
 }",
 @"using System;
@@ -90,7 +90,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]o != null ? o.ToString() : null;
+        var v = $$o != null ? o.ToString() : null;
     }
 }",
 @"using System;
@@ -114,7 +114,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]c != null ? c.f : null;
+        int? x = $$c != null ? c.f : null;
     }
 }",
 @"
@@ -138,7 +138,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = (object)[||]c != null ? c.f : null;
+        int? x = (object)$$c != null ? c.f : null;
     }
 }",
 @"
@@ -162,7 +162,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]null != o ? o.ToString() : null;
+        var v = $$null != o ? o.ToString() : null;
     }
 }",
 @"using System;
@@ -186,7 +186,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]o == null ? null : o[0];
+        var v = $$o == null ? null : o[0];
     }
 }",
 @"using System;
@@ -210,7 +210,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]o == null ? null : o.B?.C;
+        var v = $$o == null ? null : o.B?.C;
     }
 }",
 @"using System;
@@ -234,7 +234,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]o == null ? null : o.B;
+        var v = $$o == null ? null : o.B;
     }
 }",
 @"using System;
@@ -258,7 +258,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]o == null ? null : o;
+        var v = $$o == null ? null : o;
     }
 }");
         }
@@ -273,7 +273,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||](o == null) ? null : o.ToString();
+        var v = $$(o == null) ? null : o.ToString();
     }
 }",
 @"using System;
@@ -348,7 +348,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]o == null ? 0 : o.ToString();
+        var v = $$o == null ? 0 : o.ToString();
     }
 }");
         }
@@ -364,7 +364,7 @@ class C
 {
     void M(object o)
     {
-        var v = [||]o != null ? o.ToString() : 0;
+        var v = $$o != null ? o.ToString() : 0;
     }
 }");
         }
@@ -382,7 +382,7 @@ class D
     void Goo()
     {
         var c = new C();
-        Action<string> a = [||]c != null ? c.M : (Action<string>)null;
+        Action<string> a = $$c != null ? c.M : (Action<string>)null;
     }
 }
 class C { public void M(string s) { } }");
@@ -401,7 +401,7 @@ class Program
 {
     void Main(string s)
     {
-        Method<string>(t => [||]s != null ? s.ToString() : null); // works
+        Method<string>(t => $$s != null ? s.ToString() : null); // works
     }
 
     public void Method<T>(Expression<Func<T, string>> functor)
@@ -422,7 +422,7 @@ class C
 {
     void Main(DateTime? toDate)
     {
-        var v = [||]toDate == null ? null : toDate.Value.ToString(""yyyy/MM/ dd"");
+        var v = $$toDate == null ? null : toDate.Value.ToString(""yyyy/MM/ dd"");
     }
 }
 ",
@@ -457,7 +457,7 @@ class C
 {
     void Main(S? s)
     {
-        var x = [||]s == null ? null : s.Value[0];
+        var x = $$s == null ? null : s.Value[0];
     }
 }
 ",
@@ -491,7 +491,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]c is null ? null : c.f;
+        int? x = $$c is null ? null : c.f;
     }
 }",
 @"
@@ -516,7 +516,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]c is C ? null : c.f;
+        int? x = $$c is C ? null : c.f;
     }
 }");
         }
@@ -531,7 +531,7 @@ class C
 {
     void M(string s)
     {
-        int? x = [||]s is """" ? null : (int?)s.Length;
+        int? x = $$s is """" ? null : (int?)s.Length;
     }
 }");
         }
@@ -547,7 +547,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]ReferenceEquals(c, null) ? null : c.f;
+        int? x = $$ReferenceEquals(c, null) ? null : c.f;
     }
 }",
 @"
@@ -572,7 +572,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]ReferenceEquals(null, c) ? null : c.f;
+        int? x = $$ReferenceEquals(null, c) ? null : c.f;
     }
 }",
 @"
@@ -597,7 +597,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]ReferenceEquals(c, other) ? null : c.f;
+        int? x = $$ReferenceEquals(c, other) ? null : c.f;
     }
 }");
         }
@@ -613,7 +613,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]ReferenceEquals(other, c) ? null : c.f;
+        int? x = $$ReferenceEquals(other, c) ? null : c.f;
     }
 }");
         }
@@ -629,7 +629,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]object.ReferenceEquals(c, null) ? null : c.f;
+        int? x = $$object.ReferenceEquals(c, null) ? null : c.f;
     }
 }",
 @"
@@ -654,7 +654,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]object.ReferenceEquals(null, c) ? null : c.f;
+        int? x = $$object.ReferenceEquals(null, c) ? null : c.f;
     }
 }",
 @"
@@ -679,7 +679,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]object.ReferenceEquals(c, other) ? null : c.f;
+        int? x = $$object.ReferenceEquals(c, other) ? null : c.f;
     }
 }");
         }
@@ -695,7 +695,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]object.ReferenceEquals(other, c) ? null : c.f;
+        int? x = $$object.ReferenceEquals(other, c) ? null : c.f;
     }
 }");
         }
@@ -711,7 +711,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]!(c is null) ? c.f : null;
+        int? x = $$!(c is null) ? c.f : null;
     }
 }",
 @"
@@ -736,7 +736,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]!(c is C) ? c.f : null;
+        int? x = $$!(c is C) ? c.f : null;
     }
 }");
         }
@@ -751,7 +751,7 @@ class C
 {
     void M(string s)
     {
-        int? x = [||]!(s is """") ? (int?)s.Length : null;
+        int? x = $$!(s is """") ? (int?)s.Length : null;
     }
 }");
         }
@@ -767,7 +767,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]!ReferenceEquals(c, null) ? c.f : null;
+        int? x = $$!ReferenceEquals(c, null) ? c.f : null;
     }
 }",
 @"
@@ -792,7 +792,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]!ReferenceEquals(null, c) ? c.f : null;
+        int? x = $$!ReferenceEquals(null, c) ? c.f : null;
     }
 }",
 @"
@@ -817,7 +817,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]!ReferenceEquals(c, other) ? c.f : null;
+        int? x = $$!ReferenceEquals(c, other) ? c.f : null;
     }
 }");
         }
@@ -833,7 +833,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]!ReferenceEquals(other, c) ? c.f : null;
+        int? x = $$!ReferenceEquals(other, c) ? c.f : null;
     }
 }");
         }
@@ -849,7 +849,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]!object.ReferenceEquals(c, null) ? c.f : null;
+        int? x = $$!object.ReferenceEquals(c, null) ? c.f : null;
     }
 }",
 @"
@@ -874,7 +874,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]!object.ReferenceEquals(null, c) ? c.f : null;
+        int? x = $$!object.ReferenceEquals(null, c) ? c.f : null;
     }
 }",
 @"
@@ -899,7 +899,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]!object.ReferenceEquals(c, other) ? c.f : null;
+        int? x = $$!object.ReferenceEquals(c, other) ? c.f : null;
     }
 }");
         }
@@ -915,7 +915,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]!object.ReferenceEquals(other, c) ? c.f : null;
+        int? x = $$!object.ReferenceEquals(other, c) ? c.f : null;
     }
 }");
         }
@@ -931,7 +931,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]!(c == null) ? c.f : null;
+        int? x = $$!(c == null) ? c.f : null;
     }
 }",
 @"
@@ -956,7 +956,7 @@ class C
     public int? f;
     void M(C c)
     {
-        int? x = [||]!(c != null) ? null : c.f;
+        int? x = $$!(c != null) ? null : c.f;
     }
 }",
 @"
@@ -981,7 +981,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]!(c == other) ? c.f : null;
+        int? x = $$!(c == other) ? c.f : null;
     }
 }");
         }
@@ -997,7 +997,7 @@ class C
     public int? f;
     void M(C c, C other)
     {
-        int? x = [||]!(c != other) ? null : c.f;
+        int? x = $$!(c != other) ? null : c.f;
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
 
     void M()
     {
-        var c = [||]new C();
+        var c = $$new C();
         c.i = 1;
     }
 }",
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
 
     void M()
     {
-        var c = [||]new C();
+        var c = $$new C();
         c.i = 1;
         c.i = c.i + 1;
     }
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
 
     void M()
     {
-        var c = [||]new C();
+        var c = $$new C();
         c.i = c.i + 1;
     }
 }");
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
     void M()
     {
         C c;
-        c = [||]new C();
+        c = $$new C();
         c.i = 1;
         c.i = c.i + 1;
     }
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
     void M()
     {
         C c;
-        c = [||]new C();
+        c = $$new C();
         c.i = c.i + 1;
     }
 }");
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
     void M()
     {
         C c = null;
-        c = [||]new C();
+        c = $$new C();
         c.i = 1;
     }
 }",
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
 
     void M()
     {
-        var c = [||]new C();
+        var c = $$new C();
         c.i = 1;
         c.i = 2;
     }
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
     void M()
     {
         C[] array;
-        array[0] = [||]new C();
+        array[0] = $$new C();
         array[0].i = 1;
         array[0].j = 2;
     }
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
 
     void M()
     {
-        var c = [||]new C();
+        var c = $$new C();
         c.i = 1;
         c.j += 1;
     }
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
 
     void M()
     {
-        var c = [||]new C() { i = 1 };
+        var c = $$new C() { i = 1 };
         c.j = 1;
     }
 }");
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
 
     void M()
     {
-        var c = [||]new C();
+        var c = $$new C();
         c.j = 1;
     }
 }", new TestParameters(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp2)));
@@ -431,7 +431,7 @@ class C
     int j;
     void M()
     {
-        var c = [||]new C();
+        var c = $$new C();
         c.i = 1; // Goo
         c.j = 2; // Bar
     }
@@ -460,7 +460,7 @@ class C
 @"class C {
 	int a;
 	C Add(int x) {
-		var c = Add([||]new int());
+		var c = Add($$new int());
 		c.a = 1;
 		return c;
 	}
@@ -478,7 +478,7 @@ class C
 {
     void Goo()
     {
-        dynamic body = [||]new ExpandoObject();
+        dynamic body = $$new ExpandoObject();
         body.content = new ExpandoObject();
     }
 }");
@@ -494,7 +494,7 @@ public class Goo
 {
     public void M()
     {
-        var goo = [||]new Goo();
+        var goo = $$new Goo();
 #if true
         goo.Value = "";
 #endif
@@ -515,7 +515,7 @@ public class Goo
     public void M()
     {
 #if true
-        var goo = [||]new Goo();
+        var goo = $$new Goo();
         goo.Value = "";
 #endif
     }
@@ -554,7 +554,7 @@ class MyClass
 {
     public void Main()
     {
-        var goo = [||]new Goo();
+        var goo = $$new Goo();
         goo.Bar = 1;
 
         int horse = 1;

--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
     int i;
     bool M(object obj)
     {
-        return [||]obj is TestFile && ((TestFile)obj).i > 0;
+        return $$obj is TestFile && ((TestFile)obj).i > 0;
     }
 }",
 @"class TestFile
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
     int i;
     bool M(object obj)
     {
-        return [||]obj is TestFile && ((TestFile)obj).i > 0;
+        return $$obj is TestFile && ((TestFile)obj).i > 0;
     }
 }", parameters: new TestParameters(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6)));
         }
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
 {
     int i;
     bool M(object obj)
-        => [||]obj is TestFile && ((TestFile)obj).i > 0;
+        => $$obj is TestFile && ((TestFile)obj).i > 0;
 }",
 
 @"class TestFile
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
     int i;
     static object obj;
 
-    bool M = [||]obj is TestFile && ((TestFile)obj).i > 0;
+    bool M = $$obj is TestFile && ((TestFile)obj).i > 0;
 }",
 
 @"class TestFile
@@ -106,7 +106,7 @@ class TestFile
     void Goo(Func<bool> f) { }
 
     bool M(object obj)
-        => Goo(() => [||]obj is TestFile && ((TestFile)obj).i > 0, () => obj is TestFile && ((TestFile)obj).i > 0);
+        => Goo(() => $$obj is TestFile && ((TestFile)obj).i > 0, () => obj is TestFile && ((TestFile)obj).i > 0);
 }",
 @"
 using System;
@@ -131,7 +131,7 @@ class TestFile
     int i;
     bool M(object obj)
     {
-        if ([||]obj is TestFile)
+        if ($$obj is TestFile)
         {
             M(((TestFile)obj).i);
             M(((TestFile)obj).i);
@@ -171,7 +171,7 @@ class TestFile
     int i;
     bool M(object obj)
     {
-        if (!([||]obj is TestFile))
+        if (!($$obj is TestFile))
         {
             M(((TestFile)obj).i);
             M(((TestFile)obj).i);
@@ -210,7 +210,7 @@ class TestFile
 {
     bool M(object obj)
     {
-        if ([||]obj is TestFile)
+        if ($$obj is TestFile)
         {
             var file = (TestFile)obj;
         }
@@ -226,7 +226,7 @@ class TestFile
 {
     bool M(object obj)
     {
-        if ([||]obj is TestFile?)
+        if ($$obj is TestFile?)
         {
             var i = ((TestFile?)obj).Value;
         }
@@ -243,7 +243,7 @@ class TestFile
     int i;
     bool M(object obj)
     {
-        return [||]M(null) is TestFile && ((TestFile)M(null)).i > 0;
+        return $$M(null) is TestFile && ((TestFile)M(null)).i > 0;
     }
 }",
 
@@ -266,7 +266,7 @@ class TestFile
     int i;
     bool M(object obj)
     {
-        return [||]obj is TestFile && /*before*/ ((TestFile)obj) /*after*/.i > 0;
+        return $$obj is TestFile && /*before*/ ((TestFile)obj) /*after*/.i > 0;
     }
 }",
 
@@ -289,7 +289,7 @@ class TestFile
     int i;
     bool M(object obj)
     {
-        return ((TestFile)obj).i > 0 && [||]obj is TestFile && ((TestFile)obj).i > 0;
+        return ((TestFile)obj).i > 0 && $$obj is TestFile && ((TestFile)obj).i > 0;
     }
 }",
 
@@ -312,7 +312,7 @@ class TestFile
     int i;
     bool M(object obj)
     {
-        return [||]obj is int[] && ((int[])obj) > 0;
+        return $$obj is int[] && ((int[])obj) > 0;
     }
 }",
 
@@ -336,7 +336,7 @@ class TestFile
     bool M(object obj)
     {
         TestFile file = null;
-        return [||]obj is TestFile && ((TestFile)obj).i > 0;
+        return $$obj is TestFile && ((TestFile)obj).i > 0;
     }
 }",
 
@@ -360,7 +360,7 @@ class TestFile
     int i;
     bool M(object obj)
     {
-        if ([||]obj is TestFile)
+        if ($$obj is TestFile)
         {
             TestFile file = null;
             M(((TestFile)obj).i);
@@ -390,7 +390,7 @@ class TestFile
     int i;
     bool M(object obj)
     {
-        if ([||]obj is TestFile)
+        if ($$obj is TestFile)
         {
             var v = new { file = 0 };
             M(((TestFile)obj).i);
@@ -420,7 +420,7 @@ class TestFile
     int i;
     bool M(object obj)
     {
-        if ([||]obj is TestFile)
+        if ($$obj is TestFile)
         {
             var v = (file: 0, x: 1);
             M(((TestFile)obj).i);
@@ -453,7 +453,7 @@ class TestFile
     int i;
     bool M(object obj, X x)
     {
-        if ([||]obj is TestFile)
+        if ($$obj is TestFile)
         {
             var v = new { x.file };
             M(((TestFile)obj).i);
@@ -489,7 +489,7 @@ class TestFile
     int i;
     bool M(object obj, X x)
     {
-        if ([||]obj is TestFile)
+        if ($$obj is TestFile)
         {
             var v = (x.file, 0);
             M(((TestFile)obj).i);

--- a/src/EditorFeatures/CSharpTest/ValidateFormatString/ValidateFormatStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ValidateFormatString/ValidateFormatStringTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
 {
     static void Main(string[] args)
     {
-        string.Format(""This {0[||]} works"", ""test""); 
+        string.Format(""This {0$$} works"", ""test""); 
     }     
 }");
         }
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
 {
     static void Main(string[] args)
     {
-        string.Format(""This {0[||]} {1} works"", ""test"", ""also""); 
+        string.Format(""This {0$$} {1} works"", ""test"", ""also""); 
     }     
 }");
         }
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
 {
     static void Main(string[] args)
     {
-        string.Format(""This {0} {1[||]} works {2} "", ""test"", ""also"", ""well""); 
+        string.Format(""This {0} {1$$} works {2} "", ""test"", ""also"", ""well""); 
     }     
 }");
         }
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
 {
     static void Main(string[] args)
     {
-        string.Format(""This {1} is {2} my {6[||]} test "", ""teststring1"", ""teststring2"",
+        string.Format(""This {1} is {2} my {6$$} test "", ""teststring1"", ""teststring2"",
             ""teststring3"", ""teststring4"", ""teststring5"", ""teststring6"", ""teststring7"");
     }     
 }");
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
     static void Main(string[] args)
     {
         object[] objectArray = { 1.25, ""2"", ""teststring""};
-        string.Format(""This {0} {1} {2[||]} works"", objectArray); 
+        string.Format(""This {0} {1} {2$$} works"", objectArray); 
     }     
 }");
         }
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
     static void Main(string[] args)
     {
         object[] objectArray = { 1.25, ""2"", ""teststring""};
-        string.Format(""This {0} {1} {2[||]} works"", objectArray, objectArray, objectArray, objectArray); 
+        string.Format(""This {0} {1} {2$$} works"", objectArray, objectArray, objectArray, objectArray); 
     }     
 }");
         }
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
     static void Main(string[] args)
     {
         int[] intArray = {1, 2, 3};
-        string.Format(""This {0[||]} works"", intArray); 
+        string.Format(""This {0$$} works"", intArray); 
     }     
 }");
         }
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
     static void Main(string[] args)
     {
         string[] stringArray = {""test1"", ""test2"", ""test3""};
-        string.Format(""This {0} {1} {2[||]} works"", stringArray); 
+        string.Format(""This {0} {1} {2$$} works"", stringArray); 
     }     
 }");
         }
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
     static void Main(string[] args)
     {
         string[] stringArray = {""test1"", ""test2""};
-        string.Format(""This {0} {1} {2[||]} works"", stringArray); 
+        string.Format(""This {0} {1} {2$$} works"", stringArray); 
     }     
 }");
         }
@@ -156,7 +156,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0[||]:C2} per ounce"", 2.45);
+        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0$$:C2} per ounce"", 2.45);
     }     
 }");
         }
@@ -169,7 +169,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0[||]:C2} per {1} "", 2.45, ""ounce"");
+        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0$$:C2} per {1} "", 2.45, ""ounce"");
     }     
 }");
         }
@@ -182,7 +182,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0} {[||]1} {2} "", 
+        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0} {$$1} {2} "", 
             2.45, ""per"", ""ounce"");
     }     
 }");
@@ -196,7 +196,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0} {1[||]} {2} {3} "", 
+        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0} {1$$} {2} {3} "", 
             2.45, ""per"", ""ounce"", ""today only"");
     }     
 }");
@@ -211,7 +211,7 @@ class Program
     static void Main(string[] args)
     {
         object[] objectArray = { 1.25, ""2"", ""teststring""};
-        string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""This {0} {1} {[||]2} works"", objectArray); 
+        string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""This {0} {1} {$$2} works"", objectArray); 
     }     
 }");
         }
@@ -223,7 +223,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(""{0[||],6}"", 34);
+        string.Format(""{0$$,6}"", 34);
     }     
 }");
         }
@@ -235,7 +235,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(""{[||]0:N0}"", 34);
+        string.Format(""{$$0:N0}"", 34);
     }     
 }");
         }
@@ -247,7 +247,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(""Test {0,[||]15:N0} output"", 34);
+        string.Format(""Test {0,$$15:N0} output"", 34);
     }     
 }");
         }
@@ -259,7 +259,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(""{0[||]} is my test case"", ""This"");
+        string.Format(""{0$$} is my test case"", ""This"");
     }     
 }");
         }
@@ -271,7 +271,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(""This is my {0[||]}"", ""test"");
+        string.Format(""This is my {0$$}"", ""test"");
     }     
 }");
         }
@@ -283,7 +283,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format("" {{ 2}} This {1[||]} is {2} {{ my {0} test }} "", ""teststring1"", ""teststring2"", ""teststring3"");
+        string.Format("" {{ 2}} This {1$$} is {2} {{ my {0} test }} "", ""teststring1"", ""teststring2"", ""teststring3"");
     }     
 }");
         }
@@ -295,7 +295,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(""{{ 2}} This {1[||]} is {2} {{ my {0} test }} "", ""teststring1"", ""teststring2"", ""teststring3"");
+        string.Format(""{{ 2}} This {1$$} is {2} {{ my {0} test }} "", ""teststring1"", ""teststring2"", ""teststring3"");
     }     
 }");
         }
@@ -307,7 +307,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format("" {{ 2}} This {1[||]} is {2} {{ my {0} test }}"", ""teststring1"", ""teststring2"", ""teststring3"");
+        string.Format("" {{ 2}} This {1$$} is {2} {{ my {0} test }}"", ""teststring1"", ""teststring2"", ""teststring3"");
     }     
 }");
         }
@@ -319,7 +319,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format("" {{{2}} This {1[||]} is {2} {{ my {0} test }}"", ""teststring1"", ""teststring2"", ""teststring3"");
+        string.Format("" {{{2}} This {1$$} is {2} {{ my {0} test }}"", ""teststring1"", ""teststring2"", ""teststring3"");
     }     
 }");
         }
@@ -331,7 +331,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(arg0: ""test"", arg1: ""also"", format: ""This {0} {[||]1} works""); 
+        string.Format(arg0: ""test"", arg1: ""also"", format: ""This {0} {$$1} works""); 
     }     
 }");
         }
@@ -344,7 +344,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(arg0: ""test"", provider: new CultureInfo(""pt-BR"", useUserOverride: false), format: ""This {0[||]} works""); 
+        string.Format(arg0: ""test"", provider: new CultureInfo(""pt-BR"", useUserOverride: false), format: ""This {0$$} works""); 
     }     
 }");
         }
@@ -357,7 +357,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        stringAlias.Format(""This {0[||]} works"", ""test""); 
+        stringAlias.Format(""This {0$$} works"", ""test""); 
     }     
 }");
         }
@@ -370,7 +370,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Console.WriteLine(string.Format(format: ""This {0[||]} works"", arg0:""test"")); 
+        Console.WriteLine(string.Format(format: ""This {0$$} works"", arg0:""test"")); 
     }
 }");
         }
@@ -383,7 +383,7 @@ class Program
     static void Main(string[] args)
     {
         string.Format(@""This {0} 
-{1} {2[||]} works"", ""multiple"", ""line"", ""test"")); 
+{1} {2$$} works"", ""multiple"", ""line"", ""test"")); 
     }
 }");
         }
@@ -398,7 +398,7 @@ class Program
         var Name = ""Peter"";
         var Age = 30;
        
-        string.Format($""{Name,[||] 20} is {Age:D3} ""); 
+        string.Format($""{Name,$$ 20} is {Age:D3} ""); 
     }
 }");
         }
@@ -410,7 +410,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(""[||]""); 
+        string.Format(""$$""); 
     }
 }");
         }
@@ -422,7 +422,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format([||]; 
+        string.Format($$; 
     }
 }");
         }
@@ -434,7 +434,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format([||]); 
+        string.Format($$); 
     }
 }");
         }
@@ -446,7 +446,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(""[||]""); 
+        string.Format(""$$""); 
     }
 }");
         }
@@ -459,7 +459,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Format(""[||]""); 
+        Format(""$$""); 
     }
 }");
         }
@@ -471,7 +471,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format( : ""value""[||])); 
+        string.Format( : ""value""$$)); 
     }     
 }");
         }
@@ -483,7 +483,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(format:""This [||] "", format:"" test ""); 
+        string.Format(format:""This $$ "", format:"" test ""); 
     }     
 }");
         }
@@ -511,7 +511,7 @@ namespace Generics_CSharp
         static void Main(string[] args)
         {
             String<int> testList = new String<int>();
-            testList.Format<int>(""Test[||]String"");
+            testList.Format<int>(""Test$$String"");
         }
     }
 }
@@ -535,7 +535,7 @@ class C
 {
     static void Main(string[] args)
     {
-        Console.WriteLine(String.Format(""test {[||]5} "", 1));
+        Console.WriteLine(String.Format(""test {$$5} "", 1));
     }
 }
 ");
@@ -548,7 +548,7 @@ class C
 {
     static void Main(string[] args)
     {
-        string.Format(""This {1[||]} works"", ""test""); 
+        string.Format(""This {1$$} works"", ""test""); 
     }   
 }
 ", new TestParameters(options: CSharpOptionOffVBOptionOn()));

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.DynamicDelegatesAndIndexers.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.DynamicDelegatesAndIndexers.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 
@@ -43,9 +43,9 @@ class B
     {
         A a = new A();
         dynamic d = 1;
-        var a1 = a$$[1];
+        var a1 = a[||][1];
         var a2 = a["hello"];
-        var a3 = a$$[d];
+        var a3 = a[||][d];
     }
 }
         </Document>
@@ -72,8 +72,8 @@ class B
         A a = new A();
         dynamic d = 1;
         var a1 = a[1];
-        var a2 = a$$["hello"];
-        var a3 = a$$[d];
+        var a2 = a[||]["hello"];
+        var a3 = a[||][d];
     }
 }        </Document>
     </Project>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.DynamicDelegatesAndIndexers.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.DynamicDelegatesAndIndexers.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 
@@ -43,9 +43,9 @@ class B
     {
         A a = new A();
         dynamic d = 1;
-        var a1 = a[||][1];
+        var a1 = a$$[1];
         var a2 = a["hello"];
-        var a3 = a[||][d];
+        var a3 = a$$[d];
     }
 }
         </Document>
@@ -72,8 +72,8 @@ class B
         A a = new A();
         dynamic d = 1;
         var a1 = a[1];
-        var a2 = a[||]["hello"];
-        var a3 = a[||][d];
+        var a2 = a$$["hello"];
+        var a3 = a$$[d];
     }
 }        </Document>
     </Project>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.IndexerSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.IndexerSymbols.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 
@@ -21,7 +21,7 @@ class D
     void Goo()
     {
         var q = new C();
-        var b = q[||][4];
+        var b = q$$[4];
     }
 }
         </Document>
@@ -48,7 +48,7 @@ end class
 class D
     sub Goo()
         dim q = new C()
-        dim b = q[||](4)
+        dim b = q$$(4)
     end sub
 end class
         </Document>
@@ -71,7 +71,7 @@ Class A
     End Property
     Shared Sub Main()
         Dim x As New A
-        Dim y = x[||](1)
+        Dim y = x$$(1)
     End Sub
 End Class
         </Document>
@@ -99,9 +99,9 @@ Public Class C
 
     Public Sub Goo(c As C)
         c = c.[|Item|](2)
-        c[||](1) = c
+        c$$(1) = c
         c.[|Item|](1) = c
-        c[||](1).[|Item|](1) = c
+        c$$(1).[|Item|](1) = c
     End Sub
 End Class
         </Document>
@@ -130,9 +130,9 @@ End Class
 Module Program
     Sub Main(args As String())
         Dim x As New C
-        Dim y = x![||]HELLO
-        Dim z = x![||]HI
-        x[||]("HELLO") = ""
+        Dim y = x!$$HELLO
+        Dim z = x!$$HI
+        x$$("HELLO") = ""
     End Sub
 End Module
 

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.IndexerSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.IndexerSymbols.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 
@@ -21,7 +21,7 @@ class D
     void Goo()
     {
         var q = new C();
-        var b = q$$[4];
+        var b = q[||][4];
     }
 }
         </Document>
@@ -48,7 +48,7 @@ end class
 class D
     sub Goo()
         dim q = new C()
-        dim b = q$$(4)
+        dim b = q[||](4)
     end sub
 end class
         </Document>
@@ -71,7 +71,7 @@ Class A
     End Property
     Shared Sub Main()
         Dim x As New A
-        Dim y = x$$(1)
+        Dim y = x[||](1)
     End Sub
 End Class
         </Document>
@@ -99,9 +99,9 @@ Public Class C
 
     Public Sub Goo(c As C)
         c = c.[|Item|](2)
-        c$$(1) = c
+        c[||](1) = c
         c.[|Item|](1) = c
-        c$$(1).[|Item|](1) = c
+        c[||](1).[|Item|](1) = c
     End Sub
 End Class
         </Document>
@@ -130,9 +130,9 @@ End Class
 Module Program
     Sub Main(args As String())
         Dim x As New C
-        Dim y = x!$$HELLO
-        Dim z = x!$$HI
-        x$$("HELLO") = ""
+        Dim y = x![||]HELLO
+        Dim z = x![||]HI
+        x[||]("HELLO") = ""
     End Sub
 End Module
 

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 
@@ -840,7 +840,7 @@ End Interface
 
 Class M
     Sub F(x As IC)
-        Dim y = x[||](1L)
+        Dim y = x$$(1L)
         Dim y2 = x(1)
     End Sub
 End Class
@@ -848,7 +848,7 @@ End Class
         <Document>
 Class M2
     Sub F(x As IC)
-        Dim y = x[||](1L)
+        Dim y = x$$(1L)
         Dim y2 = x(1)
     End Sub
 End Class
@@ -877,7 +877,7 @@ End Interface
 Class M
     Sub F(x As IC)
         Dim y = x(1L)
-        Dim y2 = x[||](1)
+        Dim y2 = x$$(1)
     End Sub
 End Class
         </Document>
@@ -885,7 +885,7 @@ End Class
 Class M2
     Sub F(x As IC)
         Dim y = x(1L)
-        Dim y2 = x[||](1)
+        Dim y2 = x$$(1)
     End Sub
 End Class
         </Document>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 
@@ -840,7 +840,7 @@ End Interface
 
 Class M
     Sub F(x As IC)
-        Dim y = x$$(1L)
+        Dim y = x[||](1L)
         Dim y2 = x(1)
     End Sub
 End Class
@@ -848,7 +848,7 @@ End Class
         <Document>
 Class M2
     Sub F(x As IC)
-        Dim y = x$$(1L)
+        Dim y = x[||](1L)
         Dim y2 = x(1)
     End Sub
 End Class
@@ -877,7 +877,7 @@ End Interface
 Class M
     Sub F(x As IC)
         Dim y = x(1L)
-        Dim y2 = x$$(1)
+        Dim y2 = x[||](1)
     End Sub
 End Class
         </Document>
@@ -885,7 +885,7 @@ End Class
 Class M2
     Sub F(x As IC)
         Dim y = x(1L)
-        Dim y2 = x$$(1)
+        Dim y2 = x[||](1)
     End Sub
 End Class
         </Document>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 
@@ -1434,7 +1434,7 @@ End Class]]>
                 class Test
                 {
                     /// <summary>
-                    /// <see cref="[||]this[int]"/>
+                    /// <see cref="$$this[int]"/>
                     /// </summary>
                     /// <param name="i"></param>
                     /// <returns></returns>
@@ -1552,7 +1552,7 @@ End Class]]>
             using System;
             class Program
             {
-                /// <see cref="GetDNSaliases.[||]this[int]"/>
+                /// <see cref="GetDNSaliases.$$this[int]"/>
                 static void Main(string[] args) { }
                 {
                 }

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 
@@ -1434,7 +1434,7 @@ End Class]]>
                 class Test
                 {
                     /// <summary>
-                    /// <see cref="$$this[int]"/>
+                    /// <see cref="[||]this[int]"/>
                     /// </summary>
                     /// <param name="i"></param>
                     /// <returns></returns>
@@ -1552,7 +1552,7 @@ End Class]]>
             using System;
             class Program
             {
-                /// <see cref="GetDNSaliases.$$this[int]"/>
+                /// <see cref="GetDNSaliases.[||]this[int]"/>
                 static void Main(string[] args) { }
                 {
                 }

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -119,7 +119,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         protected abstract Task<ImmutableArray<CodeAction>> GetCodeActionsWorkerAsync(
             TestWorkspace workspace, TestParameters parameters);
 
-
         protected abstract Task<ImmutableArray<Diagnostic>> GetDiagnosticsWorkerAsync(
             TestWorkspace workspace, TestParameters parameters);
 

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -60,11 +60,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             CodeRefactoringProvider provider,
             TestWorkspace workspace)
         {
-            var documentsWithSelections = workspace.Documents.Where(d => !d.IsLinkFile && d.SelectedSpans.Count == 1);
-            Debug.Assert(documentsWithSelections.Count() == 1, "One document must have a single span annotation");
-            var span = documentsWithSelections.Single().SelectedSpans.Single();
+            Assert.True(workspace.TryGetDocumentWithSelectedSpan(allowLinkedFile: false, out var document, out var span));
+
             var actions = ArrayBuilder<CodeAction>.GetInstance();
-            var document = workspace.CurrentSolution.GetDocument(documentsWithSelections.Single().Id);
             var context = new CodeRefactoringContext(document, span, actions.Add, CancellationToken.None);
             await provider.ComputeRefactoringsAsync(context);
 

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -69,9 +69,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var hostDocument = workspace.Documents.FirstOrDefault(d => d.SelectedSpans.Any());
             if (hostDocument == null)
             {
-                document = null;
-                span = default(TextSpan);
-                return false;
+                // If there wasn't a span, see if there was a $$ caret.  we'll create an empty span
+                // there if so.
+                hostDocument = workspace.Documents.FirstOrDefault(d => d.CursorPosition != null);
+                if (hostDocument == null)
+                {
+                    document = null;
+                    span = default;
+                    return false;
+                }
+
+                span = new TextSpan(hostDocument.CursorPosition.Value, 0);
+                document = workspace.CurrentSolution.GetDocument(hostDocument.Id);
+                return true;
             }
 
             span = hostDocument.SelectedSpans.Single();

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -65,29 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         }
 
         protected bool TryGetDocumentAndSelectSpan(TestWorkspace workspace, out Document document, out TextSpan span)
-        {
-            var hostDocument = workspace.Documents.FirstOrDefault(d => d.SelectedSpans.Any());
-            if (hostDocument == null)
-            {
-                // If there wasn't a span, see if there was a $$ caret.  we'll create an empty span
-                // there if so.
-                hostDocument = workspace.Documents.FirstOrDefault(d => d.CursorPosition != null);
-                if (hostDocument == null)
-                {
-                    document = null;
-                    span = default;
-                    return false;
-                }
-
-                span = new TextSpan(hostDocument.CursorPosition.Value, 0);
-                document = workspace.CurrentSolution.GetDocument(hostDocument.Id);
-                return true;
-            }
-
-            span = hostDocument.SelectedSpans.Single();
-            document = workspace.CurrentSolution.GetDocument(hostDocument.Id);
-            return true;
-        }
+            => workspace.TryGetDocumentWithSelectedSpan(out document, out span);
 
         protected Document GetDocumentAndAnnotatedSpan(TestWorkspace workspace, out string annotation, out TextSpan span)
         {

--- a/src/EditorFeatures/TestUtilities/GoToAdjacentMember/AbstractGoToAdjacentMemberTests.cs
+++ b/src/EditorFeatures/TestUtilities/GoToAdjacentMember/AbstractGoToAdjacentMemberTests.cs
@@ -31,8 +31,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToAdjacentMember
                     parseOptions: DefaultParseOptions.WithKind(kind),
                     content: code))
                 {
+                    Assert.True(workspace.TryGetDocumentWithSelectedSpan(out var document, out var span));
+
                     var hostDocument = workspace.DocumentWithCursor;
-                    var document = workspace.CurrentSolution.GetDocument(hostDocument.Id);
                     Assert.Empty((await document.GetSyntaxTreeAsync()).GetDiagnostics());
                     var targetPosition = await GoToAdjacentMemberCommandHandler.GetTargetPositionAsync(
                         document,
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToAdjacentMember
                         CancellationToken.None);
 
                     Assert.NotNull(targetPosition);
-                    Assert.Equal(hostDocument.SelectedSpans.Single().Start, targetPosition.Value);
+                    Assert.Equal(span.Start, targetPosition.Value);
                 }
             }
         }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -642,5 +642,30 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
             this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.SolutionChanged, oldSolution, newSolution);
         }
+
+        public bool TryGetDocumentWithSelectedSpan(out Document document, out TextSpan span)
+        {
+            var hostDocument = this.Documents.FirstOrDefault(d => d.SelectedSpans.Any());
+            if (hostDocument == null)
+            {
+                // If there wasn't a span, see if there was a $$ caret.  we'll create an empty span
+                // there if so.
+                hostDocument = this.Documents.FirstOrDefault(d => d.CursorPosition != null);
+                if (hostDocument == null)
+                {
+                    document = null;
+                    span = default;
+                    return false;
+                }
+
+                span = new TextSpan(hostDocument.CursorPosition.Value, 0);
+                document = this.CurrentSolution.GetDocument(hostDocument.Id);
+                return true;
+            }
+
+            span = hostDocument.SelectedSpans.Single();
+            document = this.CurrentSolution.GetDocument(hostDocument.Id);
+            return true;
+        }
     }
 }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -644,13 +644,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         }
 
         public bool TryGetDocumentWithSelectedSpan(out Document document, out TextSpan span)
+            => TryGetDocumentWithSelectedSpan(allowLinkedFile: true, out document, out span);
+
+        public bool TryGetDocumentWithSelectedSpan(
+            bool allowLinkedFile, out Document document, out TextSpan span)
         {
-            var hostDocument = this.Documents.FirstOrDefault(d => d.SelectedSpans.Any());
+            var documents = this.Documents.Where(d => allowLinkedFile || !d.IsLinkFile);
+            var hostDocument = documents.FirstOrDefault(d => d.SelectedSpans.Any());
             if (hostDocument == null)
             {
                 // If there wasn't a span, see if there was a $$ caret.  we'll create an empty span
                 // there if so.
-                hostDocument = this.Documents.FirstOrDefault(d => d.CursorPosition != null);
+                hostDocument = documents.FirstOrDefault(d => d.CursorPosition != null);
                 if (hostDocument == null)
                 {
                     document = null;

--- a/src/EditorFeatures/VisualBasicTest/AddFileBanner/AddFileBannerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddFileBanner/AddFileBannerTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.CodeRefactorings
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.AddFileBanner
 "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]Imports System
+        <Document>$$Imports System
 
 class Program1
     sub Main()
@@ -62,7 +62,7 @@ end class
 "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]Imports System
+        <Document>$$Imports System
 
 class Program1
     sub Main()
@@ -106,7 +106,7 @@ end class
 "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]' I already have a banner
+        <Document>$$' I already have a banner
 
 Imports System
 
@@ -130,7 +130,7 @@ end class
 "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]
+        <Document>$$
 
 Imports System
 
@@ -154,7 +154,7 @@ end class
 "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>[||]
+        <Document>$$
 
 Imports System
 

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/ChangeSignatureTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/ChangeSignatureTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ChangeSignature
         Public Async Function TestNotInLeadingWhitespace() As Task
             Dim markup = "
 class C
-    [||]
+    $$
     sub Goo(i as integer, j as integer)
     end sub
 end class
@@ -26,7 +26,7 @@ end class
         Public Async Function TestNotInLeadingTrivia1() As Task
             Dim markup = "
 class C
-    ' [||]
+    ' $$
     sub Goo(i as integer, j as integer)
     end sub
 end class
@@ -40,7 +40,7 @@ end class
         Public Async Function TestNotInLeadingTrivia2() As Task
             Dim markup = "
 class C
-    [||] '
+    $$ '
     sub Goo(i as integer, j as integer)
     end sub
 end class
@@ -54,7 +54,7 @@ end class
         Public Async Function TestNotInLeadingAttributes1() As Task
             Dim markup = "
 class C
-    [||]<X>
+    $$<X>
     sub Goo(i as integer, j as integer)
     end sub
 end class
@@ -68,7 +68,7 @@ end class
         Public Async Function TestNotInLeadingAttributes2() As Task
             Dim markup = "
 class C
-    <X>[||]
+    <X>$$
     sub Goo(i as integer, j as integer)
     end sub
 end class

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParameters.InvocationLocations.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParameters.InvocationLocations.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 
@@ -586,7 +586,7 @@ End Class]]></Text>.NormalizedValue()
         Public Async Function ReorderIndexerParameters_CodeRefactoring_InMethodDeclaration() As Threading.Tasks.Task
             Dim markup = <Text><![CDATA[
 Class C
-    Sub Goo(x As Integer[||], y As Integer)
+    Sub Goo(x As Integer$$, y As Integer)
     End Sub
 End Class]]></Text>.NormalizedValue()
             Dim permutation = {1, 0}
@@ -604,7 +604,7 @@ End Class]]></Text>.NormalizedValue()
             Dim markup = <Text><![CDATA[
 Class C
     Sub Goo(x As Integer, y As Integer)
-        [||]
+        $$
     End Sub
 End Class]]></Text>.NormalizedValue()
 
@@ -637,7 +637,7 @@ End Class]]></Text>.NormalizedValue()
             Dim markup = <Text><![CDATA[
 Class C
     Sub Goo(x As Integer, y As Integer)
-        Goo([||]1, 2)
+        Goo($$1, 2)
     End Sub
 End Class]]></Text>.NormalizedValue()
 

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.Conver
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(i As Integer)
-        [||]If i = 1 OrElse 2 = i OrElse i = 3 Then
+        $$If i = 1 OrElse 2 = i OrElse i = 3 Then
             M(0)
         ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
             M(1)
@@ -46,7 +46,7 @@ End Class")
 "Class C
     Sub M(i As Integer)
         Const A = 1, B = 2, C = 3
-        [||]If i = A OrElse B = i OrElse i = C Then
+        $$If i = A OrElse B = i OrElse i = C Then
             M(0)
         End If
     End Sub
@@ -68,7 +68,7 @@ End Class")
 "Class C
     Sub M(i As Integer)
         Dim A = 1, B = 2, C = 3
-        [||]If A = 1 OrElse 2 = B OrElse C = 3 Then
+        $$If A = 1 OrElse 2 = B OrElse C = 3 Then
             M(0)
         End If
     End Sub
@@ -80,7 +80,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Sub M(i As Integer, j As Integer)
-        [||]If i = 5 OrElse 6 = j Then
+        $$If i = 5 OrElse 6 = j Then
             M(0)
         End If
     End Sub
@@ -92,7 +92,7 @@ End Class")
             Await TestMissingAsync(
 "Class C
     Sub M(i As Integer)
-        [||]If i = 5 Then
+        $$If i = 5 Then
         End If
     End Sub
 End Class")
@@ -103,7 +103,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(i As Integer)
-        [||]If 5 >= i AndAlso 1 <= i Then
+        $$If 5 >= i AndAlso 1 <= i Then
         Else If 7 >= i AndAlso 6 <= i
         End If
     End Sub
@@ -123,7 +123,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(i As Integer)
-        [||]If i <= 5 OrElse i >= 1 Then
+        $$If i <= 5 OrElse i >= 1 Then
         End If
     End Sub
 End Class",
@@ -141,7 +141,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(i As Integer)
-        [||]If i < 10 OrElse 20 < i OrElse (i >= 30 AndAlso 40 >= i) OrElse i = 50 Then
+        $$If i < 10 OrElse 20 < i OrElse (i >= 30 AndAlso 40 >= i) OrElse i = 50 Then
         End If
     End Sub
 End Class",
@@ -159,7 +159,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(i As Integer)
-        [||]If i = 10 Then M(5) Else M(6)
+        $$If i = 10 Then M(5) Else M(6)
     End Sub
 End Class",
 "Class C
@@ -179,7 +179,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Function M(i As Integer) As Integer
-        [||]If i = 10 Then Return 5
+        $$If i = 10 Then Return 5
         If i = 20 Then Return 6
         Return 7
     End Function
@@ -202,7 +202,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Function M(i As Integer) As Integer
-        [||]If i = 10 Then Return 5
+        $$If i = 10 Then Return 5
         If i = 20 Then Return 6 Else Return 7
     End Function
 End Class",
@@ -225,7 +225,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Function M(i As Integer) As Integer
-        [||]If i = 10 Then Return 5
+        $$If i = 10 Then Return 5
         If i = 20 Then M(6)
         If i = 30 Then Return 6
         Return 7
@@ -250,7 +250,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Function M(i As Integer) As Integer
-        [||]If i = 10 Then Return 5
+        $$If i = 10 Then Return 5
         If i = 20 Then Return 6
         If i = i Then Return 0
         Return 7
@@ -275,7 +275,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Function M(i As Integer) As Integer
-        [||]If i = 10 Then Return 5
+        $$If i = 10 Then Return 5
         If i = 20 Then
             Return 6
         ElseIf i = 30 Then
@@ -306,7 +306,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Function M(i As Integer) As Integer
-        [||]If i = 10 Then Return 5 Else Return 4
+        $$If i = 10 Then Return 5 Else Return 4
         If i = 20 Then
             Return 6
         ElseIf i = i Then
@@ -341,7 +341,7 @@ End Class")
 "Class C
     Sub M(i As Integer)
         While i = i
-            [||]If i = 10 Then
+            $$If i = 10 Then
                 Exit While
             Else If i = 1 Then
             End If
@@ -371,7 +371,7 @@ End Class")
         Console.WriteLine()
 #end if
 
-        [||]If i = 1 OrElse 2 = i OrElse i = 3 Then
+        $$If i = 1 OrElse 2 = i OrElse i = 3 Then
             M(0)
         ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
             M(1)

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ConvertNumericLiteral/ConvertNumericLiteralTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ConvertNumericLiteral/ConvertNumericLiteralTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -19,11 +19,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.Conver
         End Enum
 
         Private Async Function TestMissingOneAsync(initial As String) As Task
-            Await TestMissingInRegularAndScriptAsync(CreateTreeText("[||]" + initial))
+            Await TestMissingInRegularAndScriptAsync(CreateTreeText("$$" + initial))
         End Function
 
         Private Async Function TestFixOneAsync(initial As String, expected As String, refactoring As Refactoring) As Task
-            Await TestInRegularAndScriptAsync(CreateTreeText("[||]" + initial), CreateTreeText(expected), index:=DirectCast(refactoring, Integer))
+            Await TestInRegularAndScriptAsync(CreateTreeText("$$" + initial), CreateTreeText(expected), index:=DirectCast(refactoring, Integer))
         End Function
 
         Private Shared Function CreateTreeText(initial As String) As String
@@ -98,7 +98,7 @@ End Class"
     Sub M()
         Dim x As Integer() =
         {
-            [||]&H1, &H2
+            $$&H1, &H2
         }
     End Sub
 End Class",
@@ -117,7 +117,7 @@ End Class", index:=Refactoring.ChangeBase2)
         Public Async Function TestCaretPositionAtTheEnd() As Task
             Await TestInRegularAndScriptAsync(
 "Class C
-    Dim a As Integer = 42[||]
+    Dim a As Integer = 42$$
 End Class",
 "Class C
     Dim a As Integer = &B101010

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.CodeStyle
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.E
         Public Async Function TestEncapsulatePrivateFieldAndUpdateReferences() As Task
             Dim text = <File>
 Class C
-    Private ReadOnly x[||] As Integer
+    Private ReadOnly x$$ As Integer
 
     Public Sub New()
         x = 3
@@ -54,7 +54,7 @@ End Class</File>.ConvertTestSourceTag()
         Public Async Function TestEncapsulateDimField() As Task
             Dim text = <File>
 Class C
-    Dim x[||] As Integer
+    Dim x$$ As Integer
 
     Sub goo()
         Dim z = x
@@ -87,7 +87,7 @@ End Class</File>.ConvertTestSourceTag()
         Public Async Function TestEncapsulateGenericField() As Task
             Dim text = <File>
 Class C(Of T)
-    Dim x[||] As T
+    Dim x$$ As T
 
     Sub goo()
         Dim z = x
@@ -466,7 +466,7 @@ End Class
         Public Async Function TestAvailableNotJustOnVariableName() As Task
             Dim text = <File>
 Class C
-    Private [||] ReadOnly x As Integer
+    Private $$ ReadOnly x As Integer
 End Class</File>.ConvertTestSourceTag()
 
             Await TestActionCountAsync(text, 2)

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict Off
 Imports Microsoft.CodeAnalysis.CodeRefactorings
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.I
         Public Async Function TestNotWithNoInitializer1() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer
+Dim $$i As Integer
 Console.WriteLine(i)
 </MethodBody>
 
@@ -27,7 +27,7 @@ Console.WriteLine(i)
         Public Async Function TestNotWithNoInitializer2() As Task
             Dim code =
 <MethodBody>
-Dim i As Integer = 0, [||]j As Integer
+Dim i As Integer = 0, $$j As Integer
 Console.WriteLine(j)
 </MethodBody>
 
@@ -38,7 +38,7 @@ Console.WriteLine(j)
         Public Async Function TestNotWithNoInitializer3() As Task
             Dim code =
 <MethodBody>
-Dim i As Integer = 0, j As Integer = 1, [||]k As Integer
+Dim i As Integer = 0, j As Integer = 1, $$k As Integer
 Console.WriteLine(k)
 </MethodBody>
 
@@ -49,7 +49,7 @@ Console.WriteLine(k)
         Public Async Function TestNotWithNoReference1() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 0
+Dim $$i As Integer = 0
 Console.WriteLine(0)
 </MethodBody>
 
@@ -60,7 +60,7 @@ Console.WriteLine(0)
         Public Async Function TestNotWithNoReference2() As Task
             Dim code =
 <MethodBody>
-Dim i As Integer = 0, [||]j As Integer = 1
+Dim i As Integer = 0, $$j As Integer = 1
 Console.WriteLine(i)
 </MethodBody>
 
@@ -71,7 +71,7 @@ Console.WriteLine(i)
         Public Async Function TestNotWithNoReference3() As Task
             Dim code =
 <MethodBody>
-Dim i As Integer = 0, j As Integer = 1, [||]k As Integer = 2
+Dim i As Integer = 0, j As Integer = 1, $$k As Integer = 2
 Console.WriteLine(i + j)
 </MethodBody>
 
@@ -82,7 +82,7 @@ Console.WriteLine(i + j)
         Public Async Function TestNotOnField() As Task
             Dim code =
 <ClassDeclaration>
-Dim [||]i As Integer = 0
+Dim $$i As Integer = 0
 
 Sub M()
     Console.WriteLine(i)
@@ -96,7 +96,7 @@ End Sub
         Public Async Function TestSingleDeclarator() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 0
+Dim $$i As Integer = 0
 Console.WriteLine(i)
 </MethodBody>
 
@@ -119,7 +119,7 @@ Class C1
         Stop
 #End If
 
-        Dim [||]i As Integer = 0
+        Dim $$i As Integer = 0
         Console.WriteLine(i)
     End Sub
 End Class
@@ -150,7 +150,7 @@ End Class
 Imports System
 Class C1
     Sub M()
-        Dim [||]i As Integer = 0
+        Dim $$i As Integer = 0
 #If True Then
         Console.WriteLine(i)
 #End If
@@ -180,7 +180,7 @@ End Class
 <File>
 Module Program
     Sub Main()
-        Dim x As Integer = 10 : Dim [||]y As Integer = 5
+        Dim x As Integer = 10 : Dim $$y As Integer = 5
         Console.Write(x + y)
     End Sub
 End Module
@@ -203,7 +203,7 @@ End Module
         Public Async Function TestSingleDeclaratorInPropertyGetter() As Task
             Dim code =
 <PropertyGetter>
-Dim [||]i As Integer = 0
+Dim $$i As Integer = 0
 Console.WriteLine(i)
 </PropertyGetter>
 
@@ -219,7 +219,7 @@ Console.WriteLine(0)
         Public Async Function TestTwoDeclarators1() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 0, j As Integer = 1
+Dim $$i As Integer = 0, j As Integer = 1
 Console.WriteLine(i)
 </MethodBody>
 
@@ -236,7 +236,7 @@ Console.WriteLine(0)
         Public Async Function TestTwoDeclarators2() As Task
             Dim code =
 <MethodBody>
-Dim i As Integer = 0, [||]j As Integer = 1
+Dim i As Integer = 0, $$j As Integer = 1
 Console.WriteLine(j)
 </MethodBody>
 
@@ -253,7 +253,7 @@ Console.WriteLine(1)
         Public Async Function TestThreeDeclarators1() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 0, j As Integer = 1, k As Integer = 2
+Dim $$i As Integer = 0, j As Integer = 1, k As Integer = 2
 Console.WriteLine(i)
 </MethodBody>
 
@@ -270,7 +270,7 @@ Console.WriteLine(0)
         Public Async Function TestThreeDeclarators2() As Task
             Dim code =
 <MethodBody>
-Dim i As Integer = 0, [||]j As Integer = 1, k As Integer = 2
+Dim i As Integer = 0, $$j As Integer = 1, k As Integer = 2
 Console.WriteLine(j)
 </MethodBody>
 
@@ -287,7 +287,7 @@ Console.WriteLine(1)
         Public Async Function TestThreeDeclarators3() As Task
             Dim code =
 <MethodBody>
-Dim i As Integer = 0, j As Integer = 1, [||]k As Integer = 2
+Dim i As Integer = 0, j As Integer = 1, $$k As Integer = 2
 Console.WriteLine(k)
 </MethodBody>
 
@@ -305,7 +305,7 @@ Console.WriteLine(2)
         Public Async Function TestThreeDeclarators4() As Task
             Dim code =
 <MethodBody>
-Dim x, z[||] As New Integer, y As Integer
+Dim x, z$$ As New Integer, y As Integer
 x.ToString()
 z.ToString()
 </MethodBody>
@@ -325,7 +325,7 @@ Call New Integer.ToString()
         Public Async Function TestInlineIntoNextDeclarator() As Task
             Dim code =
 <MethodBody>
-Dim [||]x As Action = Sub() Console.WriteLine(), y = x
+Dim $$x As Action = Sub() Console.WriteLine(), y = x
 </MethodBody>
 
             Dim expected =
@@ -340,7 +340,7 @@ Dim y = CType(Sub() Console.WriteLine(), Action)
         Public Async Function TestTwoNames1() As Task
             Dim code =
 <MethodBody>
-Dim [||]i, j As New String(" "c, 10)
+Dim $$i, j As New String(" "c, 10)
 Console.WriteLine(i)
 </MethodBody>
 
@@ -357,7 +357,7 @@ Console.WriteLine(New String(" "c, 10))
         Public Async Function TestTwoNames2() As Task
             Dim code =
 <MethodBody>
-Dim i, [||]j As New String(" "c, 10)
+Dim i, $$j As New String(" "c, 10)
 Console.WriteLine(j)
 </MethodBody>
 
@@ -374,7 +374,7 @@ Console.WriteLine(New String(" "c, 10))
         Public Async Function TestThreeNames1() As Task
             Dim code =
 <MethodBody>
-Dim [||]i, j, k As New String(" "c, 10)
+Dim $$i, j, k As New String(" "c, 10)
 Console.WriteLine(i)
 </MethodBody>
 
@@ -391,7 +391,7 @@ Console.WriteLine(New String(" "c, 10))
         Public Async Function TestThreeNames2() As Task
             Dim code =
 <MethodBody>
-Dim i, [||]j, k As New String(" "c, 10)
+Dim i, $$j, k As New String(" "c, 10)
 Console.WriteLine(j)
 </MethodBody>
 
@@ -408,7 +408,7 @@ Console.WriteLine(New String(" "c, 10))
         Public Async Function TestThreeNames3() As Task
             Dim code =
 <MethodBody>
-Dim i, j, [||]k As New String(" "c, 10)
+Dim i, j, $$k As New String(" "c, 10)
 Console.WriteLine(k)
 </MethodBody>
 
@@ -425,7 +425,7 @@ Console.WriteLine(New String(" "c, 10))
         Public Async Function TestInlineIntoExpression1() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 0
+Dim $$i As Integer = 0
 Dim j As Integer = 1
 Dim k As Integer = 2 + 3
 Console.WriteLine(i + j * k)
@@ -446,7 +446,7 @@ Console.WriteLine(0 + j * k)
             Dim code =
 <MethodBody>
 Dim i As Integer = 0
-Dim [||]j As Integer = 1
+Dim $$j As Integer = 1
 Dim k As Integer = 2 + 3
 Console.WriteLine(i + j * k)
 </MethodBody>
@@ -466,7 +466,7 @@ Console.WriteLine(i + 1 * k)
         Public Async Function TestInlineIntoExpression3() As Task
             Dim code =
 <MethodBody>
-Dim x[||] As Int32 = New Int32
+Dim x$$ As Int32 = New Int32
 Console.Write(x + 10)
 </MethodBody>
 
@@ -484,7 +484,7 @@ Console.Write(New Int32 + 10)
 <MethodBody>
 Dim i As Integer = 0
 Dim j As Integer = 1
-Dim [||]k As Integer = 2 + 3
+Dim $$k As Integer = 2 + 3
 Console.WriteLine(i + j * k)
 </MethodBody>
 
@@ -502,7 +502,7 @@ Console.WriteLine(i + j * (2 + 3))
         Public Async Function TestInlineIntoMemberAccess1() As Task
             Dim code =
 <MethodBody>
-Dim [||]s As New String(" "c, 10)
+Dim $$s As New String(" "c, 10)
 Console.WriteLine(s.Length)
 </MethodBody>
 
@@ -518,7 +518,7 @@ Console.WriteLine(New String(" "c, 10).Length)
         Public Async Function TestInlineIntoMemberAccess2() As Task
             Dim code =
 <MethodBody>
-Dim [||]s As String = "a" &amp; "b"
+Dim $$s As String = "a" &amp; "b"
 Console.WriteLine(s.Length)
 </MethodBody>
 
@@ -535,7 +535,7 @@ Console.WriteLine(("a" &amp; "b").Length)
         Public Async Function TestInlineIntoMemberAccess3() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = New String(" "c, 10).Length
+Dim $$i As Integer = New String(" "c, 10).Length
 Console.Write(i)
 </MethodBody>
 
@@ -553,7 +553,7 @@ Console.Write(New String(" "c, 10).Length)
         Public Async Function TestInlineIntoMemberAccess4() As Task
             Dim code =
 <MethodBody>
-Dim x[||] As Int32 = New Int32
+Dim x$$ As Int32 = New Int32
 Call x.ToString
 </MethodBody>
 
@@ -574,7 +574,7 @@ Function GetString() As String
 End Function
 
 Sub Test()
-    Dim [||]s As String = GetString
+    Dim $$s As String = GetString
     Call s.ToString
 End Sub
 </ClassDeclaration>
@@ -602,7 +602,7 @@ Function GetString() As String
 End Function
 
 Sub Test()
-    Dim [||]s As String = GetString()
+    Dim $$s As String = GetString()
     Call s.ToString
 End Sub
 </ClassDeclaration>
@@ -626,7 +626,7 @@ End Sub
         Public Async Function TestInlineIntoMemberAccess7() As Task
             Dim code =
 <MethodBody>
-Dim z[||] As IEnumerable(Of Char) = From x In "ABC" Select x
+Dim z$$ As IEnumerable(Of Char) = From x In "ABC" Select x
 Console.WriteLine(z.First())
 </MethodBody>
 
@@ -643,7 +643,7 @@ Console.WriteLine((From x In "ABC" Select x).First())
         Public Async Function TestInlineIntoMemberAccess8() As Task
             Dim code =
 <MethodBody>
-Dim x[||] As New List(Of Integer)
+Dim x$$ As New List(Of Integer)
 x.ToString()
 </MethodBody>
 
@@ -665,7 +665,7 @@ Sub Goo(i As Integer)
 End Sub
 
 Sub Test()
-    Dim [||]i As Object = 1
+    Dim $$i As Object = 1
     Goo(i)
 End Sub
 </ClassDeclaration>
@@ -695,7 +695,7 @@ Sub Goo(i As Integer)
 End Sub
 
 Sub Test()
-    Dim [||]i As Long = 1
+    Dim $$i As Long = 1
     Goo(i)
 End Sub
 </ClassDeclaration>
@@ -725,7 +725,7 @@ Sub Goo(i As Integer)
 End Sub
 
 Sub Test()
-    Dim [||]i As Long = CByte(1)
+    Dim $$i As Long = CByte(1)
     Goo(i)
 End Sub
 </ClassDeclaration>
@@ -755,7 +755,7 @@ Sub Goo(s As String)
 End Sub
 
 Sub Test()
-    Dim [||]s As String = Nothing
+    Dim $$s As String = Nothing
     Goo(s)
 End Sub
 </ClassDeclaration>
@@ -785,7 +785,7 @@ Sub Goo(s As String)
 End Sub
 
 Sub Test()
-    Dim [||]o As Object = Nothing
+    Dim $$o As Object = Nothing
     Goo(o)
 End Sub
 </ClassDeclaration>
@@ -815,7 +815,7 @@ Option Strict On
  
 Class M
     Sub Main()
-        Dim x[||] As Long = 1
+        Dim x$$ As Long = 1
         Dim y As System.IComparable(Of Long) = x
     End Sub
 End Class
@@ -844,7 +844,7 @@ Option Strict On
 Imports System
 Module M
     Sub Goo()
-        Dim x[||] As Long() = {1, 2, 3}
+        Dim x$$ As Long() = {1, 2, 3}
         Dim y = x
         Dim z As IComparable(Of Long) = y(0)
     End Sub
@@ -875,7 +875,7 @@ End Module
 Option Strict On
 Class M
     Sub Main()
-        Dim x[||] As Long? = 1
+        Dim x$$ As Long? = 1
         Dim y As System.IComparable(Of Long) = x
     End Sub
 End Class
@@ -902,7 +902,7 @@ End Class
 Module Program
     Sub Main()
         Dim x As Integer() = {1}
-        Dim [||]y = If(True, x, x)
+        Dim $$y = If(True, x, x)
         y(0) = 1
     End Sub
 End Module
@@ -929,7 +929,7 @@ End Module
 Imports System
 Module Program
     Sub Main()
-        Dim [||]x As Action = AddressOf Console.WriteLine
+        Dim $$x As Action = AddressOf Console.WriteLine
         x()
     End Sub
 End Module
@@ -960,7 +960,7 @@ Imports System
 
 Public Class X
     Shared Sub Main()
-        Dim a[||] = Sub() Return
+        Dim a$$ = Sub() Return
         Dim x As X = a
     End Sub
 
@@ -997,7 +997,7 @@ Module M
     Function Goo(Of T)(x As T, y As T) As T
     End Function
     Sub Main()
-        Dim [||]x As Long = 1
+        Dim $$x As Long = 1
         Dim y As IComparable(Of Long) = Goo(x, x)
     End Sub
 End Module
@@ -1025,7 +1025,7 @@ End Module
 Option Strict On
 Module M
     Sub Main(args As String())
-        Dim [||]x() As Long? = {1}
+        Dim $$x() As Long? = {1}
         For Each y As System.IComparable(Of Long) In x
             Console.WriteLine(y)
         Next
@@ -1055,7 +1055,7 @@ End Module
         Public Async Function TestInlineIntoExpressionHole1() As Task
             Dim code =
 <MethodBody>
-Dim s[||] = Sub() If True Then Else
+Dim s$$ = Sub() If True Then Else
 Dim x = &lt;x &lt;%= s %&gt;/&gt;
 </MethodBody>
 
@@ -1071,7 +1071,7 @@ Dim x = &lt;x &lt;%= Sub() If True Then Else %&gt;/&gt;
         Public Async Function TestInlineIntoExpressionHole2() As Task
             Dim code =
 <MethodBody>
-Dim s[||] As Action = Sub() If True Then Else
+Dim s$$ As Action = Sub() If True Then Else
 Dim x = &lt;x &lt;%= s %&gt;/&gt;
 </MethodBody>
 
@@ -1087,7 +1087,7 @@ Dim x = &lt;x &lt;%= Sub() If True Then Else %&gt;/&gt;
         Public Async Function TestInlineLambda1() As Task
             Dim code =
 <MethodBody>
-Dim [||]f As Func(Of Integer) = Function() 1
+Dim $$f As Func(Of Integer) = Function() 1
 Dim i = f.Invoke()
 </MethodBody>
 
@@ -1103,7 +1103,7 @@ Dim i = (Function() 1).Invoke()
         Public Async Function TestInlineLambda2() As Task
             Dim code =
 <MethodBody>
-Dim [||]f As Func(Of Integer) = Function()
+Dim $$f As Func(Of Integer) = Function()
                                     Return 1
                                 End Function
 Dim i = f.Invoke()
@@ -1124,7 +1124,7 @@ Dim i = Function()
             Dim code =
 <MethodBody>
 Dim f As Func(Of Integer) = Function()
-                                Dim [||]x As Integer = 0
+                                Dim $$x As Integer = 0
                                 Console.WriteLine(x)
                             End Function
 </MethodBody>
@@ -1143,7 +1143,7 @@ Dim f As Func(Of Integer) = Function()
         Public Async Function TestInlineIntoLambda() As Task
             Dim code =
 <MethodBody>
-Dim [||]x As Integer = 0
+Dim $$x As Integer = 0
 Dim f As Func(Of Integer) = Function()
                                 Console.WriteLine(x)
                             End Function
@@ -1163,7 +1163,7 @@ Dim f As Func(Of Integer) = Function()
         Public Async Function TestDontInlineTrailingComment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1 + 1 ' First
+Dim $$i As Integer = 1 + 1 ' First
 Console.WriteLine(i * 2)
 </MethodBody>
 
@@ -1181,7 +1181,7 @@ Console.WriteLine((1 + 1) * 2)
         Public Async Function TestDontRemoveLineBreakAfterComment() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = 1 ' comment
+Dim $$x = 1 ' comment
 Dim y = x
 </MethodBody>
 
@@ -1198,7 +1198,7 @@ Dim y = 1
         Public Async Function TestRemoveTrailingColon() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1 + 1 : Dim j As Integer = 2 ' First
+Dim $$i As Integer = 1 + 1 : Dim j As Integer = 2 ' First
 Console.WriteLine(i * j)
 </MethodBody>
 
@@ -1215,7 +1215,7 @@ Console.WriteLine((1 + 1) * j)
         Public Async Function TestDontInsertUnnecessaryCast1() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Object = 1 + 1
+Dim $$i As Object = 1 + 1
 Dim j As Integer = i
 </MethodBody>
 
@@ -1231,7 +1231,7 @@ Dim j As Integer = 1 + 1
         Public Async Function TestDontInsertUnnecessaryCast2() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1 + 1
+Dim $$i As Integer = 1 + 1
 Dim j As Integer = i * 2
 Console.WriteLine(j)
 </MethodBody>
@@ -1249,7 +1249,7 @@ Console.WriteLine(j)
         Public Async Function TestDontInsertUnnecessaryCast3() As Task
             Dim code =
 <MethodBody>
-Dim [||]x As Action = Sub()
+Dim $$x As Action = Sub()
                       End Sub
 Dim y As Action = x
 </MethodBody>
@@ -1269,7 +1269,7 @@ Dim y As Action = Sub()
             Dim code =
 <ClassDeclaration>
 Sub S
-    Dim [||]t = New With {.Name = ""}
+    Dim $$t = New With {.Name = ""}
     M(t)
 End Sub
 
@@ -1300,7 +1300,7 @@ Imports System
  
 Module Program
     Sub Main
-        Dim [||]x = Sub() Return
+        Dim $$x = Sub() Return
         x.Invoke()
     End Sub
 End Module
@@ -1331,7 +1331,7 @@ Option Strict On
  
 Module M
     Sub Main()
-        Dim x[||] = Function() 1
+        Dim x$$ = Function() 1
         Dim y = x
         Dim z = y()
     End Sub
@@ -1362,7 +1362,7 @@ End Module
 Imports System
 Module M
     Sub Main()
-        Dim e1[||] As Exception = New ArgumentException()
+        Dim e1$$ As Exception = New ArgumentException()
         Dim t1 = e1.GetType()
     End Sub
 End Module
@@ -1390,7 +1390,7 @@ Option Strict On
 Imports System.Collections.Generic
 Module M
     Sub Main()
-        Dim x[||] = {1}
+        Dim x$$ = {1}
         Dim y = New List(Of Integer()) From {{x}}
     End Sub
 End Module
@@ -1420,7 +1420,7 @@ Imports System.Linq
 
 Module Program
     Sub Main()
-        Dim p[||] = {1, 2, 3}
+        Dim p$$ = {1, 2, 3}
         Dim z = p.ToList
     End Sub
 End Module
@@ -1449,7 +1449,7 @@ End Module
 Imports System
 Class X
     Shared Sub Main()
-        Dim [||]x As Object = New X()
+        Dim $$x As Object = New X()
         Dim s = x.ToString()
     End Sub
     Public Overrides Function ToString() As String
@@ -1478,7 +1478,7 @@ End Class
         Public Async Function TestInsertCallIfNecessary1() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = New Exception()
+Dim $$x = New Exception()
 x.ToString
 </MethodBody>
 
@@ -1494,7 +1494,7 @@ Call New Exception().ToString
         Public Async Function TestInsertCallIfNecessary2() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = New Exception
+Dim $$x = New Exception
 x.ToString
 </MethodBody>
 
@@ -1510,7 +1510,7 @@ Call New Exception().ToString
         Public Async Function TestInsertCallIfNecessary3() As Task
             Dim code =
 <MethodBody>
-Dim [||]s As Action = Sub() Exit Sub
+Dim $$s As Action = Sub() Exit Sub
 s
 </MethodBody>
 
@@ -1526,7 +1526,7 @@ Call (Sub() Exit Sub)
         Public Async Function TestInsertCallIfNecessary4() As Task
             Dim code =
 <MethodBody>
-Dim [||]q = From x in "abc"
+Dim $$q = From x in "abc"
 q.Distinct()
 </MethodBody>
 
@@ -1542,7 +1542,7 @@ Call (From x in "abc").Distinct()
         Public Async Function TestInsertCallIfNecessary5() As Task
             Dim code =
 <MethodBody>
-Dim [||]s = "abc"
+Dim $$s = "abc"
 s.ToLower()
 </MethodBody>
 
@@ -1558,7 +1558,7 @@ Call "abc".ToLower()
         Public Async Function TestInsertCallIfNecessary6() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = 1
+Dim $$x = 1
 x.ToString()
 </MethodBody>
 
@@ -1574,7 +1574,7 @@ Call 1.ToString()
         Public Async Function TestInsertCallIfNecessary7() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = 1 + 1
+Dim $$x = 1 + 1
 x.ToString()
 </MethodBody>
 
@@ -1590,7 +1590,7 @@ Call (1 + 1).ToString()
         Public Async Function TestInsertCallIfNecessary8() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = New Exception().Message
+Dim $$x = New Exception().Message
 x.ToString
 </MethodBody>
 
@@ -1607,7 +1607,7 @@ Call New Exception().Message.ToString
         Public Async Function TestInsertCallIfNecessary9() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = If(True, 1, 2)
+Dim $$x = If(True, 1, 2)
 x.ToString
 </MethodBody>
 
@@ -1624,7 +1624,7 @@ Call If(True, 1, 2).ToString
         Public Async Function TestInsertCallIfNecessary10() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = If(Nothing, "")
+Dim $$x = If(Nothing, "")
 x.ToString
 </MethodBody>
 
@@ -1641,7 +1641,7 @@ Call If(Nothing, "").ToString
         Public Async Function TestParenthesizeIfNecessary1() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = From y In "" Select y
+Dim $$x = From y In "" Select y
 Dim a = x, b
 </MethodBody>
 
@@ -1658,7 +1658,7 @@ Dim a = (From y In "" Select y), b
         Public Async Function TestParenthesizeIfNecessary2() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = From y In "" Select y
+Dim $$x = From y In "" Select y
 Dim a = Nothing, b = x
 </MethodBody>
 
@@ -1675,7 +1675,7 @@ Dim a = Nothing, b = From y In "" Select y
         Public Async Function TestParenthesizeIfNecessary3() As Task
             Dim code =
 <MethodBody>
-Dim [||]x As Func(Of IEnumerable(Of Char)) = Function() From y In "" Select y
+Dim $$x As Func(Of IEnumerable(Of Char)) = Function() From y In "" Select y
 Dim a = x, b
 </MethodBody>
 
@@ -1691,7 +1691,7 @@ Dim a = CType((Function() From y In "" Select y), Func(Of IEnumerable(Of Char)))
         Public Async Function TestParenthesizeIfNecessary4() As Task
             Dim code =
 <MethodBody>
-Dim [||]z As IEnumerable(Of Char) = From x In "ABC" Select x
+Dim $$z As IEnumerable(Of Char) = From x In "ABC" Select x
 Dim y = New IEnumerable(Of Char)() {z, z}
 </MethodBody>
 
@@ -1708,7 +1708,7 @@ Dim y = New IEnumerable(Of Char)() {(From x In "ABC" Select x), From x In "ABC" 
         Public Async Function TestParenthesizeIfNecessary5() As Task
             Dim code =
 <MethodBody>
-Dim [||]z As IEnumerable(Of Char) = From x In "ABC" Select x
+Dim $$z As IEnumerable(Of Char) = From x In "ABC" Select x
 Dim y = New IEnumerable(Of Char)() {(From x In "ABC" Select x), z}
 </MethodBody>
 
@@ -1726,7 +1726,7 @@ Dim y = New IEnumerable(Of Char)() {(From x In "ABC" Select x), From x In "ABC" 
             Dim code =
 <ModuleDeclaration>
 Sub Goo()
-    Dim [||]z As IEnumerable(Of Char) = From x In "ABC" Select x ' Inline z
+    Dim $$z As IEnumerable(Of Char) = From x In "ABC" Select x ' Inline z
     Bar(z, z)
 End Sub
 
@@ -1754,7 +1754,7 @@ End Sub
             Dim code =
 <ModuleDeclaration>
 Sub Goo()
-    Dim [||]z As Func(Of IEnumerable(Of Char)) = Function() From x In "ABC" Select x
+    Dim $$z As Func(Of IEnumerable(Of Char)) = Function() From x In "ABC" Select x
     Bar(z, z)
 End Sub
 
@@ -1780,7 +1780,7 @@ End Sub
         Public Async Function TestParenthesizeIfNecessary8() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = From y In "" Select y Order By y
+Dim $$x = From y In "" Select y Order By y
 Dim a = x, b
 </MethodBody>
 
@@ -1798,7 +1798,7 @@ Dim a = (From y In "" Select y Order By y), b
             Dim code =
 <ModuleDeclaration>
 Sub Goo()
-    Dim [||]z As Func(Of IEnumerable(Of IEnumerable(Of Char))) = Function() From x In "ABC" Select From y In "ABC" Select y
+    Dim $$z As Func(Of IEnumerable(Of IEnumerable(Of Char))) = Function() From x In "ABC" Select From y In "ABC" Select y
     Bar(z, z)
 End Sub
 
@@ -1824,7 +1824,7 @@ End Sub
         Public Async Function TestParenthesizeIfNecessary10() As Task
             Dim code =
 <MethodBody>
-Dim [||]x As Collections.ArrayList = New Collections.ArrayList()
+Dim $$x As Collections.ArrayList = New Collections.ArrayList()
 Dim y = x(0)
 </MethodBody>
 
@@ -1841,7 +1841,7 @@ Dim y = (New Collections.ArrayList())(0)
         Public Async Function TestParenthesizeIfNecessary11() As Task
             Dim code =
 <MethodBody>
-Dim [||]y As Action = Sub() If True Then Dim x
+Dim $$y As Action = Sub() If True Then Dim x
 Dim a As Action = y, b = a
 </MethodBody>
 
@@ -1858,7 +1858,7 @@ Dim a As Action = (Sub() If True Then Dim x), b = a
         Public Async Function TestParenthesizeIfNecessary12() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = From y In "" Select y Order By y Ascending
+Dim $$x = From y In "" Select y Order By y Ascending
 Dim a = x, b
 </MethodBody>
 
@@ -1875,7 +1875,7 @@ Dim a = (From y In "" Select y Order By y Ascending), b
         Public Async Function TestParenthesizeIfNecessary13() As Task
             Dim code =
 <MethodBody>
-Dim [||]x As Collections.ArrayList = New Collections.ArrayList
+Dim $$x As Collections.ArrayList = New Collections.ArrayList
 Dim y = x(0)
 </MethodBody>
 
@@ -1892,7 +1892,7 @@ Dim y = (New Collections.ArrayList)(0)
         Public Async Function TestParenthesizeIfNecessary14() As Task
             Dim code =
 <MethodBody>
-Dim [||]q = From x In ""
+Dim $$q = From x In ""
 Dim p = From y In "", z In q Distinct
 </MethodBody>
 
@@ -1909,7 +1909,7 @@ Dim p = From y In "", z In (From x In "") Distinct
         Public Async Function TestParenthesizeIfNecessary15() As Task
             Dim code =
 <MethodBody>
-Dim [||]z = From x In "" Group By x Into Count
+Dim $$z = From x In "" Group By x Into Count
 Dim y = z(0)
 </MethodBody>
 
@@ -1926,7 +1926,7 @@ Dim y = (From x In "" Group By x Into Count)(0)
         Public Async Function TestParenthesizeIfNecessary16() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = Function() Console.ReadLine
+Dim $$x = Function() Console.ReadLine
 Dim y As String = x()
 </MethodBody>
 
@@ -1943,7 +1943,7 @@ Dim y As String = (Function() Console.ReadLine)()
         Public Async Function TestParenthesizeIfNecessary17() As Task
             Dim code =
 <MethodBody>
-Dim [||]s = Sub() Return
+Dim $$s = Sub() Return
 Dim q = From x In "" Select z = s Distinct
 </MethodBody>
 
@@ -1960,7 +1960,7 @@ Dim q = From x In "" Select z = (Sub() Return) Distinct
         Public Async Function TestParenthesizeIfNecessary18() As Task
             Dim code =
 <MethodBody>
-Dim [||]s = Sub() Return
+Dim $$s = Sub() Return
 Dim q = From x In "" Select z = s _
         Distinct
 </MethodBody>
@@ -1979,7 +1979,7 @@ Dim q = From x In "" Select z = (Sub() Return) _
         Public Async Function TestParenthesizeIfNecessary19() As Task
             Dim code =
 <MethodBody>
-Dim [||]s = Sub() Return
+Dim $$s = Sub() Return
 Dim q = From x In "" Select z = s
 </MethodBody>
 
@@ -1998,7 +1998,7 @@ Dim q = From x In "" Select z = Sub() Return
 <MethodBody>
 With ""
     Dim x = From c In "" Distinct
-    Dim y[||] = 1
+    Dim y$$ = 1
     .ToLower()
     Console.WriteLine(y)
 End With
@@ -2021,7 +2021,7 @@ End With
         Public Async Function TestParenthesizeIfNecessary21() As Task
             Dim code =
 <MethodBody>
-Dim y[||] = Sub() Exit Sub
+Dim y$$ = Sub() Exit Sub
 y.Invoke()
 </MethodBody>
 
@@ -2038,7 +2038,7 @@ Call (Sub() Exit Sub).Invoke()
         Public Async Function TestParenthesizeIfNecessary22() As Task
             Dim code =
 <MethodBody>
-Dim x[||] = {Sub() Return}
+Dim x$$ = {Sub() Return}
 Dim y = {x}
 Console.WriteLine(y.Rank)
 </MethodBody>
@@ -2064,7 +2064,7 @@ Module Program
     Sub Main()
         With New StringBuilder
             Dim x = From c In "" Distinct
-            Dim [||]y = 1
+            Dim $$y = 1
             .Length = 0
             Console.WriteLine(y)
         End With
@@ -2096,7 +2096,7 @@ End Module
         Public Async Function TestParenthesizeIfNecessary24() As Task
             Dim code =
 <MethodBody>
-Dim [||]x = From z In ""
+Dim $$x = From z In ""
 Dim y = x
 Select 1
 End Select
@@ -2121,7 +2121,7 @@ End Select
 <File>
 Module A
     Sub Main()
-        Dim y[||] = Preserve.X
+        Dim y$$ = Preserve.X
         ReDim y(0)
     End Sub
 End Module
@@ -2153,7 +2153,7 @@ End Module
             Dim code =
 <ModuleDeclaration>
 Sub Main()
-    Dim [||]x = Goo
+    Dim $$x = Goo
     Dim y As Integer = x(0)
 End Sub
 
@@ -2186,7 +2186,7 @@ End Function
             Dim code =
 <ModuleDeclaration>
 Sub Main()
-    Dim [||]x = Goo(Of Integer)
+    Dim $$x = Goo(Of Integer)
     Dim y As Integer = x(0)
 End Sub
 
@@ -2219,7 +2219,7 @@ End Function
             Dim code =
 <ModuleDeclaration>
 Sub Main()
-    Dim [||]x = Goo
+    Dim $$x = Goo
     Dim y As Integer = x(0)
 End Sub
 
@@ -2256,7 +2256,7 @@ End Property
 Module Program
     Sub Main()
         Dim x As Action = Sub() Console.WriteLine("Hello")
-        Dim [||]y = x : y : Console.WriteLine()
+        Dim $$y = x : y : Console.WriteLine()
     End Sub
 End Module
 </ModuleDeclaration>
@@ -2281,7 +2281,7 @@ End Module
 <ModuleDeclaration>
 Module Program
     Sub Main()
-        Dim [||]y = x
+        Dim $$y = x
         y
     End Sub
 
@@ -2307,7 +2307,7 @@ End Module
         Public Async Function TestConflict_Assignment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i = 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2326,7 +2326,7 @@ Console.WriteLine(1)
         Public Async Function TestConflict_AddAssignment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i += 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2345,7 +2345,7 @@ Console.WriteLine(1)
         Public Async Function TestConflict_SubtractAssignment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i -= 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2364,7 +2364,7 @@ Console.WriteLine(1)
         Public Async Function TestConflict_MultiplyAssignment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i *= 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2383,7 +2383,7 @@ Console.WriteLine(1)
         Public Async Function TestConflict_DivideAssignment1() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i /= 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2402,7 +2402,7 @@ Console.WriteLine(1)
         Public Async Function TestConflict_IntegerDivideAssignment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i \= 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2421,7 +2421,7 @@ Console.WriteLine(1)
         Public Async Function TestConflict_ConcatenateAssignment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i &amp;= 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2440,7 +2440,7 @@ Console.WriteLine(1)
         Public Async Function TestConflict_LeftShiftAssignment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i &lt;&lt;= 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2459,7 +2459,7 @@ Console.WriteLine(1)
         Public Async Function TestConflict_RightShiftAssignment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i &gt;&gt;= 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2478,7 +2478,7 @@ Console.WriteLine(1)
         Public Async Function TestConflict_PowerAssignment() As Task
             Dim code =
 <MethodBody>
-Dim [||]i As Integer = 1
+Dim $$i As Integer = 1
 i ^= 2
 Console.WriteLine(i)
 </MethodBody>
@@ -2500,7 +2500,7 @@ Console.WriteLine(1)
 <File>
 Module Program
     Sub Main(args As String())
-        Dim bar[||] As String = "TEST"
+        Dim bar$$ As String = "TEST"
         goo(bar)
         Console.WriteLine(bar)
     End Sub
@@ -2538,7 +2538,7 @@ End Module
 Module Program
     Sub Main(args As String())
         Dim x = y
-        Dim y[||] = 45
+        Dim y$$ = 45
     End Sub
 End Module
 </File>
@@ -2566,7 +2566,7 @@ Option Explicit Off
 
 Module Program
     Sub Main(args As String())
-        Dim y[||] As Integer = q
+        Dim y$$ As Integer = q
         z = y
     End Sub
 End Module
@@ -2596,7 +2596,7 @@ Option Explicit Off
 
 Module Program
     Sub Main(args As String())
-        Dim y2[||] As Integer = q2
+        Dim y2$$ As Integer = q2
         Dim z2 As Object = y2
     End Sub
 End Module
@@ -2625,7 +2625,7 @@ Option Infer Off
 
 Module Program
     Sub Main(args As String())
-        Dim y[||] As Integer = 42
+        Dim y$$ As Integer = 42
         Dim z = y
     End Sub
 End Module
@@ -2654,7 +2654,7 @@ Imports System.Xml.Linq
 Module M
     Sub Main()
         ' Inline a
-        Dim [||]a = &lt;x/&gt;.@a
+        Dim $$a = &lt;x/&gt;.@a
         Dim b = a : Return
     End Sub
 End Module
@@ -2681,7 +2681,7 @@ End Module
 <File>
 Module M
     Sub Main()
-        Dim [||]a(10 = {0,0}
+        Dim $$a(10 = {0,0}
         System.Console.WriteLine(a)
     End Sub
 End Module
@@ -2710,7 +2710,7 @@ Module M
  
     Sub M()
         Using nonexistent
-            Dim [||]localGoo = goo
+            Dim $$localGoo = goo
         Dim baz As IBaz
         Dim result = localGoo.Goo(baz)
     End Sub
@@ -2728,7 +2728,7 @@ End Module
 Imports System.Linq
 Module Program
     Sub Main(args As String())
-        Dim y = From x In "" Distinct, [||]z = 1
+        Dim y = From x In "" Distinct, $$z = 1
         Take()
         Console.WriteLine(z)
     End Sub
@@ -2762,7 +2762,7 @@ End Module
 Imports System.Linq
 Module Program
     Sub Main()
-        Dim [||]x = From z In ""
+        Dim $$x = From z In ""
         Dim y = x
         Take()
     End Sub
@@ -2798,7 +2798,7 @@ Imports System.Linq
 Module Program
     Sub Main()
         Dim y = From x In ""
-        Dim [||]z = 1
+        Dim $$z = 1
         Take()
         Console.WriteLine(z)
     End Sub
@@ -2832,7 +2832,7 @@ End Module
 Imports System.Linq
 Module Program
     Sub Main()
-        Dim [||]x = Take(Of Integer)()
+        Dim $$x = Take(Of Integer)()
         Dim y = From z In ""
         x.ToString()
     End Sub
@@ -2869,7 +2869,7 @@ Module Program
     Sub Main()
         Dim y = From x In ""
  _
-        Dim z[||] = 1
+        Dim z$$ = 1
         Take()
         Dim t = z
     End Sub
@@ -2903,7 +2903,7 @@ End Module
 <File>
 Module M
     Sub F()
-        Dim a[||] = Await()
+        Dim a$$ = Await()
         Dim b = Await()
         Dim singleW = Async Function() a
         Dim singleWo = Function() a
@@ -2954,7 +2954,7 @@ End Module
 <File>
 Module Program
     Sub Main()
-        Dim x[||] = Sub() If True Then Dim y = Sub(z As Integer)
+        Dim x$$ = Sub() If True Then Dim y = Sub(z As Integer)
                                            End Sub
         x.Invoke()
     End Sub
@@ -2981,7 +2981,7 @@ End Module
 <File>
 Module Program
     Sub Main()
-        Dim x[||] = Sub() If True Then Dim y = Sub(z As Integer)
+        Dim x$$ = Sub() If True Then Dim y = Sub(z As Integer)
                                            End Sub
         x()
     End Sub
@@ -3008,7 +3008,7 @@ End Module
 <File>
 Module Program
     Sub Main()
-        Dim increment1[||] = Function(x) x + 1
+        Dim increment1$$ = Function(x) x + 1
         Console.WriteLine(increment1(1))
     End Sub
 End Module
@@ -3033,7 +3033,7 @@ End Module
 <File>
 Module Program
     Sub Main()
-        Dim x[||] = Sub() If True Then Dim y = Sub()
+        Dim x$$ = Sub() If True Then Dim y = Sub()
                                            End Sub
         Dim z As Boolean = x Is Nothing
     End Sub
@@ -3060,7 +3060,7 @@ End Module
 Module Program
     Sub Main()
         Dim a(0)
-        Dim b[||] = Sub() ReDim a(1)
+        Dim b$$ = Sub() ReDim a(1)
         Dim c = b, d
     End Sub
 End Module
@@ -3085,7 +3085,7 @@ End Module
 <File>
 Module Program
     Sub Main()
-        Dim x[||] = Sub() If True Then Dim y = Sub()
+        Dim x$$ = Sub() If True Then Dim y = Sub()
                                            End Sub
         Dim z As Boolean = TypeOf x Is Object
     End Sub
@@ -3111,7 +3111,7 @@ End Module
 <File>
 Module Program
     Sub Main()
-        Dim x[||] = Sub() If True Then Dim y = Sub()
+        Dim x$$ = Sub() If True Then Dim y = Sub()
                                            End Sub
         Dim z As Boolean = TypeOf x IsNot Object
     End Sub
@@ -3137,7 +3137,7 @@ End Module
 <File>
 Module M
     Sub Main()
-        Dim x = Sub() If True Then, [||]y = 1
+        Dim x = Sub() If True Then, $$y = 1
         Dim z = y
     End Sub
 End Module
@@ -3164,7 +3164,7 @@ End Module
 <File>
 Module M
     Sub Goo()
-        Dim x[||] = &lt;x/&gt;.GetHashCode
+        Dim x$$ = &lt;x/&gt;.GetHashCode
         Dim y = 1 &lt; x
         Dim z = x
     End Sub
@@ -3191,7 +3191,7 @@ End Module
 <File>
 Module Program
     Sub Main()
-        Dim y[||] = Function() From x In ""
+        Dim y$$ = Function() From x In ""
         Dim z = y
         Select 1
         End Select
@@ -3223,7 +3223,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 Module Program
     Sub Main()
-        Dim y[||] = Nothing Is From x In ""
+        Dim y$$ = Nothing Is From x In ""
         Dim z = y
         Select 1
         End Select
@@ -3257,7 +3257,7 @@ Imports System.Runtime.CompilerServices
 Module Program
     Sub Main()
         Dim a As Action
-        Dim y[||] = Sub() Call From x In a
+        Dim y$$ = Sub() Call From x In a
         Dim z = y
         Select 1
         End Select
@@ -3298,7 +3298,7 @@ Imports System.Linq
 Module Program
     Sub Main()
         With New Hashtable
-            Dim x[||] = From c In "" Distinct
+            Dim x$$ = From c In "" Distinct
             Dim y = x
             !A = !B
         End With
@@ -3335,7 +3335,7 @@ Imports System.Linq
 Module Program
     Sub Main()
         Dim x As Action = Sub() Console.WriteLine("Hello")
-        Dim y[||] = 1 : x() : Console.WriteLine(y)
+        Dim y$$ = 1 : x() : Console.WriteLine(y)
     End Sub
 End Module
 </File>
@@ -3368,7 +3368,7 @@ Imports System.Runtime.CompilerServices
 Module Program
     Sub Main()
         Dim s = ""
-        Dim y[||] = 1
+        Dim y$$ = 1
         s.Goo(y)
     End Sub
 End Module
@@ -3429,7 +3429,7 @@ Imports System.Linq
 
 Module M
     Sub Main()
-        Dim x[||] = From y In ""
+        Dim x$$ = From y In ""
                 Select &lt;?xml version="1.0"?>
                        &lt;root/>
         Dim z = x
@@ -3449,7 +3449,7 @@ Imports System.Linq
 
 Module M
     Sub Main()
-        Dim z[||] = From y In ""
+        Dim z$$ = From y In ""
                 Select &lt;?xml version="1.0"?>
                        &lt;root/>
 
@@ -3472,7 +3472,7 @@ End Module
 Module Program
     Sub Main()
         Dim a(0)
-        Dim b[||] = Sub() ReDim a(1) ' Inline b
+        Dim b$$ = Sub() ReDim a(1) ' Inline b
         Dim c = b, d = 1
     End Sub
 End Module
@@ -3500,7 +3500,7 @@ End Module
 Module Program
     Sub Main()
         If True Then
-            Dim x[||] = Sub() If True Then Return ' Inline x
+            Dim x$$ = Sub() If True Then Return ' Inline x
             Dim y = x : ElseIf True Then
             Return
         End If
@@ -3531,7 +3531,7 @@ End Module
 <File>
 Module Program
     Sub Main()
-        Dim x[||] = Long.MinValue
+        Dim x$$ = Long.MinValue
         x.ToString()
     End Sub
 End Module
@@ -3559,7 +3559,7 @@ Option Strict On
 Module M
     Sub Main()
         With ""
-            Dim x[||] = .Equals("", "", StringComparison.InvariantCulture) ' Inline x
+            Dim x$$ = .Equals("", "", StringComparison.InvariantCulture) ' Inline x
             Dim y = New List(Of String) With {.Capacity = x.GetHashCode}
         End With
     End Sub
@@ -3593,7 +3593,7 @@ Imports System
 
 Public Class X
     Shared Sub Main()
-        Dim a[||] As X = 42
+        Dim a$$ As X = 42
         Console.WriteLine(a)
     End Sub
 
@@ -3644,7 +3644,7 @@ Imports System
 
 Public Class X
     Shared Sub Main()
-        Dim a[||] As X = 42
+        Dim a$$ As X = 42
         Console.WriteLine(a + a)
     End Sub
 
@@ -3692,7 +3692,7 @@ End Class
 <File>
 Public Class A
     Public Shared Sub Main()
-        Dim a[||] = New A() ' Inline a
+        Dim a$$ = New A() ' Inline a
         Goo(a)
     End Sub
 
@@ -3746,7 +3746,7 @@ Imports System.Linq
 Imports System.Threading.Tasks
 Class X
     Public Async Sub Test(i As Integer)
-        Dim s[||] = Await Task.Run(Function() i)
+        Dim s$$ = Await Task.Run(Function() i)
         i = s.ToString()
         Console.WriteLine(i)
     End Sub
@@ -3781,7 +3781,7 @@ Imports System.Linq
 Imports System.Threading.Tasks
 Class X
     Public Async Sub Test(i As Integer)
-        Dim s[||] = Await Task.Run(Function() i)
+        Dim s$$ = Await Task.Run(Function() i)
         Goo(s, 5)
         Console.WriteLine(i)
     End Sub
@@ -3815,7 +3815,7 @@ End Class
 <File>
 Class C
     Sub M(i As Integer)
-        Dim s[||] = NameOf(i)
+        Dim s$$ = NameOf(i)
         s.ToString()
     End Sub
 End Class
@@ -4057,7 +4057,7 @@ End Class
         Public Async Function TestReplaceReferencesInWithBlocks() As Task
             Dim code =
 <MethodBody>
-Dim [||]s As String = "test"
+Dim $$s As String = "test"
 With s
     .ToLower()
 End With
@@ -4078,7 +4078,7 @@ End With
         Public Async Function TestDontParenthesizeInterpolatedStringWithNoInterpolation() As Task
             Dim code =
 <MethodBody>
-Dim [||]s1 = $"hello"
+Dim $$s1 = $"hello"
 Dim s2 = AscW(s1)
 </MethodBody>
 
@@ -4096,7 +4096,7 @@ Dim s2 = AscW($"hello")
             Dim code =
 <MethodBody>
 Dim x = 42
-Dim [||]s1 = $"hello {x}"
+Dim $$s1 = $"hello {x}"
 Dim s2 = AscW(s1)
 </MethodBody>
 
@@ -4120,7 +4120,7 @@ Class C
     End Sub
 
     Sub N(x As Integer, y As Integer)
-        Dim [||]s As FormattableString = $""{x}, {y}""
+        Dim $$s As FormattableString = $""{x}, {y}""
         M(s)
     End Sub
 End Class
@@ -4156,7 +4156,7 @@ Class C
     End Sub
 
     Sub N(x As Integer, y As Integer)
-        Dim [||]s As FormattableString = $""{x}, {y}""
+        Dim $$s As FormattableString = $""{x}, {y}""
         M(s)
     End Sub
 End Class
@@ -4188,7 +4188,7 @@ End Class
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim [||]List As New List(Of String)
+        Dim $$List As New List(Of String)
         List.Add(""Apple"")
         list.Add(""Banana"")
     End Sub
@@ -4213,7 +4213,7 @@ End Class
             Dim code = "
 Class C
     Sub M()
-        Dim [||]i = 1 + 2
+        Dim $$i = 1 + 2
         Dim t = (i, 3)
     End Sub
 End Class
@@ -4233,7 +4233,7 @@ End Class
             Dim code = "
 Class C
     Sub M()
-        Dim [||]i = 1 + 2
+        Dim $$i = 1 + 2
         Dim t = (
             i, 'comment
             3 'comment
@@ -4259,7 +4259,7 @@ End Class
             Dim code = "
 Class C
     Sub M()
-        Dim [||]i = 1 + 2
+        Dim $$i = 1 + 2
         Dim t = (i, i)
     End Sub
 End Class
@@ -4279,7 +4279,7 @@ End Class
             Dim code = "
 Class C
     Sub M()
-        Dim [||]rest = 1 + 2
+        Dim $$rest = 1 + 2
         Dim t = (rest, 3)
     End Sub
 End Class
@@ -4299,7 +4299,7 @@ End Class
             Dim code = "
 Class C
     Sub M()
-        Dim [||]item1 = 1 + 2
+        Dim $$item1 = 1 + 2
         Dim t = (item1, 3)
     End Sub
 End Class
@@ -4319,7 +4319,7 @@ End Class
             Dim code = "
 Class C
     Sub M()
-        Dim [||][Integer] = 1 + 2
+        Dim $$[Integer] = 1 + 2
         Dim t = ([Integer], 3)
     End Sub
 End Class
@@ -4339,7 +4339,7 @@ End Class
             Dim code = "
 Class C
     Sub M()
-        Dim [||]i = 1 + 2
+        Dim $$i = 1 + 2
         Dim t = New With {i, i} ' Error already
     End Sub
 End Class
@@ -4360,7 +4360,7 @@ End Class
 Class C
     Sub M()
         Dim j = 0
-        Dim [||]i = j = 1
+        Dim $$i = j = 1
         Dim t = New With {i, .k = 3}
     End Sub
 End Class
@@ -4381,7 +4381,7 @@ End Class
             Dim code = "
 Class C
     Sub M()
-        Dim [||]i = 1 + 2
+        Dim $$i = 1 + 2
         Dim t = New With {
             i, 'comment
             .k = 3 'comment
@@ -4409,7 +4409,7 @@ End Class
             Dim code = "
 Class C
     Sub M()
-        Dim [||]i = 1 + 2
+        Dim $$i = 1 + 2
         Dim t = (i, i:=3)
     End Sub
 End Class

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.CodeRefactorings.IntroduceVariable
@@ -2975,7 +2975,7 @@ End Module"
         Public Async Function TestSimpleParameterName_EmptySelection() As Task
             Dim source = "Module Program
     Sub Main(x As Integer)
-        Goo([||]x)
+        Goo($$x)
     End Sub
 End Module"
             Await TestMissingAsync(source)

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.MoveType
     Partial Public Class MoveTypeTests
@@ -8,7 +8,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.M
         Public Async Function MoveType_ActionCounts_RenameOnly() As Task
             Dim code =
 <File>
-[||]Class Class1
+$$Class Class1
 End Class
 </File>.ConvertTestSourceTag()
 
@@ -20,7 +20,7 @@ End Class
         Public Async Function MoveType_ActionCounts_MoveOnly() As Task
             Dim code =
 <File>
-[||]Class Class1
+$$Class Class1
 End Class
 
 Class test1 'this matches file name assigned by TestWorkspace
@@ -35,7 +35,7 @@ End Class
         Public Async Function MoveType_ActionCounts_RenameAndMove() As Task
             Dim code =
 <File>
-[||]Class Class1
+$$Class Class1
 End Class
 
 Class Class2
@@ -51,7 +51,7 @@ End Class
             Dim code =
 <File>
 Class Class1
-    Class Class2[||]
+    Class Class2$$
     End Class
 End Class
 Class Class3

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.MoveType
     Partial Public Class MoveTypeTests
@@ -8,7 +8,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.M
         Public Async Function TestMissing_OnMatchingFileName() As Task
             Dim code =
 "
-[||]Class test1
+$$Class test1
 End Class
 "
 
@@ -20,7 +20,7 @@ End Class
             Dim code =
 "
 Class Outer
-    [||]Class test1
+    $$Class test1
     End Class
 End Class
 "
@@ -32,7 +32,7 @@ End Class
         Public Async Function MultipleTypesInFileWithNoContainerNamespace() As Task
             Dim code =
 "
-[||]Class Class1
+$$Class Class1
 End Class
 
 Class Class2
@@ -57,7 +57,7 @@ End Class
             Dim code =
 "
 Public Class Class1
-    Class Class2[||]
+    Class Class2$$
     End Class
 End Class
 "
@@ -83,7 +83,7 @@ End Class
             Dim code =
 "
 Public Class Class1
-    Class Class2[||]
+    Class Class2$$
     End Class
 End Class
 "
@@ -112,7 +112,7 @@ End Class
 ''' Outer comment
 Public Class Class1
     ''' Inner comment
-    Class Class2[||]
+    Class Class2$$
     End Class
 End Class
 "
@@ -148,7 +148,7 @@ Imports System
 Imports System.Collections
 
 Class Outer
-    [||]Class Inner
+    $$Class Inner
         Sub M(d as DateTime)
         End Sub
     End Class
@@ -192,7 +192,7 @@ Class Outer
     Inherits Something
     Implements ISomething
 
-    [||]Class Inner
+    $$Class Inner
         Inherits Other
         Implements IOther
 
@@ -232,7 +232,7 @@ End Class
 "' Banner Text
 imports System
 
-[||]class Class1
+$$class Class1
     sub Foo()
         Console.WriteLine()
     end sub
@@ -282,7 +282,7 @@ class Class1
     end sub
 end class
 
-[||]class Class2
+$$class Class2
     sub Foo()
         Console.WriteLine()
     end sub

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameFile.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameFile.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.MoveType
     Partial Public Class MoveTypeTests
@@ -7,7 +7,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.M
         Public Async Function SingleClassInFileWithNoContainerNamespace_RenameFile() As Task
             Dim code =
 <File>
-[||]Class Class1
+$$Class Class1
 End Class
 </File>
             Dim expectedDocumentName = "Class1.vb"
@@ -20,7 +20,7 @@ End Class
             ' so type name matches filename here And rename file action should Not be offered.
             Dim code =
 <File>
-[||]Class test1
+$$Class test1
 End Class
 </File>
 
@@ -31,7 +31,7 @@ End Class
         Public Async Function TestMissing_MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameFile() As Task
             Dim code =
 <File>
-[||]Class Class1
+$$Class Class1
 End Class
 
 Class test1
@@ -45,7 +45,7 @@ End Class
         Public Async Function MultipleTopLevelTypesInFileAndNoneMatchFileName1_RenameFile() As Task
             Dim code =
 <File>
-[||]Class Class1
+$$Class Class1
 End Class
 
 Class Class2

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameType.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameType.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.MoveType
     Partial Public Class MoveTypeTests
@@ -7,7 +7,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.M
         Public Async Function SingleClassInFileWithNoContainerNamespace_RenameType() As Task
             Dim code =
 <File>
-[||]Class Class1
+$$Class Class1
 End Class
 </File>
 
@@ -26,7 +26,7 @@ End Class
             ' so type name matches filename here And rename file action should Not be offered.
             Dim code =
 <File>
-[||]Class test1
+$$Class test1
 End Class
 </File>
 
@@ -37,7 +37,7 @@ End Class
         Public Async Function TestMissing_MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameType() As Task
             Dim code =
 <File>
-[||]Class Class1
+$$Class Class1
 End Class
 
 Class test1
@@ -51,7 +51,7 @@ End Class
         Public Async Function MultipleTopLevelTypesInFileAndNoneMatchFileName1_RenameType() As Task
             Dim code =
 <File>
-[||]Class Class1
+$$Class Class1
 End Class
 
 Class Class2

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.Replac
         Public Async Function TestMethodWithGetName() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
 End class",
 "class C
@@ -32,7 +32,7 @@ End class")
         Public Async Function TestMissingParameterList() As Task
             Await TestInRegularAndScript1Async(
 "class C
-    function [||]GetGoo as integer
+    function $$GetGoo as integer
     End function
 End class",
 "class C
@@ -47,7 +47,7 @@ End class")
         Public Async Function TestMethodWithoutGetName() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]Goo() as integer
+    function $$Goo() as integer
     End function
 End class",
 "class C
@@ -62,7 +62,7 @@ End class")
         Public Async Function TestMethodWithoutBody() As Task
             Await TestInRegularAndScriptAsync(
 "mustinherit class C
-    MustOverride function [||]GetGoo() as integer
+    MustOverride function $$GetGoo() as integer
 End class",
 "mustinherit class C
     MustOverride ReadOnly Property Goo as integer
@@ -73,7 +73,7 @@ End class")
         Public Async Function TestMethodWithModifiers() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public shared function [||]GetGoo() as integer
+    public shared function $$GetGoo() as integer
     End function
 End class",
 "class C
@@ -88,7 +88,7 @@ End class")
         Public Async Function TestMethodWithAttributes() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    <A> function [||]GetGoo() as integer
+    <A> function $$GetGoo() as integer
     End function
 End class",
 "class C
@@ -105,7 +105,7 @@ End class")
             Await TestInRegularAndScriptAsync(
 "class C
     ' Goo
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
 End class",
 "class C
@@ -122,7 +122,7 @@ End class")
             Await TestInRegularAndScriptAsync(
 "class C
 #if true
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
 #End if
 End class",
@@ -141,7 +141,7 @@ End class")
             Await TestInRegularAndScriptAsync(
 "class C
 #if true
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
 
     sub SetGoo(i as integer)
@@ -166,7 +166,7 @@ End class")
             Await TestInRegularAndScriptAsync(
 "class C
 #if true
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
 
     sub SetGoo(i as integer)
@@ -193,7 +193,7 @@ End class", index:=1)
     sub SetGoo(i as integer)
     end sub
 
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
 #End if
 End class",
@@ -218,7 +218,7 @@ End class")
     sub SetGoo(i as integer)
     end sub
 
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
 #End if
 End class",
@@ -241,7 +241,7 @@ End class", index:=1)
             Await TestInRegularAndScriptAsync(
 "class C
     ' Goo
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
     ' SetGoo
     sub SetGoo(i as integer)
@@ -268,7 +268,7 @@ index:=1)
 End interface
 class C
     implements I
-    function [||]GetGoo() as integer implements I.GetGoo
+    function $$GetGoo() as integer implements I.GetGoo
     End function
 End class",
 "interface I
@@ -287,7 +287,7 @@ End class")
         Public Async Function TestExplicitInterfaceMethod_3() As Task
             Await TestInRegularAndScriptAsync(
 "interface I
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
 End interface
 class C
     implements I
@@ -310,7 +310,7 @@ End class")
         Public Async Function TestInAttribute() As Task
             Await TestMissingInRegularAndScriptAsync(
 "class C
-    <At[||]tr> function GetGoo() as integer
+    <At$$tr> function GetGoo() as integer
     End function
 End class")
         End Function
@@ -321,7 +321,7 @@ End class")
 "class C
     function GetGoo() as integer
 
-[||]    End function
+$$    End function
 End class")
         End Function
 
@@ -329,7 +329,7 @@ End class")
         Public Async Function TestSubMethod() As Task
             Await TestMissingInRegularAndScriptAsync(
 "class C
-    sub [||]GetGoo()
+    sub $$GetGoo()
     End sub
 End class")
         End Function
@@ -338,7 +338,7 @@ End class")
         Public Async Function TestAsyncMethod() As Task
             Await TestMissingInRegularAndScriptAsync(
 "class C
-    async function [||]GetGoo() as Task
+    async function $$GetGoo() as Task
     End function
 End class")
         End Function
@@ -347,7 +347,7 @@ End class")
         Public Async Function TestGenericMethod() As Task
             Await TestMissingInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo(of T)() as integer
+    function $$GetGoo(of T)() as integer
     End function
 End class")
         End Function
@@ -356,7 +356,7 @@ End class")
         Public Async Function TestExtensionMethod() As Task
             Await TestMissingInRegularAndScriptAsync(
 "module C
-    <System.Runtime.CompilerServices.Extension> function [||]GetGoo(i as integer) as integer
+    <System.Runtime.CompilerServices.Extension> function $$GetGoo(i as integer) as integer
     End function
 End module")
         End Function
@@ -365,7 +365,7 @@ End module")
         Public Async Function TestMethodWithParameters_1() As Task
             Await TestMissingInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo(i as integer) as integer
+    function $$GetGoo(i as integer) as integer
     End function
 End class")
         End Function
@@ -374,7 +374,7 @@ End class")
         Public Async Function TestUpdateGetReferenceNotInMethod() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
     sub Bar()
         dim x = GetGoo()
@@ -396,7 +396,7 @@ End class")
         Public Async Function TestUpdateGetReferenceMemberAccessInvocation() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
     sub Bar()
         dim x = me.GetGoo()
@@ -418,7 +418,7 @@ End class")
         Public Async Function TestUpdateGetReferenceBindingMemberInvocation() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
     sub Bar()
         dim x as C
@@ -442,7 +442,7 @@ End class")
         Public Async Function TestUpdateGetReferenceInMethod() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
         return GetGoo()
     End function
 End class",
@@ -459,7 +459,7 @@ End class")
         Public Async Function TestOverride() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public overridable function [||]GetGoo() as integer
+    public overridable function $$GetGoo() as integer
     End function
 End class
 class D
@@ -486,7 +486,7 @@ End class")
         Public Async Function TestUpdateGetReference_NonInvoked() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
     sub Bar()
         dim i = GetGoo
@@ -508,7 +508,7 @@ End class")
         Public Async Function TestUpdateGetSet() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
     sub SetGoo(i as integer)
     End sub
@@ -529,7 +529,7 @@ index:=1)
             Await TestInRegularAndScriptAsync(
 "Imports System
 class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
     sub SetGoo(i as integer)
     End sub
@@ -557,7 +557,7 @@ index:=1)
         Public Async Function TestUpdateGetSet_SetterAccessibility() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public function [||]GetGoo() as integer
+    public function $$GetGoo() as integer
     End function
     private sub SetGoo(i as integer)
     End sub
@@ -577,7 +577,7 @@ index:=1)
         Public Async Function TestUpdateGetSet_GetInSetReference() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
     sub SetGoo(i as integer)
     End sub
@@ -603,7 +603,7 @@ index:=1)
         Public Async Function TestUpdateGetSet_SetReferenceInSetter() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
     sub SetGoo(i as integer)
         SetGoo(i - 1)
@@ -625,7 +625,7 @@ index:=1)
         Public Async Function TestVirtualGetWithOverride_1() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    protected overridable function [||]GetGoo() as integer
+    protected overridable function $$GetGoo() as integer
     End function
 End class
 class D
@@ -652,7 +652,7 @@ End class")
         Public Async Function TestVirtualGetWithOverride_2() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    protected overridable function [||]GetGoo() as integer
+    protected overridable function $$GetGoo() as integer
     End function
 End class
 class D
@@ -681,7 +681,7 @@ End class")
         Public Async Function TestWithPartialClasses() As Task
             Await TestInRegularAndScriptAsync(
 "partial class C
-    function [||]GetGoo() as integer
+    function $$GetGoo() as integer
     End function
 End class
 partial class C
@@ -711,7 +711,7 @@ public class Goo
         dim v = GetValue().GetValue()
     end sub
 
-    Public Function [||]GetValue() As Goo 
+    Public Function $$GetValue() As Goo 
     End Function
 end class",
 "
@@ -731,7 +731,7 @@ end class")
         Public Async Function TestIndentation() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    Public Function [||]GetProp() As Integer
+    Public Function $$GetProp() As Integer
         dim count = 0
         for each x in y
             count = count + z
@@ -756,7 +756,7 @@ end class")
         Public Async Function TestInterfaceImplementation() As Task
             Await TestInRegularAndScriptAsync(
 "Interface IGoo
-    Function [||]GetGoo() As Integer
+    Function $$GetGoo() As Integer
 End Interface
 
 Class C
@@ -790,7 +790,7 @@ End Class")
         Public Async Function TestSystemObjectMetadataOverride() As Task
             Await TestMissingAsync(
 "class C
-    public overrides function [||]ToString() as string
+    public overrides function $$ToString() as string
     End function
 End class")
         End Function
@@ -802,7 +802,7 @@ End class")
 "class C
     inherits system.type
 
-    public overrides function [||]GetArrayRank() as integer
+    public overrides function $$GetArrayRank() as integer
     End function
 End class",
 "class C

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.vb
@@ -1,4 +1,4 @@
-﻿Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
 Imports Microsoft.CodeAnalysis.ReplacePropertyWithMethods
 
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.Replac
         Public Async Function TestGetWithBody() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    readonly property [||]Prop as integer
+    readonly property $$Prop as integer
         get 
             return 0
         end get
@@ -31,7 +31,7 @@ end class")
         Public Async Function TestIndentation() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    readonly property [||]Prop As Integer
+    readonly property $$Prop As Integer
         get 
             dim count = 0
             for each x in y
@@ -56,7 +56,7 @@ end class")
         Public Async Function TestPrivateProperty() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    private readonly property [||]Prop as integer
+    private readonly property $$Prop as integer
         get
             return 0
         end get
@@ -73,7 +73,7 @@ end class")
         Public Async Function TestAnonyousType1() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public readonly property [||]Prop as integer 
+    public readonly property $$Prop as integer 
         get
             return 0
         end get
@@ -97,7 +97,7 @@ end class")
         Public Async Function TestAnonyousType2() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public readonly property [||]Prop as integer
+    public readonly property $$Prop as integer
         get
             return 0
         end get
@@ -122,7 +122,7 @@ end class")
         Public Async Function TestPassedToRef1() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public readonly property [||]Prop as integer
+    public readonly property $$Prop as integer
         get
             return 0
         end get
@@ -155,7 +155,7 @@ imports System
 class CAttribute 
     inherits Attribute
 
-    public readonly property [||]Prop as integer
+    public readonly property $$Prop as integer
         get
             return 0
         end get
@@ -187,7 +187,7 @@ end class
         Public Async Function TestSetWithBody1() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    writeonly property [||]Prop as integer 
+    writeonly property $$Prop as integer 
         set
             dim v = value
         end set
@@ -204,7 +204,7 @@ end class")
         Public Async Function TestSetWithBody2() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    writeonly property [||]Prop as integer 
+    writeonly property $$Prop as integer 
         set(val as integer)
             dim v = val
         end set
@@ -221,7 +221,7 @@ end class")
         Public Async Function TestSetReference1() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    writeonly property [||]Prop as integer 
+    writeonly property $$Prop as integer 
         set(val as integer)
             dim v = val
         end set
@@ -245,7 +245,7 @@ end class")
         Public Async Function TestGetterAndSetter() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    property [||]Prop as integer
+    property $$Prop as integer
         get
             return 0
         end get
@@ -269,7 +269,7 @@ end class")
         Public Async Function TestRecursiveGet() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    readonly property [||]Prop as integer
+    readonly property $$Prop as integer
         get
             return me.Prop + 1
         end get
@@ -286,7 +286,7 @@ end class")
         Public Async Function TestRecursiveSet() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    writeonly property [||]Prop as integer
+    writeonly property $$Prop as integer
         set
             me.Prop = value + 1
         end set
@@ -304,7 +304,7 @@ end class")
         Public Async Function TestAbstractProperty() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public readonly mustoverride property [||]Prop as integer
+    public readonly mustoverride property $$Prop as integer
     public sub M()
         dim v = me.Prop
     end sub
@@ -322,7 +322,7 @@ end class")
         Public Async Function TestVirtualProperty() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public readonly overridable property [||]Prop as integer
+    public readonly overridable property $$Prop as integer
         get
             return 0
         end get
@@ -347,7 +347,7 @@ end class")
         Public Async Function TestInterfaceProperty1() As Task
             Await TestInRegularAndScriptAsync(
 "interface I
-    readonly property [||]Prop as integer
+    readonly property $$Prop as integer
 end interface",
 "interface I
     Function GetProp() As Integer
@@ -358,7 +358,7 @@ end interface")
         Public Async Function TestInterfaceProperty2() As Task
             Await TestInRegularAndScriptAsync(
 "interface I
-    writeonly property [||]Prop as integer
+    writeonly property $$Prop as integer
 end interface",
 "interface I
     Sub SetProp(Value As Integer)
@@ -369,7 +369,7 @@ end interface")
         Public Async Function TestInterfaceProperty3() As Task
             Await TestInRegularAndScriptAsync(
 "interface I
-    property [||]Prop as integer
+    property $$Prop as integer
 end interface",
 "interface I
     Function GetProp() As Integer
@@ -381,7 +381,7 @@ end interface")
         Public Async Function TestAutoProperty1() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public readonly property [||]Prop as integer
+    public readonly property $$Prop as integer
 end class",
 "class C
     Private _Prop As Integer
@@ -396,7 +396,7 @@ end class")
         Public Async Function TestAutoProperty2() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public readonly property [||]Prop as integer
+    public readonly property $$Prop as integer
     public sub new()
         me.Prop = 1
     end sub
@@ -418,7 +418,7 @@ end class")
         Public Async Function TestAutoProperty4() As Task
             Await TestInRegularAndScriptAsync(
 "class C
-    public readonly property [||]Prop as integer = 1
+    public readonly property $$Prop as integer = 1
 end class",
 "class C
     Private _Prop As Integer = 1
@@ -439,7 +439,7 @@ end class")
     ''' <value>
     '''     An that provides access to the language service for the active configured project.
     ''' </value>
-    ReadOnly Property [||]ActiveProjectContext As Object
+    ReadOnly Property $$ActiveProjectContext As Object
 End Interface",
 "Interface ILanguageServiceHost
     ''' <summary>
@@ -463,7 +463,7 @@ End Interface")
     ''' <value>
     '''     An that provides access to the language service for the active configured project.
     ''' </value>
-    WriteOnly Property [||]ActiveProjectContext As Object
+    WriteOnly Property $$ActiveProjectContext As Object
 End Interface",
 "Interface ILanguageServiceHost
     ''' <summary>
@@ -487,7 +487,7 @@ End Interface")
     ''' <value>
     '''     An that provides access to the language service for the active configured project.
     ''' </value>
-    Property [||]ActiveProjectContext As Object
+    Property $$ActiveProjectContext As Object
 End Interface",
 "Interface ILanguageServiceHost
     ''' <summary>
@@ -516,7 +516,7 @@ End Interface")
     '''     Sets <see cref=""ActiveProjectContext""/>.
     ''' </summary>
     ''' <seealso cref=""ActiveProjectContext""/>
-    WriteOnly Property [||]ActiveProjectContext As Object
+    WriteOnly Property $$ActiveProjectContext As Object
 End Interface
 Structure AStruct
     ''' <seealso cref=""ILanguageServiceHost.ActiveProjectContext""/>
@@ -544,7 +544,7 @@ End Structure")
     '''     Gets or sets <see cref=""ActiveProjectContext""/>.
     ''' </summary>
     ''' <seealso cref=""ActiveProjectContext""/>
-    Property [||]ActiveProjectContext As Object
+    Property $$ActiveProjectContext As Object
 End Interface
 Structure AStruct
     ''' <seealso cref=""ILanguageServiceHost.ActiveProjectContext""/>
@@ -574,7 +574,7 @@ End Structure")
             Await TestInRegularAndScriptAsync(
 "Interface ISomeInterface(Of T)
     ''' <seealso cref=""Context""/>
-    WriteOnly Property [||]Context As ISomeInterface(Of T)
+    WriteOnly Property $$Context As ISomeInterface(Of T)
 End Interface
 Structure AStruct
     ''' <seealso cref=""ISomeInterface(Of T).Context""/>
@@ -595,7 +595,7 @@ End Structure")
         Public Async Function TestInterfaceReplacement1() As Task
             Await TestInRegularAndScriptAsync(
 "Interface IGoo
-    Property [||]Goo As Integer
+    Property $$Goo As Integer
 End Interface
 
 Class C

--- a/src/EditorFeatures/VisualBasicTest/ConvertAutoPropertyToFullProperty/ConvertAutoPropertyToFullPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertAutoPropertyToFullProperty/ConvertAutoPropertyToFullPropertyTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ValidateFormatStri
         Public Async Function SimpleTest() As Task
             Dim initial = "
 Class C
-    Public Property T[||]est1 As Integer
+    Public Property T$$est1 As Integer
 End Class"
             Dim expected = "
 Class C
@@ -38,7 +38,7 @@ End Class"
         Public Async Function WithInitializer() As Task
             Dim initial = "
 Class C
-    Public Property T[||]est2 As Integer = 4
+    Public Property T$$est2 As Integer = 4
 End Class"
             Dim expected = "
 Class C
@@ -60,7 +60,7 @@ End Class"
         Public Async Function WithReadonly() As Task
             Dim initial = "
 Class C
-    Public ReadOnly Property T[||]est5 As String
+    Public ReadOnly Property T$$est5 As String
 End Class"
             Dim expected = "
 Class C
@@ -79,7 +79,7 @@ End Class"
         Public Async Function WithReadonlyAndInitializer() As Task
             Dim initial = "
 Class C
-    Public ReadOnly Property Tes[||]t4 As String = ""Initial Value""
+    Public ReadOnly Property Tes$$t4 As String = ""Initial Value""
 End Class"
             Dim expected = "
 Class C
@@ -99,7 +99,7 @@ End Class"
         Public Async Function PrivateProperty() As Task
             Dim initial = "
 Class C
-    Private Property Tes[||]t4 As String
+    Private Property Tes$$t4 As String
 End Class"
             Dim expected = "
 Class C
@@ -122,7 +122,7 @@ End Class"
             Dim initial = "
 Class C
     '' Comment before
-    Public Property Test1 As In[||]teger ''Comment during
+    Public Property Test1 As In$$teger ''Comment during
     '' Comment after
 
 End Class"
@@ -148,7 +148,7 @@ End Class"
         Public Async Function SharedProperty() As Task
             Dim initial = "
 Class C
-    Public Sha[||]red Property Test1 As Double
+    Public Sha$$red Property Test1 As Double
 End Class"
 
             Dim expected = "
@@ -171,7 +171,7 @@ End Class"
         Public Async Function WithOverridable() As Task
             Dim initial = "
 Class C
-    Public Overridable Proper[||]ty Test4 As Decimal
+    Public Overridable Proper$$ty Test4 As Decimal
 End Class"
 
             Dim expected = "
@@ -194,7 +194,7 @@ End Class"
         Public Async Function WithMustOverride() As Task
             Await TestMissingAsync("
 Class C
-    Public MustOverride Property Tes[||]t4 As String
+    Public MustOverride Property Tes$$t4 As String
 End Class")
         End Function
 
@@ -202,7 +202,7 @@ End Class")
         Public Async Function CursorOnInitializer() As Task
             Await TestMissingAsync("
 Class C
-    Public Property Test2 As Integer [||]= 4
+    Public Property Test2 As Integer $$= 4
 End Class")
         End Function
 
@@ -210,7 +210,7 @@ End Class")
         Public Async Function InInterface() As Task
             Await TestMissingAsync("
 Interface I
-    Public Property Tes[||]t2 As Integer
+    Public Property Tes$$t2 As Integer
 End Interface")
         End Function
 
@@ -218,10 +218,10 @@ End Interface")
         Public Async Function InvalidLocation() As Task
             Await TestMissingAsync("
 Namespace NS
-    Public Property Tes[||]t2 As Integer
+    Public Property Tes$$t2 As Integer
 End Namespace")
 
-            Await TestMissingAsync("Public Property Tes[||]t2 As Integer")
+            Await TestMissingAsync("Public Property Tes$$t2 As Integer")
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/ConvertForEachToFor/ConvertForEachToForTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertForEachToFor/ConvertForEachToForTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertForEachToFo
 Class Test
     Sub Method()
         Dim array = New Integer() {1, 2, 3}
-        For Each [||] a In array
+        For Each $$ a In array
         Next
     End Sub
 End Class
@@ -44,7 +44,7 @@ End Class
 Class Test
     Sub Method()
         Dim array = New Integer() {1, 2, 3}
-        For Each [||] a In array : Next
+        For Each $$ a In array : Next
     End Sub
 End Class
 "
@@ -57,7 +57,7 @@ End Class
 Class Test
     Sub Method()
         Dim array = New Integer() {1, 2, 3}
-        For Each [||] a In array : Console.WriteLine(a) : Next
+        For Each $$ a In array : Console.WriteLine(a) : Next
     End Sub
 End Class
 "
@@ -70,7 +70,7 @@ End Class
 Class Test
     Sub Method()
         Dim array = New Integer() {1, 2, 3}
-        For Each [||] a In array
+        For Each $$ a In array
             Console.WriteLine(a)
         Next
     End Sub
@@ -98,7 +98,7 @@ Class Test
     Sub Method()
         Dim array = New Integer() {1, 2, 3}
         ' comment
-        For Each [||] a In array ' comment
+        For Each $$ a In array ' comment
             Console.WriteLine(a)
         Next
     End Sub
@@ -126,7 +126,7 @@ End Class
 Class Test
     Sub Method()
         Dim array = New Integer() {1, 2, 3}
-        For Each [||] a In array
+        For Each $$ a In array
             ' comment
             Console.WriteLine(a)
         Next ' comment
@@ -155,7 +155,7 @@ End Class
 Class Test
     Sub Method()
         Dim array = New Integer() {1, 2, 3}
-        For Each [||] a In array
+        For Each $$ a In array
             Console.WriteLine(a)
         Next a ' comment
     End Sub
@@ -181,7 +181,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] a In New Integer() {1, 2, 3} ' test 
+        For Each $$ a In New Integer() {1, 2, 3} ' test 
             Console.WriteLine(a)
         Next
     End Sub
@@ -208,7 +208,7 @@ End Class
 Class Test
     Sub Method()
         ' test
-        For Each [||] a In New Integer() {1, 2, 3}
+        For Each $$ a In New Integer() {1, 2, 3}
         Next
     End Sub
 End Class
@@ -232,7 +232,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] a ' test
+        For Each $$ a ' test
             In ' test
             New Integer() {1, 2, 3}
         Next
@@ -248,7 +248,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] a _
+        For Each $$ a _
             In
             New Integer() {1, 2, 3}
         Next
@@ -273,7 +273,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] a In New Integer() {1, 2, 3}
+        For Each $$ a In New Integer() {1, 2, 3}
         Next
     End Sub
 End Class
@@ -298,7 +298,7 @@ Class Test
     Sub Method()
         Dim array = 1
 
-        For Each [||] a In New Integer() {1, 2, 3}
+        For Each $$ a In New Integer() {1, 2, 3}
             Console.WriteLine(a)
         Next
     End Sub
@@ -326,7 +326,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] a In New Integer() {1, 2, 3}
+        For Each $$ a In New Integer() {1, 2, 3}
             Dim i = 1
             Console.WriteLine(a)
         Next
@@ -354,7 +354,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] a In New Integer() {1, 2, 3}
+        For Each $$ a In New Integer() {1, 2, 3}
             a = 1
         Next
     End Sub
@@ -369,7 +369,7 @@ End Class
 Class Test
     Sub Method()
         For Each a In New Integer() {1, 2, 3}
-            [||]
+            $$
         Next
     End Sub
 End Class
@@ -382,7 +382,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        [||] For Each a In New Integer() {1, 2, 3}
+        $$ For Each a In New Integer() {1, 2, 3}
         Next
     End Sub
 End Class
@@ -395,7 +395,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each a In New Integer() {1, 2, 3} [||] 
+        For Each a In New Integer() {1, 2, 3} $$ 
         Next
     End Sub
 End Class
@@ -410,7 +410,7 @@ Class Test
     Dim list As Integer() = New Integer() {1, 2, 3}
 
     Sub Method()
-        For Each [||] a In list
+        For Each $$ a In list
         Next
     End Sub
 End Class
@@ -437,7 +437,7 @@ Imports System.Collections.Generic
 Class Test
     Sub Method()
         Dim list = DirectCast(New Integer() {1, 2, 3}, IList(Of Integer))
-        For [||] Each a In list
+        For $$ Each a In list
         Next
     End Sub
 End Class
@@ -467,7 +467,7 @@ Imports System.Collections.Generic
 Class Test
     Sub Method()
         Dim list = New Explicit()
-        For [||] Each a In list
+        For $$ Each a In list
             Console.WriteLine(a)
         Next
     End Sub
@@ -547,7 +547,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each a [||] In New Integer() {}
+        For Each a $$ In New Integer() {}
             For Each b In New Integer() {}
                 Console.WriteLine(a)
         Next b, a
@@ -563,7 +563,7 @@ End Class"
 Class Test
     Sub Method()
         For Each a In New Integer() {}
-            For Each [||] b In New Integer() {}
+            For Each $$ b In New Integer() {}
                 Console.WriteLine(a)
         Next b, a
     End Sub
@@ -577,7 +577,7 @@ End Class"
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] a In New Integer() {}
+        For Each $$ a In New Integer() {}
             Console.WriteLine(a)
         Next b
     End Sub
@@ -591,7 +591,7 @@ End Class"
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] a In New Integer() {1, 2, 3}
+        For Each $$ a In New Integer() {1, 2, 3}
         Next a
     End Sub
 End Class
@@ -614,7 +614,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] i In New Integer() {1, 2, 3}
+        For Each $$ i In New Integer() {1, 2, 3}
             Console.WriteLine(a)
         Next
     End Sub
@@ -640,7 +640,7 @@ End Class
             Dim initial = "
 Class Test
     Sub Method()
-        For Each [||] a As Integer In New Integer() {1, 2, 3}
+        For Each $$ a As Integer In New Integer() {1, 2, 3}
             Console.WriteLine(a)
         Next
     End Sub
@@ -669,7 +669,7 @@ Imports System.Collections.Generic
 
 Class Test
     Sub Method()
-        For Each [||] a In New List(Of Integer)()
+        For Each $$ a In New List(Of Integer)()
             Console.WriteLine(a)
         Next
     End Sub

--- a/src/EditorFeatures/VisualBasicTest/ConvertForToForEach/ConvertForToForEachTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertForToForEach/ConvertForToForEachTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertForToForEac
 
 class C
     sub Test(array as string())
-        [||]For i = 0 to array.Length - 1
+        $$For i = 0 to array.Length - 1
             Console.WriteLine(array(i))
         next
     end sub
@@ -65,7 +65,7 @@ end class")
 
 class C
     sub Test(array as string())
-        For i = 0 to array.Length - 1[||]
+        For i = 0 to array.Length - 1$$
             Console.WriteLine(array(i))
         next
     end sub
@@ -88,7 +88,7 @@ end class")
 
 class C
     sub Test(array as string())
-       [||] For i = 0 to array.Length - 1
+       $$ For i = 0 to array.Length - 1
             Console.WriteLine(array(i))
         next
     end sub
@@ -102,7 +102,7 @@ end class")
 
 class C
     sub Test(array as string())
-        For [||]i = 0 to array.Length - 1
+        For $$i = 0 to array.Length - 1
             Console.WriteLine(array(i))
         next
     end sub
@@ -116,7 +116,7 @@ end class")
 
 class C
     sub Test(array as string())
-        [||]For i = 0 to array.Length - 1 step 1
+        $$For i = 0 to array.Length - 1 step 1
             Console.WriteLine(array(i))
         next
     end sub
@@ -139,7 +139,7 @@ end class")
 
 class C
     sub Test(array as string())
-        [||]For i = 0 to array.Length - 1 step 2
+        $$For i = 0 to array.Length - 1 step 2
             Console.WriteLine(array(i))
         next
     end sub
@@ -154,7 +154,7 @@ end class")
 class C
     sub Test(array as string())
         dim i as integer
-        [||]For i = 0 to array.Length - 1 step 2
+        $$For i = 0 to array.Length - 1 step 2
             Console.WriteLine(array(i))
         next
     end sub
@@ -168,7 +168,7 @@ end class")
 
 class C
     sub Test(array as string())
-        [||]For i = 0 to array.Length
+        $$For i = 0 to array.Length
         {
             Console.WriteLine(array(i))
         next
@@ -183,7 +183,7 @@ end class")
 
 class C
     sub Test(array as string())
-        [||]For i = 0 to GetLength(array) - 1 
+        $$For i = 0 to GetLength(array) - 1 
         {
             Console.WriteLine(array(i))
         next
@@ -198,7 +198,7 @@ end class")
 
 class C
     sub Test(array as string())
-        [||]For i = 0 to array.Length - 2
+        $$For i = 0 to array.Length - 2
         {
             Console.WriteLine(array(i))
         next
@@ -213,7 +213,7 @@ end class")
 
 class C
     sub Test(array as string())
-        [||]For i = 1 to array.Length - 1
+        $$For i = 1 to array.Length - 1
         {
             Console.WriteLine(array(i))
         next
@@ -229,7 +229,7 @@ imports System.Collections.Generic
 
 class C
     sub Test(list as IList(of string))
-        [||]For i = 0 to list.Count - 1
+        $$For i = 0 to list.Count - 1
             Console.WriteLine(list(i))
         next
     end sub
@@ -254,7 +254,7 @@ imports System.Collections.Generic
 
 class C
     sub Test(list as IList(of string))
-        [||]For i = 0 to list.Count - 1
+        $$For i = 0 to list.Count - 1
             dim val = list(i)
             Console.WriteLine(list(i))
         next
@@ -280,7 +280,7 @@ imports System.Collections.Generic
 
 class C
     sub Test(list as IList(of string))
-        [||]For i = 0 to list.Count - 1
+        $$For i = 0 to list.Count - 1
             dim val As Object = list(i)
             Console.WriteLine(list(i))
         next
@@ -306,7 +306,7 @@ imports System.Collections.Generic
 
 class C
     sub Test(list as IList(of string))
-        [||]For i = 0 to list.Count - 1
+        $$For i = 0 to list.Count - 1
             ' loop comment
 
             dim val = list(i)
@@ -336,7 +336,7 @@ imports System.Collections.Generic
 
 class C
     sub Test(list as IList(of string))
-        [||]For i = 0 to list.Count - 1
+        $$For i = 0 to list.Count - 1
 #if true
 
             dim val = list(i)
@@ -369,7 +369,7 @@ end class")
 
 class C
     sub Test(array as string())
-        [||]For i = 0 to array.Length - 1
+        $$For i = 0 to array.Length - 1
             Console.WriteLine(i)
         next
     end sub
@@ -383,7 +383,7 @@ end class")
 
 class C
     sub Test(array as string())
-        [||]For i = 0 to array.Length - 1
+        $$For i = 0 to array.Length - 1
             Console.WriteLine(other(i))
         next
     end sub
@@ -397,7 +397,7 @@ end class")
 
 class C
     sub Test(array as string())
-        [||]For i = 0 to array.Length - 1
+        $$For i = 0 to array.Length - 1
             array(i) = 1
         next
     end sub
@@ -432,7 +432,7 @@ end class
 class C
     sub Test(list as MyList)
         ' need to use 'string' here to preserve original index semantics.
-        [||]For i = 0 to list.Length - 1
+        $$For i = 0 to list.Length - 1
             Console.WriteLine(list(i))
         next
     end sub
@@ -479,7 +479,7 @@ end class
 class C
     sub Test(list as MyList)
         ' can omit type here since the type stayed the same.
-        [||]For i = 0 to list.Count - 1
+        $$For i = 0 to list.Count - 1
             Console.WriteLine(list(i))
         next
     end sub
@@ -515,7 +515,7 @@ end class")
 class C
     sub Test(array as string())
         ' trivia 1
-        [||]For i = 0 to array.Length - 1 ' trivia 2
+        $$For i = 0 to array.Length - 1 ' trivia 2
             Console.WriteLine(array(i))
         next ' trivia 3
     end sub

--- a/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertToInterpola
 "
 Public Class C
     Sub M()
-        dim v = [||]""string""
+        dim v = $$""string""
     End Sub
 End Class")
         End Function
@@ -29,7 +29,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = [||]""string"" & 1
+        dim v = $$""string"" & 1
     End Sub
 End Class",
 "
@@ -46,7 +46,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = ""string""[||] & 1
+        dim v = ""string""$$ & 1
     End Sub
 End Class",
 "
@@ -63,7 +63,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = 1 & [||]""string""
+        dim v = 1 & $$""string""
     End Sub
 End Class",
 "
@@ -80,7 +80,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = 1 + 2 & [||]""string""
+        dim v = 1 + 2 & $$""string""
     End Sub
 End Class",
 "
@@ -97,7 +97,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = 1 + 2 & [||]""string"" ' trailing trivia
+        dim v = 1 + 2 & $$""string"" ' trailing trivia
     End Sub
 End Class",
 "
@@ -114,7 +114,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = 1 + 2 & [||]""string"" & 3 & 4
+        dim v = 1 + 2 & $$""string"" & 3 & 4
     End Sub
 End Class",
 "
@@ -131,7 +131,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = ""\r"" & 2 & [||]""string"" & 3 & ""\n""
+        dim v = ""\r"" & 2 & $$""string"" & 3 & ""\n""
     End Sub
 End Class",
 "
@@ -148,7 +148,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = ""\\r"" & 2 & [||]""string"" & 3 & ""\\n""
+        dim v = ""\\r"" & 2 & $$""string"" & 3 & ""\\n""
     End Sub
 End Class",
 "
@@ -173,7 +173,7 @@ end class
 Public Class C
     Sub M()
         dim d as D = nothing
-        dim v = 1 & [||]""string"" & d
+        dim v = 1 & $$""string"" & d
     End Sub
 End Class",
 "
@@ -206,7 +206,7 @@ end class
 Public Class C
     Sub M()
         dim d as D = nothing
-        dim v = d & [||]""string"" & 1
+        dim v = d & $$""string"" & 1
     End Sub
 End Class")
         End Function
@@ -218,7 +218,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = ""A"" & 1 & [||]""B"" & ""C""
+        dim v = ""A"" & 1 & $$""B"" & ""C""
     End Sub
 End Class",
 "
@@ -237,7 +237,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = ""A"" & [||]""B"" & ""C"" & 1
+        dim v = ""A"" & $$""B"" & ""C"" & 1
     End Sub
 End Class",
 "
@@ -256,7 +256,7 @@ End Class")
 "
 Public Class C
     Sub M()
-        dim v = ""A"" & 1 & [||]""B"" & ""C"" & 2 & ""D"" & ""E"" & ""F"" & 3  
+        dim v = ""A"" & 1 & $$""B"" & ""C"" & 2 & ""D"" & ""E"" & ""F"" & 3  
     End Sub
 End Class",
 "

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAwaitTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAwaitTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -306,7 +306,7 @@ End Module")
 "Imports System.Threading.Tasks
 Module Program
     Sub MyTestMethod1Async()
-        Dim myInt As Long = MyInt[||]MethodAsync()
+        Dim myInt As Long = MyInt$$MethodAsync()
     End Sub
     Private Function MyIntMethodAsync() As Task(Of Object)
         Return Task.FromResult(New Object())

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEndConstruct
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestIf() As Task
             Dim text = <MethodBody>
-If True Then[||]
+If True Then$$
 </MethodBody>
 
             Dim expected = <MethodBody>
@@ -29,7 +29,7 @@ End If</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestUsing() As Task
             Dim text = <MethodBody>
-Using (goo)[||]
+Using (goo)$$
 </MethodBody>
 
             Dim expected = <MethodBody>
@@ -43,7 +43,7 @@ End Using</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestStructure() As Task
             Dim text = <File>
-Structure Goo[||]</File>
+Structure Goo$$</File>
 
             Dim expected = StringFromLines("", "Structure Goo", "End Structure", "")
 
@@ -53,7 +53,7 @@ Structure Goo[||]</File>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestModule() As Task
             Dim text = <File>
-Module Goo[||]
+Module Goo$$
 </File>
 
             Dim expected = StringFromLines("", "Module Goo", "", "End Module", "")
@@ -64,7 +64,7 @@ Module Goo[||]
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestNamespace() As Task
             Dim text = <File>
-Namespace Goo[||]
+Namespace Goo$$
 </File>
 
             Dim expected = StringFromLines("", "Namespace Goo", "", "End Namespace", "")
@@ -75,7 +75,7 @@ Namespace Goo[||]
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestClass() As Task
             Dim text = <File>
-Class Goo[||]
+Class Goo$$
 </File>
 
             Dim expected = StringFromLines("", "Class Goo", "", "End Class", "")
@@ -86,7 +86,7 @@ Class Goo[||]
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestInterface() As Task
             Dim text = <File>
-Interface Goo[||]
+Interface Goo$$
 </File>
 
             Dim expected = StringFromLines("", "Interface Goo", "", "End Interface", "")
@@ -97,7 +97,7 @@ Interface Goo[||]
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestEnum() As Task
             Dim text = <File>
-Enum Goo[||]
+Enum Goo$$
 </File>
 
             Dim expected = StringFromLines("", "Enum Goo", "", "End Enum", "")
@@ -108,7 +108,7 @@ Enum Goo[||]
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestWhile() As Task
             Dim text = <MethodBody>
-While True[||]</MethodBody>
+While True$$</MethodBody>
 
             Dim expected = <MethodBody>
 While True
@@ -121,7 +121,7 @@ End While</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestWith() As Task
             Dim text = <MethodBody>
-With True[||]</MethodBody>
+With True$$</MethodBody>
 
             Dim expected = <MethodBody>
 With True
@@ -134,7 +134,7 @@ End With</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestSyncLock() As Task
             Dim text = <MethodBody>
-SyncLock Me[||]</MethodBody>
+SyncLock Me$$</MethodBody>
 
             Dim expected = <MethodBody>
 SyncLock Me
@@ -147,7 +147,7 @@ End SyncLock</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestDoLoop() As Task
             Dim text = <MethodBody>
-Do While True[||]</MethodBody>
+Do While True$$</MethodBody>
 
             Dim expected = <MethodBody>
 Do While True
@@ -160,7 +160,7 @@ Loop</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestForNext() As Task
             Dim text = <MethodBody>
-For x = 1 to 3[||]</MethodBody>
+For x = 1 to 3$$</MethodBody>
 
             Dim expected = <MethodBody>
 For x = 1 to 3
@@ -173,7 +173,7 @@ Next</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestForEachNext() As Task
             Dim text = <MethodBody>
-For Each x in {}[||]</MethodBody>
+For Each x in {}$$</MethodBody>
 
             Dim expected = <MethodBody>
 For Each x in {}
@@ -186,7 +186,7 @@ Next</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestEndTry() As Task
             Dim text = <MethodBody>
-Try[||]</MethodBody>
+Try$$</MethodBody>
 
             Dim expected = <MethodBody>
 Try
@@ -199,7 +199,7 @@ End Try</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestEndTryCatch() As Task
             Dim text = <MethodBody>
-Try[||]
+Try$$
 Catch</MethodBody>
 
             Dim expected = <MethodBody>
@@ -214,7 +214,7 @@ End Try</MethodBody>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestEndTryCatchFinally() As Task
             Dim text = <MethodBody>
-Try[||]
+Try$$
 Catch
 Finally</MethodBody>
 
@@ -232,7 +232,7 @@ End Try</MethodBody>
         Public Async Function TestProperty() As Task
             Dim text = <File>
 Class C
-    Property P As Integer[||]
+    Property P As Integer$$
         Get
 End Class</File>
 
@@ -253,7 +253,7 @@ End Class</File>
         Public Async Function TestReadOnlyProperty() As Task
             Dim text = <File>
 Class C
-    ReadOnly Property P As Integer[||]
+    ReadOnly Property P As Integer$$
         Get
 End Class</File>
 
@@ -272,7 +272,7 @@ End Class</File>
         Public Async Function TestWriteOnlyProperty() As Task
             Dim text = <File>
 Class C
-    WriteOnly Property P As Integer[||]
+    WriteOnly Property P As Integer$$
         Set
 End Class</File>
 
@@ -292,7 +292,7 @@ End Class</File>
             Dim text = <File>
 Class C
     WriteOnly Property P As Integer
-        Set[||]
+        Set$$
 End Class</File>
 
             Dim expected = <File>
@@ -309,7 +309,7 @@ End Class</File>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestInvInsideEndsEnum() As Task
             Dim text = <File>
-Public Enum e[||]
+Public Enum e$$
     e1
 Class Goo
 End Class</File>
@@ -329,7 +329,7 @@ End Class</File>
         Public Async Function TestMissingEndSub() As Task
             Dim text = <File>
 Class C
-    Sub Bar()[||]
+    Sub Bar()$$
 End Class</File>
 
             Dim expected = <File>
@@ -346,7 +346,7 @@ End Class</File>
         Public Async Function TestMissingEndFunction() As Task
             Dim text = <File>
 Class C
-    Function Bar() as Integer[||]
+    Function Bar() as Integer$$
 End Class</File>
 
             Dim expected = <File>
@@ -365,7 +365,7 @@ End Class</File>
             Dim text = <File>
 Class C
     Sub Main(args As String())
-        While True[||]
+        While True$$
 
         Dim x = 1
         Dim y = 2
@@ -395,7 +395,7 @@ End Class</File>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestDoNotWrapCLass() As Task
             Dim text = <File>
-Class C[||]
+Class C$$
         Function f1() As Integer
             Return 1
         End Function
@@ -434,7 +434,7 @@ Module Program
     Sub Main(args As String())
     End Sub
     Function goo()
-        Dim op = Sub[||](c)
+        Dim op = Sub$$(c)
                      Dim kl = Sub(g)
                               End Sub 
  End Function
@@ -445,7 +445,7 @@ End Module")
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Async Function TestNamespaceThatEndsAtFile() As Task
             Dim text = <File>
-Namespace N[||]
+Namespace N$$
     Interface I
         Module Program
         Sub Main(args As String())

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
@@ -2023,7 +2023,7 @@ End Module")
         Public Async Function TestNotOnMissingMethodName() As Task
             Await TestMissingInRegularAndScriptAsync("Class C
     Sub M()
-        Me.[||] 
+        Me.$$ 
  End Sub
 End Class")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/InsertMissingCast/InsertMissingCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/InsertMissingCast/InsertMissingCastTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -229,7 +229,7 @@ End Module")
 "Option Strict On
 Module Program
     Sub Main(args As String())
-        Dim x As Double = 10[||]
+        Dim x As Double = 10$$
     End Sub
 End Module")
         End Function
@@ -242,7 +242,7 @@ Class A
 End Class
 Class B
 End Class
-Module Program[||]
+Module Program$$
     Sub Main(args As String())
         Dim x As A = New B()
     End Sub

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 
@@ -1648,7 +1648,7 @@ Imports System.Threading.Tasks
 
 Module Program
     Sub Main(args() As String)
-        Console.[||]
+        Console.$$
     End Sub
 End Module
 </Code>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeActions
@@ -484,7 +484,7 @@ End Class")
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Async Function TestTestMissingName() As Task
             Await TestMissingInRegularAndScriptAsync(
-"<Assembly: Microsoft.CodeAnalysis.[||]>")
+"<Assembly: Microsoft.CodeAnalysis.$$>")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>

--- a/src/EditorFeatures/VisualBasicTest/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -218,7 +218,7 @@ End Class")
             Await TestWithPickMembersDialogAsync(
 "Class Program
     Private i As Integer
-    [||]
+    $$
 End Class",
 "Class Program
     Private i As Integer
@@ -234,7 +234,7 @@ End Class", chosenSymbols:={"i"})
             Await TestWithPickMembersDialogAsync(
 "Class Program
     Private i As Integer
-    [||]
+    $$
 End Class",
 "Class Program
     Private i As Integer
@@ -250,7 +250,7 @@ End Class", chosenSymbols:={})
 "Class Program
     Private i As Integer
     Private j As String
-    [||]
+    $$
 End Class",
 "Class Program
     Private i As Integer
@@ -266,7 +266,7 @@ End Class", chosenSymbols:={"j", "i"})
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)>
         Public Async Function TestWithDialog4() As Task
             Await TestWithPickMembersDialogAsync(
-"Class [||]Program
+"Class $$Program
     Private i As Integer
 End Class",
 "Class Program
@@ -283,7 +283,7 @@ End Class", chosenSymbols:={"i"})
             Await TestMissingInRegularAndScriptAsync(
 "Class Program
     Private i As Integer
-    [||]Sub M()
+    $$Sub M()
     End Sub
 End Class")
         End Function
@@ -294,14 +294,14 @@ End Class")
 "Class Program
     Private i As Integer
     Sub M()
-    End Sub[||]
+    End Sub$$
 End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)>
         Public Async Function TestMissingOnAttributes() As Task
             Await TestMissingInRegularAndScriptAsync(
-"<X>[||]
+"<X>$$
 Class Program
     Private i As Integer
     Sub M()

--- a/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.GenerateDefaultCon
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits [||]Exception
+    Inherits $$Exception
     Sub Main(args As String())
     End Sub
 End Class",
@@ -44,7 +44,7 @@ End Class")
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits [||]Exception
+    Inherits $$Exception
     Sub Main(args As String())
     End Sub
 End Class",
@@ -71,7 +71,7 @@ index:=1)
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits [||]Exception
+    Inherits $$Exception
     Sub Main(args As String())
     End Sub
 End Class",
@@ -98,7 +98,7 @@ index:=2)
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits [||]Exception
+    Inherits $$Exception
     Sub Main(args As String())
     End Sub
 End Class",
@@ -127,7 +127,7 @@ index:=3)
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits [||]Exception
+    Inherits $$Exception
     Sub Main(args As String())
     End Sub
 End Class",
@@ -167,7 +167,7 @@ index:=4)
 "Class Base
 End Class
 Class Derived
-    Inherits B[||]ase
+    Inherits B$$ase
 End Class",
 "Class Base
 End Class
@@ -183,7 +183,7 @@ End Class")
         Public Async Function TestNotOfferedOnUnresolvedBaseClassName() As Task
             Await TestMissingInRegularAndScriptAsync(
 "Class Derived
-    Inherits [||]Base
+    Inherits $$Base
 End Class")
         End Function
 
@@ -191,14 +191,14 @@ End Class")
         Public Async Function TestNotOfferedOnInheritsStatementForStructures() As Task
             Await TestMissingInRegularAndScriptAsync(
 "Structure Derived
-    Inherits [||]Base
+    Inherits $$Base
 End Structure")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestNotOfferedForIncorrectlyParentedInheritsStatement() As Task
             Await TestMissingInRegularAndScriptAsync(
-"Inherits [||]Goo")
+"Inherits $$Goo")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
@@ -208,7 +208,7 @@ End Structure")
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits [||]Exception
+    Inherits $$Exception
     Public Sub New()
     End Sub
     Sub Main(args As String())
@@ -249,7 +249,7 @@ index:=3)
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits [||]Exception
+    Inherits $$Exception
     Public Sub New(message As String)
         MyBase.New(message)
     End Sub
@@ -292,7 +292,7 @@ End Class")
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits [||]Exception
+    Inherits $$Exception
     Public Sub New(message As String, innerException As Exception)
         MyBase.New(message, innerException)
     End Sub
@@ -335,7 +335,7 @@ index:=2)
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits Exception[||]
+    Inherits Exception$$
     Sub Main(args As String())
     End Sub
 End Class",
@@ -360,7 +360,7 @@ End Class")
 Imports System.Collections.Generic
 Imports System.Linq
 Class Program
-    Inherits Exce[||]ption
+    Inherits Exce$$ption
     Public Sub New()
     End Sub
     Sub Main(args As String())
@@ -388,7 +388,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         Public Async Function TestDefaultConstructorGeneration() As Task
             Await TestInRegularAndScriptAsync(
 <Text>Class C
-    Inherits B[||]
+    Inherits B$$
     Public Sub New(y As Integer)
     End Sub
 End Class
@@ -418,7 +418,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
             Await TestInRegularAndScriptAsync(
 <Text>
 Class C
-    Inherits [||]B
+    Inherits $$B
 
     Public Sub New(y As Boolean)
     End Sub
@@ -481,7 +481,7 @@ index:=2)
             Await TestInRegularAndScriptAsync(
 <Text>
 Class C
-    Inherits [||]B
+    Inherits $$B
 
     Public Sub New(y As (Boolean, Boolean))
     End Sub
@@ -548,7 +548,7 @@ Public Class Base
     End Sub
 End Class
 
-Public [||]Class ;;Derived
+Public $$Class ;;Derived
     Inherits Base
 
 End Class",
@@ -579,7 +579,7 @@ Public Class Base
     End Sub
 End Class
 
-Public Class [||]Derived
+Public Class $$Derived
     Inherits Base
 
 End Class",
@@ -610,7 +610,7 @@ Public Class Base
     End Sub
 End Class
 
-Public Class [||]Derived
+Public Class $$Derived
     Inherits Base
 
 End Class",
@@ -635,7 +635,7 @@ End Class")
         Public Async Function TestNotOnEnum() As Task
             Await TestMissingInRegularAndScriptAsync(
 "
-Public Enum [||]E
+Public Enum $$E
 End Enum")
         End Function
 
@@ -644,7 +644,7 @@ End Enum")
         Public Async Function TestGenerateConstructorFromFriendConstructor() As Task
             Await TestInRegularAndScriptAsync(
 <Text>Class C
-    Inherits B[||]
+    Inherits B$$
 End Class
 
 MustInherit Class B
@@ -670,7 +670,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         Public Async Function TestGenerateConstructorFromFriendConstructor2() As Task
             Await TestInRegularAndScriptAsync(
 <Text>MustInherit Class C
-    Inherits B[||]
+    Inherits B$$
 End Class
 
 MustInherit Class B
@@ -696,7 +696,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         Public Async Function TestGenerateConstructorFromProtectedConstructor() As Task
             Await TestInRegularAndScriptAsync(
 <Text>Class C
-    Inherits B[||]
+    Inherits B$$
 End Class
 
 MustInherit Class B
@@ -722,7 +722,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         Public Async Function TestGenerateConstructorFromProtectedConstructor2() As Task
             Await TestInRegularAndScriptAsync(
 <Text>MustInherit Class C
-    Inherits B[||]
+    Inherits B$$
 End Class
 
 MustInherit Class B
@@ -748,7 +748,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         Public Async Function TestGenerateConstructorFromProtectedFriendConstructor() As Task
             Await TestInRegularAndScriptAsync(
 <Text>Class C
-    Inherits B[||]
+    Inherits B$$
 End Class
 
 MustInherit Class B
@@ -774,7 +774,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         Public Async Function TestGenerateConstructorFromProtectedFriendConstructor2() As Task
             Await TestInRegularAndScriptAsync(
 <Text>MustInherit Class C
-    Inherits B[||]
+    Inherits B$$
 End Class
 
 MustInherit Class B
@@ -800,7 +800,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         Public Async Function TestGenerateConstructorFromPublicConstructor() As Task
             Await TestInRegularAndScriptAsync(
 <Text>Class C
-    Inherits B[||]
+    Inherits B$$
 End Class
 
 MustInherit Class B
@@ -826,7 +826,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         Public Async Function TestGenerateConstructorFromPublicConstructor2() As Task
             Await TestInRegularAndScriptAsync(
 <Text>MustInherit Class C
-    Inherits B[||]
+    Inherits B$$
 End Class
 
 MustInherit Class B

--- a/src/EditorFeatures/VisualBasicTest/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -114,7 +114,7 @@ Imports System.Collections.Generic
 
 Class Program
     Public s As String
-    [||]
+    $$
 End Class",
 "
 Imports System.Collections.Generic
@@ -148,7 +148,7 @@ Imports System.Collections.Generic
 
 Class Program
     Public s As String
-    [||]
+    $$
 
     Public Shared Operator =(program1 As Program, program2 As Program) As Boolean
         Return True
@@ -182,7 +182,7 @@ Imports System.Collections.Generic
 
 Structure Program
     Public s As String
-    [||]
+    $$
 End Structure",
 "
 Imports System.Collections.Generic
@@ -219,7 +219,7 @@ Imports System.Collections.Generic
 
 structure Program
     Public s As String
-    [||]
+    $$
 End structure",
 "
 Imports System
@@ -250,7 +250,7 @@ Imports System.Collections.Generic
 
 Class Program
     Public s As String
-    [||]
+    $$
 End Class",
 "
 Imports System

--- a/src/EditorFeatures/VisualBasicTest/GenerateOverrides/GenerateOverridesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateOverrides/GenerateOverridesTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.GenerateOverrides
             Await TestWithPickMembersDialogAsync(
 "
 class C
-    [||]
+    $$
 end class",
 "
 class C

--- a/src/EditorFeatures/VisualBasicTest/GoToAdjacentMember/VisualBasicGoToAdjacentMemberTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GoToAdjacentMember/VisualBasicGoToAdjacentMemberTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.GoToAdjacentMember
 
@@ -29,7 +29,7 @@ End Class"
         Public Async Function BeforeClassWithMember() As Task
             Dim code = "$$
 Class C
-    [||]Sub M()
+    $$Sub M()
     End Sub
 End Class"
 
@@ -41,7 +41,7 @@ End Class"
         Public Async Function AfterClassWithMember() As Task
             Dim code = "
 Class C
-    [||]Sub M()
+    $$Sub M()
     End Sub
 End Class
 
@@ -62,7 +62,7 @@ End Class
 $$
 
 Class C2
-    [||]Sub M()
+    $$Sub M()
     End Sub
 End Class"
 
@@ -74,7 +74,7 @@ End Class"
         Public Async Function BetweenClassesPrevious() As Task
             Dim code = "
 Class C1
-    [||]Sub M()
+    $$Sub M()
     End Sub
 End Class
 
@@ -95,7 +95,7 @@ End Class"
 Class C
     $$Sub M1()
     End Sub
-    [||]Sub M2()
+    $$Sub M2()
     End Sub
 End Class"
 
@@ -107,7 +107,7 @@ End Class"
         Public Async Function FromSecondToFirst() As Task
             Dim code = "
 Class C
-    [||]Sub M1()
+    $$Sub M1()
     End Sub
     $$Sub M2()
     End Sub
@@ -121,7 +121,7 @@ End Class"
         Public Async Function NextWraps() As Task
             Dim code = "
 Class C
-    [||]Sub M1()
+    $$Sub M1()
     End Sub
     $$Sub M2()
     End Sub
@@ -137,7 +137,7 @@ End Class"
 Class C
     $$Sub M1()
     End Sub
-    [||]Sub M2()
+    $$Sub M2()
     End Sub
 End Class"
 
@@ -153,7 +153,7 @@ Class C
     End Sub
 
     Class N
-        [||]Sub M2()
+        $$Sub M2()
         End Sub
     End Class
 End Class"
@@ -169,7 +169,7 @@ Class C
     $$Sub M1()
     End Sub
 
-    [||]Public Sub New()
+    $$Public Sub New()
     End Sub
 End Class"
             Await AssertNavigatedAsync(code, next:=True)
@@ -182,7 +182,7 @@ End Class"
 Class C
     $$Sub M1()
     End Sub
-    [||]Shared Operator +(left As C, right As C) As C
+    $$Shared Operator +(left As C, right As C) As C
         Throw New System.NotImplementedException()
     End Operator
 End Class"
@@ -202,7 +202,7 @@ Class C
     $$Sub M1()
     End Sub
 
-    [||]Dim f as Integer
+    $$Dim f as Integer
 End Class"
             Await AssertNavigatedAsync(code, next:=True)
         End Function
@@ -215,7 +215,7 @@ Class C
     $$Sub M1()
     End Sub
 
-    [||]Event E As System.EventHandler
+    $$Event E As System.EventHandler
 End Class"
             Await AssertNavigatedAsync(code, next:=True)
         End Function
@@ -227,7 +227,7 @@ End Class"
 Class C
     $$Sub M1()
     End Sub
-    [||]Property P As Integer
+    $$Property P As Integer
 End Class"
             Await AssertNavigatedAsync(code, next:=True)
         End Function
@@ -240,7 +240,7 @@ Class C
     $$Sub M1()
     End Sub
 
-    [||]Property P As Integer
+    $$Property P As Integer
         Get
             Return 42
         End Get
@@ -268,7 +268,7 @@ Class C
         End Set
     End Property
 
-    [||]Sub M2()
+    $$Sub M2()
     End Sub
 End Class"
 
@@ -291,7 +291,7 @@ Class C
         End Set
     End Property
 
-    [||]Sub M2()
+    $$Sub M2()
     End Sub
 End Class"
 
@@ -306,7 +306,7 @@ Class C
     $$Sub M1()
     End Sub
 
-    [||]Custom Event E As EventHandler
+    $$Custom Event E As EventHandler
         AddHandler(value As EventHandler)
 
         End AddHandler
@@ -342,7 +342,7 @@ Class C
         End RaiseEvent
     End Event
 
-    [||]Sub M2()
+    $$Sub M2()
     End Sub
 End Class"
 
@@ -358,7 +358,7 @@ Class C
         $$System.Console.WriteLine()
     End Sub
 
-    [||]Sub M2()
+    $$Sub M2()
     End Sub
 End Class"
 
@@ -375,7 +375,7 @@ Class C
 
     $$
 
-    [||]Sub M2()
+    $$Sub M2()
     End Sub
 End Class"
 
@@ -387,7 +387,7 @@ End Class"
         Public Async Function PreviousFromBetweenMethods() As Task
             Dim code = "
 Class C
-    [||]Sub M1()
+    $$Sub M1()
     End Sub
 
     $$
@@ -407,7 +407,7 @@ Class C
     Sub M1()
     End Sub $$
 
-    [||]Sub M2()
+    $$Sub M2()
     End Sub
 End Class"
 
@@ -420,7 +420,7 @@ End Class"
         Public Async Function PreviousFromInsideCurrent() As Task
             Dim code = "
 class C
-    [||]Sub M1()
+    $$Sub M1()
         Console.WriteLine($$)
     End Sub
 
@@ -436,7 +436,7 @@ End Class"
         Public Async Function PreviousFromBetweenMethodsInTrailingTrivia() As Task
             Dim code = "
 Class C
-    [||]Sub M1()
+    $$Sub M1()
     End Sub $$
 
     Sub M2()
@@ -453,7 +453,7 @@ End Class"
 $$Sub M1()
 End Sub
 
-[||]Sub M2()
+$$Sub M2()
 End Sub"
 
             Await AssertNavigatedAsync(code, next:=True, sourceCodeKind:=SourceCodeKind.Script)
@@ -463,7 +463,7 @@ End Sub"
         <WorkItem(4311, "https://github.com/dotnet/roslyn/issues/4311")>
         Public Async Function PrevInScript() As Task
             Dim code = "
-[||]Sub M1()
+$$Sub M1()
 End Sub
 
 $$Sub M2()

--- a/src/EditorFeatures/VisualBasicTest/InitializeParameter/AddParameterCheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/InitializeParameter/AddParameterCheckTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.InitializeParamete
 Imports System
 
 class C
-    public sub new([||]s as string)
+    public sub new($$s as string)
     end sub
 end class",
 "
@@ -41,7 +41,7 @@ end class")
 Imports System
 
 class C
-    public sub new([||]i as integer?)
+    public sub new($$i as integer?)
     end sub
 end class",
 "
@@ -63,7 +63,7 @@ end class")
 Imports System
 
 class C
-    public sub new([||]i as integer)
+    public sub new($$i as integer)
     end sub
 end class")
         End Function
@@ -75,7 +75,7 @@ end class")
 Imports System
 
 interface I
-    sub M([||]s as string)
+    sub M($$s as string)
 end class")
         End Function
 
@@ -86,7 +86,7 @@ end class")
 Imports System
 
 class C
-    mustoverride sub M([||]s as string)
+    mustoverride sub M($$s as string)
 end class")
         End Function
 
@@ -99,7 +99,7 @@ Imports System
 class C
     private _s as string 
 
-    public sub new([||]s as string)
+    public sub new($$s as string)
         _s = s
     end sub
 end class",
@@ -128,7 +128,7 @@ Imports System
 class C
     private property S as string
 
-    public sub new([||]s as string)
+    public sub new($$s as string)
         Me.S = s
     end sub
 end class",
@@ -155,7 +155,7 @@ end class")
 Imports System
 
 class C
-    public sub new(a as string, [||]s as string)
+    public sub new(a as string, $$s as string)
         If a is nothing
         End If
     end sub
@@ -182,7 +182,7 @@ end class")
 Imports System
 
 class C
-    public sub new([||]a as string, s as string)
+    public sub new($$a as string, s as string)
         If s Is Nothing Then
         End If
     end sub
@@ -209,7 +209,7 @@ end class")
 Imports System
 
 class C
-    public sub new([||]s as string)
+    public sub new($$s as string)
         If s Is Nothing Then
             Throw New ArgumentNullException()
         End If
@@ -224,7 +224,7 @@ end class")
 Imports System
 
 class C
-    public sub new([||]s as string)
+    public sub new($$s as string)
         If String.IsNullOrEmpty(s)
         End If
     end sub
@@ -238,7 +238,7 @@ end class")
 Imports System
 
 class C
-    public sub new([||]s as string)
+    public sub new($$s as string)
         If String.IsNullOrWhiteSpace(s)
         End If
     end sub
@@ -252,7 +252,7 @@ end class")
 Imports System
 
 class C
-    sub F([||]s as string)
+    sub F($$s as string)
     end sub
 end class",
 "
@@ -275,7 +275,7 @@ Imports System
 
 class C
     public sub new()
-        dim f = function ([||]s as string)
+        dim f = function ($$s as string)
                 end function
     end sub
 end class")
@@ -288,7 +288,7 @@ end class")
 Imports System
 
 class C
-    public sub new([||]s as string)
+    public sub new($$s as string)
     end sub
 end class",
 "
@@ -310,7 +310,7 @@ end class", index:=1)
 Imports System
 
 class C
-    public sub new([||]s as string)
+    public sub new($$s as string)
     end sub
 end class",
 "

--- a/src/EditorFeatures/VisualBasicTest/InitializeParameter/InitializeMemberFromParameterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/InitializeParameter/InitializeMemberFromParameterTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.InitializeParamete
 class C
     private s As String
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
 
     end sub
 end class",
@@ -42,7 +42,7 @@ end class")
 class C
     private s As String
 
-    public sub new(s As String[||])
+    public sub new(s As String$$)
 
     end sub
 end class",
@@ -64,7 +64,7 @@ end class")
 class C
     private s As String
 
-    public sub new(s As String[||], t As String)
+    public sub new(s As String$$, t As String)
     end sub
 end class",
 "
@@ -85,7 +85,7 @@ end class")
 class C
     private _s As String
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
 
     end sub
 end class",
@@ -106,7 +106,7 @@ end class")
 class C
     Private ReadOnly property S As String
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
 
     end sub
 end class",
@@ -127,7 +127,7 @@ end class")
 class C
     private t As String
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
     end sub
 end class",
 "
@@ -150,7 +150,7 @@ end class")
 class C
     Private ReadOnly Property T As String
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
 
     end sub
 end class",
@@ -172,7 +172,7 @@ end class")
 class C
     private s As Integer
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
 
     end sub
 end class",
@@ -195,7 +195,7 @@ end class")
 class C
     private s As Integer
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
 
     end sub
 end class",
@@ -217,7 +217,7 @@ end class", index:=1)
 class C
     private s As Object
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
 
     end sub
 end class",
@@ -240,7 +240,7 @@ class C
     private s As Integer
     private x As Integer
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
         x = s
     end sub
 end class")
@@ -254,7 +254,7 @@ class C
 
     private s As Integer
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
         Me.s = 0
     end sub
 end class",
@@ -263,7 +263,7 @@ class C
 
     private s As Integer
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
         Me.s = 0
         S1 = s
     end sub
@@ -281,7 +281,7 @@ class C
     private s As String
     private t As String
 
-    public sub new([||]s As String, t As String)
+    public sub new($$s As String, t As String)
         Me.t = t   
     end sub
 end class",
@@ -306,7 +306,7 @@ class C
     private s As String
     private t As String
 
-    public sub new(s As String, [||]t As String)
+    public sub new(s As String, $$t As String)
         Me.s = s   
     end sub
 end class",
@@ -330,7 +330,7 @@ class C
 
     private s As String
 
-    public sub new([||]s As String)
+    public sub new($$s As String)
         if true then
         end if
     end sub
@@ -357,7 +357,7 @@ class C
 
     private s As String
 
-    public function M([||]s As String)
+    public function M($$s As String)
 
     end sub
 end class")
@@ -370,7 +370,7 @@ end class")
             Await TestInRegularAndScript1Async(
 "
 class C
-    public sub new(s As String, [||]t As String)
+    public sub new(s As String, $$t As String)
         Me.S = s   
     end sub
 
@@ -394,7 +394,7 @@ end class")
             Await TestInRegularAndScript1Async(
 "
 class C
-    public sub new([||]s As String, t As String)
+    public sub new($$s As String, t As String)
         Me.T = t   
     end sub
 

--- a/src/EditorFeatures/VisualBasicTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.MoveDeclarationNea
             Await TestInRegularAndScriptAsync(
 "class C
     sub M()
-        dim [||]x as integer
+        dim $$x as integer
         if true
             Console.WriteLine(x)
         end if
@@ -38,7 +38,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "class C
     sub M()
-        dim [||]x as integer
+        dim $$x as integer
         Console.WriteLine()
         Console.WriteLine(x)
     end sub
@@ -58,7 +58,7 @@ end class")
 "class C
     sub M()
 
-        dim [||]x as integer
+        dim $$x as integer
         Console.WriteLine()
         if true
             Console.WriteLine(x)
@@ -90,7 +90,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "class C
     sub M()
-        dim [||]x as integer
+        dim $$x as integer
         Console.WriteLine()
         if true
             Console.WriteLine(x)
@@ -113,7 +113,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "class C
     sub M()
-        dim [||]x as integer
+        dim $$x as integer
         if true
             x = 5
             Console.WriteLine(x)
@@ -136,7 +136,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "class C
     sub M()
-        dim [||]x as integer = 0
+        dim $$x as integer = 0
         if true
             x = 5
             Console.WriteLine(x)
@@ -158,7 +158,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "class C
     sub M()
-        dim [||]x = ctype(0, integer)
+        dim $$x = ctype(0, integer)
         if true
             x = 5
             Console.WriteLine(x)
@@ -181,7 +181,7 @@ end class")
             Await TestMissingInRegularAndScriptAsync(
 "class C
     sub M()
-        dim [||]x as integer
+        dim $$x as integer
         Console.WriteLine(x)
     end sub
 end class")
@@ -192,7 +192,7 @@ end class")
             Await TestMissingInRegularAndScriptAsync(
 "class Program
     sub M()
-        dim [||]x as object() = { x }
+        dim $$x as object() = { x }
         x.ToString()
     end sub
 end class")
@@ -203,7 +203,7 @@ end class")
             Await TestMissingInRegularAndScriptAsync(
 "class Program
     sub M()
-        dim [||]i as integer = 5
+        dim $$i as integer = 5
         dim j as integer = 10
         Console.WriteLine(i)
     end sub
@@ -217,7 +217,7 @@ end class")
 
 class Program
     sub M()
-        dim [||]gate = new object()
+        dim $$gate = new object()
         dim x = sub()
                     Console.WriteLine(gate)
                 end sub()
@@ -243,7 +243,7 @@ using System.Linq
 
 class Program
     sub M()
-        dim [||]i = 0
+        dim $$i = 0
         for each (v in x)
             Console.Write(i)
             i = i + 1
@@ -273,7 +273,7 @@ using System.Linq
 
 class Program
     sub M()
-        ' Comment [||]about goo!
+        ' Comment $$about goo!
         ' Comment about goo!
         ' Comment about goo!
         ' Comment about goo!

--- a/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -24,7 +24,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [||]e
+        Select Case $$e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -53,7 +53,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        [||]Select Case e
+        $$Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -82,7 +82,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        [||]Select Case e
+        $$Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -133,7 +133,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        [||]Select Case e
+        $$Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -182,7 +182,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        [||]Select Case e
+        $$Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -233,7 +233,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        [||]Select Case e
+        $$Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -282,7 +282,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        [||]Select Case e
+        $$Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz ' not legal.  VB does not allow fallthrough.
@@ -331,7 +331,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        [||]Select Case e
+        $$Select Case e
         End Select
     End Sub
 End Class
@@ -377,7 +377,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = CreateNew
-        [||]Select Case e
+        $$Select Case e
             Case CreateNew
                 Exit Select
             Case Create
@@ -413,7 +413,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = CreateNew
-        [||]Select Case e
+        $$Select Case e
             Case Truncate
                 Exit Select
             Case Append
@@ -449,7 +449,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = CreateNew
-        [||]Select Case e
+        $$Select Case e
             Case CreateNew
                 Exit Select
             Case Create
@@ -510,7 +510,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = CreateNew
-        [||]Select Case e
+        $$Select Case e
             
         End Select
     End Sub
@@ -564,7 +564,7 @@ End Enum
 Class Goo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        [||]Select Case e
+        $$Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -614,7 +614,7 @@ Class Goo
     End Enum
     Sub Bar()
         Dim e = MyEnum.Fizz
-        [||]Select Case e
+        $$Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -658,7 +658,7 @@ End Class
 Class Goo
     Sub Bar()
         Dim e = "Test"
-        [||]Select Case e
+        $$Select Case e
             Case "Fizz"
                 Exit Select
             Case "Test"

--- a/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ReplaceDocCommentT
         Public Async Function TestStartOfKeyword() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' Testing keyword [||]Nothing.
+''' Testing keyword $$Nothing.
 class C(Of TKey)
 end class",
 "
@@ -29,7 +29,7 @@ end class")
         Public Async Function TestStartOfKeywordCapitalized() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' Testing keyword Shared[||].
+''' Testing keyword Shared$$.
 class C(Of TKey)
 end class",
 "
@@ -42,7 +42,7 @@ end class")
         Public Async Function TestEndOfKeyword() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' Testing keyword True[||].
+''' Testing keyword True$$.
 class C(Of TKey)
 end class",
 "
@@ -55,7 +55,7 @@ end class")
         Public Async Function TestEndOfKeyword_NewLineFollowing() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' Testing keyword MustInherit[||]
+''' Testing keyword MustInherit$$
 class C(Of TKey)
 end class",
 "
@@ -81,7 +81,7 @@ end class")
         Public Async Function TestInsideKeyword() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' Testing keyword Aw[||]ait.
+''' Testing keyword Aw$$ait.
 class C(Of TKey)
 end class",
 "
@@ -103,7 +103,7 @@ end class")
         Public Async Function TestStartOfFullyQualifiedTypeName_Start() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the [||]System.IDisposable interface.
+''' TKey must implement the $$System.IDisposable interface.
 class C(Of TKey)
 end class",
 "
@@ -116,7 +116,7 @@ end class")
         Public Async Function TestStartOfFullyQualifiedTypeName_Mid1() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the System[||].IDisposable interface.
+''' TKey must implement the System$$.IDisposable interface.
 class C(Of TKey)
 end class",
 "
@@ -129,7 +129,7 @@ end class")
         Public Async Function TestStartOfFullyQualifiedTypeName_Mid2() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the System.[||]IDisposable interface.
+''' TKey must implement the System.$$IDisposable interface.
 class C(Of TKey)
 end class",
 "
@@ -142,7 +142,7 @@ end class")
         Public Async Function TestStartOfFullyQualifiedTypeName_End() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the System.IDisposable[||] interface.
+''' TKey must implement the System.IDisposable$$ interface.
 class C(Of TKey)
 end class",
 "
@@ -155,7 +155,7 @@ end class")
         Public Async Function TestStartOfFullyQualifiedTypeName_CaseInsensitive() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the [||]system.idisposable interface.
+''' TKey must implement the $$system.idisposable interface.
 class C(Of TKey)
 end class",
 "
@@ -181,7 +181,7 @@ end class")
         Public Async Function TestTypeParameterReference() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' [||]TKey must implement the System.IDisposable interface.
+''' $$TKey must implement the System.IDisposable interface.
 class C(Of TKey)
 end class",
 "
@@ -194,7 +194,7 @@ end class")
         Public Async Function TestCanSeeInnerMethod() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' Use WriteLine[||] as a Console.WriteLine replacement
+''' Use WriteLine$$ as a Console.WriteLine replacement
 class C
     sub WriteLine(Of TKey)(value as TKey)
     end sub
@@ -211,7 +211,7 @@ end class")
         Public Async Function TestNotOnMispelledName() As Task
             Await TestMissingAsync(
 "
-''' Use WriteLine1[||] as a Console.WriteLine replacement
+''' Use WriteLine1$$ as a Console.WriteLine replacement
 class C
     sub WriteLine(Of TKey)(value as TKey)
     end sub
@@ -223,7 +223,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "
 class C
-    ''' value has type TKey[||] so we don't box primitives.
+    ''' value has type TKey$$ so we don't box primitives.
     sub WriteLine(Of TKey)(value as TKey)
     end sub
 end class",
@@ -240,7 +240,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "
 class C
-    ''' value has type TKey[||] so we don't box primitives.
+    ''' value has type TKey$$ so we don't box primitives.
     sub WriteLine(Of tkey)(value as TKey)
     end sub
 end class",
@@ -257,7 +257,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "
 interface I
-    ''' value has type TKey[||] so we don't box primitives.
+    ''' value has type TKey$$ so we don't box primitives.
     sub WriteLine(Of TKey)(value as TKey)
 end interface",
 "
@@ -272,7 +272,7 @@ end interface")
             Await TestInRegularAndScriptAsync(
 "
 class C
-    ''' value[||] has type TKey so we don't box primitives.
+    ''' value$$ has type TKey so we don't box primitives.
     sub WriteLine(Of TKey)(value as TKey)
     end sub
 end class",
@@ -289,7 +289,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "
 class C
-    ''' value[||] has type TKey so we don't box primitives.
+    ''' value$$ has type TKey so we don't box primitives.
     sub WriteLine(Of TKey)(Value as TKey)
     end sub
 end class",
@@ -306,7 +306,7 @@ end class")
             Await TestInRegularAndScriptAsync(
 "
 interface I
-    ''' value[||] has type TKey so we don't box primitives.
+    ''' value$$ has type TKey so we don't box primitives.
     sub WriteLine(Of TKey)(value as TKey)
 end interface",
 "
@@ -321,7 +321,7 @@ end interface")
         Public Async Function TestNotApplicableKeyword() As Task
             Await TestMissingAsync(
 "
-''' Testing keyword interf[||]ace
+''' Testing keyword interf$$ace
 class C(Of TKey)
 end class")
         End Function
@@ -331,7 +331,7 @@ end class")
         Public Async Function TestInXMLAttribute() As Task
             Await TestMissingAsync(
 "
-''' Testing keyword inside <see langword=""Noth[||]ing"">
+''' Testing keyword inside <see langword=""Noth$$ing"">
 class C
     sub WriteLine(Of TKey)(value as TKey)
     end sub
@@ -343,7 +343,7 @@ end class")
         Public Async Function TestInXMLAttribute2() As Task
             Await TestMissingAsync(
 "
-''' Testing keyword inside <see langword=""Not[||]hing""
+''' Testing keyword inside <see langword=""Not$$hing""
 class C
     sub WriteLine(Of TKey)(value as TKey)
     end sub

--- a/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
@@ -768,7 +768,7 @@ end class"
 "imports System.Collections.Generic
 class C
     sub Goo()
-        dim b as boolean = x.[||]
+        dim b as boolean = x.$$
     end sub
 end class"
             Await TestAsync(text, "System.Boolean", testNode:=False)

--- a/src/EditorFeatures/VisualBasicTest/UseCoalesceExpression/UseCoalesceExpressionForNullableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseCoalesceExpression/UseCoalesceExpressionForNullableTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -23,7 +23,7 @@ Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?)
-        Dim z = [||]If (Not x.HasValue, y, x.Value)
+        Dim z = $$If (Not x.HasValue, y, x.Value)
     End Sub
 End Class",
 "
@@ -44,7 +44,7 @@ Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?)
-        Dim z = [||]If(x.HasValue, x.Value, y)
+        Dim z = $$If(x.HasValue, x.Value, y)
     End Sub
 End Class",
 "
@@ -65,7 +65,7 @@ Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?)
-        Dim z = [||]If (Not (x + y).HasValue, y, (x + y).Value)
+        Dim z = $$If (Not (x + y).HasValue, y, (x + y).Value)
     End Sub
 End Class",
 "
@@ -86,7 +86,7 @@ Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?)
-        Dim z = [||]If ((Not x.HasValue), y, x.Value)
+        Dim z = $$If ((Not x.HasValue), y, x.Value)
     End Sub
 End Class",
 "
@@ -153,7 +153,7 @@ Imports System.Linq.Expressions
 
 Class C
     Sub M(x as integer?, y as integer)
-        dim e as Expression(of Func(of integer)) = function() [||]If (x.HasValue, x.Value, y)
+        dim e as Expression(of Func(of integer)) = function() $$If (x.HasValue, x.Value, y)
     End Sub
 End Class",
 "

--- a/src/EditorFeatures/VisualBasicTest/UseCoalesceExpression/UseCoalesceExpressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseCoalesceExpression/UseCoalesceExpressionTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -23,7 +23,7 @@ Imports System
 
 Class C
     Sub M(x as string, y as string)
-        Dim z = [||]If (x Is Nothing, y, x)
+        Dim z = $$If (x Is Nothing, y, x)
     End Sub
 End Class",
 "
@@ -44,7 +44,7 @@ Imports System
 
 Class C
     Sub M(x as string, y as string)
-        Dim z = [||]If(x IsNot Nothing, x, y)
+        Dim z = $$If(x IsNot Nothing, x, y)
     End Sub
 End Class",
 "
@@ -65,7 +65,7 @@ Imports System
 
 Class C
     Sub M(x as string, y as string)
-        Dim z = [||]If(Nothing Is x, y, x)
+        Dim z = $$If(Nothing Is x, y, x)
     End Sub
 End Class",
 "
@@ -86,7 +86,7 @@ Imports System
 
 Class C
     Sub M(x as string, y as string)
-        Dim z = [||]If(Nothing IsNot x, x, y)
+        Dim z = $$If(Nothing IsNot x, x, y)
     End Sub
 End Class",
 "
@@ -107,7 +107,7 @@ Imports System
 
 Class C
     Sub M(x as string, y as string)
-        Dim z = [||]If (x.ToString() is Nothing, y, x.ToString())
+        Dim z = $$If (x.ToString() is Nothing, y, x.ToString())
     End Sub
 End Class",
 "
@@ -128,7 +128,7 @@ Imports System
 
 Class C
     Sub M(x as string, y as string)
-        Dim z = [||]If ((x Is Nothing), y, x)
+        Dim z = $$If ((x Is Nothing), y, x)
     End Sub
 End Class",
 "
@@ -149,7 +149,7 @@ Imports System
 
 Class C
     Sub M(x as string, y as string)
-        Dim z = [||]If ((x) Is Nothing, y, x)
+        Dim z = $$If ((x) Is Nothing, y, x)
     End Sub
 End Class",
 "
@@ -170,7 +170,7 @@ Imports System
 
 Class C
     Sub M(x as string, y as string)
-        Dim z = [||]If (x Is Nothing, y, (x))
+        Dim z = $$If (x Is Nothing, y, (x))
     End Sub
 End Class",
 "
@@ -191,7 +191,7 @@ Imports System
 
 Class C
     Sub M(x as string, y as string)
-        Dim z = [||]If (x Is Nothing, (y), x)
+        Dim z = $$If (x Is Nothing, (y), x)
     End Sub
 End Class",
 "
@@ -258,7 +258,7 @@ Imports System.Linq.Expressions
 
 Class C
     Sub M(x as string, y as string)
-        dim e as Expression(of Func(of string)) = function() [||]If (x isnot Nothing, x, y)
+        dim e as Expression(of Func(of string)) = function() $$If (x isnot Nothing, x, y)
     End Sub
 End Class",
 "

--- a/src/EditorFeatures/VisualBasicTest/UseCollectionInitializer/UseCollectionInitializerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseCollectionInitializer/UseCollectionInitializerTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.UseCol
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer)()
+        Dim c = $$New List(Of Integer)()
         c.Add(1)
     End Sub
 End Class",
@@ -42,7 +42,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer)(Nothing)
+        Dim c = $$New List(Of Integer)(Nothing)
         c.Add(1)
     End Sub
 End Class",
@@ -64,7 +64,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c As [||]New List(Of Integer)()
+        Dim c As $$New List(Of Integer)()
         c.Add(1)
     End Sub
 End Class",
@@ -87,7 +87,7 @@ Imports System.Collections.Generic
 Class C
     Sub M()
         Dim c as List(Of Integer) = Nothing
-        c = [||]New List(Of Integer)()
+        c = $$New List(Of Integer)()
         c.Add(1)
     End Sub
 End Class",
@@ -110,7 +110,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer)()
+        Dim c = $$New List(Of Integer)()
         c.Add(value:=1)
     End Sub
 End Class")
@@ -123,7 +123,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer)()
+        Dim c = $$New List(Of Integer)()
         c.Add()
     End Sub
 End Class")
@@ -136,7 +136,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer)()
+        Dim c = $$New List(Of Integer)()
         c.Add
     End Sub
 End Class")
@@ -149,7 +149,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer)()
+        Dim c = $$New List(Of Integer)()
         c.Add(1,,2)
     End Sub
 End Class")
@@ -164,7 +164,7 @@ Class C
     Sub M()
         Dim array As List(Of Integer)()
 
-        array(0) = [||]New List(Of Integer)()
+        array(0) = $$New List(Of Integer)()
         array(0).Add(1)
         array(0).Add(2)
     End Sub
@@ -190,7 +190,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer)()
+        Dim c = $$New List(Of Integer)()
         c.Add(1, 2)
     End Sub
 End Class",
@@ -212,7 +212,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer) From {
+        Dim c = $$New List(Of Integer) From {
             1
         }
         c.Add(1)
@@ -264,7 +264,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer)()
+        Dim c = $$New List(Of Integer)()
         c.Add(1) ' Goo
         c.Add(2) ' Bar
     End Sub
@@ -289,7 +289,7 @@ End Class")
 Imports System.Collections.Generic
 Class C
     Sub M()
-        Dim c = [||]New List(Of Integer)()
+        Dim c = $$New List(Of Integer)()
         ' Goo
         c.Add(1)
         ' Bar

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.UseInferredMemberN
 Class C
     Sub M()
         Dim a As Integer = 1
-        Dim t = ( [||]a:= a, 2)
+        Dim t = ( $$a:= a, 2)
     End Sub
 End Class
 ",
@@ -48,7 +48,7 @@ Class C
     Sub M()
         Dim alice As Integer = 1
         Dim Alice As Integer = 2
-        Dim t = ( [||]alice:= alice, Alice)
+        Dim t = ( $$alice:= alice, Alice)
     End Sub
 End Class
 ", parameters:=New TestParameters(s_parseOptions))
@@ -76,7 +76,7 @@ End Class
 Class C
     Sub M()
         Dim a As Integer = 2
-        Dim t = (1,  [||]a:= a )
+        Dim t = (1,  $$a:= a )
     End Sub
 End Class
 ",

--- a/src/EditorFeatures/VisualBasicTest/UseIsNullCheck/UseIsNullCheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseIsNullCheck/UseIsNullCheckTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.CodeFixes
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.UseIsNullCheck
 
 class C
     sub M(s as string)
-        if ([||]ReferenceEquals(s, Nothing))
+        if ($$ReferenceEquals(s, Nothing))
             return
         end if
     end sub
@@ -47,7 +47,7 @@ end class")
 
 class C
     sub M(s as string)
-        if (object.[||]ReferenceEquals(s, Nothing))
+        if (object.$$ReferenceEquals(s, Nothing))
             return
         end if
     end sub
@@ -70,7 +70,7 @@ end class")
 
 class C
     sub M(s as string)
-        if (Object.[||]ReferenceEquals(s, Nothing))
+        if (Object.$$ReferenceEquals(s, Nothing))
             return
         end if
     end sub
@@ -93,7 +93,7 @@ end class")
 
 class C
     sub M(s as string)
-        if ([||]ReferenceEquals(Nothing, s))
+        if ($$ReferenceEquals(Nothing, s))
             return
         end if
     end sub
@@ -116,7 +116,7 @@ end class")
 
 class C
     sub M(s as string)
-        if (not [||]ReferenceEquals(Nothing, s))
+        if (not $$ReferenceEquals(Nothing, s))
             return
         end if
     end sub
@@ -190,7 +190,7 @@ end class")
 
 class C
     sub M(Of T As Structure)(v as T)
-        if ([||]ReferenceEquals(Nothing, v))
+        if ($$ReferenceEquals(Nothing, v))
             return
         end if
     end sub

--- a/src/EditorFeatures/VisualBasicTest/UseNamedArguments/UseNamedArgumentsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseNamedArguments/UseNamedArgumentsTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.UseNamedArguments
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 As Integer, arg2 As Integer)
-        M([||]1, 2)
+        M($$1, 2)
     End Sub
 End Class",
 "Class C
@@ -32,7 +32,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 As Integer, arg2 As Integer)
-        M(1, [||]2)
+        M(1, $$2)
     End Sub
 End Class",
 "Class C
@@ -49,7 +49,7 @@ End Class")
     Sub M()
         Dim f = Sub (arg)
                 End Sub
-        f([||]1)
+        f($$1)
     End Sub
 End Class",
 "Class C
@@ -68,7 +68,7 @@ End Class")
     Sub M()
         Dim f = Sub (arg)
                 End Sub
-        f?([||]1)
+        f?($$1)
     End Sub
 End Class",
 "Class C
@@ -85,7 +85,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 as Integer, arg2 as Integer)
-        Me?.M([||]1, 2)
+        Me?.M($$1, 2)
     End Sub
 End Class",
 "Class C
@@ -100,7 +100,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 as String)
-        Dim r = arg1?([||]0)
+        Dim r = arg1?($$0)
     End Sub
 End Class",
 "Class C
@@ -115,7 +115,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub New(arg1 As Integer, arg2 As Integer)
-        Dim c = New C([||]1, 2)
+        Dim c = New C($$1, 2)
     End Sub
 End Class",
 "Class C
@@ -130,7 +130,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Function M(arg1 as String) As Char
-        Return arg1([||]0)
+        Return arg1($$0)
     End Function
 End Class",
 "Class C
@@ -145,7 +145,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Function M(arg1 as Integer() As Integer
-        Return arg1([||]0)
+        Return arg1($$0)
     End Function
 End Class")
         End Function
@@ -155,7 +155,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Function M(arg1 as Integer() As Integer
-        Return arg1?([||]0)
+        Return arg1?($$0)
     End Function
 End Class")
         End Function
@@ -165,7 +165,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Sub M()
-        M([||])
+        M($$)
     End Sub
 End Class")
         End Function
@@ -175,7 +175,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Sub M(arg as Integer)
-        M([||]arg:=1)
+        M($$arg:=1)
     End Sub
 End Class")
         End Function
@@ -185,7 +185,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Sub M(ParamArray arg1 As Integer())
-        M([||]1)
+        M($$1)
     End Sub
 End Class")
         End Function
@@ -195,7 +195,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 As Integer, ParamArray arg2 As Integer())
-        M([||]1)
+        M($$1)
     End Sub
 End Class",
 "Class C
@@ -210,7 +210,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 As Integer, optional arg2 As Integer=1, optional arg3 as Integer=1)
-        M([||]1,,3)
+        M($$1,,3)
     End Sub
 End Class")
         End Function
@@ -220,7 +220,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 As Integer, optional arg2 As Integer=1, optional arg3 as Integer=1)
-        M(1,,[||]3)
+        M(1,,$$3)
     End Sub
 End Class",
 "Class C
@@ -235,7 +235,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Sub M(optional arg1 As Integer=1, optional arg2 As Integer=1)
-        M([||], arg2:=2)
+        M($$, arg2:=2)
     End Sub
 End Class")
         End Function
@@ -245,7 +245,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Function M() As String
-        Return NameOf([||]M)
+        Return NameOf($$M)
     End Function
 End Class")
         End Function
@@ -253,7 +253,7 @@ End Class")
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNamedArguments)>
         Public Async Function TestMissingOnAttribute() As Task
             Await TestMissingInRegularAndScriptAsync(
-"<C([||]1)>
+"<C($$1)>
 Class C
     Inherits System.Attribute
     Public Sub New(arg As Integer)
@@ -267,7 +267,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 As Integer)
-        M(arg1[||])
+        M(arg1$$)
     End Sub
 End Class",
 "Class C
@@ -283,7 +283,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 As Integer, arg2 As Integer)
-        M(arg1[||], arg2)
+        M(arg1$$, arg2)
     End Sub
 End Class",
 "Class C
@@ -299,7 +299,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 As Integer, optional arg2 As Integer=1, optional arg3 as Integer=1)
-        M(1,[||],3)
+        M(1,$$,3)
     End Sub
 End Class")
         End Function
@@ -310,7 +310,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Sub M(arg1 As Integer, optional arg2 As Integer=1, optional arg3 as Integer=1)
-        M(1[||],,3)
+        M(1$$,,3)
     End Sub
 End Class")
         End Function
@@ -321,7 +321,7 @@ End Class")
             Await TestMissingInRegularAndScriptAsync(
 "Class C
     Function M(arg1 As Integer, optional arg2 As Integer=1, optional arg3 as Integer=1) As Integer
-        M(1, M(1,[||], 3))
+        M(1, M(1,$$, 3))
     End Function
 End Class")
         End Function
@@ -333,7 +333,7 @@ End Class")
 "Imports System.Linq
 Class C
     Sub M(arr as Integer())
-        arr.Zip(arr, Function(p1, p2) ([||]p1, p2))
+        arr.Zip(arr, Function(p1, p2) ($$p1, p2))
     End Sub
 End Class")
         End Function
@@ -344,7 +344,7 @@ End Class")
             Await TestInRegularAndScriptAsync(
 "Class C
     Sub M([If] As Integer, [For] As Integer)
-        M([If][||], [For])
+        M([If]$$, [For])
     End Sub
 End Class",
 "Class C

--- a/src/EditorFeatures/VisualBasicTest/UseNullPropagation/UseNullPropagationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseNullPropagation/UseNullPropagationTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -22,7 +22,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (o Is Nothing, Nothing, o.ToString())
+        Dim v = $$If (o Is Nothing, Nothing, o.ToString())
     End Sub
 End Class",
 "
@@ -43,7 +43,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (o Is Nothing, Nothing, o.ToString())
+        Dim v = $$If (o Is Nothing, Nothing, o.ToString())
     End Sub
 End Class", New TestParameters(VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12)))
         End Function
@@ -56,7 +56,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Nothing Is o, Nothing, o.ToString()
+        Dim v = $$If (Nothing Is o, Nothing, o.ToString()
     End Sub
 End Class",
 "
@@ -77,7 +77,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (o IsNot Nothing, o.ToString(), Nothing)
+        Dim v = $$If (o IsNot Nothing, o.ToString(), Nothing)
     End Sub
 End Class",
 "
@@ -99,7 +99,7 @@ Imports System
 Class C
     Dim f As Integer?
     Sub M(C c)
-        Dim v = [||]If (c IsNot Nothing, c.f, Nothing)
+        Dim v = $$If (c IsNot Nothing, c.f, Nothing)
     End Sub
 End Class",
 "
@@ -122,7 +122,7 @@ Imports System
 Class C
     Dim f As Integer?
     Sub M(C c)
-        Dim v = [||]If (DirectCast(c, Object) IsNot Nothing, c.f, Nothing)
+        Dim v = $$If (DirectCast(c, Object) IsNot Nothing, c.f, Nothing)
     End Sub
 End Class",
 "
@@ -144,7 +144,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Nothing IsNot o, o.ToString(), Nothing)
+        Dim v = $$If (Nothing IsNot o, o.ToString(), Nothing)
     End Sub
 End Class",
 "
@@ -165,7 +165,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (o Is Nothing, Nothing, o(0))
+        Dim v = $$If (o Is Nothing, Nothing, o(0))
     End Sub
 End Class",
 "
@@ -186,7 +186,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (o Is Nothing, Nothing, o.B?.C)
+        Dim v = $$If (o Is Nothing, Nothing, o.B?.C)
     End Sub
 End Class",
 "
@@ -207,7 +207,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (o Is Nothing, Nothing, o.B)
+        Dim v = $$If (o Is Nothing, Nothing, o.B)
     End Sub
 End Class",
 "
@@ -228,7 +228,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (o Is Nothing, Nothing, o)
+        Dim v = $$If (o Is Nothing, Nothing, o)
     End Sub
 End Class")
         End Function
@@ -241,7 +241,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If ((o Is Nothing), Nothing, o.ToString())
+        Dim v = $$If ((o Is Nothing), Nothing, o.ToString())
     End Sub
 End Class",
 "
@@ -306,7 +306,7 @@ Imports System
 
 Class C
     Function M(o As String) As Integer?
-        return [||]If (o Is Nothing, Nothing, o.Length)
+        return $$If (o Is Nothing, Nothing, o.Length)
     End Function
 End Class")
         End Function
@@ -319,7 +319,7 @@ Imports System
 
 Class C
     Sub M(o As String)
-        Dim x = [||]If (o Is Nothing, Nothing, o.Length)
+        Dim x = $$If (o Is Nothing, Nothing, o.Length)
     End Sub
 End Class")
         End Function
@@ -333,7 +333,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (ReferenceEquals(o, Nothing), Nothing, o.ToString())
+        Dim v = $$If (ReferenceEquals(o, Nothing), Nothing, o.ToString())
     End Sub
 End Class",
 "
@@ -355,7 +355,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (ReferenceEquals(Nothing, o), Nothing, o.ToString())
+        Dim v = $$If (ReferenceEquals(Nothing, o), Nothing, o.ToString())
     End Sub
 End Class",
 "
@@ -377,7 +377,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (ReferenceEquals(o, other), Nothing, o.ToString())
+        Dim v = $$If (ReferenceEquals(o, other), Nothing, o.ToString())
     End Sub
 End Class")
         End Function
@@ -391,7 +391,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (ReferenceEquals(other, o), Nothing, o.ToString())
+        Dim v = $$If (ReferenceEquals(other, o), Nothing, o.ToString())
     End Sub
 End Class")
         End Function
@@ -405,7 +405,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Object.ReferenceEquals(o, Nothing), Nothing, o.ToString())
+        Dim v = $$If (Object.ReferenceEquals(o, Nothing), Nothing, o.ToString())
     End Sub
 End Class",
 "
@@ -427,7 +427,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Object.ReferenceEquals(Nothing, o), Nothing, o.ToString())
+        Dim v = $$If (Object.ReferenceEquals(Nothing, o), Nothing, o.ToString())
     End Sub
 End Class",
 "
@@ -449,7 +449,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (Object.ReferenceEquals(o, other), Nothing, o.ToString())
+        Dim v = $$If (Object.ReferenceEquals(o, other), Nothing, o.ToString())
     End Sub
 End Class")
         End Function
@@ -463,7 +463,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (Object.ReferenceEquals(other, o), Nothing, o.ToString())
+        Dim v = $$If (Object.ReferenceEquals(other, o), Nothing, o.ToString())
     End Sub
 End Class")
         End Function
@@ -477,7 +477,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Object.ReferenceEquals(o, ), Nothing, o.ToString())
+        Dim v = $$If (Object.ReferenceEquals(o, ), Nothing, o.ToString())
     End Sub
 End Class")
         End Function
@@ -491,7 +491,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Object.ReferenceEquals(, Nothing), Nothing, o.ToString())
+        Dim v = $$If (Object.ReferenceEquals(, Nothing), Nothing, o.ToString())
     End Sub
 End Class")
         End Function
@@ -505,7 +505,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Not ReferenceEquals(o, Nothing), o.ToString(), Nothing)
+        Dim v = $$If (Not ReferenceEquals(o, Nothing), o.ToString(), Nothing)
     End Sub
 End Class",
 "
@@ -527,7 +527,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Not ReferenceEquals(Nothing, o), o.ToString(), Nothing)
+        Dim v = $$If (Not ReferenceEquals(Nothing, o), o.ToString(), Nothing)
     End Sub
 End Class",
 "
@@ -549,7 +549,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (Not ReferenceEquals(o, other), o.ToString(), Nothing)
+        Dim v = $$If (Not ReferenceEquals(o, other), o.ToString(), Nothing)
     End Sub
 End Class")
         End Function
@@ -563,7 +563,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (Not ReferenceEquals(other, o), o.ToString(), Nothing)
+        Dim v = $$If (Not ReferenceEquals(other, o), o.ToString(), Nothing)
     End Sub
 End Class")
         End Function
@@ -577,7 +577,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Not Object.ReferenceEquals(o, Nothing), o.ToString(), Nothing)
+        Dim v = $$If (Not Object.ReferenceEquals(o, Nothing), o.ToString(), Nothing)
     End Sub
 End Class",
 "
@@ -599,7 +599,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Not Object.ReferenceEquals(Nothing, o), o.ToString(), Nothing)
+        Dim v = $$If (Not Object.ReferenceEquals(Nothing, o), o.ToString(), Nothing)
     End Sub
 End Class",
 "
@@ -621,7 +621,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (Not Object.ReferenceEquals(o, other), o.ToString(), Nothing)
+        Dim v = $$If (Not Object.ReferenceEquals(o, other), o.ToString(), Nothing)
     End Sub
 End Class")
         End Function
@@ -635,7 +635,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (Not Object.ReferenceEquals(other, o), o.ToString(), Nothing)
+        Dim v = $$If (Not Object.ReferenceEquals(other, o), o.ToString(), Nothing)
     End Sub
 End Class")
         End Function
@@ -649,7 +649,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Not (o Is Nothing), o.ToString(), Nothing)
+        Dim v = $$If (Not (o Is Nothing), o.ToString(), Nothing)
     End Sub
 End Class",
 "
@@ -671,7 +671,7 @@ Imports System
 
 Class C
     Sub M(o As Object)
-        Dim v = [||]If (Not (o IsNot Nothing), Nothing, o.ToString())
+        Dim v = $$If (Not (o IsNot Nothing), Nothing, o.ToString())
     End Sub
 End Class",
 "
@@ -694,7 +694,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (Not (o Is other), o.ToString(), Nothing)
+        Dim v = $$If (Not (o Is other), o.ToString(), Nothing)
     End Sub
 End Class")
         End Function
@@ -708,7 +708,7 @@ Imports System
 
 Class C
     Sub M(o As Object, other as Object)
-        Dim v = [||]If (Not (o IsNot other), Nothing, o.ToString())
+        Dim v = $$If (Not (o IsNot other), Nothing, o.ToString())
     End Sub
 End Class")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.UseObj
 Class C
     Dim i As Integer
     Sub M()
-        Dim c = [||]New C()
+        Dim c = $$New C()
         c.i = 1
     End Sub
 End Class",
@@ -42,7 +42,7 @@ End Class")
 Class C
     Dim i As Integer
     Sub M()
-        Dim c As [||]New C()
+        Dim c As $$New C()
         c.i = 1
     End Sub
 End Class",
@@ -65,7 +65,7 @@ Class C
     Dim i As Integer
     Sub M()
         Dim c as C = Nothing
-        c = [||]New C()
+        c = $$New C()
         c.i = 1
     End Sub
 End Class",
@@ -88,7 +88,7 @@ End Class")
 Class C
     Dim i As Integer
     Sub M()
-        Dim c = [||]New C()
+        Dim c = $$New C()
         c.i = 1
         c.i = 2
     End Sub
@@ -115,7 +115,7 @@ Class C
     Sub M()
         Dim array As C()
 
-        array(0) = [||]New C()
+        array(0) = $$New C()
         array(0).i = 1
         array(0).j = 2
     End Sub
@@ -143,7 +143,7 @@ Class C
     Dim i As Integer
     Dim j As Integer
     Sub M()
-        Dim c = [||]New C()
+        Dim c = $$New C()
         c.i = 1
         c.j += 1
     End Sub
@@ -169,7 +169,7 @@ Class C
     Dim i As Integer
     Dim j As Integer
     Sub M()
-        Dim c = [||]New C() With {
+        Dim c = $$New C() With {
             .i = 1
         }
         c.j = 1
@@ -185,7 +185,7 @@ End Class")
 Class C
     Sub M()
         With New String()
-            Dim x As ProcessStartInfo = [||]New ProcessStartInfo()
+            Dim x As ProcessStartInfo = $$New ProcessStartInfo()
             x.Arguments = .Length.ToString()
         End With
     End Sub
@@ -199,7 +199,7 @@ End Class")
 "                            
 Class C
     Sub M()
-        Dim x As ProcessStartInfo = [||]New ProcessStartInfo()
+        Dim x As ProcessStartInfo = $$New ProcessStartInfo()
         x.Arguments = Sub()
                          With New String()
                             Dim a = .Length.ToString()
@@ -268,7 +268,7 @@ Class C
     Dim i As Integer
     Dim j As Integer
     Sub M()
-        Dim c = [||]New C()
+        Dim c = $$New C()
         c.i = 1 ' Goo
         c.j = 2 ' Bar
     End Sub
@@ -293,7 +293,7 @@ End Class")
 "
 Class C
     Sub M()
-        Dim XmlAppConfigReader As [||]New XmlTextReader(Reader)
+        Dim XmlAppConfigReader As $$New XmlTextReader(Reader)
 
         ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
         XmlAppConfigReader.DtdProcessing = DtdProcessing.Prohibit
@@ -319,7 +319,7 @@ End Class")
 "
 Class C
     Sub M()
-        Dim XmlAppConfigReader As [||]New XmlTextReader(Reader)
+        Dim XmlAppConfigReader As $$New XmlTextReader(Reader)
 
         ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
         XmlAppConfigReader.DtdProcessing = DtdProcessing.Prohibit
@@ -351,7 +351,7 @@ Class C
     Shared y As Integer
 
     Sub M()
-        Dim z = [||]New C()
+        Dim z = $$New C()
         z.x = 1
         z.y = 2
     End Sub

--- a/src/EditorFeatures/VisualBasicTest/ValidateFormatString/ValidateFormatStringTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ValidateFormatString/ValidateFormatStringTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ValidateFormatStri
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Format(""This {0} {1} {[||]2} works"", New Object  { ""test"", ""test2"", ""test3"" })
+        string.Format(""This {0} {1} {$$2} works"", New Object  { ""test"", ""test2"", ""test3"" })
     End Sub
 End Class")
         End Function
@@ -51,7 +51,7 @@ End Class")
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Format(""This {0} {1[||]} works"", ""test"", ""also"")
+        string.Format(""This {0} {1$$} works"", ""test"", ""also"")
     End Sub
 End Class")
         End Function
@@ -63,7 +63,7 @@ Imports System.Globalization
 Class C
      Sub Main 
         Dim culture as CultureInfo = ""da - da""
-        string.Format(culture, ""The current price is {0[||]:C2} per ounce"", 2.45)
+        string.Format(culture, ""The current price is {0$$:C2} per ounce"", 2.45)
     End Sub
 End Class")
         End Function
@@ -117,7 +117,7 @@ End Class",
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Format(arg0:= ""test"", arg1:= ""also"", format:= ""This {0[||]} {1} works"")
+        string.Format(arg0:= ""test"", arg1:= ""also"", format:= ""This {0$$} {1} works"")
     End Sub
 End Class")
         End Function
@@ -143,7 +143,7 @@ Imports System.Globalization
 Class C
      Sub Main 
         Dim culture As CultureInfo = ""da - da""
-        string.Format(arg0:= 2.45, provider:=culture, format :=""The current price is {0[||]:C2} per ounce -no squiggles"")
+        string.Format(arg0:= 2.45, provider:=culture, format :=""The current price is {0$$:C2} per ounce -no squiggles"")
     End Sub
 End Class")
         End Function
@@ -155,7 +155,7 @@ Imports System.Globalization
 Class C
      Sub Main 
         Dim culture As CultureInfo = ""da - da""
-        string.Format(format:= ""This {0} {1[||]} {2} works"", args:=New Object  { ""test"", ""it"", ""really"" }, provider:=culture)
+        string.Format(format:= ""This {0} {1$$} {2} works"", args:=New Object  { ""test"", ""it"", ""really"" }, provider:=culture)
     End Sub
 End Class")
         End Function
@@ -167,7 +167,7 @@ Imports System.Globalization
 Class C
      Sub Main 
         Dim culture As CultureInfo = ""da - da""
-        string.Format(format:= ""This {0} {1[||]} {2} works"", format:=New Object  { ""test"", ""it"", ""really"" }, provider:=culture)
+        string.Format(format:= ""This {0} {1$$} {2} works"", format:=New Object  { ""test"", ""it"", ""really"" }, provider:=culture)
     End Sub
 End Class")
         End Function
@@ -182,7 +182,7 @@ Imports System.Globalization
 Class C
      Sub Main 
         Dim culture As CultureInfo = ""da - da""
-        string.Format(format:= ""This {0} {1[||]} {2} works"", format:=New Object  { ""test"", ""it"", ""really"" }, provider:=culture)
+        string.Format(format:= ""This {0} {1$$} {2} works"", format:=New Object  { ""test"", ""it"", ""really"" }, provider:=culture)
     End Sub
 End Class
         </Document>
@@ -196,7 +196,7 @@ End Class
 Imports stringalias = System.String
 Class C
      Sub Main 
-        stringAlias.Format(""This {[||]0} works"", ""test"")
+        stringAlias.Format(""This {$$0} works"", ""test"")
     End Sub
 End Class")
         End Function
@@ -206,7 +206,7 @@ End Class")
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Format(@""This {[||]0} 
+        string.Format(@""This {$$0} 
 {1} {2} works"", ""multiple"", ""line"", ""test""))
     End Sub
 End Class")
@@ -218,7 +218,7 @@ End Class")
 Class C
      Sub Main 
         string.Format($""This {0} 
-{1[||]} {2} works"", ""multiple"", ""line"", ""test""))
+{1$$} {2} works"", ""multiple"", ""line"", ""test""))
     End Sub
 End Class")
         End Function
@@ -228,7 +228,7 @@ End Class")
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Format(""[||]"")
+        string.Format(""$$"")
     End Sub
 End Class")
         End Function
@@ -238,7 +238,7 @@ End Class")
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Format([||]
+        string.Format($$
     End Sub
 End Class")
         End Function
@@ -248,7 +248,7 @@ End Class")
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Format [||]
+        string.Format $$
     End Sub
 End Class")
         End Function
@@ -258,7 +258,7 @@ End Class")
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Compare [||]
+        string.Compare $$
     End Sub
 End Class")
         End Function
@@ -275,7 +275,7 @@ End Class
 Class C
     Sub Goo()
         Dim q As G(Of Integer)
-        q.Format(Of Integer)(""TestStr[||]ing"")
+        q.Format(Of Integer)(""TestStr$$ing"")
     End Sub
 End Class")
         End Function
@@ -284,7 +284,7 @@ End Class")
         Public Async Function OmittedArgument() As Task
             Await TestDiagnosticMissingAsync("Module M
     Sub Main()
-         String.Format([||],)
+         String.Format($$,)
     End Sub
 End Module")
         End Function
@@ -294,7 +294,7 @@ End Module")
             Await TestDiagnosticMissingAsync("
 Class C
      Sub Main 
-        string.Format(""This {0} {1} {[||]2} works"", New Object  { ""test"", ""test2"", ""test3"" })
+        string.Format(""This {0} {1} {$$2} works"", New Object  { ""test"", ""test2"", ""test3"" })
     End Sub
 End Class", New TestParameters(options:=VBOptionOffCSharpOptionOn))
         End Function

--- a/src/Test/Utilities/Portable/MarkedSource/MarkupTestFile.cs
+++ b/src/Test/Utilities/Portable/MarkedSource/MarkupTestFile.cs
@@ -56,8 +56,8 @@ namespace Roslyn.Test.Utilities
             var currentIndexInInput = 0;
             var inputOutputOffset = 0;
 
-            // A stack of span starts along with their associated annotation name.  [||] spans simply
-            // have empty string for their annotation name.
+            // A stack of span starts along with their associated annotation name.  [|...|]
+            // spans simply have empty string for their annotation name.
             var spanStartStack = new Stack<Tuple<int, string>>();
 
             while (true)

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using System.Threading;
@@ -19,10 +19,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
         {
             using (var workspace = TestWorkspace.CreateCSharp(markup))
             {
-                var caret = workspace.Documents.First().CursorPosition;
+                Assert.True(workspace.TryGetDocumentWithSelectedSpan(out var document, out var span));
 
                 var service = new CSharpHelpContextService();
-                var actualText = await service.GetHelpTermAsync(workspace.CurrentSolution.Projects.First().Documents.First(), workspace.Documents.First().SelectedSpans.First(), CancellationToken.None);
+                var actualText = await service.GetHelpTermAsync(document, span, CancellationToken.None);
                 Assert.Equal(expectedText, actualText);
             }
         }

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
 using System.Threading;
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
             await Test_KeywordAsync(
 @"class C
 {
-    vo[||]id goo()
+    vo$$id goo()
     {
     }
 }", "void");
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
 {
     void goo()
     {
-        ret[||]urn;
+        ret$$urn;
     }
 }", "return");
         }
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
         public async Task TestPartialType()
         {
             await Test_KeywordAsync(
-@"part[||]ial class C
+@"part$$ial class C
 {
     partial void goo();
 }", "partialtype");
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.F1Help
             await Test_KeywordAsync(
 @"partial class C
 {
-    par[||]tial void goo();
+    par$$tial void goo();
 }", "partialmethod");
         }
 
@@ -88,7 +88,7 @@ class Program<T> where T : class
     void goo(string[] args)
     {
         var x = from a in args
-                whe[||]re a.Length > 0
+                whe$$re a.Length > 0
                 select a;
     }
 }", "whereclause");
@@ -100,7 +100,7 @@ class Program<T> where T : class
             await Test_KeywordAsync(
 @"using System.Linq;
 
-class Program<T> wh[||]ere T : class
+class Program<T> wh$$ere T : class
 {
     void goo(string[] args)
     {
@@ -115,7 +115,7 @@ class Program<T> wh[||]ere T : class
         public async Task TestPreprocessor()
         {
             await TestAsync(
-@"#regi[||]on
+@"#regi$$on
 #endregion", "#region");
         }
 
@@ -196,7 +196,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        var[||] x = 3;
+        var$$ x = 3;
     }
 }", "var_CSharpKeyword");
         }
@@ -214,7 +214,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        var x =[||] 3;
+        var x =$$ 3;
     }
 }", "=_CSharpKeyword");
         }
@@ -232,7 +232,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        var x = from n i[||]n {
+        var x = from n i$$n {
             1}
 
         select n
@@ -253,7 +253,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        new UriBuilder().Fragm[||]ent;
+        new UriBuilder().Fragm$$ent;
     }
 }", "System.UriBuilder.Fragment");
         }
@@ -271,7 +271,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        foreach (var x in[||] {
+        foreach (var x in$$ {
             1} )
         {
         }
@@ -287,7 +287,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        #region Begin MyR[||]egion for testing
+        #region Begin MyR$$egion for testing
         #endregion End
     }
 }", "#region");
@@ -301,7 +301,7 @@ class Program
 {
     static void generic<T>(T t)
     {
-        generic[||]<int>(0);
+        generic$$<int>(0);
     }
 }", "Program.generic``1");
         }
@@ -320,7 +320,7 @@ class Program
     static void Main(string[] args)
     {
         int x;
-        x[||];
+        x$$;
     }
 }", "System.Int32");
         }
@@ -334,7 +334,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        var i = int.Ma[||]xValue;
+        var i = int.Ma$$xValue;
     }
 }", "System.Int32.MaxValue");
         }
@@ -346,7 +346,7 @@ class Program
             await TestAsync(
 @"class Class2
 {
-    void M1(int par[||]ameter)  // 1
+    void M1(int par$$ameter)  // 1
     {
     }
 
@@ -365,7 +365,7 @@ class Program
             await TestAsync(
 @"class Class2
 {
-    void M1(int pa[||]rameter)  // 1
+    void M1(int pa$$rameter)  // 1
     {
     }
 
@@ -387,7 +387,7 @@ class Program
     static void Main(string[] args)
     {
     }
-}[||]", "");
+}$$", "");
         }
 
         [WorkItem(862328, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/862328")]
@@ -399,7 +399,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        Main(new string[] { ""fo[||]o"" });
+        Main(new string[] { ""fo$$o"" });
     }
 }", "System.String");
         }
@@ -418,7 +418,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        global:[||]:System.Console.Write("");
+        global:$$:System.Console.Write("");
     }
 }", "::_CSharpKeyword");
         }
@@ -437,7 +437,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        int?[||] a = int.MaxValue;
+        int?$$ a = int.MaxValue;
         a.Value.GetHashCode();
     }
 }", "System.Nullable`1");
@@ -486,7 +486,7 @@ class Program
     void M()
     {
         var a = 0;
-        int v[||]ar = 1;
+        int v$$ar = 1;
     }
 }", "System.Int32");
         }
@@ -500,7 +500,7 @@ class Program
 {
     void M()
     {
-        var a = new System.Action(() =[||]> {
+        var a = new System.Action(() =$$> {
         });
     }
 }", "=>_CSharpKeyword");
@@ -517,7 +517,7 @@ class Program
 
     void M()
     {
-        e +[||]= () => {
+        e +$$= () => {
         };
     }
 }", "CCC.e.add");
@@ -527,7 +527,7 @@ class Program
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestComment()
         {
-            await TestAsync(@"// some comm[||]ents here", "comments");
+            await TestAsync(@"// some comm$$ents here", "comments");
         }
 
         [WorkItem(867529, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/867529")]
@@ -539,7 +539,7 @@ class Program
 {
     void M()
     {
-        dyna[||]mic d = 0;
+        dyna$$mic d = 0;
     }
 }", "dynamic_CSharpKeyword");
         }
@@ -558,7 +558,7 @@ class Program
     static void Main(string[] args)
     {
         var zzz = from y in args
-                  select [||]y;
+                  select $$y;
     }
 }", "System.String");
         }

--- a/src/VisualStudio/Core/Test/Help/HelpTests.vb
+++ b/src/VisualStudio/Core/Test/Help/HelpTests.vb
@@ -1,4 +1,4 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
 Imports System.Threading.Tasks
@@ -26,7 +26,7 @@ Class G
     Public Event MyEvent()
 
     Public Sub G()
-        AddH[||]andler MyEvent, AddressOf G
+        AddH$$andler MyEvent, AddressOf G
     End Sub
 End Class</a>
 
@@ -40,7 +40,7 @@ Class G
     Public Event MyEvent()
 
     Public Sub G()
-        AddHandler MyEvent,[||] AddressOf G
+        AddHandler MyEvent,$$ AddressOf G
     End Sub
 End Class</a>
 
@@ -52,7 +52,7 @@ End Class</a>
             Dim text = <a>
 Class G
     Public Sub G()
-        Dim x as integer() = new Integer() {1,[||] 2, 3}
+        Dim x as integer() = new Integer() {1,$$ 2, 3}
     End Sub
 End Class</a>
 
@@ -64,7 +64,7 @@ End Class</a>
             Dim text = <a>
 Class G
     Public Sub G()
-        Dim x as integer() = new[||] Integer() {1, 2, 3}
+        Dim x as integer() = new$$ Integer() {1, 2, 3}
     End Sub
 End Class</a>
 
@@ -76,7 +76,7 @@ End Class</a>
             Dim text = <a>
 Class G
     Public Sub G()
-        Dim x as integer() =[||] new {1, 2, 3}
+        Dim x as integer() =$$ new {1, 2, 3}
     End Sub
 End Class</a>
 
@@ -89,9 +89,9 @@ End Class</a>
 Class GAttribute
             Inherits System.Attribute
 
-    <G>[||]
+    <G>$$
     Public Sub G()
-                Dim x As Integer() =[||] New {1, 2, 3}
+                Dim x As Integer() =$$ New {1, 2, 3}
     End Sub
 End Class]]></a>
 
@@ -102,7 +102,7 @@ End Class]]></a>
         Public Async Function TestModuleAttribute() As Task
             Dim text = <a><![CDATA[
 Imports System.Reflection
-<Assembly: AssemblyTitleAttribute("Production assembly 4"), Mod[||]ule: CLSCompliant(True)>
+<Assembly: AssemblyTitleAttribute("Production assembly 4"), Mod$$ule: CLSCompliant(True)>
 Module M
 
 End Module]]></a>
@@ -114,7 +114,7 @@ End Module]]></a>
         Public Async Function TestAssemblyAttribute() As Task
             Dim text = <a><![CDATA[
 Imports System.Reflection
-<Ass[||]embly: AssemblyTitleAttribute("Production assembly 4"), Module: CLSCompliant(True)>
+<Ass$$embly: AssemblyTitleAttribute("Production assembly 4"), Module: CLSCompliant(True)>
 Module M
 
 End Module]]></a>
@@ -127,7 +127,7 @@ End Module]]></a>
             Dim text = <a><![CDATA[
 Class G
     Sub G()
-        DIm x = 2 +[||] 3
+        DIm x = 2 +$$ 3
     End Sub
 ENd Class]]></a>
 
@@ -139,7 +139,7 @@ ENd Class]]></a>
             Dim text = <a><![CDATA[
 Class G
     Sub G()
-        C[||]all G()
+        C$$all G()
     End Sub
 ENd Class]]></a>
 
@@ -153,7 +153,7 @@ Class G
     Sub G()
         Dim x = 2 + 3
         Select Case x
-            Ca[||]se 1
+            Ca$$se 1
                 G()
             Case Else
                 x = 3
@@ -173,7 +173,7 @@ Class G
         Select Case x
             Case 1
                 G()
-            Case E[||]lse
+            Case E$$lse
                 x = 3
         End Select
     End Sub
@@ -189,7 +189,7 @@ Class G
     Sub G()
         Try G()
 
-        Catch ex As[||] Exception When 2 = 2
+        Catch ex As$$ Exception When 2 = 2
 
         End Try
     End Sub
@@ -205,7 +205,7 @@ Class G
     Sub G()
         Try G()
 
-        Catch ex As Exception W[||]hen 2 = 2
+        Catch ex As Exception W$$hen 2 = 2
 
         End Try
     End Sub
@@ -238,7 +238,7 @@ End Class]]></a>
 Class G
     Sub G()
         Dim x As List(Of Integer)
-        x = New List(Of Integer) Fr[||]om {1, 2, 3}
+        x = New List(Of Integer) Fr$$om {1, 2, 3}
     End Sub
 End Class]]></a>
 
@@ -251,7 +251,7 @@ End Class]]></a>
 Class G
     Sub G()
         Dim x As List(Of Integer)
-        x = New List(Of Integer) From {1,[||] 2, 3}
+        x = New List(Of Integer) From {1,$$ 2, 3}
     End Sub
 End Class]]></a>
 
@@ -263,7 +263,7 @@ End Class]]></a>
         Public Async Function TestConstructor() As Task
             Dim text = <a><![CDATA[
 Class G
-    Sub Ne[||]w()
+    Sub Ne$$w()
     End Sub
 End Class]]></a>
 
@@ -279,7 +279,7 @@ Class G
         Dim customerOrders = From cust In {1, 2, 3}, ord In {1, 2, 3}
                      Where cust= ord
                      Select cust.CompanyName
-                     Dist[||]inct
+                     Dist$$inct
     End Sub
 End Class]]></a>
 
@@ -293,7 +293,7 @@ Class G
     Sub G()
         Do
 
-        Loop Un[||]til False
+        Loop Un$$til False
     End Sub
 End Class]]></a>
 
@@ -307,7 +307,7 @@ Class G
     Sub G()
         Do
 
-        Loop Un[||]til False
+        Loop Un$$til False
     End Sub
 End Class]]></a>
 
@@ -319,7 +319,7 @@ End Class]]></a>
             Dim text = <a><![CDATA[
 Class G
     Sub G()
-        Do[||]
+        Do$$
 
         Loop Until False
     End Sub
@@ -335,7 +335,7 @@ Class G
     Sub G()
         If True Then
 
-        ElseIf False The[||]n
+        ElseIf False The$$n
 
         End If
     End Sub
@@ -351,7 +351,7 @@ Class G
     Sub G()
         If True Then
 
-        ElseI[||]f False Then
+        ElseI$$f False Then
 
         Else
 
@@ -371,7 +371,7 @@ Class G
 
         ElseIf False Then
 
-        Els[||]e
+        Els$$e
 
         End If
     End Sub
@@ -385,7 +385,7 @@ End Class]]></a>
             Dim text = <a><![CDATA[
 Class G
     Sub G()
-        I[||]f True Then
+        I$$f True Then
 
         ElseIf False Then
 
@@ -403,7 +403,7 @@ Class G
     Sub G()
         Dim x as Function(Of Integer) = Function()
                                             return 2
-                                        End Functi[||]on
+                                        End Functi$$on
     End Sub
 End Class]]></a>
 
@@ -414,7 +414,7 @@ End Class]]></a>
         Public Async Function TestEndBlockKind() As Task
             Dim text = <a><![CDATA[
 Class G
-En[||]d Class]]></a>
+En$$d Class]]></a>
 
             Await TestAsync(text.Value, "vb.Class")
         End Function
@@ -426,7 +426,7 @@ Class G
         Public Custom Event e As EventHandler
             AddHandler(value As EventHandler)
 
-            End AddH[||]andler
+            End AddH$$andler
             RemoveHandler(value As EventHandler)
 
             End RemoveHandler
@@ -444,7 +444,7 @@ Class G
             Dim text = <a><![CDATA[
 Class G
     Sub goo()
-        End[||]
+        End$$
     ENd Sub
 End Class]]></a>
 
@@ -455,7 +455,7 @@ End Class]]></a>
         Public Async Function TestEnumMember() As Task
             Dim text = <a><![CDATA[
 Enum G
-    A[||]
+    A$$
 End Enum]]></a>
 
             Await TestAsync(text.Value, "vb.Enum")
@@ -467,7 +467,7 @@ End Enum]]></a>
 Class G
     Sub G()
         DIm x(9, 9), y(9, 9) as Integer
-        Erase[||] x, y
+        Erase$$ x, y
     End Sub
 End Class]]></a>
 
@@ -494,7 +494,7 @@ End Class]]></a>
             Dim text = <a><![CDATA[
 Class G
     Sub G()
-        Er[||]ror 1
+        Er$$ror 1
     End Sub
 End Class]]></a>
 
@@ -505,7 +505,7 @@ End Class]]></a>
         Public Async Function TestEvent() As Task
             Dim text = <a><![CDATA[
 Class G
-    Ev[||]ent e As EventHandler
+    Ev$$ent e As EventHandler
 End Class]]></a>
 
             Await TestAsync(text.Value, "vb.Event")
@@ -544,7 +544,7 @@ End Class]]></a>
         Public Async Function TestField1() As Task
             Dim text = <a><![CDATA[
 Class G
-    Protec[||]ted goo as Integer
+    Protec$$ted goo as Integer
 End Class]]></a>
 
             Await TestAsync(text.Value, "vb.Protected")
@@ -554,7 +554,7 @@ End Class]]></a>
         Public Async Function TestField2() As Task
             Dim text = <a><![CDATA[
 Class G
-    Protected ReadOn[||]ly goo as Integer
+    Protected ReadOn$$ly goo as Integer
 End Class]]></a>
 
             Await TestAsync(text.Value, "vb.ReadOnly")
@@ -640,7 +640,7 @@ End Class]]></a>
         Public Async Function TestFrom() As Task
             Dim text = <a><![CDATA[
 Class G
-    Dim z = F[||]rom x in {1 2 3} select x
+    Dim z = F$$rom x in {1 2 3} select x
 End Class]]></a>
 
             Await TestAsync(text.Value, HelpKeywords.QueryFrom)
@@ -840,7 +840,7 @@ End Class]]></a>
             Dim text = <a><![CDATA[
 Class G
     Sub G()
-        Dim f1 As Func(Of Task(Of Integer)) = Async F[||]unction()
+        Dim f1 As Func(Of Task(Of Integer)) = Async F$$unction()
                                                   Return Await Task.FromResult(2)
                                               End Function
 
@@ -880,7 +880,7 @@ End Class]]></a>
         Public Async Function TestMainMethod() As Task
             Dim text = <a><![CDATA[
 Module Goo
-    Sub m[||]ain()
+    Sub m$$ain()
     End Sub
 End Module]]></a>
 
@@ -1175,7 +1175,7 @@ End Class]]></a>
 Class Program
     Public Event e as EventHandler
     Sub gooo()
-        RaiseEve[||]nt e(nothing, nothing)
+        RaiseEve$$nt e(nothing, nothing)
     End Sub
 End Class]]></a>
 
@@ -1217,7 +1217,7 @@ Class Program
 
     End Sub
     Sub gooo()
-        Re[||]moveHandler e, AddressOf EHandler
+        Re$$moveHandler e, AddressOf EHandler
     End Sub
 End Class]]></a>
 
@@ -1253,7 +1253,7 @@ End Class]]></a>
             Dim text = <a><![CDATA[
 Class Program
     Function gooo() as Integer
-        St[||]op
+        St$$op
     End Sub
 End Class]]></a>
 
@@ -1266,7 +1266,7 @@ End Class]]></a>
 Class Program
     Function gooo() as Integer
         DIm lock = new Object()
-        Syn[||]cLock lock
+        Syn$$cLock lock
         End SyncLock
     End Sub
 End Class]]></a>
@@ -1305,7 +1305,7 @@ End Class]]></a>
 Class Program
     Function gooo() as Integer
         Dim x as IDisposable = nothing
-        Us[||]ing x
+        Us$$ing x
         End Using
     End Sub
 End Class]]></a>
@@ -1352,7 +1352,7 @@ End Class]]></a>
             Dim text = <a><![CDATA[
 Class Program
     Private Iterator Function Goo() as IEnumerable(of Integer)
-        System.Console.Wri[||]teLine(2)
+        System.Console.Wri$$teLine(2)
     End Function
 End Class]]></a>
 
@@ -1364,7 +1364,7 @@ End Class]]></a>
             Dim text = <a><![CDATA[
 Class Program
     Private Iterator Function Goo() as IEnumerable(of Integer)
-        Dim x = #5/30/19[||]90#
+        Dim x = #5/30/19$$90#
     End Function
 End Class]]></a>
 
@@ -1379,7 +1379,7 @@ Imports System.Linq
 
 Module Program
     ''' <summary>
-    ''' [||]
+    ''' $$
     ''' </summary>
     ''' <param name="args"></param>
     Sub Main(args As String())
@@ -1393,7 +1393,7 @@ End Module]]></a>.Value, HelpKeywords.XmlDocComment)
         Public Async Function TestAnonymousType() As Task
             Await TestAsync(<a><![CDATA[Public Class Test
     Sub Subroutine()
-        Dim mm = Sub(ByRef x As String, y As Integer) System.Console.WriteLine(), k[||]k = Sub(y, x) mm(y, x)
+        Dim mm = Sub(ByRef x As String, y As Integer) System.Console.WriteLine(), k$$k = Sub(y, x) mm(y, x)
     End Sub
 End Class]]></a>.Value, "vb.AnonymousType")
         End Function
@@ -1408,7 +1408,7 @@ Imports System.Linq
 Module Program
     Sub Main(args As String())
         Dim query = From iii In {1, 2, 3}
-                    Select New With {.P[||]1 = iii}
+                    Select New With {.P$$1 = iii}
         Dim i = query.First().P1
 
     End Sub
@@ -1423,7 +1423,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 
 Module Program
-    Sub Main(ByV[||]al args As String())
+    Sub Main(ByV$$al args As String())
 
     End Sub
 End Module]]></a>.Value, "vb.ByVal")
@@ -1437,7 +1437,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 
 Module Program
-    Sub Main([||]Of T)(args As String())
+    Sub Main($$Of T)(args As String())
 
     End Sub
 End Module]]></a>.Value, "vb.Of")
@@ -1449,7 +1449,7 @@ End Module]]></a>.Value, "vb.Of")
             Await TestAsync(<a><![CDATA[Public Class Test
     Sub Subroutine()
         Dim i = 0
-        i [||]+= 1
+        i $$+= 1
         i -= 2
         i *= 3
         i /= 4
@@ -1467,7 +1467,7 @@ Imports System.Linq
 
 Module Program
     Sub Main(args As String())
-        Dim x As System.Collections.Generic[||].IEnumerable(Of Integer)
+        Dim x As System.Collections.Generic$$.IEnumerable(Of Integer)
 
     End Sub
 End Module]]></a>.Value, "System.Collections.Generic.IEnumerable`1")
@@ -1483,7 +1483,7 @@ Imports System.Linq
 Module Program
     Sub Main(args As String())
         
-    End S[||]ub
+    End S$$ub
 End Module]]></a>.Value, "vb.Sub")
         End Function
 
@@ -1493,7 +1493,7 @@ End Module]]></a>.Value, "vb.Sub")
             Await TestAsync(<a><![CDATA[Imports System.Text
 Public Class Test
     Sub Subroutine()
-        Dim sb A[||]s New StringBuilder
+        Dim sb A$$s New StringBuilder
     End Sub
 End Class
 ]]></a>.Value, "vb.As")
@@ -1507,7 +1507,7 @@ End Class
             Await TestAsync(<a><![CDATA[Public Class Test
     Async Sub AsyncSub()
         Dim x2 = Async Function() As Task(Of Integer)
-                     Return A[||]wait AsyncFuncNG(10)
+                     Return A$$wait AsyncFuncNG(10)
                  End Function
     End Sub
 End Class
@@ -1518,7 +1518,7 @@ End Class
         <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
         Public Async Function TestProperty() As Task
             Await TestAsync(<a><![CDATA[Class Program
-    Prope[||]rty prop As Integer
+    Prope$$rty prop As Integer
 End Class]]></a>.Value, "vb.AutoImplementedProperty")
         End Function
 
@@ -1527,7 +1527,7 @@ End Class]]></a>.Value, "vb.AutoImplementedProperty")
         Public Async Function TestPredefinedTypeMember() As Task
             Await TestAsync(<a><![CDATA[Module Program
     Sub Main(args As String())
-        Dim x = Integer.MaxVa[||]lue
+        Dim x = Integer.MaxVa$$lue
     End Sub
 End Module]]></a>.Value, "System.Int32.MaxValue")
         End Function
@@ -1535,7 +1535,7 @@ End Module]]></a>.Value, "System.Int32.MaxValue")
         <WorkItem(864237, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/864237")>
         <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
         Public Async Function TestModuleModifier() As Task
-            Await TestAsync(<a><![CDATA[Publi[||]c Module M
+            Await TestAsync(<a><![CDATA[Publi$$c Module M
     Public Class C
         Protected Sub S1()
         End Sub
@@ -1566,7 +1566,7 @@ Public Delegate Sub Dele()
         End Get
     End Property
 End Module
-Publi[||]c Delegate Sub Dele()
+Publi$$c Delegate Sub Dele()
 ]]></a>.Value, "vb.Public")
         End Function
 
@@ -1575,7 +1575,7 @@ Publi[||]c Delegate Sub Dele()
         Public Async Function TestAssignment() As Task
             Await TestAsync(<a><![CDATA[Public Class Test
     Sub Subroutine()
-        Dim x =[||] Int32.Parse("1")
+        Dim x =$$ Int32.Parse("1")
     End Sub
 End Class
 ]]></a>.Value, "vb.=")
@@ -1586,7 +1586,7 @@ End Class
         Public Async Function TestRem() As Task
             Await TestAsync(<a><![CDATA[Module Program
     Sub Main(args As String())
-        ' COmm[||]ent!
+        ' COmm$$ent!
     End Sub
 End Module]]></a>.Value, "vb.Rem")
         End Function
@@ -1596,7 +1596,7 @@ End Module]]></a>.Value, "vb.Rem")
         Public Async Function TestTodo() As Task
             Await TestAsync(<a><![CDATA[Module Program
     Sub Main(args As String())
-        ' TODO: COmm[||]ent!
+        ' TODO: COmm$$ent!
     End Sub
 End Module]]></a>.Value, HelpKeywords.TaskListUserComments)
         End Function
@@ -1608,7 +1608,7 @@ End Module]]></a>.Value, HelpKeywords.TaskListUserComments)
     Sub Subroutine()
     End Sub
     Sub AnotherSub()
-        Subroutine()[||]
+        Subroutine()$$
     End Sub
 End Class
 ]]></a>.Value, "vb.Call")
@@ -1617,7 +1617,7 @@ End Class
         <WorkItem(864202, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/864202")>
         <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
         Public Async Function TestImportsXmlns() As Task
-            Await TestAsync(<a><![CDATA[Imports <xmln[||]s:ns="goo">]]></a>.Value, "vb.ImportsXmlns")
+            Await TestAsync(<a><![CDATA[Imports <xmln$$s:ns="goo">]]></a>.Value, "vb.ImportsXmlns")
         End Function
 
         <WorkItem(862420, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/862420")>
@@ -1628,7 +1628,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 
 Module Program
-    Sub Main(a[||]rgs As String())
+    Sub Main(a$$rgs As String())
         
     End Sub
 End Module]]></a>.Value, "System.String()")
@@ -1639,7 +1639,7 @@ End Module]]></a>.Value, "System.String()")
         Public Async Function TestNoToken() As Task
             Await TestAsync(<a><![CDATA[Module Program
     Sub Main(args As String())
-[||]
+$$
     End Sub
 End Module]]></a>.Value, "")
         End Function
@@ -1653,7 +1653,7 @@ Imports System.Linq
 
 Module Program
     Sub Main(args As String())
-        Int32.[||]Parse("1")
+        Int32.$$Parse("1")
     End Sub
 End Module]]></a>.Value, "System.Int32.Parse")
         End Function
@@ -1668,7 +1668,7 @@ Imports System.Linq
 Module Program
     Sub Main(args As String())
 
-        Dim local5 = If(CTy[||]pe(3, Object), Nothing)
+        Dim local5 = If(CTy$$pe(3, Object), Nothing)
     End Sub
 End Module]]></a>.Value, "vb.CType")
         End Function
@@ -1683,7 +1683,7 @@ Imports System.Linq
 Module Program
     Sub Main(args As String())
 
-        Dim local5 = If(CType(3, Object), Noth[||]ing)
+        Dim local5 = If(CType(3, Object), Noth$$ing)
     End Sub
 End Module]]></a>.Value, "vb.Nothing")
         End Function
@@ -1697,7 +1697,7 @@ Imports System.Linq
 
 Module Program
     Sub Main(args As String())
-        Dim Value1a As Integer?[||] = 10
+        Dim Value1a As Integer?$$ = 10
     End Sub
 End Module]]></a>.Value, "vb.Nullable")
         End Function
@@ -1712,7 +1712,7 @@ Imports System.Linq
 Module Program
     Sub Main(args As String())
 
-#Region "mor[||]e"
+#Region "mor$$e"
 #End Region
 
     End Sub
@@ -1724,7 +1724,7 @@ End Module]]></a>.Value, "vb.String")
         Public Async Function TestTypeCharacter() As Task
             Await TestAsync(<a><![CDATA[Public Module M
     Sub M1()
-        Dim u = 1[||]UI
+        Dim u = 1$$UI
         Dim ul = &HBADC0DE
         Dim l = -1L
     End Sub
@@ -1734,7 +1734,7 @@ End Module]]></a>.Value, "vb.UInteger")
         <WorkItem(865061, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/865061")>
         <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
         Public Async Function TestStructure() As Task
-            Await TestAsync(<a><![CDATA[Structure S[||]1
+            Await TestAsync(<a><![CDATA[Structure S$$1
 End Structure
 ]]></a>.Value, "vb.Structure")
         End Function
@@ -1744,7 +1744,7 @@ End Structure
         Public Async Function TestXmlLiteralDocument() As Task
             Await TestAsync(<a><![CDATA[Public Module M
     Sub M1()
-        Dim MyXMLLiteral = <?xml versio[||]n="1.0" encoding="utf-8"?>
+        Dim MyXMLLiteral = <?xml versio$$n="1.0" encoding="utf-8"?>
                            <Details>
 
                            </Details>
@@ -1768,7 +1768,7 @@ End Module
                            </Details>
 
         Dim y = <!-- -->
-        Dim z = <e[||]/>
+        Dim z = <e$$/>
 
     End Sub
 End Module
@@ -1785,7 +1785,7 @@ End Module
 
                            </Details>
 
-        Dim y = <!--[||] -->
+        Dim y = <!--$$ -->
         Dim z = <e/>
 
     End Sub
@@ -1799,7 +1799,7 @@ End Module
             Await TestAsync(<a><![CDATA[Class C
     Sub M()
         Dim icount = 0
-        Wh[||]ile icount <= 100
+        Wh$$ile icount <= 100
             icount += 1
         End While
 
@@ -1815,7 +1815,7 @@ Sub M()
 End Interface
 Class C
 Implements I1
-Public Sub M() Imple[||]ments I1.M
+Public Sub M() Imple$$ments I1.M
 End Sub
 End Class
 ]]></a>.Value, "vb.ImplementsClause")
@@ -1829,7 +1829,7 @@ Class C
 Sub M1()
 End Sub
 Sub M()
-Dim d1 As New mydele(Addre[||]ssOf M1)
+Dim d1 As New mydele(Addre$$ssOf M1)
 Dim addr As mydele = AddressOf M1
 End Sub
 End Class
@@ -1901,7 +1901,7 @@ End Class
         Public Async Function TestImplementsIDisposable() As Task
             Await TestAsync(<a><![CDATA[Imports System
 Class C
-    Implements IDis[||]posable
+    Implements IDis$$posable
     Public Sub Dispose() Implements IDisposable.Dispose
         Throw New NotImplementedException()
     End Sub
@@ -1913,7 +1913,7 @@ End Class
         Public Async Function TestInherits() As Task
             Await TestAsync(<a><![CDATA[Imports System
 Class C
-    Inherits Exc[||]eption
+    Inherits Exc$$eption
 
 End Class
 ]]></a>.Value, "System.Exception")
@@ -1924,7 +1924,7 @@ End Class
             Await TestAsync(<a><![CDATA[Class C
     Sub M()
         Dim b = False
-        b = N[||]ot b
+        b = N$$ot b
     End Sub
 End Class]]></a>.Value, "vb.Not")
         End Function
@@ -1934,7 +1934,7 @@ End Class]]></a>.Value, "vb.Not")
             Await TestAsync(<a><![CDATA[Class C
     Sub M()
         Dim a(4) As Integer
-        a[||](0) = 1
+        a$$(0) = 1
     End Sub
 End Class]]></a>.Value, "vb.Integer")
         End Function
@@ -1951,7 +1951,7 @@ End Class]]></a>.Value, "vb.Integer")
         Dim query1 = From c In customers
                      Let d = c
                      Where d IsNot Nothing
-                     Group Jo[||]in c1 In customers On d.Address.GetHashCode() Equals c1.Address.GetHashCode() Into e = Group
+                     Group Jo$$in c1 In customers On d.Address.GetHashCode() Equals c1.Address.GetHashCode() Into e = Group
                      Group c By c.Address Into g = Group
                      Order By g.Count() Ascending
                      Order By Address Descending
@@ -1975,7 +1975,7 @@ End Module]]></a>.Value, "vb.QueryGroupJoin")
         Dim query1 = From c In customers
                      Let d = c
                      Where d IsNot Nothing
-                     Group Join c1 I[||]n customers On d.Address.GetHashCode() Equals c1.Address.GetHashCode() Into e = Group
+                     Group Join c1 I$$n customers On d.Address.GetHashCode() Equals c1.Address.GetHashCode() Into e = Group
                      Group c By c.Address Into g = Group
                      Order By g.Count() Ascending
                      Order By Address Descending
@@ -1999,7 +1999,7 @@ End Module]]></a>.Value, "vb.QueryGroupJoinIn")
         Dim query1 = From c In customers
                      Let d = c
                      Where d IsNot Nothing
-                     Group Join c1 In customers On d.Address.GetHashCode() Equ[||]als c1.Address.GetHashCode() Into e = Group
+                     Group Join c1 In customers On d.Address.GetHashCode() Equ$$als c1.Address.GetHashCode() Into e = Group
                      Group c By c.Address Into g = Group
                      Order By g.Count() Ascending
                      Order By Address Descending
@@ -2027,7 +2027,7 @@ End Module]]></a>.Value, "vb.Equals")
                      Group c By c.Address Into g = Group
                      Order By g.Count() Ascending
                      Order By Address Descending
-                     Sele[||]ct New With {Key .Address = Address, Key .CustCount = g.Count()}
+                     Sele$$ct New With {Key .Address = Address, Key .CustCount = g.Count()}
     End Sub
     Class Customer
         Public Property ID() As Integer
@@ -2051,7 +2051,7 @@ End Module]]></a>.Value, "vb.QuerySelect")
                      Group c By c.Address Into g = Group
                      Order By g.Count() Ascending
                      Order By Address Descending
-                     Select New With {Key .Address = Address, Key .CustCount = g.Coun[||]t()}
+                     Select New With {Key .Address = Address, Key .CustCount = g.Coun$$t()}
     End Sub
     Class Customer
         Public Property ID() As Integer
@@ -2064,7 +2064,7 @@ End Module]]></a>.Value, "System.Linq.Enumerable.Count")
         <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
         Public Async Function TestOperatorOverload() As Task
             Await TestAsync(<a><![CDATA[Class C
-    Public Shared Operator IsTr[||]ue(ByVal a As C) As Boolean
+    Public Shared Operator IsTr$$ue(ByVal a As C) As Boolean
         Return False
     End Operator
 End Class]]></a>.Value, "vb.IsTrue")
@@ -2079,7 +2079,7 @@ Imports System.Linq
 
 Module Program
     Sub Main(args As String())
-        Dim produc[||]tList = {New With {.category = "Condiments", .name = "Ketchup"}, New With {.category = "Seafood", .name = "Code"}}
+        Dim produc$$tList = {New With {.category = "Condiments", .name = "Ketchup"}, New With {.category = "Seafood", .name = "Code"}}
     End Sub
 End Module]]></a>.Value, "vb.AnonymousType")
         End Function
@@ -2091,7 +2091,7 @@ End Module]]></a>.Value, "vb.AnonymousType")
 Class C
     Sub M()
         Dim x = "hello"
-        Dim t = x.Get[||]Type
+        Dim t = x.Get$$Type
     End Sub
 End Class]]></a>.Value, "System.Object.GetType")
         End Function
@@ -2105,7 +2105,7 @@ Imports System.Linq
 
 Module Program
     Sub Main(args As String())
-        args.Le[||]ngth
+        args.Le$$ngth
     End Sub
 End Module]]></a>.Value, "System.Array.Length")
         End Function
@@ -2114,7 +2114,7 @@ End Module]]></a>.Value, "System.Array.Length")
         Public Async Function TestParameterFromReference() As Task
             Await TestAsync(<a><![CDATA[Module Program
     Sub Main(args As String())
-        a[||]rgs
+        a$$rgs
     End Sub
 End Module]]></a>.Value, "System.String()")
         End Function
@@ -2124,7 +2124,7 @@ End Module]]></a>.Value, "System.String()")
             Await TestAsync(<a><![CDATA[Module Program
     Sub Main(args As String())
         Dim x As Integer
-        x[||]
+        x$$
     End Sub
 End Module]]></a>.Value, "System.Int32")
         End Function
@@ -2135,7 +2135,7 @@ End Module]]></a>.Value, "System.Int32")
 
 Module Program
     Sub Main(args As String())
-        Dim x As s[||]
+        Dim x As s$$
     End Sub
 End Module]]></a>.Value, "System.Linq.Enumerable")
         End Function
@@ -2144,7 +2144,7 @@ End Module]]></a>.Value, "System.Linq.Enumerable")
         Public Async Function TestRangeVariable() As Task
             Await TestAsync(<a><![CDATA[Module Program
     Sub Main(args As String())
-        Dim z = From x In args Select x[||]
+        Dim z = From x In args Select x$$
     End Sub
 End Module]]></a>.Value, "vb.String")
         End Function
@@ -2157,7 +2157,7 @@ Imports System.Linq
 
 Module Program
     Sub Main(args As String())
-        Dim x = (2).[||]ToString()
+        Dim x = (2).$$ToString()
     End Sub
 End Module]]></a>.Value, "System.Int32.ToString")
         End Function
@@ -2170,7 +2170,7 @@ Imports System.Linq
 
 Module Program
     Sub Main(args As String())
-        Dim x = (2)[||].ToString()
+        Dim x = (2)$$.ToString()
     End Sub
 End Module]]></a>.Value, "System.Int32.ToString")
         End Function

--- a/src/VisualStudio/Core/Test/Help/HelpTests.vb
+++ b/src/VisualStudio/Core/Test/Help/HelpTests.vb
@@ -1,9 +1,11 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.Help
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Utilities
@@ -13,9 +15,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Help
     Public Class HelpTests
         Public Async Function TestAsync(markup As String, expected As String) As Tasks.Task
             Using workspace = TestWorkspace.CreateVisualBasic(markup)
-                Dim caret = workspace.Documents.First().CursorPosition
+                Dim document As Document = Nothing
+                Dim span As TextSpan = Nothing
+                Assert.True(workspace.TryGetDocumentWithSelectedSpan(document, span))
                 Dim service = New VisualBasicHelpContextService()
-                Assert.Equal(expected, Await service.GetHelpTermAsync(workspace.CurrentSolution.Projects.First().Documents.First(), workspace.Documents.First().SelectedSpans.First(), CancellationToken.None))
+                Assert.Equal(expected, Await service.GetHelpTermAsync(document, span, CancellationToken.None))
             End Using
         End Function
 


### PR DESCRIPTION
@dpoeschl Commented that this would be nice during the review of hte parentheses-precedence PR.  I decided to do this as a separate PR.

An empty-selection at a position is the same as just specifying where the caret is as far as our tests are concerned.  So this change allows many tests to be simpler, and helps avoid some confusing cases where ```[||]``` is used around things like ```||```, causing visual confusion.