### PR TITLE
Add test to ensure we do not regress already-fixed pattern-matching bug.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
@@ -1220,6 +1220,40 @@ class Program1
                 );
         }
 
+        [Fact, WorkItem(25591, "https://github.com/dotnet/roslyn/issues/25591")]
+        public void TupleSubsumptionError()
+        {
+            var source =
+@"class Program2
+{
+    public static void Main()
+    {
+        M(new Fox());
+        M(new Cat());
+        M(new Program2());
+    }
+    static void M(object o)
+    {
+        switch ((o, 0))
+        {
+            case (Fox fox, _):
+                System.Console.Write(""Fox "");
+                break;
+            case (Cat cat, _):
+                System.Console.Write(""Cat"");
+                break;
+        }
+    }
+}
+class Fox {}
+class Cat {}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.VerifyDiagnostics(
+                );
+            var comp = CompileAndVerify(compilation, expectedOutput: @"Fox Cat");
+        }
+
         // PROTOTYPE(patterns2): Need to have tests that exercise:
         // PROTOTYPE(patterns2): Building the decision tree for the var-pattern
         // PROTOTYPE(patterns2): Definite assignment for the var-pattern


### PR DESCRIPTION
Fixes #25591

@cston @agocke @dotnet/roslyn-compiler Could one of you review this test-only addition please?
