### PR TITLE
Update ICSharpCode.Decompiler to version 3.1.0.3652

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -14,7 +14,7 @@
     <dotnetxunitVersion>2.3.1</dotnetxunitVersion>
     <FakeSignVersion>0.9.2</FakeSignVersion>
     <HumanizerCoreVersion>2.2.0</HumanizerCoreVersion>
-    <ICSharpCodeDecompilerVersion>3.0.0.3403-beta4</ICSharpCodeDecompilerVersion>
+    <ICSharpCodeDecompilerVersion>3.1.0.3652</ICSharpCodeDecompilerVersion>
     <LibGit2SharpVersion>0.22.0</LibGit2SharpVersion>
     <MicroBuildCoreVersion>0.2.0</MicroBuildCoreVersion>
     <MicroBuildCoreSentinelVersion>1.0.0</MicroBuildCoreSentinelVersion>


### PR DESCRIPTION
See release notes: https://github.com/icsharpcode/ILSpy/releases/tag/v3.1-final

### Customer scenario

A user enables the **Navigate to decompiled sources** feature, and the generated code does not appear as expected.

### Bugs this fixes

* Fixes dotnet/roslyn#25251 (Decompilation should simplify "type" usage)
* Fixes dotnet/roslyn#25246 (Decompilation cannot decompile xUnit's `Assert.All`)
* Fixes icsharpcode/ILSpy#1095 (C# decompilation, for flags enums always use hex prefix)

### Workarounds, if any

None.

### Risk

Low. No changes were made to transitive dependencies for the update, and the library is only used as part of an experimental feature which is disabled by default.

### Performance impact

No performance impact outside of the experimental scenario.

### Is this a regression from a previous update?

No.

### Root cause analysis

N/A

### How was the bug found?

Dogfooding, customer reporting

### Test documentation updated?

No.
