### PR TITLE
Add empty Directory.Build.rsp files

### DIFF
--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,0 +1,1 @@
+# This file intentionally left blank to avoid accidental import during build.

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -642,6 +642,7 @@ function Redirect-Temp() {
     Copy-Item (Join-Path $repoDir "src\Workspaces\CoreTestUtilities\Resources\.editorconfig") $temp
     Copy-Item (Join-Path $repoDir "src\Workspaces\CoreTestUtilities\Resources\Directory.Build.props") $temp
     Copy-Item (Join-Path $repoDir "src\Workspaces\CoreTestUtilities\Resources\Directory.Build.targets") $temp
+    Copy-Item (Join-Path $repoDir "src\Workspaces\CoreTestUtilities\Resources\Directory.Build.rsp") $temp
     ${env:TEMP} = $temp
     ${env:TMP} = $temp
 }

--- a/src/Workspaces/CoreTestUtilities/Resources/Directory.Build.rsp
+++ b/src/Workspaces/CoreTestUtilities/Resources/Directory.Build.rsp
@@ -1,0 +1,1 @@
+# This file intentionally left blank to avoid accidental import during testing


### PR DESCRIPTION
When msbuild.exe is invoked it will search the current directory looking
for a Directory.Build.rsp file to provide additional command line
arguments. This search follows the same logic as for
Directory.Build.props files and has the same type of implications
for build reliability.

Adding a dummy empty file for both our standard build and tests.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
