### PR TITLE
Compiler.SyntaxTest.IncrementalParser Refactored

### DIFF
--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -10,9 +10,9 @@ Microsoft.CodeAnalysis.MetadataImportOptions
 Microsoft.CodeAnalysis.MetadataImportOptions.All = 2 -> Microsoft.CodeAnalysis.MetadataImportOptions
 Microsoft.CodeAnalysis.MetadataImportOptions.Internal = 1 -> Microsoft.CodeAnalysis.MetadataImportOptions
 Microsoft.CodeAnalysis.MetadataImportOptions.Public = 0 -> Microsoft.CodeAnalysis.MetadataImportOptions
-Microsoft.CodeAnalysis.OperationKind.TupleBinaryOperator = 87 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.ConstructorBodyOperation = 89 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.MethodBodyOperation = 88 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.OperationKind.TupleBinaryOperator = 87 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.Operations.IConstructorBodyOperation
 Microsoft.CodeAnalysis.Operations.IConstructorBodyOperation.Initializer.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Operations.IConstructorBodyOperation.Locals.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ILocalSymbol>
@@ -26,14 +26,15 @@ Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation.LeftOperand.get -> Micro
 Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation.OperatorKind.get -> Microsoft.CodeAnalysis.Operations.BinaryOperatorKind
 Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation.RightOperand.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Operations.ITupleOperation.NaturalType.get -> Microsoft.CodeAnalysis.ITypeSymbol
+Microsoft.CodeAnalysis.Platform.Arm64 = 6 -> Microsoft.CodeAnalysis.Platform
 abstract Microsoft.CodeAnalysis.DataFlowAnalysis.CapturedInside.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISymbol>
 abstract Microsoft.CodeAnalysis.DataFlowAnalysis.CapturedOutside.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISymbol>
 const Microsoft.CodeAnalysis.WellKnownMemberNames.DeconstructMethodName = "Deconstruct" -> string
 static Microsoft.CodeAnalysis.Diagnostic.Create(Microsoft.CodeAnalysis.DiagnosticDescriptor descriptor, Microsoft.CodeAnalysis.Location location, Microsoft.CodeAnalysis.DiagnosticSeverity effectiveSeverity, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Location> additionalLocations, System.Collections.Immutable.ImmutableDictionary<string, string> properties, params object[] messageArgs) -> Microsoft.CodeAnalysis.Diagnostic
-virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitTupleBinaryOperator(Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation operation) -> void
-virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitTupleBinaryOperator(Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation operation, TArgument argument) -> TResult
-Microsoft.CodeAnalysis.Platform.Arm64 = 6 -> Microsoft.CodeAnalysis.Platform
+static readonly Microsoft.CodeAnalysis.Text.TextSpan.NullSpan -> Microsoft.CodeAnalysis.Text.TextSpan
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitConstructorBodyOperation(Microsoft.CodeAnalysis.Operations.IConstructorBodyOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitMethodBodyOperation(Microsoft.CodeAnalysis.Operations.IMethodBodyOperation operation) -> void
+virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitTupleBinaryOperator(Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitConstructorBodyOperation(Microsoft.CodeAnalysis.Operations.IConstructorBodyOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitMethodBodyOperation(Microsoft.CodeAnalysis.Operations.IMethodBodyOperation operation, TArgument argument) -> TResult
+virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitTupleBinaryOperator(Microsoft.CodeAnalysis.Operations.ITupleBinaryOperation operation, TArgument argument) -> TResult

--- a/src/Compilers/Core/Portable/Text/TextSpan.cs
+++ b/src/Compilers/Core/Portable/Text/TextSpan.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.Text
     /// </summary>
     public struct TextSpan : IEquatable<TextSpan>, IComparable<TextSpan>
     {
+        public static readonly TextSpan NullSpan = new TextSpan(0, 0);
         /// <summary>
         /// Creates a TextSpan instance beginning with the position Start and having the Length
         /// specified with <paramref name="length" />.

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -204,10 +204,16 @@ Friend Module ParserTestUtilities
     ''' <field cref="IncParseNode.changeSpan">OF type TextSpan. The start and length of the change</field>
     ''' <field cref="IncParseNode.changeType">Whether text was added, removed or replaced</field>
     Public Structure IncParseNode
-        Public oldText As String
-        Public changeText As String
-        Public changeSpan As TextSpan
-        Public changeType As ChangeType
+        Public Sub New(oldText As String, changeText As String, changeSpan As TextSpan, changeType As ChangeType)
+            Me.oldText = oldText
+            Me.changeText = changeText
+            Me.changeSpan = changeSpan
+            Me.changeType = changeType
+        End Sub
+        Public ReadOnly oldText As String
+        Public ReadOnly changeText As String
+        Public ReadOnly changeSpan As TextSpan
+        Public ReadOnly changeType As ChangeType
     End Structure
 
     Public Sub IncParseAndVerify(oldIText As SourceText, newIText As SourceText)

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IPEndBlockStatements.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IPEndBlockStatements.vb
@@ -27,11 +27,11 @@ Public Class IPEndBlockStatements
             "Dim i = 1" & vbCrLf
         Dim change As String = "End Function"
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.Length, 0),
+        changeType:=ChangeType.Insert))
     End Sub
 
     <Fact>
@@ -47,11 +47,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Function" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" 1", StringComparison.Ordinal) + 4, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" 1", StringComparison.Ordinal) + 4, 0),
+        changeType:=ChangeType.Insert))
     End Sub
 
     <Fact>
@@ -69,11 +69,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Function" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" Sub()", StringComparison.Ordinal) + 8, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" Sub()", StringComparison.Ordinal) + 8, 0),
+        changeType:=ChangeType.Insert))
     End Sub
 
     ''' <summary>
@@ -91,11 +91,11 @@ Public Class IPEndBlockStatements
             "End Function" & vbCrLf
         Dim change As String = "End Function"
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("End Function", StringComparison.Ordinal), change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("End Function", StringComparison.Ordinal), change.Length),
+        changeType:=ChangeType.Remove))
 
     End Sub
 
@@ -113,11 +113,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Function" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" 1", StringComparison.Ordinal) + 4, change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" 1", StringComparison.Ordinal) + 4, change.Length),
+        changeType:=ChangeType.Remove))
 
     End Sub
 
@@ -136,11 +136,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Function" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" Sub()", StringComparison.Ordinal) + 8, change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" Sub()", StringComparison.Ordinal) + 8, change.Length),
+        changeType:=ChangeType.Remove))
     End Sub
 
 
@@ -157,11 +157,11 @@ Public Class IPEndBlockStatements
             "Dim i = 1" & vbCrLf
         Dim change As String = "End Sub"
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.Length, 0),
+        changeType:=ChangeType.Insert))
 
     End Sub
 
@@ -178,11 +178,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Sub" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" 1", StringComparison.Ordinal) + 4, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" 1", StringComparison.Ordinal) + 4, 0),
+        changeType:=ChangeType.Insert))
 
     End Sub
 
@@ -201,11 +201,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Sub" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" Function()", StringComparison.Ordinal) + 13, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" Function()", StringComparison.Ordinal) + 13, 0),
+        changeType:=ChangeType.Insert))
     End Sub
 
     ''' <summary>
@@ -222,11 +222,11 @@ Public Class IPEndBlockStatements
             "End Sub" & vbCrLf
         Dim change As String = "End Sub"
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("End Sub", StringComparison.Ordinal), change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("End Sub", StringComparison.Ordinal), change.Length),
+        changeType:=ChangeType.Remove))
 
     End Sub
 
@@ -247,12 +247,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Sub" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" 1", StringComparison.Ordinal) + 4, change.Length),
-        .changeType = ChangeType.Remove})
-
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" 1", StringComparison.Ordinal) + 4, change.Length),
+        changeType:=ChangeType.Remove))
     End Sub
 
     ''' <summary>
@@ -273,11 +272,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Sub" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("= Function()", StringComparison.Ordinal) + 14, change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("= Function()", StringComparison.Ordinal) + 14, change.Length),
+        changeType:=ChangeType.Remove))
     End Sub
 
     ''' <summary>
@@ -295,11 +294,11 @@ Public Class IPEndBlockStatements
             "While True" & vbCrLf
         Dim change = "End If" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.Length, 0),
+        changeType:=ChangeType.Insert))
     End Sub
 
     ''' <summary>
@@ -319,11 +318,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End If" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" True", StringComparison.Ordinal) + 7, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" True", StringComparison.Ordinal) + 7, 0),
+        changeType:=ChangeType.Insert))
     End Sub
 
     ''' <summary>
@@ -343,11 +342,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Sub" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" Then", StringComparison.Ordinal) + 7, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" Then", StringComparison.Ordinal) + 7, 0),
+        changeType:=ChangeType.Insert))
     End Sub
 
     ''' <summary>
@@ -366,11 +365,11 @@ Public Class IPEndBlockStatements
             "End If" & vbCrLf
         Dim change = "End If" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("End If", StringComparison.Ordinal), change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("End If", StringComparison.Ordinal), change.Length),
+        changeType:=ChangeType.Remove))
     End Sub
 
     ''' <summary>
@@ -392,11 +391,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End If" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" True", StringComparison.Ordinal) + 7, change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" True", StringComparison.Ordinal) + 7, change.Length),
+        changeType:=ChangeType.Remove))
     End Sub
 
     ''' <summary>
@@ -418,11 +417,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End If" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(" Then", StringComparison.Ordinal) + 7, change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf(" Then", StringComparison.Ordinal) + 7, change.Length),
+        changeType:=ChangeType.Remove))
     End Sub
 
     ''' <summary>
@@ -441,11 +440,11 @@ Public Class IPEndBlockStatements
             "Select el " & vbCrLf
         Dim change = "End Select" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.Length, 0),
+        changeType:=ChangeType.Insert))
     End Sub
 
     ''' <summary>
@@ -467,11 +466,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Select" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("Select el ", StringComparison.Ordinal) + 12, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("Select el ", StringComparison.Ordinal) + 12, 0),
+        changeType:=ChangeType.Insert))
 
     End Sub
 
@@ -492,11 +491,11 @@ Public Class IPEndBlockStatements
             "End Select" & vbCrLf
         Dim change = "End Select" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("End Select", StringComparison.Ordinal), change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("End Select", StringComparison.Ordinal), change.Length),
+        changeType:=ChangeType.Remove))
 
     End Sub
 
@@ -520,11 +519,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Select" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("Select el ", StringComparison.Ordinal) + 12, change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("Select el ", StringComparison.Ordinal) + 12, change.Length),
+        changeType:=ChangeType.Remove))
 
     End Sub
 
@@ -544,11 +543,11 @@ Public Class IPEndBlockStatements
         Dim change = "End Using" & vbCrLf
 
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.Length, 0),
+        changeType:=ChangeType.Insert))
 
     End Sub
 
@@ -571,11 +570,11 @@ Public Class IPEndBlockStatements
         Dim change = "End Using" & vbCrLf
 
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("New Integer ", StringComparison.Ordinal) + 14, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("New Integer ", StringComparison.Ordinal) + 14, 0),
+        changeType:=ChangeType.Insert))
 
     End Sub
 
@@ -598,11 +597,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "Using" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("End With", StringComparison.Ordinal) + 4, 4),
-        .changeType = ChangeType.Replace})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("End With", StringComparison.Ordinal) + 4, 4),
+        changeType:=ChangeType.Replace))
 
     End Sub
 
@@ -621,11 +620,11 @@ Public Class IPEndBlockStatements
             "With New Integer " & vbCrLf
         Dim change = "End Using" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("New", StringComparison.Ordinal), change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("New", StringComparison.Ordinal), change.Length),
+        changeType:=ChangeType.Remove))
 
     End Sub
 
@@ -649,11 +648,11 @@ Public Class IPEndBlockStatements
             "End Namespace" & vbCrLf
         Dim change = "End Select" & vbCrLf
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf("Select el ", StringComparison.Ordinal) + 12, change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=change,
+        changeSpan:=New TextSpan(code.IndexOf("Select el ", StringComparison.Ordinal) + 12, change.Length),
+        changeType:=ChangeType.Remove))
 
     End Sub
 End Class

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -914,7 +914,7 @@ End Module
     <WorkItem(546698, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546698")>
     <Fact>
     Public Sub Bug16596()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Sub M()
         If True Then
@@ -922,7 +922,7 @@ Module M
         End If
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Uncomment "Else".
@@ -935,14 +935,14 @@ End Module
     <WorkItem(530662, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530662")>
     <Fact>
     Public Sub Bug16662()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Sub M()
         ''' <[
         1: X
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Remove "X".
@@ -955,7 +955,7 @@ End Module
     <WorkItem(546774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546774")>
     <Fact>
     Public Sub Bug16786()
-        Dim source = <![CDATA[
+        Dim source = "
 Namespace N
     ''' <summary/>
     Class A
@@ -965,7 +965,7 @@ Class B
 End Class
 Class C
 End Class
-]]>.Value.Trim()
+".Trim()
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -982,7 +982,7 @@ End Class
     <WorkItem(530841, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530841")>
     <Fact>
     Public Sub Bug17031()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Sub M()
         If True Then
@@ -991,7 +991,7 @@ Module M
         End If
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Insert blank line at start of method.
@@ -1005,19 +1005,19 @@ End Module
     <WorkItem(531017, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531017")>
     <Fact>
     Public Sub Bug17409()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Sub M()
         Dim ch As Char
         Dim ch As Char
         Select Case ch
-            Case "~"c
+            Case ""~""c
 
             Case Else
         End Select
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Remove second instance of "Dim ch As Char".
@@ -1030,10 +1030,10 @@ End Module
 
     <Fact, WorkItem(547242, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547242")>
     Public Sub IncParseAddRemoveStopAtAofAs()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Public obj0 As Object
-    Public obj1 A]]>.Value
+    Public obj1 A"
 
         Dim tree = VisualBasicSyntaxTree.ParseText(code)
         Dim oldIText = tree.GetText()
@@ -1051,11 +1051,11 @@ Module M
 
     <Fact, WorkItem(547242, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547242")>
     Public Sub IncParseAddRemoveStopAtAofAs02()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Sub M()
         Try
-        Catch ex A]]>.Value
+        Catch ex A"
 
         Dim fullTree = VisualBasicSyntaxTree.ParseText(code)
         Dim fullText = fullTree.GetText()
@@ -1067,10 +1067,10 @@ Module M
     <Fact, WorkItem(547251, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547251")>
     Public Sub IncParseAddRemoveStopAtAofPropAs()
         Dim code As String =
-        <![CDATA[Class C
+"Class C
     Inherits Attribute
-]]>.Value
-        Dim code1 As String = <![CDATA[    Property goo() A]]>.Value
+"
+        Dim code1 As String = "    Property goo() A"
 
         Dim tree = VisualBasicSyntaxTree.ParseText(code)
         Dim oldIText = tree.GetText()
@@ -1094,11 +1094,11 @@ Module M
 
     <Fact, WorkItem(547303, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547303")>
     Public Sub IncParseAddRemoveStopAtTofThen()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Sub M()
         If True Then
-        ElseIf False T]]>.Value
+        ElseIf False T"
 
         Dim fullTree = VisualBasicSyntaxTree.ParseText(code)
         Dim fullText = fullTree.GetText()
@@ -1110,13 +1110,13 @@ Module M
     <WorkItem(571105, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/571105")>
     <Fact()>
     Public Sub IncParseInsertLineBreakBeforeLambda()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Sub F()
         Dim a1 = If(Sub()
                     End Sub, Nothing)
     End Sub
-End Module]]>.Value
+End Module"
 
         Dim tree = VisualBasicSyntaxTree.ParseText(code)
         Dim oldText = tree.GetText()
@@ -1131,11 +1131,11 @@ End Module]]>.Value
     <WorkItem(578279, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/578279")>
     <Fact()>
     Public Sub IncParseInsertLineBreakBetweenEndSub()
-        Dim code As String = <![CDATA[Class C
+        Dim code As String = "Class C
     Sub M()
     En Sub
     Private F = 1
-End Class]]>.Value
+End Class"
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' insert line break
@@ -1148,12 +1148,12 @@ End Class]]>.Value
 
     <Fact()>
     Public Sub InsertWithinLookAhead()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Function F(s As String)
         Return From c In s
     End Function
-End Module]]>.Value
+End Module"
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Insert "Select c" at end of method.
@@ -1167,7 +1167,7 @@ End Module]]>.Value
 #Region "Async & Iterator"
     <Fact>
     Public Sub AsyncToSyncMethod()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Async Function M(t As Task) As Task
         Await (t)
@@ -1177,7 +1177,7 @@ Class C
         Return Nothing
     End Function
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1191,7 +1191,7 @@ End Class
 
     <Fact>
     Public Sub AsyncToSyncLambda()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Function M(t As Task)
         Dim lambda = Async Function() Await(t)
@@ -1201,7 +1201,7 @@ Class C
         Return Nothing
     End Function
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1215,7 +1215,7 @@ End Class
 
     <Fact>
     Public Sub SyncToAsyncMethod()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Function M(t As Task) As Task
         Await (t)
@@ -1225,7 +1225,7 @@ Class C
         Return Nothing
     End Function
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1239,7 +1239,7 @@ End Class
 
     <Fact>
     Public Sub SyncToAsyncLambda()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Function M(t As Task)
         Dim lambda = Function() Await(t)
@@ -1249,7 +1249,7 @@ Class C
         Return Nothing
     End Function
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1263,7 +1263,7 @@ End Class
 
     <Fact>
     Public Sub AsyncToSyncMethodDecl()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Async Function M(a As Await, t As Task) As Task
         Await t
@@ -1272,7 +1272,7 @@ End Class
 
 Class Await
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1286,7 +1286,7 @@ End Class
 
     <Fact>
     Public Sub SyncToAsyncMethodDecl()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Function M(a As Await, t As Task) As Task
         Await t
@@ -1295,7 +1295,7 @@ End Class
 
 Class Await
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1309,13 +1309,13 @@ End Class
 
     <Fact>
     Public Sub IteratorToNonIteratorMethod()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Iterator Function Goo() As IEnumerable
         Yield (1)
     End Function
 End Module
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1329,13 +1329,13 @@ End Module
 
     <Fact>
     Public Sub NonIteratorToIteratorMethod()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Function Goo() As IEnumerable
         Yield (1)
     End Function
 End Module
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1349,13 +1349,13 @@ End Module
 
     <Fact>
     Public Sub IteratorToNonIteratorMethodDecl()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Iterator Function Goo(Yield As Integer) As IEnumerable
         Yield (1)
     End Function
 End Module
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1369,13 +1369,13 @@ End Module
 
     <Fact>
     Public Sub NonIteratorToIteratorMethodDecl()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Function Goo(Yield As Integer) As IEnumerable
         Yield (1)
     End Function
 End Module
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1392,7 +1392,7 @@ End Module
     <WorkItem(554442, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/554442")>
     <Fact>
     Public Sub SplitCommentAtPreprocessorSymbol()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Function F()
         ' comment # 1 and # 2
@@ -1401,7 +1401,7 @@ Module M
         Return Nothing
     End Function
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Split comment at "#".
@@ -1414,7 +1414,7 @@ End Module
     <WorkItem(586698, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/586698")>
     <Fact>
     Public Sub SortUsings()
-        Dim oldSource = ToText(<![CDATA[
+        Dim oldSource = "
 Imports System.Linq
 Imports System
 Imports Microsoft.VisualBasic
@@ -1422,8 +1422,8 @@ Module Module1
     Sub Main()
     End Sub
 End Module
-]]>)
-        Dim newSource = ToText(<![CDATA[
+"
+        Dim newSource = "
 Imports System
 Imports System.Linq
 Imports Microsoft.VisualBasic
@@ -1431,7 +1431,7 @@ Module Module1
     Sub Main()
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(oldSource)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Changes:
@@ -1446,7 +1446,7 @@ End Module
 
     <Fact>
     Public Sub Reformat()
-        Dim oldSource = ToText(<![CDATA[
+        Dim oldSource = "
 Class C
     Sub Method()
                                 Dim i = 1
@@ -1455,8 +1455,8 @@ Select          Case            i
                                                     End             Select              
     End Sub
 End Class
-]]>)
-        Dim newSource = ToText(<![CDATA[
+"
+        Dim newSource = "
 Class C
     Sub Method()
         Dim i = 1
@@ -1465,7 +1465,7 @@ Class C
         End Select
     End Sub
 End Class
-]]>)
+"
         Dim oldText = SourceText.From(oldSource)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim startOfNew = newSource.IndexOf("Dim", StringComparison.Ordinal)
@@ -1480,7 +1480,7 @@ End Class
     <WorkItem(604044, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/604044")>
     <Fact>
     Public Sub BunchALabels()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Sub Main()
 &HF:
@@ -1496,7 +1496,7 @@ Module Program
     End Sub
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Add enter after &HFFFFFFFFFF:.
@@ -1510,7 +1510,7 @@ End Module
     <Fact()>
     Public Sub LabelAfterColon()
         ' Label following another label on separate lines.
-        LabelAfterColonCore(True, <![CDATA[Module M
+        LabelAfterColonCore(True, "Module M
             Sub M()
         10:
         20:
@@ -1521,9 +1521,9 @@ End Module
         70:
             End Sub
         End Module
-        ]]>.Value)
+        ")
         ' Label following another label on separate lines.
-        LabelAfterColonCore(True, <![CDATA[Module M
+        LabelAfterColonCore(True, "Module M
             Sub M()
         10: : 
         20:
@@ -1534,9 +1534,9 @@ End Module
         70:
             End Sub
         End Module
-        ]]>.Value)
+        ")
         ' Label following on the same line as another label.
-        LabelAfterColonCore(False, <![CDATA[Module M
+        LabelAfterColonCore(False, "Module M
     Sub M()
 10: 20:
 30:
@@ -1546,9 +1546,9 @@ End Module
 70:
     End Sub
 End Module
-]]>.Value)
+")
         ' Label following on the same line as another label.
-        LabelAfterColonCore(False, <![CDATA[Module M
+        LabelAfterColonCore(False, "Module M
     Sub M()
 10: : 20:
 30:
@@ -1558,9 +1558,9 @@ End Module
 70:
     End Sub
 End Module
-]]>.Value)
+")
         ' Label following on the same line as another statement.
-        LabelAfterColonCore(False, <![CDATA[Module M
+        LabelAfterColonCore(False, "Module M
     Sub M()
 M() : 20:
 30:
@@ -1570,9 +1570,9 @@ M() : 20:
 70:
     End Sub
 End Module
-]]>.Value)
+")
         ' Label following a colon within a single-line statement.
-        LabelAfterColonCore(False, <![CDATA[Module M
+        LabelAfterColonCore(False, "Module M
     Sub M()
 If True Then M() : 20:
 30:
@@ -1582,7 +1582,7 @@ If True Then M() : 20:
 70:
     End Sub
 End Module
-]]>.Value)
+")
     End Sub
 
     Private Sub LabelAfterColonCore(valid As Boolean, code As String)
@@ -1601,12 +1601,12 @@ End Module
     <WorkItem(529260, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529260")>
     <Fact()>
     Public Sub DoNotReuseAnnotatedNodes()
-        Dim text As String = <![CDATA[
+        Dim text As String = "
 Class C
 End Class
 Class D
 End Class
-]]>.Value.Replace(vbCr, vbCrLf)
+".Replace(vbCr, vbCrLf)
 
         ' NOTE: We're using the class statement, rather than the block, because the
         ' change region is expanded enough to impinge on the block.
@@ -1667,7 +1667,7 @@ End Class
         'Sub Block
         'Function Block
         'Property Block
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Namespace N
     Module M
         Function F() as Boolean
@@ -1682,7 +1682,7 @@ Namespace N
     End Module
 End Namespace
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1697,7 +1697,7 @@ End Namespace
     <Fact>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxClass()
         'Class Block         
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M        
     Sub M()
     End Sub
@@ -1709,7 +1709,7 @@ Module M
     Class C2        
     End Class
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1724,7 +1724,7 @@ End Module
     <Fact>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxStructure()
         'Structure Block
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M        
     Sub M()
     End Sub
@@ -1738,7 +1738,7 @@ Module M
         Dim i as integer
     End Structure
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1753,12 +1753,12 @@ End Module
     <Fact()>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxOptionStatement()
         'Option Statement
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Option Strict Off
 Option Infer On
 Option Explicit On
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1773,11 +1773,11 @@ Option Explicit On
     <Fact()>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxImports()
         'Imports Statement
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Imports System
 Imports System.Collections
 Imports Microsoft.Visualbasic
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1793,7 +1793,7 @@ Imports Microsoft.Visualbasic
     <Fact>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxDelegateSub()
         'ExecutableStatementBlock -> DelegateSub
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
 
@@ -1803,7 +1803,7 @@ Module Module1
     Public Delegate Sub GooWithModifier()
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1817,7 +1817,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxOperatorBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
         Dim x As New SomeClass
@@ -1834,8 +1834,8 @@ Module Module1
         End Operator
     End Class
 End Module
+"
 
-]]>)
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1850,7 +1850,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxEventBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
         
@@ -1869,7 +1869,7 @@ Module Module1
     End Class
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1884,7 +1884,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxPropertyBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()        
     End Sub
@@ -1900,7 +1900,7 @@ Module Module1
         End Property
     End Class
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim TextToRemove As String = "Class SomeClass"
@@ -1914,7 +1914,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxNamespaceModuleBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 
 Namespace NS1
     Module Module1
@@ -1931,7 +1931,7 @@ Namespace NS1
         Dim x
     End Module
 End Namespace
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim TextToRemove As String = "End Module 'Remove"
@@ -1945,7 +1945,7 @@ End Namespace
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxNamespaceNamespaceBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 
 Namespace NS1
     Module Module1
@@ -1963,7 +1963,7 @@ Namespace NS1
 
     End Namespace
 End Namespace
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim TextToRemove As String = "End Module 'Remove"
@@ -1977,12 +1977,12 @@ End Namespace
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxItems()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
     Class SomeClass
         Dim member As Long = 2
         Sub abc() 'Remove
             Dim xyz as integer = 2
-            IF member = 1 then Console.writeline("TEST");
+            IF member = 1 then Console.writeline(""TEST"");
             Dim SingleLineDeclare as integer = 2
         End Sub
 
@@ -1993,7 +1993,7 @@ End Namespace
                 Item1
         End Enum
     End Class
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim TextToRemove As String = "Sub abc() 'Remove"
@@ -2008,7 +2008,7 @@ End Namespace
     <Fact>
     Public Sub IncrementalParsing_PropertyContextBlock_TryLinkSyntaxSetAccessor()
         'PropertyContextBlock -> SetAccessor 
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Private _p As Integer = 0
 
@@ -2024,7 +2024,7 @@ Class C
     Private _d As Integer = 1
 End Class
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2039,7 +2039,7 @@ End Class
 
     <Fact>
     Public Sub IncrementalParsing_BlockContext_TryLinkSyntaxSelectBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Private _p As Integer = 0
     Sub Bar()
@@ -2060,7 +2060,7 @@ Module Module1
         Catch ex As exception
         End Try
 
-        If y = 1 Then Console.WriteLine("Test")
+        If y = 1 Then Console.WriteLine(""Test"")
         Y = 1
 
         While y <= 10
@@ -2105,7 +2105,7 @@ End Module
 Class Goo
     Implements IDisposable
 
-#Region "IDisposable Support"
+#Region ""IDisposable Support""
     Private disposedValue As Boolean ' To detect redundant calls
     ' IDisposable
     Protected Overridable Sub Dispose(disposing As Boolean)
@@ -2126,7 +2126,7 @@ End Class
 Class OtherClass
 
 End Class
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2141,7 +2141,7 @@ End Class
 
     <Fact>
     Public Sub IncrementalParsing_EventBlockContext_TryLinkSyntax1()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Public Custom Event AnyName As EventHandler
         AddHandler(ByVal value As EventHandler)
@@ -2158,7 +2158,7 @@ Module Module1
     Sub Main()
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2173,7 +2173,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_EventBlockContext_TryLinkSyntax2()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Public Custom Event AnyName As EventHandler
         AddHandler(ByVal value As EventHandler)
@@ -2192,7 +2192,7 @@ Module Module1
     End Sub
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2207,7 +2207,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_InterfaceBlockContext_TryLinkSyntaxClass()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
     End Sub
@@ -2218,7 +2218,7 @@ Module Module1
     End Class
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2233,7 +2233,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_InterfaceBlockContext_TryLinkSyntaxEnum()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
 
@@ -2249,7 +2249,7 @@ Module Module1
     End Enum
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2264,7 +2264,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_CaseBlockContext_TryLinkSyntaxCase()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Goo()
         Dim i As Integer
@@ -2283,7 +2283,7 @@ Module Module1
 
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2297,7 +2297,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_CatchContext_TryLinkSyntaxCatch()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Goo()
         Dim x1 As Integer = 1
@@ -2319,7 +2319,7 @@ Module Module1
     End Function
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2334,7 +2334,7 @@ End Module
 
     <Fact()>
     Public Sub IncrementalParsing_NamespaceBlockContext_TryLinkSyntaxModule()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Namespace NS1
 Module ModuleTemp 'Remove
 End Module
@@ -2347,7 +2347,7 @@ Module Module1 'Remove
     End Function
 End Module
 End Namespace
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2362,7 +2362,7 @@ End Namespace
 
     <Fact>
     Public Sub IncrementalParsing_IfBlockContext_TryLinkSyntax()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 
 Module Module1
     Private _p As Integer = 0
@@ -2381,7 +2381,7 @@ Module Module1
         End If 
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2397,7 +2397,7 @@ End Module
     <WorkItem(719787, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/719787")>
     <Fact()>
     Public Sub Bug719787_EOF()
-        Dim source = <![CDATA[
+        Dim source = "
 Namespace N
     Class C
         Property P As Integer
@@ -2406,7 +2406,7 @@ Namespace N
         Private F As Object
     End Structure
 End Namespace
-]]>.Value.Trim()
+".Trim()
         ' Add two line breaks at end.
         source += vbCrLf
         Dim position = source.Length
@@ -2425,7 +2425,7 @@ End Namespace
     <WorkItem(719787, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/719787")>
     <Fact>
     Public Sub Bug719787_MultiLineIf()
-        Dim source = <![CDATA[
+        Dim source = "
 Class C
     Sub M()
         If e1 Then
@@ -2462,7 +2462,7 @@ Class C
     End Sub
     ' Comment
 End Class
-]]>.Value.Trim()
+".Trim()
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim toReplace = "' Comment"
@@ -2512,21 +2512,6 @@ End Class
         Next
     End Sub
 
-    Private Shared Function ToText(code As XCData) As String
-        Dim str = code.Value.Trim()
-        ' Normalize line terminators.
-        Dim builder = ArrayBuilder(Of Char).GetInstance()
-        For i = 0 To str.Length - 1
-            Dim c = str(i)
-            If (c = vbLf(0)) AndAlso
-                ((i = str.Length - 1) OrElse (str(i + 1) <> vbCr(0))) Then
-                builder.AddRange(vbCrLf)
-            Else
-                builder.Add(c)
-            End If
-        Next
-        Return New String(builder.ToArrayAndFree())
-    End Function
 #End Region
 
 End Class

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -144,19 +144,18 @@ End Module]]>.Value
     <WorkItem(899264, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseWithEventsFollowingProperty()
-        'Unable to verify this using CDATA, since CDATA value only has Cr appended at end of each line, 
-        'where as this bug is reproducible only with CrLf at the end of each line
-        Dim code As String = "Public Class HasPublicMembersToConflictWith" & vbCrLf &
-    "Public ConflictWithProp" & vbCrLf &
-    "" & vbCrLf &
-    "Public Property _ConflictWithBF() As String" & vbCrLf &
-    "    Get" & vbCrLf &
-    "    End Get" & vbCrLf &
-    "    Set(value As String)" & vbCrLf &
-    "    End Set" & vbCrLf &
-    "End Property" & vbCrLf &
-    "" & vbCrLf &
-    "Public WithEvents ConflictWithBoth As Ob"
+        Dim code As String =
+"Public Class HasPublicMembersToConflictWith
+Public ConflictWithProp
+
+Public Property _ConflictWithBF() As String
+    Get
+    End Get
+    Set(value As String)
+    End Set
+End Property
+
+Public WithEvents ConflictWithBoth As Ob"
 
         ParseAndVerify(code,
         <errors>

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -168,12 +168,12 @@ Public WithEvents ConflictWithBoth As Ob"
     <WorkItem(899596, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseClassFollowingDocComments()
-        Dim code As String = <![CDATA[Class VBQATestcase
+        Dim code As String = "Class VBQATestcase
     '''-----------------------------------------------------------------------------
     ''' <summary>
     '''Text
     ''' </summary>
-    '''-----------------------------------------------------------------------------]]>.Value
+    '''-----------------------------------------------------------------------------"
 
         ParseAndVerify(code,
                        <errors>
@@ -186,11 +186,13 @@ Public WithEvents ConflictWithBoth As Ob"
     <WorkItem(899918, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseDirInElse()
-        Dim code As String = "Sub Sub1()" & vbCr &
-"If true Then" & vbCr &
-"goo("""")" & vbCr &
-"Else" & vbCr & vbCr &
-"#If Not ULTRAVIOLET Then" & vbCr
+        Dim code =
+"Sub Sub1()
+If true Then
+goo("""")
+Else
+
+#If Not ULTRAVIOLET Then"
 
         ParseAndVerify(code,
                        <errors>
@@ -205,11 +207,12 @@ Public WithEvents ConflictWithBoth As Ob"
     <WorkItem(899938, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseNamespaceFollowingEvent()
-        Dim code As String = "Class cls1" & vbCrLf &
-"Custom Event myevent As del" & vbCrLf &
-"End Event" & vbCrLf &
-"End Class" & vbCrLf &
-"Namespace r"
+        Dim code =
+"Class cls1
+Custom Event myevent As del
+End Event
+End Class
+Namespace r"
 
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="e", changeSpan:=New TextSpan(code.Length, 0), changeType:=ChangeType.Insert))
     End Sub
@@ -217,14 +220,15 @@ Public WithEvents ConflictWithBoth As Ob"
     <WorkItem(900209, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseCaseElse()
-        Dim code As String = (<![CDATA[
+        Dim code =
+"
       Sub main()
          Select Case 5
             Case Else
                vvv = 6
             Case Else
                vvv = 7
-]]>).Value
+"
 
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:=vbCrLf, changeSpan:=New TextSpan(code.Length, 0), changeType:=ChangeType.Insert))
     End Sub
@@ -232,10 +236,11 @@ Public WithEvents ConflictWithBoth As Ob"
     <WorkItem(901386, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseExplicitOnGroupBy()
-        Dim code As String = (<![CDATA[
+        Dim code =
+"
 Option Explicit On
 Sub goo()
-Dim q2 = From x In col let y = x Group x, y By]]>).Value
+Dim q2 = From x In col let y = x Group x, y By"
 
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="a", changeSpan:=New TextSpan(code.Length, 0), changeType:=ChangeType.Insert))
     End Sub
@@ -243,20 +248,22 @@ Dim q2 = From x In col let y = x Group x, y By]]>).Value
     <WorkItem(901639, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseExprLambdaInSubContext()
-        Dim code As String = (<![CDATA[Function() NewTextPI.UnwrapObject().FileCodeModel)
+        Dim code =
+"Function() NewTextPI.UnwrapObject().FileCodeModel)
 If True Then
 End If
 End Sub
 Class WillHaveAnError
 End class
 Class willBeReused
-End class]]>).Value
+End class"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="(", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <Fact>
     Public Sub IncParseExprLambdaInSubContext2()
-        Dim code As String = (<![CDATA[Function() NewTextPI.UnwrapObject().FileCodeModel)
+        Dim code =
+"Function() NewTextPI.UnwrapObject().FileCodeModel)
 If True Then
 Else
 End If
@@ -264,16 +271,17 @@ End Sub
 Class WillHaveAnError
 End class
 Class willBeReused
-End class]]>).Value
+End class"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="(", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901645, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseExitFunction()
-        Dim code As String = (<![CDATA[Function
-If strSwitches <> "" Then strCLine = strCLine & " " & strSwitches
-End Sub]]>).Value
+        Dim code =
+"Function
+If strSwitches <> """" Then strCLine = strCLine & "" "" & strSwitches
+End Sub"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Exit ", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
@@ -286,7 +294,8 @@ End Sub]]>).Value
 
     <Fact>
     Public Sub IncParsePPElse()
-        Dim code As String = (<![CDATA[
+        Dim code =
+"
 Function goo() As Boolean
 
 #Else
@@ -297,13 +306,14 @@ Function goo() As Boolean
 
 
 End Function
-]]>).Value
+"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="#End If", changeSpan:=New TextSpan(code.IndexOf("Next roleName", StringComparison.Ordinal) + 15, 2), changeType:=ChangeType.Replace))
     End Sub
 
     <Fact>
     Public Sub IncParsePPElse1()
-        Dim code As String = (<![CDATA[
+        Dim code =
+"
 Function goo() As Boolean
 
 #Else
@@ -315,30 +325,31 @@ Function goo() As Boolean
 #End IF
 
 End Function
-]]>).Value
+"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="#If true " & vbCrLf, changeSpan:=New TextSpan(code.IndexOf("#Else", StringComparison.Ordinal), 0), changeType:=ChangeType.Replace))
     End Sub
 
     <WorkItem(901669, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseXmlTagWithExprHole()
-        Dim code As String = (<![CDATA[e a=<%= b %>>]]>).Value
+        Dim code = "e a=<%= b %>>"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="<", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901671, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseEndBeforeSubWithX()
-        Dim code As String = (<![CDATA[Sub
+        Dim code = "Sub
         End Class
-    X]]>).Value
+    X"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="End ", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901676, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseInterfaceFollByConstructs()
-        Dim code As String = (<![CDATA[
+        Dim code =
+"
         Public Interface I2
         End Interface
         Sub SEHIllegal501()
@@ -347,64 +358,69 @@ End Function
             End Try
             Exit Sub
         End Sub
-    X]]>).Value
+    X"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Interface", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901680, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseLCFunctionCompoundAsn()
-        Dim code As String = (<![CDATA[Public Function goo() As String
+        Dim code =
+"Public Function goo() As String
             For i As Integer = 0 To  1
                 total += y(i)
             Next
-End Function]]>).Value
+End Function"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="> _" & vbCrLf, changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(902710, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseInsertFunctionBeforeEndClass()
-        Dim code As String = (<![CDATA[End Class
+        Dim code =
+"End Class
 MustInherit Class C10
-End Class]]>).Value
+End Class"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Function" & vbCrLf, changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(903134, "DevDiv/Personal")>
     <Fact>
     Public Sub InsertSubBeforeCustomEvent()
-        Dim code As String = (<![CDATA[            Custom Event e As del
-                AddHandler(ByVal value As del)
-                End AddHandler
-            End Event]]>).Value
+        Dim code =
+" Custom Event e As del
+     AddHandler(ByVal value As del)
+     End AddHandler
+ End Event"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Sub" & vbCrLf, changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(903555, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseMergedForEachAndDecl()
-        Dim code As String = (<![CDATA[#Region "abc"
+        Dim code =
+"#Region ""abc""
 Function goo() As Boolean
 Dim roleName As Object
 For Each roleName In wbirFields
 Next roleName
 End Function
-#End Region]]>).Value
+#End Region"
         IncParseAndVerify(New IncParseNode(oldText:=code, changeText:=vbCrLf, changeSpan:=New TextSpan(code.IndexOf("Dim roleName As Object", StringComparison.Ordinal) + 22, 2), changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(903805, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseEnumWithoutEnd()
-        Dim code As String = (<![CDATA[Public Class Class2
+        Dim code =
+"Public Class Class2
     Protected Enum e
         e1
         e2
 	End Enum
     Public Function Goo(ByVal arg1 As e) As e
     End Function
-End Class]]>).Value
+End Class"
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
         changeText:=vbCrLf,
@@ -415,14 +431,15 @@ End Class]]>).Value
     <WorkItem(903826, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseWrongSelectFollByIf()
-        Dim code As String = (<![CDATA[        Sub goo()
-                Select Case lng
-                    Case 44
-                        int1 = 4
-                End Select
-                If true Then
-                End If
-        End Sub]]>).Value
+        Dim code =
+"Sub goo()
+         Select Case lng
+             Case 44
+                 int1 = 4
+         End Select
+         If true Then
+         End If
+ End Sub"
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
         changeText:="End ",
@@ -433,12 +450,13 @@ End Class]]>).Value
     <WorkItem(904768, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseDoLoop()
-        Dim code As String = (<![CDATA[        Sub AnonTConStmnt()
-                Do
-                    i += 1
-                Loop Until true
-        End Sub
-]]>).Value
+        Dim code =
+"Sub AnonTConStmnt()
+         Do
+             i += 1
+         Loop Until true
+ End Sub
+]"
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
         changeText:=vbCrLf,
@@ -449,14 +467,14 @@ End Class]]>).Value
     <WorkItem(904771, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseClassWithOpDecl()
-        Dim code As String = (<![CDATA[
+        Dim code = "
 Friend Module m1
 Class Class1
 Shared Operator -(ByVal x As Class1) As Boolean
 End Operator
 End Class
 End Module
-]]>).Value
+"
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
         changeText:="Class ",
@@ -467,7 +485,7 @@ End Module
     <WorkItem(904782, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParsePropFollIncompleteLambda()
-        Dim code As String = (<![CDATA[        Class c1
+        Dim code = "        Class c1
 
             Public Function goo() As Object
                 Dim res = Function(x As Integer) c1.Goo(x)
@@ -479,7 +497,7 @@ End Module
                 Set(ByVal value As Integer)
                 End Set
             End Property
-        End Class]]>).Value
+        End Class"
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
         changeText:=")",
@@ -490,10 +508,10 @@ End Module
     <WorkItem(904792, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseErroneousGroupByQuery()
-        Dim code As String = (<![CDATA[        Sub goo() 
+        Dim code = "        Sub goo() 
                 Dim q2 = From i In str Group i By key1 = x
                 Dim q3 =From j In str Group By key = i 
-        End Sub]]>).Value
+        End Sub"
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
         changeText:=" By",
@@ -504,12 +522,12 @@ End Module
     <WorkItem(904804, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseSetAfterIncompleteSub()
-        Dim code As String = (<![CDATA[Sub goo()
+        Dim code = "Sub goo()
 End Sub
 Public WriteOnly Property bar() as short
 Set
 End Set
-End Property]]>).Value
+End Property"
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
         changeText:=vbCrLf,
@@ -520,10 +538,12 @@ End Property]]>).Value
     <WorkItem(911100, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseEmbeddedIfsInsideCondCompile()
-        Dim code As String = "Sub bar() " & vbCrLf &
-"#If true Then" & vbCrLf &
-    "if true Then goo()" & vbCrLf &
- "If Command() <" & vbCrLf
+        Dim code As String =
+"Sub bar()
+#If true Then
+If true Then goo()
+If Command() <
+"
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
         changeText:=">",
@@ -534,9 +554,10 @@ End Property]]>).Value
     <WorkItem(911103, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseErrorIfStatement()
-        Dim code As String = "Public Sub Run() " & vbCrLf &
-"If NewTextPI.DTE Is Nothing Then End" & vbCrLf &
- "End Sub"
+        Dim code =
+"Public Sub Run() 
+If NewTextPI.DTE Is Nothing Then End
+End Sub"
 
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
@@ -548,9 +569,9 @@ End Property]]>).Value
     <WorkItem(537168, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537168")>
     <Fact>
     Public Sub IncParseSubBeforePartialClass()
-        Dim code As String = (<![CDATA[End Class
+        Dim code = "End Class
 Partial Class class3
-End Class]]>).Value
+End Class"
 
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
@@ -562,7 +583,7 @@ End Class]]>).Value
     <WorkItem(537172, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537172")>
     <Fact>
     Public Sub IncParseInterfaceDeleteWithColon()
-        Dim code As String = (<![CDATA[Interface I : Sub Goo() : End Interface]]>).Value
+        Dim code = "Interface I : Sub Goo() : End Interface"
 
         IncParseAndVerify(New IncParseNode(
                           oldText:=code,
@@ -574,18 +595,19 @@ End Class]]>).Value
     <WorkItem(537174, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537174")>
     <Fact>
     Public Sub IncParseMissingEndAddHandler()
-        Dim code As String = (<![CDATA[
-                Class C
-                    Custom Event e As del
-                        AddHandler(ByVal value As del)
-                        End AddHandler
-                        RemoveHandler(ByVal value As del)
-                        End RemoveHandler
-                        RaiseEvent()
-                        End RaiseEvent
-                    End Event
-                End Class
-]]>).Value
+        Dim code =
+"
+Class C
+    Custom Event e As del
+        AddHandler(ByVal value As del)
+        End AddHandler
+        RemoveHandler(ByVal value As del)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+"
         Dim change = "End AddHandler"
         IncParseAndVerify(New IncParseNode(
                           oldText:=code,
@@ -597,8 +619,9 @@ End Class]]>).Value
     <WorkItem(539038, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539038")>
     <Fact>
     Public Sub IncParseInvalidText()
-        Dim code As String = (<![CDATA[1. Verify that INT accepts an constant of each type as the
-        '                  argument.]]>).Value
+        Dim code =
+"1. Verify that INT accepts an constant of each type as the
+'                  argument."
 
         IncParseAndVerify(New IncParseNode(
                           oldText:=code,
@@ -610,11 +633,12 @@ End Class]]>).Value
     <WorkItem(539053, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539053")>
     <Fact>
     Public Sub IncParseAddSubValid()
-        Dim code As String = (<![CDATA[Class CGoo
+        Dim code =
+"Class CGoo
     Public S()
         Dim x As Integer = 0
     End Sub
-End Class]]>).Value
+End Class"
 
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -645,7 +669,8 @@ End Class]]>).Value
     <WorkItem(538577, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538577")>
     <Fact>
     Public Sub IncParseAddSpaceAfterForNext()
-        Dim code As String = (<![CDATA[Module M
+        Dim code =
+"Module M
   Sub Main()
    Dim i(1) As Integer
    For i(0) = 1 To 10
@@ -653,7 +678,7 @@ End Class]]>).Value
    Next j, i(0) 
   End Sub
 End Module 
-]]>).Value
+"
 
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -672,13 +697,13 @@ End Module
     <WorkItem(540667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540667")>
     Public Sub IncrementalParseAddSpaceInSingleLineIf()
         ' The code below intentionally is missing a space between the "Then" and "Console"
-        Dim code As String = (<![CDATA[
+        Dim code = "
 Module M
   Sub Main()
-    If False ThenConsole.WriteLine("FIRST") : Console.WriteLine("TEST") Else Console.WriteLine("TRUE!") : 'comment
+    If False ThenConsole.WriteLine(""FIRST"") : Console.WriteLine(""TEST"") Else Console.WriteLine(""TRUE!"") : 'comment
   End Sub
 End Module 
-]]>).Value
+"
 
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -696,13 +721,14 @@ End Module
     <Fact>
     <WorkItem(405887, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=405887")>
     Public Sub IncrementalParseInterpolationInSingleLineIf()
-        Dim code As String = (<![CDATA[
+        Dim code =
+"
 Module Module1
     Sub Test1(val1 As Integer)
-        If val1 = 1 Then System.Console.WriteLine($"abc '" & sServiceName & "'")
+        If val1 = 1 Then System.Console.WriteLine($""abc '"" & sServiceName & ""'"")
     End Sub
 End Module
-]]>).Value
+"
 
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -723,7 +749,8 @@ End Module
     <Fact>
     Public Sub Bug11296()
 
-        Dim source As String = <![CDATA[    
+        Dim source =
+"    
 Module M
     Sub Main()
         GoTo 100
@@ -734,13 +761,13 @@ Module M
         End If
     End Sub
 End Module
-]]>.Value
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Assert.Equal(1, oldTree.GetDiagnostics().Count)
         Assert.Equal("Syntax error.", oldTree.GetDiagnostics()(0).GetMessage(EnsureEnglishUICulture.PreferredOrNull))
-        Assert.Equal("[131..134)", oldTree.GetDiagnostics()(0).Location.SourceSpan.ToString)
+        Assert.Equal("[138..141)", oldTree.GetDiagnostics()(0).Location.SourceSpan.ToString)
 
         ' commenting out the goto
         Dim pos = source.IndexOf("GoTo 100", StringComparison.Ordinal)
@@ -751,17 +778,18 @@ End Module
         Dim tmpTree = VisualBasicSyntaxTree.ParseText(newText)
         Assert.Equal(1, tmpTree.GetDiagnostics().Count)
         Assert.Equal("Syntax error.", tmpTree.GetDiagnostics()(0).GetMessage(EnsureEnglishUICulture.PreferredOrNull))
-        Assert.Equal("[132..135)", tmpTree.GetDiagnostics()(0).Location.SourceSpan.ToString)
+        Assert.Equal("[139..142)", tmpTree.GetDiagnostics()(0).Location.SourceSpan.ToString)
     End Sub
 
     <Fact>
     Public Sub IncParseTypeNewLine()
-        Dim code As String = (<![CDATA[
+        Dim code =
+"
 Module m
 Sub s
 End Sub
 End Module     
-]]>).Value
+"
 
         IncParseAndVerify(New IncParseNode(
                           oldText:=code,
@@ -773,11 +801,10 @@ End Module
     <WorkItem(545667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545667")>
     <Fact>
     Public Sub Bug14266()
-        Dim source = <![CDATA[
-Enum E
+        Dim source =
+"Enum E
     A
-End Enum
-]]>.Value.Trim()
+End Enum"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -790,13 +817,14 @@ End Enum
     <WorkItem(546680, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546680")>
     <Fact>
     Public Sub Bug16533()
-        Dim source = <![CDATA[
+        Dim source =
+"
 Module M
     Sub M()
         If True Then M() Else : 
     End Sub
 End Module
-]]>.Value
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Replace "True" with "True".
@@ -810,14 +838,13 @@ End Module
     <WorkItem(546685, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546685")>
     <Fact>
     Public Sub MultiLineIf()
-        Dim source = <![CDATA[
-Module M
+        Dim source =
+"Module M
     Sub M(b As Boolean)
         If b Then
         End If
     End Sub
-End Module
-]]>.Value.Trim()
+End Module"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -837,16 +864,15 @@ End Module
     ''' </summary>
     <Fact>
     Public Sub MultiLineIf_2()
-        Dim source = <![CDATA[
-Module M
+        Dim source =
+"Module M
     Sub M()
         Dim b = False
         b = True
         If b Then
         End If
     End Sub
-End Module
-]]>.Value.Trim()
+End Module"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -866,16 +892,15 @@ End Module
     ''' </summary>
     <Fact>
     Public Sub MultiLineIf_3()
-        Dim source = <![CDATA[
-Module M
+        Dim source =
+"Module M
     Sub M(b As Boolean)
         If b Then
         End If
         While b
         End While
     End Sub
-End Module
-]]>.Value.Trim()
+End Module"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -892,14 +917,13 @@ End Module
     <WorkItem(546692, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546692")>
     <Fact>
     Public Sub Bug16575()
-        Dim source = <![CDATA[
-Module M
+        Dim source =
+"Module M
     Sub M()
         If True Then Else Dim x = 1 : Dim y = x
         If True Then Else Dim x = 1 : Dim y = x
     End Sub
-End Module
-]]>.Value
+End Module"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Add newline after first single line If
@@ -954,8 +978,8 @@ End Module
     <WorkItem(546774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546774")>
     <Fact>
     Public Sub Bug16786()
-        Dim source = "
-Namespace N
+        Dim source =
+"Namespace N
     ''' <summary/>
     Class A
     End Class
@@ -963,8 +987,7 @@ End Namespace
 Class B
 End Class
 Class C
-End Class
-".Trim()
+End Class"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2396,16 +2419,15 @@ End Module
     <WorkItem(719787, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/719787")>
     <Fact()>
     Public Sub Bug719787_EOF()
-        Dim source = "
-Namespace N
+        Dim source =
+"Namespace N
     Class C
         Property P As Integer
     End Class
     Structure S
         Private F As Object
     End Structure
-End Namespace
-".Trim()
+End Namespace"
         ' Add two line breaks at end.
         source += vbCrLf
         Dim position = source.Length
@@ -2424,8 +2446,8 @@ End Namespace
     <WorkItem(719787, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/719787")>
     <Fact>
     Public Sub Bug719787_MultiLineIf()
-        Dim source = "
-Class C
+        Dim source =
+"Class C
     Sub M()
         If e1 Then
             If e2 Then
@@ -2460,8 +2482,7 @@ Class C
         End If
     End Sub
     ' Comment
-End Class
-".Trim()
+End Class"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim toReplace = "' Comment"

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -252,7 +252,7 @@ Class WillHaveAnError
 End class
 Class willBeReused
 End class]]>).Value
-        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="(", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="(", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <Fact>
@@ -266,7 +266,7 @@ Class WillHaveAnError
 End class
 Class willBeReused
 End class]]>).Value
-        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="(", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="(", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901645, "DevDiv/Personal")>
@@ -275,14 +275,14 @@ End class]]>).Value
         Dim code As String = (<![CDATA[Function
 If strSwitches <> "" Then strCLine = strCLine & " " & strSwitches
 End Sub]]>).Value
-        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Exit ", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Exit ", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901655, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseDateLiteral()
 
-        IncParseAndVerify(New IncParseNode(oldText:="", changeText:="#10/18/1969# hello 123", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:="", changeText:="#10/18/1969# hello 123", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <Fact>
@@ -324,7 +324,7 @@ End Function
     <Fact>
     Public Sub ParseXmlTagWithExprHole()
         Dim code As String = (<![CDATA[e a=<%= b %>>]]>).Value
-        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="<", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="<", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901671, "DevDiv/Personal")>
@@ -333,7 +333,7 @@ End Function
         Dim code As String = (<![CDATA[Sub
         End Class
     X]]>).Value
-        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="End ", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="End ", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901676, "DevDiv/Personal")>
@@ -349,7 +349,7 @@ End Function
             Exit Sub
         End Sub
     X]]>).Value
-        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Interface", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Interface", changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901680, "DevDiv/Personal")>
@@ -360,7 +360,7 @@ End Function
                 total += y(i)
             Next
 End Function]]>).Value
-        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="> _" & vbCrLf, changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="> _" & vbCrLf, changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(902710, "DevDiv/Personal")>
@@ -369,7 +369,7 @@ End Function]]>).Value
         Dim code As String = (<![CDATA[End Class
 MustInherit Class C10
 End Class]]>).Value
-        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Function" & vbCrLf, changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Function" & vbCrLf, changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(903134, "DevDiv/Personal")>
@@ -379,7 +379,7 @@ End Class]]>).Value
                 AddHandler(ByVal value As del)
                 End AddHandler
             End Event]]>).Value
-        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Sub" & vbCrLf, changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Sub" & vbCrLf, changeSpan:=TextSpan.NullSpan, changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(903555, "DevDiv/Personal")>
@@ -556,7 +556,7 @@ End Class]]>).Value
         IncParseAndVerify(New IncParseNode(
         oldText:=code,
         changeText:="Sub" & vbCrLf,
-        changeSpan:=New TextSpan(0, 0),
+        changeSpan:=TextSpan.NullSpan,
         changeType:=ChangeType.InsertBefore))
     End Sub
 
@@ -604,7 +604,7 @@ End Class]]>).Value
         IncParseAndVerify(New IncParseNode(
                           oldText:=code,
                           changeText:="os:    ",
-                          changeSpan:=New TextSpan(0, 0),
+                          changeSpan:=TextSpan.NullSpan,
                           changeType:=ChangeType.InsertBefore))
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -163,11 +163,7 @@ End Module]]>.Value
             <error id="30481"/>
         </errors>)
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "j",
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="j", changeSpan:=New TextSpan(code.Length, 0), changeType:=ChangeType.Insert))
     End Sub
 
     <WorkItem(899596, "DevDiv/Personal")>
@@ -185,11 +181,7 @@ End Module]]>.Value
                            <error id="30481"/>
                        </errors>)
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = vbCrLf & "Pub",
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:=vbCrLf & "Pub", changeSpan:=New TextSpan(code.Length, 0), changeType:=ChangeType.Insert))
     End Sub
 
     <WorkItem(899918, "DevDiv/Personal")>
@@ -208,11 +200,7 @@ End Module]]>.Value
                            <error id="30026"/>
                        </errors>)
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "a",
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="a", changeSpan:=New TextSpan(code.Length, 0), changeType:=ChangeType.Insert))
     End Sub
 
     <WorkItem(899938, "DevDiv/Personal")>
@@ -224,11 +212,7 @@ End Module]]>.Value
 "End Class" & vbCrLf &
 "Namespace r"
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "e",
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="e", changeSpan:=New TextSpan(code.Length, 0), changeType:=ChangeType.Insert))
     End Sub
 
     <WorkItem(900209, "DevDiv/Personal")>
@@ -243,11 +227,7 @@ End Module]]>.Value
                vvv = 7
 ]]>).Value
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = vbCrLf,
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:=vbCrLf, changeSpan:=New TextSpan(code.Length, 0), changeType:=ChangeType.Insert))
     End Sub
 
     <WorkItem(901386, "DevDiv/Personal")>
@@ -258,11 +238,7 @@ Option Explicit On
 Sub goo()
 Dim q2 = From x In col let y = x Group x, y By]]>).Value
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "a",
-        .changeSpan = New TextSpan(code.Length, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="a", changeSpan:=New TextSpan(code.Length, 0), changeType:=ChangeType.Insert))
     End Sub
 
     <WorkItem(901639, "DevDiv/Personal")>
@@ -276,12 +252,7 @@ Class WillHaveAnError
 End class
 Class willBeReused
 End class]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "(",
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
-
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="(", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <Fact>
@@ -295,12 +266,7 @@ Class WillHaveAnError
 End class
 Class willBeReused
 End class]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "(",
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
-
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="(", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901645, "DevDiv/Personal")>
@@ -309,24 +275,14 @@ End class]]>).Value
         Dim code As String = (<![CDATA[Function
 If strSwitches <> "" Then strCLine = strCLine & " " & strSwitches
 End Sub]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "Exit ",
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
-
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Exit ", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901655, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseDateLiteral()
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = "",
-        .changeText = "#10/18/1969# hello 123",
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
-
+        IncParseAndVerify(New IncParseNode(oldText:="", changeText:="#10/18/1969# hello 123", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <Fact>
@@ -343,11 +299,7 @@ Function goo() As Boolean
 
 End Function
 ]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "#End If",
-        .changeSpan = New TextSpan(code.IndexOf("Next roleName", StringComparison.Ordinal) + 15, 2),
-        .changeType = ChangeType.Replace})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="#End If", changeSpan:=New TextSpan(code.IndexOf("Next roleName", StringComparison.Ordinal) + 15, 2), changeType:=ChangeType.Replace))
     End Sub
 
     <Fact>
@@ -365,22 +317,14 @@ Function goo() As Boolean
 
 End Function
 ]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "#If true " & vbCrLf,
-        .changeSpan = New TextSpan(code.IndexOf("#Else", StringComparison.Ordinal), 0),
-        .changeType = ChangeType.Replace})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="#If true " & vbCrLf, changeSpan:=New TextSpan(code.IndexOf("#Else", StringComparison.Ordinal), 0), changeType:=ChangeType.Replace))
     End Sub
 
     <WorkItem(901669, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseXmlTagWithExprHole()
         Dim code As String = (<![CDATA[e a=<%= b %>>]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "<",
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="<", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901671, "DevDiv/Personal")>
@@ -389,11 +333,7 @@ End Function
         Dim code As String = (<![CDATA[Sub
         End Class
     X]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "End ",
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="End ", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901676, "DevDiv/Personal")>
@@ -409,11 +349,7 @@ End Function
             Exit Sub
         End Sub
     X]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "Interface",
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Interface", changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(901680, "DevDiv/Personal")>
@@ -424,11 +360,7 @@ End Function
                 total += y(i)
             Next
 End Function]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "> _" & vbCrLf,
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="> _" & vbCrLf, changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(902710, "DevDiv/Personal")>
@@ -437,11 +369,7 @@ End Function]]>).Value
         Dim code As String = (<![CDATA[End Class
 MustInherit Class C10
 End Class]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "Function" & vbCrLf,
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Function" & vbCrLf, changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(903134, "DevDiv/Personal")>
@@ -451,11 +379,7 @@ End Class]]>).Value
                 AddHandler(ByVal value As del)
                 End AddHandler
             End Event]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "Sub" & vbCrLf,
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:="Sub" & vbCrLf, changeSpan:=New TextSpan(0, 0), changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(903555, "DevDiv/Personal")>
@@ -468,11 +392,7 @@ For Each roleName In wbirFields
 Next roleName
 End Function
 #End Region]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = vbCrLf,
-        .changeSpan = New TextSpan(code.IndexOf("Dim roleName As Object", StringComparison.Ordinal) + 22, 2),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(oldText:=code, changeText:=vbCrLf, changeSpan:=New TextSpan(code.IndexOf("Dim roleName As Object", StringComparison.Ordinal) + 22, 2), changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(903805, "DevDiv/Personal")>
@@ -486,11 +406,11 @@ End Function
     Public Function Goo(ByVal arg1 As e) As e
     End Function
 End Class]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = vbCrLf,
-        .changeSpan = New TextSpan(code.IndexOf("e2", StringComparison.Ordinal) + 2, 2),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=vbCrLf,
+        changeSpan:=New TextSpan(code.IndexOf("e2", StringComparison.Ordinal) + 2, 2),
+        changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(903826, "DevDiv/Personal")>
@@ -504,11 +424,11 @@ End Class]]>).Value
                 If true Then
                 End If
         End Sub]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "End ",
-        .changeSpan = New TextSpan(code.IndexOf("End ", StringComparison.Ordinal), 4),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:="End ",
+        changeSpan:=New TextSpan(code.IndexOf("End ", StringComparison.Ordinal), 4),
+        changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(904768, "DevDiv/Personal")>
@@ -520,11 +440,11 @@ End Class]]>).Value
                 Loop Until true
         End Sub
 ]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = vbCrLf,
-        .changeSpan = New TextSpan(code.IndexOf("Do", StringComparison.Ordinal) + 2, 2),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=vbCrLf,
+        changeSpan:=New TextSpan(code.IndexOf("Do", StringComparison.Ordinal) + 2, 2),
+        changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(904771, "DevDiv/Personal")>
@@ -538,11 +458,11 @@ End Operator
 End Class
 End Module
 ]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "Class ",
-        .changeSpan = New TextSpan(code.IndexOf("Class ", StringComparison.Ordinal), 6),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:="Class ",
+        changeSpan:=New TextSpan(code.IndexOf("Class ", StringComparison.Ordinal), 6),
+        changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(904782, "DevDiv/Personal")>
@@ -561,11 +481,11 @@ End Module
                 End Set
             End Property
         End Class]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = ")",
-        .changeSpan = New TextSpan(code.IndexOf("x As Integer)", StringComparison.Ordinal) + 12, 1),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=")",
+        changeSpan:=New TextSpan(code.IndexOf("x As Integer)", StringComparison.Ordinal) + 12, 1),
+        changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(904792, "DevDiv/Personal")>
@@ -575,11 +495,11 @@ End Module
                 Dim q2 = From i In str Group i By key1 = x
                 Dim q3 =From j In str Group By key = i 
         End Sub]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = " By",
-        .changeSpan = New TextSpan(code.IndexOf(" By key1", StringComparison.Ordinal), 3),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=" By",
+        changeSpan:=New TextSpan(code.IndexOf(" By key1", StringComparison.Ordinal), 3),
+        changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(904804, "DevDiv/Personal")>
@@ -591,11 +511,11 @@ Public WriteOnly Property bar() as short
 Set
 End Set
 End Property]]>).Value
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = vbCrLf,
-        .changeSpan = New TextSpan(code.IndexOf("End Sub", StringComparison.Ordinal) + 7, 2),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=vbCrLf,
+        changeSpan:=New TextSpan(code.IndexOf("End Sub", StringComparison.Ordinal) + 7, 2),
+        changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(911100, "DevDiv/Personal")>
@@ -605,11 +525,11 @@ End Property]]>).Value
 "#If true Then" & vbCrLf &
     "if true Then goo()" & vbCrLf &
  "If Command() <" & vbCrLf
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = ">",
-        .changeSpan = New TextSpan(code.IndexOf("If Command() <", StringComparison.Ordinal) + 14, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:=">",
+        changeSpan:=New TextSpan(code.IndexOf("If Command() <", StringComparison.Ordinal) + 14, 0),
+        changeType:=ChangeType.Insert))
     End Sub
 
     <WorkItem(911103, "DevDiv/Personal")>
@@ -619,11 +539,11 @@ End Property]]>).Value
 "If NewTextPI.DTE Is Nothing Then End" & vbCrLf &
  "End Sub"
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "NewTextPI",
-        .changeSpan = New TextSpan(code.IndexOf("NewTextPI.DTE", StringComparison.Ordinal), 9),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:="NewTextPI",
+        changeSpan:=New TextSpan(code.IndexOf("NewTextPI.DTE", StringComparison.Ordinal), 9),
+        changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(537168, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537168")>
@@ -633,11 +553,11 @@ End Property]]>).Value
 Partial Class class3
 End Class]]>).Value
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "Sub" & vbCrLf,
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
+        IncParseAndVerify(New IncParseNode(
+        oldText:=code,
+        changeText:="Sub" & vbCrLf,
+        changeSpan:=New TextSpan(0, 0),
+        changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(537172, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537172")>
@@ -645,11 +565,11 @@ End Class]]>).Value
     Public Sub IncParseInterfaceDeleteWithColon()
         Dim code As String = (<![CDATA[Interface I : Sub Goo() : End Interface]]>).Value
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "Interface ",
-        .changeSpan = New TextSpan(0, 10),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+                          oldText:=code,
+                          changeText:="Interface ",
+                          changeSpan:=New TextSpan(0, 10),
+                          changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(537174, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537174")>
@@ -668,11 +588,11 @@ End Class]]>).Value
                 End Class
 ]]>).Value
         Dim change = "End AddHandler"
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = change,
-        .changeSpan = New TextSpan(code.IndexOf(change, StringComparison.Ordinal), change.Length),
-        .changeType = ChangeType.Remove})
+        IncParseAndVerify(New IncParseNode(
+                          oldText:=code,
+                          changeText:=change,
+                          changeSpan:=New TextSpan(code.IndexOf(change, StringComparison.Ordinal), change.Length),
+                          changeType:=ChangeType.Remove))
     End Sub
 
     <WorkItem(539038, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539038")>
@@ -681,11 +601,11 @@ End Class]]>).Value
         Dim code As String = (<![CDATA[1. Verify that INT accepts an constant of each type as the
         '                  argument.]]>).Value
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = "os:    ",
-        .changeSpan = New TextSpan(0, 0),
-        .changeType = ChangeType.InsertBefore})
+        IncParseAndVerify(New IncParseNode(
+                          oldText:=code,
+                          changeText:="os:    ",
+                          changeSpan:=New TextSpan(0, 0),
+                          changeType:=ChangeType.InsertBefore))
     End Sub
 
     <WorkItem(539053, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539053")>
@@ -844,11 +764,11 @@ End Sub
 End Module     
 ]]>).Value
 
-        IncParseAndVerify(New IncParseNode With {
-        .oldText = code,
-        .changeText = vbCrLf,
-        .changeSpan = New TextSpan(15, 0),
-        .changeType = ChangeType.Insert})
+        IncParseAndVerify(New IncParseNode(
+                          oldText:=code,
+                          changeText:=vbCrLf,
+                          changeSpan:=New TextSpan(15, 0),
+                          changeType:=ChangeType.Insert))
     End Sub
 
     <WorkItem(545667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545667")>


### PR DESCRIPTION
Refactored the UnitTest code of `CompilerSyntax\IncrementalParser\` 
* Made `IncParserNode` immutable.
* Added a Shared ReadOnly Instance of TextSpan to represent a "NullSpan" eg `New TextSpan(0,0)`
* Removed the helper method `ToText`.
** Which converted `XCData` to `String` correcting the different line feeds used in XML Literals to those used in strings.
* Convert the XML Literals over to Multiline Strings.
* Simplify some of the string.
