### PR TITLE
Debugger EE 'Internal error' if DebuggerBrowsable when 'newslot' C# property overrides field

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
@@ -124,14 +124,16 @@ abstract class A
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public object P1;
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    internal virtual object P2 { get { return 0; } }
+    public object P2;
+    internal object P3 => 0;
 }
 class B : A
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     new public object P1 => base.P1;
+    new public object P2 => 1;
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    internal override object P2 { get { return 0; } }
+    internal new object P3 => 2;
 }";
             var assembly = GetAssembly(source);
             var type = assembly.GetType("B");
@@ -142,7 +144,10 @@ class B : A
                 valueFlags: DkmClrValueFlags.Synthetic);
             var evalResult = FormatResult("this", value);
             Verify(evalResult,
-                EvalResult("this", "{B}", "B", "this", DkmEvaluationResultFlags.None));
+                EvalResult("this", "{B}", "B", "this", DkmEvaluationResultFlags.Expandable));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("P3 (A)", "0", "object {int}", "((A)this).P3", DkmEvaluationResultFlags.ReadOnly));
         }
 
         /// <summary>

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
@@ -115,7 +115,7 @@ class C
         }
 
         [Fact]
-        public void HiddenMembers()
+        public void DuplicateAttributes()
         {
             var source =
 @"using System.Diagnostics;
@@ -123,11 +123,15 @@ abstract class A
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public object P1;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    internal virtual object P2 { get { return 0; } }
 }
 class B : A
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     new public object P1 => base.P1;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    internal override object P2 { get { return 0; } }
 }";
             var assembly = GetAssembly(source);
             var type = assembly.GetType("B");

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
@@ -114,6 +114,33 @@ class C
                 EvalResult("P6", "6", "object {int}", "((B)c.o).P6", DkmEvaluationResultFlags.ReadOnly));
         }
 
+        [Fact]
+        public void HiddenMembers()
+        {
+            var source =
+@"using System.Diagnostics;
+abstract class A
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public object P1;
+}
+class B : A
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    new public object P1 => base.P1;
+}";
+            var assembly = GetAssembly(source);
+            var type = assembly.GetType("B");
+            var value = CreateDkmClrValue(
+                value: type.Instantiate(),
+                type: type,
+                evalFlags: DkmEvaluationResultFlags.None,
+                valueFlags: DkmClrValueFlags.Synthetic);
+            var evalResult = FormatResult("this", value);
+            Verify(evalResult,
+                EvalResult("this", "{B}", "B", "this", DkmEvaluationResultFlags.None));
+        }
+
         /// <summary>
         /// DkmClrDebuggerBrowsableAttributes are obtained from the
         /// containing type and associated with the member name. For

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -517,7 +517,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     result = new Dictionary<string, DkmClrDebuggerBrowsableAttributeState>();
                 }
 
-                // There can be multiple same atributes for nested classes.
+                // There can be multiple same attributes for nested classes.
                 // Debugger provides attributes starting from nested classes and then up to base ones.
                 // We should use nested attributes if there is more than one instance.
                 if (!result.ContainsKey(browsableAttribute.TargetMember))

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -516,7 +516,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 {
                     result = new Dictionary<string, DkmClrDebuggerBrowsableAttributeState>();
                 }
-                result.Add(browsableAttribute.TargetMember, browsableAttribute.State);
+
+                // There can be multiple same atributes for nested classes.
+                // Debugger provides attributes starting from nested classes and then up to base ones.
+                // We should use nested attributes if there is more than one instance.
+                if (!result.ContainsKey(browsableAttribute.TargetMember))
+                {
+                    result.Add(browsableAttribute.TargetMember, browsableAttribute.State);
+                }
             }
             return result;
         }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -517,9 +517,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     result = new Dictionary<string, DkmClrDebuggerBrowsableAttributeState>();
                 }
 
-                // There can be multiple same attributes for nested classes.
-                // Debugger provides attributes starting from nested classes and then up to base ones.
-                // We should use nested attributes if there is more than one instance.
+                // There can be multiple same attributes for derived classes.
+                // Debugger provides attributes starting from derived classes and then up to base ones.
+                // We should use derived attributes if there is more than one instance.
                 if (!result.ContainsKey(browsableAttribute.TargetMember))
                 {
                     result.Add(browsableAttribute.TargetMember, browsableAttribute.State);

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrType.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrType.cs
@@ -20,6 +20,16 @@ namespace Microsoft.VisualStudio.Debugger.Clr
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     public class DkmClrType
     {
+        /// <summary>
+        /// We would accept inherited members for tests purposes comparing to <see cref="TypeHelpers.MemberBindingFlags"/> 
+        /// because an actual VS <see cref="GetEvalAttributes(Type)"/> may return attributes from base types.
+        /// Therefore, we do not check here for <see cref="BindingFlags.DeclaredOnly"/>.
+        /// </summary>
+        internal const BindingFlags MemberBindingFlags = BindingFlags.Public |
+                                                         BindingFlags.NonPublic |
+                                                         BindingFlags.Instance |
+                                                         BindingFlags.Static;
+
         private readonly DkmClrModuleInstance _module;
         private readonly DkmClrAppDomain _appDomain;
         private readonly Type _lmrType;
@@ -188,11 +198,10 @@ namespace Microsoft.VisualStudio.Debugger.Clr
                 attributes.Add(new DkmClrDebuggerTypeProxyAttribute(new DkmClrType((TypeImpl)proxyType)));
             }
 
-            var members = type.GetMembers(TypeHelpers.MemberBindingFlags).Where(TypeHelpers.IsVisibleMember);
+            var members = type.GetMembers(MemberBindingFlags).Where(TypeHelpers.IsVisibleMember);
             foreach (var member in members)
             {
-                var attribute = GetBrowsableAttribute(type, member);
-                if (attribute != null)
+                foreach (var attribute in GetBrowsableAttributes(type, member))
                 {
                     attributes.Add(attribute);
                 }
@@ -213,18 +222,20 @@ namespace Microsoft.VisualStudio.Debugger.Clr
             return attributes.ToImmutableAndFree();
         }
 
-        private static DkmClrDebuggerBrowsableAttribute GetBrowsableAttribute(Type type, MemberInfo member)
+        private static ReadOnlyCollection<DkmClrDebuggerBrowsableAttribute> GetBrowsableAttributes(Type type, MemberInfo member)
         {
+            var attributes = ArrayBuilder<DkmClrDebuggerBrowsableAttribute>.GetInstance();
             foreach (var attribute in member.GetCustomAttributesData())
             {
                 var data = ((CustomAttributeDataImpl)attribute).CustomAttributeData;
                 if (data.AttributeType == typeof(DebuggerBrowsableAttribute))
                 {
                     var state = (DebuggerBrowsableState)data.ConstructorArguments[0].Value;
-                    return new DkmClrDebuggerBrowsableAttribute(member.Name, ConvertBrowsableState(state));
+                    attributes.Add(new DkmClrDebuggerBrowsableAttribute(member.Name, ConvertBrowsableState(state)));
                 }
             }
-            return null;
+
+            return attributes.ToImmutableAndFree();
         }
 
         private static DkmClrDebuggerBrowsableAttributeState ConvertBrowsableState(DebuggerBrowsableState state)

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrType.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrType.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
         /// because an actual VS <see cref="GetEvalAttributes(Type)"/> may return attributes from base types.
         /// Therefore, we do not check here for <see cref="BindingFlags.DeclaredOnly"/>.
         /// </summary>
-        internal const BindingFlags MemberBindingFlags = BindingFlags.Public |
+        private const BindingFlags MemberBindingFlags = BindingFlags.Public |
                                                          BindingFlags.NonPublic |
                                                          BindingFlags.Instance |
                                                          BindingFlags.Static;


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/196121/debugger-ee-internal-error-if-debuggerbrowsable-wh.html