### PR TITLE
Change the topological sort's successor function to return an immutable array

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -974,16 +974,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <summary>
             /// A successor function used to topologically sort the DagState set.
             /// </summary>
-            private static IEnumerable<DagState> Successor(DagState state)
+            private static ImmutableArray<DagState> Successor(DagState state)
             {
-                if (state.TrueBranch != null)
-                {
-                    yield return state.TrueBranch;
-                }
 
-                if (state.FalseBranch != null)
+                if (state.TrueBranch != null && state.FalseBranch != null)
                 {
-                    yield return state.FalseBranch;
+                    return ImmutableArray.Create(state.TrueBranch, state.FalseBranch);
+                }
+                else if (state.TrueBranch != null)
+                {
+                    return ImmutableArray.Create(state.TrueBranch);
+                }
+                else if (state.FalseBranch != null)
+                {
+                    return ImmutableArray.Create(state.FalseBranch);
+                }
+                else
+                {
+                    return ImmutableArray<DagState>.Empty;
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDag.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDag.cs
@@ -15,30 +15,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         private HashSet<LabelSymbol> _reachableLabels;
         private ImmutableArray<BoundDecisionDagNode> _topologicallySortedNodes;
 
-        private static IEnumerable<BoundDecisionDagNode> Successors(BoundDecisionDagNode node)
+        private static ImmutableArray<BoundDecisionDagNode> Successors(BoundDecisionDagNode node)
         {
             switch (node)
             {
                 case BoundEvaluationDecisionDagNode p:
-                    yield return p.Next;
-                    yield break;
+                    return ImmutableArray.Create(p.Next);
                 case BoundTestDecisionDagNode p:
-                    Debug.Assert(p.WhenFalse != null);
-                    yield return p.WhenFalse;
-                    Debug.Assert(p.WhenTrue != null);
-                    yield return p.WhenTrue;
-                    yield break;
+                    return ImmutableArray.Create(p.WhenFalse, p.WhenTrue);
                 case BoundLeafDecisionDagNode d:
-                    yield break;
+                    return ImmutableArray<BoundDecisionDagNode>.Empty;
                 case BoundWhenDecisionDagNode w:
-                    Debug.Assert(w.WhenTrue != null);
-                    yield return w.WhenTrue;
-                    if (w.WhenFalse != null)
-                    {
-                        yield return w.WhenFalse;
-                    }
-
-                    yield break;
+                    return (w.WhenFalse != null) ? ImmutableArray.Create(w.WhenTrue, w.WhenFalse) : ImmutableArray.Create(w.WhenTrue);
                 default:
                     throw ExceptionUtilities.UnexpectedValue(node.Kind);
             }

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/TopologicalSortTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             };
 
             Func<int, IEnumerable<int>> succF = x => successors[x];
-            var sorted = TopologicalSort.IterativeSort<int>(new[] { 4, 5 }, succF);
+            var sorted = TopologicalSort.IterativeSort<int>(new[] { 4, 5 }, i => succF(i).ToImmutableArray());
             AssertTopologicallySorted(sorted, succF, "Test01");
             Assert.Equal(6, sorted.Length);
             AssertEx.Equal(new[] { 4, 5, 2, 3, 1, 0 }, sorted);
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             };
 
             Func<string, IEnumerable<string>> succF = x => successors[int.Parse(x)];
-            var sorted = TopologicalSort.IterativeSort<string>(new[] { "4", "5" }, succF);
+            var sorted = TopologicalSort.IterativeSort<string>(new[] { "4", "5" }, i => succF(i).ToImmutableArray());
             AssertTopologicallySorted(sorted, succF, "Test01");
             Assert.Equal(6, sorted.Length);
             AssertEx.Equal(new[] { "4", "5", "2", "3", "1", "0" }, sorted);
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             };
 
             Func<int, IEnumerable<int>> succF = x => successors[x];
-            var sorted = TopologicalSort.IterativeSort<int>(new[] { 1, 6 }, succF);
+            var sorted = TopologicalSort.IterativeSort<int>(new[] { 1, 6 }, i => succF(i).ToImmutableArray());
             AssertTopologicallySorted(sorted, succF, "Test02");
             Assert.Equal(7, sorted.Length);
             AssertEx.Equal(new[] { 1, 4, 3, 5, 6, 7, 2 }, sorted);
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             // 1 -> 4 -> 3 -> 5 -> 1
             Assert.Throws<ArgumentException>(() =>
             {
-                var sorted = TopologicalSort.IterativeSort<int>(new[] { 1 }, x => successors[x]);
+                var sorted = TopologicalSort.IterativeSort<int>(new[] { 1 }, x => successors[x].ToImmutableArray());
             });
         }
 
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
             // Perform a topological sort and check it.
             Func<int, IEnumerable<int>> succF = x => successors[x];
-            var sorted = TopologicalSort.IterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), succF);
+            var sorted = TopologicalSort.IterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), i => succF(i).ToImmutableArray());
             Assert.Equal(numberOfNodes, sorted.Length);
             AssertTopologicallySorted(sorted, succF, $"TestRandom(seed: {seed})");
 
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
             Assert.Throws<ArgumentException>(() =>
             {
-                TopologicalSort.IterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), succF);
+                TopologicalSort.IterativeSort<int>(Enumerable.Range(0, numberOfNodes).ToArray(), i => succF(i).ToImmutableArray());
             });
 
             // where

--- a/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
+++ b/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="nodes">Any subset of the nodes that includes all nodes with no predecessors</param>
         /// <param name="successors">A function mapping a node to its set of successors</param>
         /// <returns>A list of all reachable nodes, in which each node always precedes its successors</returns>
-        public static ImmutableArray<TNode> IterativeSort<TNode>(IEnumerable<TNode> nodes, Func<TNode, IEnumerable<TNode>> successors)
+        public static ImmutableArray<TNode> IterativeSort<TNode>(IEnumerable<TNode> nodes, Func<TNode, ImmutableArray<TNode>> successors)
         {
             // First, count the predecessors of each node
             PooledDictionary<TNode, int> predecessorCounts = PredecessorCounts(nodes, successors, out ImmutableArray<TNode> allNodes);
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis
 
         private static PooledDictionary<TNode, int> PredecessorCounts<TNode>(
             IEnumerable<TNode> nodes,
-            Func<TNode, IEnumerable<TNode>> successors,
+            Func<TNode, ImmutableArray<TNode>> successors,
             out ImmutableArray<TNode> allNodes)
         {
             var predecessorCounts = PooledDictionary<TNode, int>.GetInstance();


### PR DESCRIPTION
Fixes #25754

@cston @agocke @dotnet/roslyn-compiler May I please have a couple of reviews for this small change?

