### PR TITLE
VB: Debugger Bug when using type Date Properties in Classes in .NET Core Projects

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -383,10 +383,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             object obj;
             if (value.Type.GetLmrType().IsDateTime())
             {
-                DkmClrValue dateDataValue = value.GetFieldValue(DateTimeUtilities.DateTimeDateDataFieldName, inspectionContext);
+                DkmClrValue dateDataValue = value.GetPropertyValue(DateTimeUtilities.DateTimeInternalTicksPropertyName, inspectionContext);
                 Debug.Assert(dateDataValue.HostObjectValue != null);
 
-                obj = DateTimeUtilities.ToDateTime((ulong)dateDataValue.HostObjectValue);
+                obj = new DateTime((long)dateDataValue.HostObjectValue);
             }
             else
             {

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             object obj;
             if (value.Type.GetLmrType().IsDateTime())
             {
-                DkmClrValue dateDataValue = value.GetPropertyValue(DateTimeUtilities.DateTimeInternalTicksPropertyName, inspectionContext);
+                DkmClrValue dateDataValue = value.GetPropertyValue("Ticks", inspectionContext);
                 Debug.Assert(dateDataValue.HostObjectValue != null);
 
                 obj = new DateTime((long)dateDataValue.HostObjectValue);

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -330,6 +330,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return value.GetMemberValue(name, (int)MemberTypes.Field, ParentTypeName: null, InspectionContext: inspectionContext);
         }
 
+        internal static DkmClrValue GetPropertyValue(this DkmClrValue value, string name, DkmInspectionContext inspectionContext)
+        {
+            return value.GetMemberValue(name, (int)MemberTypes.Property, ParentTypeName: null, InspectionContext: inspectionContext);
+        }
+
         internal static DkmClrValue GetNullableValue(this DkmClrValue value, Type nullableTypeArg, DkmInspectionContext inspectionContext)
         {
             var valueType = value.Type.GetLmrType();

--- a/src/Test/PdbUtilities/Shared/DateTimeUtilities.cs
+++ b/src/Test/PdbUtilities/Shared/DateTimeUtilities.cs
@@ -6,7 +6,7 @@ namespace Roslyn.Utilities
 {
     internal static class DateTimeUtilities
     {
-        internal const string DateTimeDateDataFieldName = "dateData";
+        internal const string DateTimeInternalTicksPropertyName = "InternalTicks";
 
         // From DateTime.cs.
         private const long TicksMask = 0x3FFFFFFFFFFFFFFF;
@@ -16,14 +16,6 @@ namespace Roslyn.Utilities
             // This mechanism for getting the tick count from the underlying ulong field is copied
             // from System.DateTime.InternalTicks (ndp\clr\src\BCL\System\DateTime.cs).
             var tickCount = BitConverter.DoubleToInt64Bits(raw) & TicksMask;
-            return new DateTime(tickCount);
-        }
-
-        internal static DateTime ToDateTime(ulong raw)
-        {
-            // This mechanism for getting the tick count from the underlying ulong field is copied
-            // from System.DateTime.InternalTicks (ndp\clr\src\BCL\System\DateTime.cs).
-            var tickCount = unchecked((long)raw) & TicksMask;
             return new DateTime(tickCount);
         }
     }

--- a/src/Test/PdbUtilities/Shared/DateTimeUtilities.cs
+++ b/src/Test/PdbUtilities/Shared/DateTimeUtilities.cs
@@ -6,8 +6,6 @@ namespace Roslyn.Utilities
 {
     internal static class DateTimeUtilities
     {
-        internal const string DateTimeInternalTicksPropertyName = "InternalTicks";
-
         // From DateTime.cs.
         private const long TicksMask = 0x3FFFFFFFFFFFFFFF;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/25018

Tests are already there: http://source.roslyn.io/#Roslyn.ExpressionEvaluator.VisualBasic.ResultProvider.UnitTests/ValueFormatterTests.vb,568

Filed a separate bug to support tests under .NET Core: https://github.com/dotnet/roslyn/issues/26153

Tagging @r-ramesh for review

