### PR TITLE
Avoid creating all metadata references in the TargetFrameworkUtil static constructor

### DIFF
--- a/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
+++ b/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
@@ -46,19 +46,19 @@ namespace Roslyn.Test.Utilities
     {
         public static MetadataReference StandardCSharpReference => CoreClrShim.IsRunningOnCoreClr ? NetStandard20.MicrosoftCSharpRef : TestBase.CSharpDesktopRef;
 
-        public static readonly ImmutableArray<MetadataReference> Mscorlib40References = ImmutableArray.Create(TestBase.MscorlibRef);
-        public static readonly ImmutableArray<MetadataReference> Mscorlib40ExtendedReferences = ImmutableArray.Create(TestBase.MscorlibRef, TestBase.SystemRef, TestBase.SystemCoreRef, TestBase.ValueTupleRef, TestBase.SystemRuntimeFacadeRef);
-        public static readonly ImmutableArray<MetadataReference> Mscorlib40andSystemCoreReferences = ImmutableArray.Create(TestBase.MscorlibRef, TestBase.SystemCoreRef);
-        public static readonly ImmutableArray<MetadataReference> Mscorlib45References = ImmutableArray.Create(TestBase.MscorlibRef_v4_0_30316_17626);
-        public static readonly ImmutableArray<MetadataReference> Mscorlib45ExtendedReferences = ImmutableArray.Create(TestBase.MscorlibRef_v4_0_30316_17626, TestBase.SystemRef, TestBase.SystemCoreRef, TestBase.ValueTupleRef, TestBase.SystemRuntimeFacadeRef);
-        public static readonly ImmutableArray<MetadataReference> Mscorlib45AndCSharpReferences = ImmutableArray.Create(TestBase.MscorlibRef_v4_0_30316_17626, TestBase.SystemCoreRef, TestBase.CSharpRef);
-        public static readonly ImmutableArray<MetadataReference> Mscorlib46References = ImmutableArray.Create(TestBase.MscorlibRef_v46);
-        public static readonly ImmutableArray<MetadataReference> Mscorlib46ExtendedReferences = ImmutableArray.Create(TestBase.MscorlibRef_v46, TestBase.SystemRef_v46, TestBase.SystemCoreRef_v46, TestBase.ValueTupleRef, TestBase.SystemRuntimeFacadeRef);
-        public static readonly ImmutableArray<MetadataReference> NetStandard20References = ImmutableArray.Create<MetadataReference>(NetStandard20.NetStandard, NetStandard20.MscorlibRef, NetStandard20.SystemRuntimeRef, NetStandard20.SystemCoreRef, NetStandard20.SystemDynamicRuntimeRef);
-        public static readonly ImmutableArray<MetadataReference> WinRTReferences = ImmutableArray.Create(TestBase.WinRtRefs);
-        public static readonly ImmutableArray<MetadataReference> StandardReferences = CoreClrShim.IsRunningOnCoreClr ? NetStandard20References : Mscorlib46ExtendedReferences;
-        public static readonly ImmutableArray<MetadataReference> StandardAndCSharpReferences = StandardReferences.Add(StandardCSharpReference);
-        public static readonly ImmutableArray<MetadataReference> StandardCompatReferences = CoreClrShim.IsRunningOnCoreClr ? NetStandard20References : Mscorlib40References;
+        public static ImmutableArray<MetadataReference> Mscorlib40References => ImmutableArray.Create(TestBase.MscorlibRef);
+        public static ImmutableArray<MetadataReference> Mscorlib40ExtendedReferences => ImmutableArray.Create(TestBase.MscorlibRef, TestBase.SystemRef, TestBase.SystemCoreRef, TestBase.ValueTupleRef, TestBase.SystemRuntimeFacadeRef);
+        public static ImmutableArray<MetadataReference> Mscorlib40andSystemCoreReferences => ImmutableArray.Create(TestBase.MscorlibRef, TestBase.SystemCoreRef);
+        public static ImmutableArray<MetadataReference> Mscorlib45References => ImmutableArray.Create(TestBase.MscorlibRef_v4_0_30316_17626);
+        public static ImmutableArray<MetadataReference> Mscorlib45ExtendedReferences => ImmutableArray.Create(TestBase.MscorlibRef_v4_0_30316_17626, TestBase.SystemRef, TestBase.SystemCoreRef, TestBase.ValueTupleRef, TestBase.SystemRuntimeFacadeRef);
+        public static ImmutableArray<MetadataReference> Mscorlib45AndCSharpReferences => ImmutableArray.Create(TestBase.MscorlibRef_v4_0_30316_17626, TestBase.SystemCoreRef, TestBase.CSharpRef);
+        public static ImmutableArray<MetadataReference> Mscorlib46References => ImmutableArray.Create(TestBase.MscorlibRef_v46);
+        public static ImmutableArray<MetadataReference> Mscorlib46ExtendedReferences => ImmutableArray.Create(TestBase.MscorlibRef_v46, TestBase.SystemRef_v46, TestBase.SystemCoreRef_v46, TestBase.ValueTupleRef, TestBase.SystemRuntimeFacadeRef);
+        public static ImmutableArray<MetadataReference> NetStandard20References => ImmutableArray.Create<MetadataReference>(NetStandard20.NetStandard, NetStandard20.MscorlibRef, NetStandard20.SystemRuntimeRef, NetStandard20.SystemCoreRef, NetStandard20.SystemDynamicRuntimeRef);
+        public static ImmutableArray<MetadataReference> WinRTReferences => ImmutableArray.Create(TestBase.WinRtRefs);
+        public static ImmutableArray<MetadataReference> StandardReferences => CoreClrShim.IsRunningOnCoreClr ? NetStandard20References : Mscorlib46ExtendedReferences;
+        public static ImmutableArray<MetadataReference> StandardAndCSharpReferences => StandardReferences.Add(StandardCSharpReference);
+        public static ImmutableArray<MetadataReference> StandardCompatReferences => CoreClrShim.IsRunningOnCoreClr ? NetStandard20References : Mscorlib40References;
 
         public static ImmutableArray<MetadataReference> GetReferences(TargetFramework tf)
         {


### PR DESCRIPTION
Test only change based on the following build:

https://ci.dot.net/job/dotnet_roslyn/job/dev15.7.x-vs-deps/job/windows_debug_spanish_unit32_prtest/9/

```
xUnit.net Console Runner (32-bit Desktop .NET 4.0.30319.42000)
  Discovering: Roslyn.ExpressionEvaluator.CSharp.ResultProvider.UnitTests
  Discovered:  Roslyn.ExpressionEvaluator.CSharp.ResultProvider.UnitTests
  Starting:    Roslyn.ExpressionEvaluator.CSharp.ResultProvider.UnitTests
    Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests.DebuggerDisplayAttributeTests.PointerDereferenceExpansion_NonNull
System.Reflection.TargetInvocationException: Se produjo una excepción en el destino de la invocación.
System.TypeInitializationException: Se produjo una excepción en el inicializador de tipo de 'Roslyn.Test.Utilities.TargetFrameworkUtil'.
System.AccessViolationException: Intento de leer o escribir en la memoria protegida. A menudo, esto indica que hay otra memoria dañada.
```

I've seen hints of this in the past and it might be the underlying cause of #25961, but I wasn't able to prove it to date. The goal with this change is to throw the exception somewhere other than the static constructor, and hopefully have a better stack trace to work with.