### PR TITLE
Document the use of lazy initialization in TargetFrameworkUtil

### DIFF
--- a/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
+++ b/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
@@ -46,6 +46,13 @@ namespace Roslyn.Test.Utilities
     {
         public static MetadataReference StandardCSharpReference => CoreClrShim.IsRunningOnCoreClr ? NetStandard20.MicrosoftCSharpRef : TestBase.CSharpDesktopRef;
 
+        /*
+         * ⚠ Dev note ⚠: properties in TestBase are backed by Lazy<T>. Avoid changes to the following properties
+         * which would force the initialization of these properties in the static constructor, since the stack traces
+         * for a TypeLoadException are missing important information for resolving problems if/when they occur.
+         * https://github.com/dotnet/roslyn/issues/25961
+         */
+
         public static ImmutableArray<MetadataReference> Mscorlib40References => ImmutableArray.Create(TestBase.MscorlibRef);
         public static ImmutableArray<MetadataReference> Mscorlib40ExtendedReferences => ImmutableArray.Create(TestBase.MscorlibRef, TestBase.SystemRef, TestBase.SystemCoreRef, TestBase.ValueTupleRef, TestBase.SystemRuntimeFacadeRef);
         public static ImmutableArray<MetadataReference> Mscorlib40andSystemCoreReferences => ImmutableArray.Create(TestBase.MscorlibRef, TestBase.SystemCoreRef);


### PR DESCRIPTION
Test only change.

Implements the request in https://github.com/dotnet/roslyn/pull/26065#discussion_r180452083.