### PR TITLE
Use a unique job name for each target branch

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -43,7 +43,7 @@ static void addRoslynJob(def myJob, String jobName, String branchName, Boolean i
       triggerCore = "${triggerCore}|${triggerPhraseExtra}"
     }
     def triggerPhrase = "(?im)^\\s*(@?dotnet-bot\\,?\\s+)?(re)?test\\s+(${triggerCore})(\\s+please\\.?)?\\s*\$";
-    def contextName = jobName
+    def contextName = "${branchName}/${jobName}"
     Utilities.addGithubPRTriggerForBranch(myJob, branchName, contextName, triggerPhrase, triggerPhraseOnly)
   } else {
     Utilities.standardJobSetupPush(myJob, projectName, "*/${branchName}");


### PR DESCRIPTION
This change avoids a conflict when a single commit is used as the source for multiple pull requests to different target branches. In such a cases, the commit statuses from each target branch need to be preserved without overwriting each other.

When reporting build status, Jenkins will include the target branch in the result, e.g. **dev15.7.x/perf_correctness_prtest** instead of just **perf_correctness_prtest**. Under this change, it's possible for pull requests to have extraneous statuses appearing, but such a situation will no longer result in falsely reporting a failed build as passing.