### PR TITLE
Allow an embedded language to participate in document highlighting.

### DIFF
--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -60,6 +61,12 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
         private async Task<ImmutableArray<DocumentHighlights>> GetDocumentHighlightsInCurrentProcessAsync(
             Document document, int position, IImmutableSet<Document> documentsToSearch, CancellationToken cancellationToken)
         {
+            var result = await TryGetEmbeddedLanguageHighlightsAsync(document, position, cancellationToken).ConfigureAwait(false);
+            if (!result.IsDefaultOrEmpty)
+            {
+                return result;
+            }
+
             // use speculative semantic model to see whether we are on a symbol we can do HR
             var span = new TextSpan(position, 0);
             var solution = document.Project.Solution;
@@ -82,6 +89,35 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
             return await GetTagsForReferencedSymbolAsync(
                 new SymbolAndProjectId(symbol, document.Project.Id),
                 document, documentsToSearch, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<ImmutableArray<DocumentHighlights>> TryGetEmbeddedLanguageHighlightsAsync(
+            Document document, int position, CancellationToken cancellationToken)
+        {
+            var embeddedLanguageProvider = document.GetLanguageService<IEmbeddedLanguageProvider>();
+            foreach (var language in embeddedLanguageProvider.GetEmbeddedLanguages())
+            {
+                var highlighter = language.Highlighter;
+                if (highlighter != null)
+                {
+                    var highlights = await highlighter.GetHighlightsAsync(
+                        document, position, cancellationToken).ConfigureAwait(false);
+
+                    if (highlights.Length > 0)
+                    {
+                        var result = ArrayBuilder<HighlightSpan>.GetInstance();
+                        foreach (var span in highlights)
+                        {
+                            result.Add(new HighlightSpan(span, HighlightSpanKind.None));
+                        }
+
+                        return ImmutableArray.Create(new DocumentHighlights(
+                            document, result.ToImmutableAndFree()));
+                    }
+                }
+            }
+
+            return default;
         }
 
         private static async Task<ISymbol> GetSymbolToSearchAsync(Document document, int position, SemanticModel semanticModel, ISymbol symbol, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/IEmbeddedHighlighter.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/IEmbeddedHighlighter.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
+{
+    interface IEmbeddedHighlighter
+    {
+        Task<ImmutableArray<TextSpan>> GetHighlightsAsync(Document document, int position, CancellationToken cancellationToken);
+    }
+}

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/IEmbeddedLanguage.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/IEmbeddedLanguage.cs
@@ -20,6 +20,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
         IEmbeddedClassifier Classifier { get; }
 
         /// <summary>
+        /// A optional highlighter that can highlight spans for an embedded language string.
+        /// </summary>
+        IEmbeddedHighlighter Highlighter { get; }
+
+        /// <summary>
         /// An optional analyzer that produces diagnostics for an embedded language string.
         /// </summary>
         IEmbeddedDiagnosticAnalyzer DiagnosticAnalyzer { get; }


### PR DESCRIPTION
This wasn't part of the previous embedded-language-services PR because that PR just contained the features necessary for embedded-json.  Embedded-json doesn't have a need (afaict) for 'document highlights', whereas embedded-regex does.  

Note: this should be reviewed after https://github.com/dotnet/roslyn/pull/26074 goes in.