### PR TITLE
De-duplicate strings in DiagnosticIncrementalAnalyzer.StateSet

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -128,12 +128,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return false;
         }
 
-        public static ValueTuple<string, VersionStamp> GetAnalyzerIdAndVersion(this DiagnosticAnalyzer analyzer)
+        public static (string analyzerId, VersionStamp version) GetAnalyzerIdAndVersion(this DiagnosticAnalyzer analyzer)
         {
             // Get the unique ID for given diagnostic analyzer.
             // note that we also put version stamp so that we can detect changed analyzer.
             var typeInfo = analyzer.GetType().GetTypeInfo();
-            return ValueTuple.Create(analyzer.GetAnalyzerId(), GetAnalyzerVersion(CorLightup.Desktop.GetAssemblyLocation(typeInfo.Assembly)));
+            return (analyzer.GetAnalyzerId(), GetAnalyzerVersion(CorLightup.Desktop.GetAssemblyLocation(typeInfo.Assembly)));
         }
 
         public static string GetAnalyzerAssemblyName(this DiagnosticAnalyzer analyzer)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Roslyn.Utilities;
@@ -17,20 +19,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         /// </summary>
         private class StateSet
         {
-            private const string UserDiagnosticsPrefixTableName = "<UserDiagnostics2>";
-
             private readonly string _language;
             private readonly DiagnosticAnalyzer _analyzer;
             private readonly string _errorSourceName;
 
             // analyzer version this state belong to
             private readonly VersionStamp _analyzerVersion;
-
-            // name of each analysis kind persistent storage
-            private readonly string _stateName;
-            private readonly string _syntaxStateName;
-            private readonly string _semanticStateName;
-            private readonly string _nonLocalStateName;
+            private readonly AnalyzerTypeData _analyzerTypeData;
 
             private readonly ConcurrentDictionary<DocumentId, ActiveFileState> _activeFileStates;
             private readonly ConcurrentDictionary<ProjectId, ProjectState> _projectStates;
@@ -41,23 +36,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _analyzer = analyzer;
                 _errorSourceName = errorSourceName;
 
-                var nameAndVersion = GetNameAndVersion(_analyzer);
-                _analyzerVersion = nameAndVersion.Item2;
-
-                _stateName = nameAndVersion.Item1;
-
-                _syntaxStateName = _stateName + ".Syntax";
-                _semanticStateName = _stateName + ".Semantic";
-                _nonLocalStateName = _stateName + ".NonLocal";
+                var (analyzerId, version) = _analyzer.GetAnalyzerIdAndVersion();
+                _analyzerVersion = version;
+                _analyzerTypeData = AnalyzerTypeData.ForType(_analyzer.GetType());
+                Debug.Assert(_analyzerTypeData.StateName == $"<UserDiagnostics2>_{analyzerId}", "Expected persistence information for analyzer instance to be derived from its type alone.");
 
                 _activeFileStates = new ConcurrentDictionary<DocumentId, ActiveFileState>(concurrencyLevel: 2, capacity: 10);
                 _projectStates = new ConcurrentDictionary<ProjectId, ProjectState>(concurrencyLevel: 2, capacity: 1);
             }
 
-            public string StateName => _stateName;
-            public string SyntaxStateName => _syntaxStateName;
-            public string SemanticStateName => _semanticStateName;
-            public string NonLocalStateName => _nonLocalStateName;
+            public string StateName => _analyzerTypeData.StateName;
+            public string SyntaxStateName => _analyzerTypeData.SyntaxStateName;
+            public string SemanticStateName => _analyzerTypeData.SemanticStateName;
+            public string NonLocalStateName => _analyzerTypeData.NonLocalStateName;
 
             public string Language => _language;
             public string ErrorSourceName => _errorSourceName;
@@ -265,19 +256,34 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 InMemoryStorage.DropCache(Analyzer);
             }
 
-            /// <summary>
-            /// Get the unique state name for the given analyzer.
-            /// Note that this name is used by the underlying persistence stream of the corresponding <see cref="ProjectState"/> to Read/Write diagnostic data into the stream.
-            /// If any two distinct analyzer have the same diagnostic state name, we will end up sharing the persistence stream between them, leading to duplicate/missing/incorrect diagnostic data.
-            /// </summary>
-            private static ValueTuple<string, VersionStamp> GetNameAndVersion(DiagnosticAnalyzer analyzer)
+            private sealed class AnalyzerTypeData
             {
-                Contract.ThrowIfNull(analyzer);
+                private const string UserDiagnosticsPrefixTableName = "<UserDiagnostics2>";
+                private static readonly ConditionalWeakTable<Type, AnalyzerTypeData> s_analyzerTypeData
+                    = new ConditionalWeakTable<Type, AnalyzerTypeData>();
 
-                // Get the unique ID for given diagnostic analyzer.
-                // note that we also put version stamp so that we can detect changed analyzer.
-                var tuple = analyzer.GetAnalyzerIdAndVersion();
-                return ValueTuple.Create(UserDiagnosticsPrefixTableName + "_" + tuple.Item1, tuple.Item2);
+                private AnalyzerTypeData(Type type)
+                {
+                    StateName = UserDiagnosticsPrefixTableName + "_" + type.AssemblyQualifiedName;
+                    SyntaxStateName = StateName + ".Syntax";
+                    SemanticStateName = StateName + ".Semantic";
+                    NonLocalStateName = StateName + ".NonLocal";
+                }
+
+                /// <summary>
+                /// Get the unique state name for the given analyzer.
+                /// Note that this name is used by the underlying persistence stream of the corresponding <see cref="ProjectState"/> to Read/Write diagnostic data into the stream.
+                /// If any two distinct analyzer have the same diagnostic state name, we will end up sharing the persistence stream between them, leading to duplicate/missing/incorrect diagnostic data.
+                /// </summary>
+                public string StateName { get; }
+                public string SyntaxStateName { get; }
+                public string SemanticStateName { get; }
+                public string NonLocalStateName { get; }
+
+                public static AnalyzerTypeData ForType(Type type)
+                {
+                    return s_analyzerTypeData.GetValue(type, t => new AnalyzerTypeData(t));
+                }
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var (analyzerId, version) = _analyzer.GetAnalyzerIdAndVersion();
                 _analyzerVersion = version;
                 _analyzerTypeData = AnalyzerTypeData.ForType(_analyzer.GetType());
-                Debug.Assert(_analyzerTypeData.StateName == $"<UserDiagnostics2>_{analyzerId}", "Expected persistence information for analyzer instance to be derived from its type alone.");
+                Debug.Assert(_analyzerTypeData.StateName == $"{AnalyzerTypeData.UserDiagnosticsPrefixTableName}_{analyzerId}", "Expected persistence information for analyzer instance to be derived from its type alone.");
 
                 _activeFileStates = new ConcurrentDictionary<DocumentId, ActiveFileState>(concurrencyLevel: 2, capacity: 10);
                 _projectStates = new ConcurrentDictionary<ProjectId, ProjectState>(concurrencyLevel: 2, capacity: 1);
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private sealed class AnalyzerTypeData
             {
-                private const string UserDiagnosticsPrefixTableName = "<UserDiagnostics2>";
+                internal const string UserDiagnosticsPrefixTableName = "<UserDiagnostics2>";
                 private static readonly ConcurrentDictionary<Type, AnalyzerTypeData> s_analyzerTypeData
                     = new ConcurrentDictionary<Type, AnalyzerTypeData>();
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Roslyn.Utilities;
@@ -259,8 +258,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private sealed class AnalyzerTypeData
             {
                 private const string UserDiagnosticsPrefixTableName = "<UserDiagnostics2>";
-                private static readonly ConditionalWeakTable<Type, AnalyzerTypeData> s_analyzerTypeData
-                    = new ConditionalWeakTable<Type, AnalyzerTypeData>();
+                private static readonly ConcurrentDictionary<Type, AnalyzerTypeData> s_analyzerTypeData
+                    = new ConcurrentDictionary<Type, AnalyzerTypeData>();
 
                 private AnalyzerTypeData(Type type)
                 {
@@ -282,7 +281,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 public static AnalyzerTypeData ForType(Type type)
                 {
-                    return s_analyzerTypeData.GetValue(type, t => new AnalyzerTypeData(t));
+                    return s_analyzerTypeData.GetOrAdd(type, t => new AnalyzerTypeData(t));
                 }
             }
         }


### PR DESCRIPTION
Fixes #25771

:memo: The one field which is still not de-duplicated is `_errorSourceName`, when the string is created by the following:

https://github.com/dotnet/roslyn/blob/d595992949899fa522a1f44cf8f61881f146ba27/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs#L282

### Customer scenario

A customer with a large number of projects *and* a large number of analyzers experiences memory pressure (low virtual memory), including increased chances of `OutOfMemoryException` and/or other crashes.

### Bugs this fixes

Fixes #25771 

### Workarounds, if any

Reduce the number of analyzers in use.

### Risk

Low. The strings were constructed in a predictable manner so their values do not change as part of this pull request.

### Performance impact

Performance is improved, in some outlier cases substantially.

### Is this a regression from a previous update?

No.

### Root cause analysis

The underlying problem is an algorithm which produces an O(m*n) number of string instances, where *m* is the number of projects and *n* is the number of analyzers. The strings themselves are not large, but some customers have 400+ projects with 200+ analyzers, leading to substantial net impact.

### How was the bug found?

Heap dump analysis.

### Test documentation updated?

N/A