### PR TITLE
Redirect the temporary directory for testing

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -38,6 +38,7 @@ param (
     [switch]$testDesktop = $false,
     [switch]$testCoreClr = $false,
     [switch]$testIOperation = $false,
+    [switch]$noRedirect = $false,
 
     # Special test options
     [switch]$testDeterminism = $false,
@@ -696,6 +697,9 @@ try {
     if ($cibuild) { 
         List-VSProcesses
         List-BuildProcesses
+    }
+
+    if (-not $noRedirect) {
         Redirect-Temp
     }
 


### PR DESCRIPTION
This test-only change avoids the creation of large numbers of files and folders in the user's
temporary directory. The original behavior can still be used by passing `-noRedirect`
to **Test.cmd** or **build.ps1**.

:memo: No redirection occurs when running tests through Test Explorer in Visual Studio.