### PR TITLE
Add SourceRootMappedPathsFeatureSupported property

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -88,7 +88,14 @@
       <SourceRoot Include="@(_MappedSourceRoot)" />
     </ItemGroup>
   </Target>
-  
+
+  <!-- 
+    Declare that target InitializeSourceRootMappedPaths that populates MappedPaths metadata on SourceRoot items is available.
+  -->
+  <PropertyGroup>
+    <SourceRootMappedPathsFeatureSupported>true</SourceRootMappedPathsFeatureSupported>
+  </PropertyGroup>
+
   <!-- 
     If InitializeSourceControlInformation target isn't supported, we just continue without invoking that synchronization target. 
     We'll proceed with SourceRoot (and other source control properties) provided by the user (or blank).

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -74,7 +74,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 {
                     "@(SourceRoot->'%(Identity): %(MappedPath)')",
                     "$(DeterministicSourcePaths)",
-                    "$(PathMap)"
+                    "$(PathMap)",
+                    "$(SourceRootMappedPathsFeatureSupported)"
                 },
                 expectedResults: new[] 
                 {
@@ -82,8 +83,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                     $@"{root1}: /_/",
                     $@"{root1}sub1\: /_/sub1/",
                     $@"{root1}sub2\: /_/sub2/",
-                    @"true",
-                    $@"{root2}=/_1/,{root1}=/_/,PreviousPathMap"
+                    "true",
+                    $@"{root2}=/_1/,{root1}=/_/,PreviousPathMap",
+                    "true"
                 });
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(


### PR DESCRIPTION
### Customer scenario

Add a property to `Microsoft.Managed.Core.targets` that declares that target `InitializeSourceRootMappedPaths` is available. This property allows SourceLink package targets to detect whether or not to depend on this target and avoid the dependency if the compiler doesn't support the target (e.g. F# projects, projects using older C# compiler version). Without this property available SourceLink package would fail with with a cryptic build error that doesn't tell the customer anything useful.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/598723

### Workarounds, if any

No reasonable workaround.

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

SourceLink package testing.

### Test documentation updated?
