### PR TITLE
Remove InternalsVisibleTo for CodeLens

### DIFF
--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -120,8 +120,6 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ErrorList.UnitTests" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.Next.UnitTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
-    <InternalsVisibleTo Include="Microsoft.VisualStudio.Alm.Shared.CodeAnalysisClient" Key="$(TypeScriptKey)" />
-    <InternalsVisibleTo Include="Microsoft.VisualStudio.CodeSense.Roslyn" Key="$(TypeScriptKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.TypeScript.EditorFeatures" Key="$(TypeScriptKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.TypeScript" Key="$(TypeScriptKey)" />
     <InternalsVisibleTo Include="Roslyn.Services.Editor.TypeScript.UnitTests" Key="$(TypeScriptKey)" />


### PR DESCRIPTION
Microsoft.VisualStudio.Alm.Shared.CodeAnalysisClient had already been deleted, and the later no longer uses project system internals as [this pull request](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/109117?_a=overview) got rid of it.