### PR TITLE
Update XliffTasks

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -237,7 +237,7 @@
     <VSSDKComponentModelHostVersion>12.0.4</VSSDKComponentModelHostVersion>
     <VsWebsiteInteropVersion>8.0.0.0-alpha</VsWebsiteInteropVersion>
     <vswhereVersion>1.0.71</vswhereVersion>
-    <XliffTasksVersion>0.2.0-beta-000081</XliffTasksVersion>
+    <XliffTasksVersion>0.2.0-beta-62730-03</XliffTasksVersion>
     <xunitVersion>2.3.1</xunitVersion>
     <xunitanalyzersVersion>0.8.0</xunitanalyzersVersion>
     <xunitassertVersion>2.3.1</xunitassertVersion>


### PR DESCRIPTION
Update to the latest version of XliffTasks. Notably, this version
attemps to insert new `trans-unit` elements into .xlf files in a sorted
order rather than always putting them at the bottom. This should help
reduce merge conflicts.

Fixes #25849.