### PR TITLE
Simplify diagnostic suppression

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
@@ -674,7 +674,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override Diagnostic FilterDiagnostic(Diagnostic diagnostic)
         {
-            return CSharpDiagnosticFilter.Filter(diagnostic, WarningLevel, GeneralDiagnosticOption, SpecificDiagnosticOptions);
+            return CSharpDiagnosticFilter.Filter(
+                diagnostic,
+                WarningLevel,
+                GeneralDiagnosticOption,
+                SpecificDiagnosticOptions,
+                ReportSuppressedDiagnostics);
         }
 
         protected override CompilationOptions CommonWithModuleName(string moduleName)

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -113,17 +113,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override ReportDiagnostic GetDiagnosticReport(DiagnosticInfo diagnosticInfo, CompilationOptions options)
         {
-            bool hasPragmaSuppression;
             return CSharpDiagnosticFilter.GetDiagnosticReport(diagnosticInfo.Severity,
-                                                              true,
+                                                              isEnabledByDefault: true,
                                                               diagnosticInfo.MessageIdentifier,
                                                               diagnosticInfo.WarningLevel,
                                                               Location.None,
                                                               diagnosticInfo.Category,
                                                               options.WarningLevel,
                                                               options.GeneralDiagnosticOption,
-                                                              options.SpecificDiagnosticOptions,
-                                                              out hasPragmaSuppression);
+                                                              options.SpecificDiagnosticOptions);
         }
 
         public override int ERR_FailedToCreateTempFile => (int)ErrorCode.ERR_CantMakeTempFile;

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
@@ -7,10 +7,12 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.VisualBasic;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers;
+using static Roslyn.Test.Utilities.TestHelpers;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 {
@@ -18,6 +20,157 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 
     public class CompilationWithAnalyzersTests : TestBase
     {
+        private static CSharpCompilation CreateCSharpCompilation(
+            string source,
+            IEnumerable<MetadataReference> references = null,
+            CSharpCompilationOptions options = null)
+            => CSharpCompilation.Create(
+                Guid.NewGuid().ToString(),
+                SpecializedCollections.SingletonEnumerable(CSharp.SyntaxFactory.ParseSyntaxTree(source)),
+                references ?? SpecializedCollections.SingletonEnumerable(MscorlibRef),
+                options);
+
+        private static VisualBasicCompilation CreateBasicCompilation(
+            string source,
+            IEnumerable<MetadataReference> references = null,
+            VisualBasicCompilationOptions options = null)
+            => VisualBasicCompilation.Create(
+                Guid.NewGuid().ToString(),
+                SpecializedCollections.SingletonEnumerable(VisualBasic.SyntaxFactory.ParseSyntaxTree(source)),
+                references ?? SpecializedCollections.SingletonEnumerable(MscorlibRef),
+                options);
+
+        [Fact]
+        public void CSharpGetEffectiveDiagnosticsPragmaSuppressed()
+        {
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+            var c = CreateCSharpCompilation(@"
+class C
+{
+#pragma warning disable CS0169
+    int _f;
+#pragma warning restore CS0169
+}", options: options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify();
+
+            options = options.WithReportSuppressedDiagnostics(true);
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                // (5,9): warning CS0169: The field 'C._f' is never used
+                //     int _f;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "_f").WithArguments("C._f").WithLocation(5, 9));
+        }
+
+        [Fact]
+        public void CSharpGetEffectiveDiagnosticsSpecificSuppressed()
+        {
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+            var c = CreateCSharpCompilation("class C { int _f; }", options: options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                // (1,15): warning CS0169: The field 'C._f' is never used
+                // class C { int _f; }
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "_f").WithArguments("C._f").WithLocation(1, 15));
+
+            options = options.WithSpecificDiagnosticOptions(CreateImmutableDictionary(("CS0169", ReportDiagnostic.Suppress)));
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify();
+
+            options = options.WithReportSuppressedDiagnostics(true);
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                // (1,15): warning CS0169: The field 'C._f' is never used
+                // class C { int _f; }
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "_f").WithArguments("C._f").WithLocation(1, 15));
+        }
+
+        [Fact]
+        public void CSharpGetEffectiveDiagnosticsGeneralSuppressed()
+        {
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+            var c = CreateCSharpCompilation("class C { int _f; }", options: options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                // (1,15): warning CS0169: The field 'C._f' is never used
+                // class C { int _f; }
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "_f").WithArguments("C._f").WithLocation(1, 15));
+
+            options = options.WithGeneralDiagnosticOption(ReportDiagnostic.Suppress);
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify();
+
+            options = options.WithReportSuppressedDiagnostics(true);
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                // (1,15): warning CS0169: The field 'C._f' is never used
+                // class C { int _f; }
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "_f").WithArguments("C._f").WithLocation(1, 15));
+        }
+
+        [Fact]
+        public void BasicGetEffectiveDiagnosticsPragmaSuppressed()
+        {
+            var options = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+            var c = CreateBasicCompilation(@"
+Class C
+    Sub M()
+#Disable Warning BC42024
+        Dim x as Integer
+#Enable Warning BC42024
+    End Sub
+End Class", options: options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify();
+
+            options = options.WithReportSuppressedDiagnostics(true);
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                Diagnostic(ERRID.WRN_UnusedLocal, "x").WithArguments("x").WithLocation(5, 13));
+        }
+
+        [Fact]
+        public void BasicGetEffectiveDiagnosticsSpecificSuppressed()
+        {
+            var options = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+            var c = CreateBasicCompilation(@"
+Class C
+    Sub M()
+        Dim x as Integer
+    End Sub
+End Class", options: options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                Diagnostic(ERRID.WRN_UnusedLocal, "x").WithArguments("x").WithLocation(4, 13));
+
+            options = options.WithSpecificDiagnosticOptions(CreateImmutableDictionary(("BC42024", ReportDiagnostic.Suppress)));
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify();
+
+            options = options.WithReportSuppressedDiagnostics(true);
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                Diagnostic(ERRID.WRN_UnusedLocal, "x").WithArguments("x").WithLocation(4, 13));
+        }
+
+        [Fact]
+        public void BasicGetEffectiveDiagnosticsGeneralSuppressed()
+        {
+            var options = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+            var c = CreateBasicCompilation(@"
+Class C
+    Sub M()
+        Dim x as Integer
+    End Sub
+End Class", options: options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                Diagnostic(ERRID.WRN_UnusedLocal, "x").WithArguments("x").WithLocation(4, 13));
+
+            options = options.WithGeneralDiagnosticOption(ReportDiagnostic.Suppress);
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify();
+
+            options = options.WithReportSuppressedDiagnostics(true);
+            c = c.WithOptions(options);
+            CompilationWithAnalyzers.GetEffectiveDiagnostics(c.GetDiagnostics(), c).Verify(
+                Diagnostic(ERRID.WRN_UnusedLocal, "x").WithArguments("x").WithLocation(4, 13));
+        }
+
         [Fact]
         public void GetEffectiveDiagnostics_Errors()
         {
@@ -36,8 +189,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                 WithSpecificDiagnosticOptions(
                     new[] { KeyValuePair.Create($"CS{(int)ErrorCode.WRN_AlwaysNull:D4}", ReportDiagnostic.Suppress) }));
 
-            var d1 = SimpleDiagnostic.Create(MessageProvider.Instance, (int)ErrorCode.WRN_AlignmentMagnitude);
-            var d2 = SimpleDiagnostic.Create(MessageProvider.Instance, (int)ErrorCode.WRN_AlwaysNull);
+            var d1 = SimpleDiagnostic.Create(CSharp.MessageProvider.Instance, (int)ErrorCode.WRN_AlignmentMagnitude);
+            var d2 = SimpleDiagnostic.Create(CSharp.MessageProvider.Instance, (int)ErrorCode.WRN_AlwaysNull);
             var ds = new[] { default(Diagnostic), d1, d2 };
 
             var filtered = CompilationWithAnalyzers.GetEffectiveDiagnostics(ds, c);

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -490,19 +490,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal Diagnostic WithReportDiagnostic(ReportDiagnostic reportAction, bool reportSuppressed)
+        internal Diagnostic WithReportDiagnostic(ReportDiagnostic reportAction, bool reportSuppressedDiagnostics)
         {
             switch (reportAction)
             {
                 case ReportDiagnostic.Suppress:
-                    if (reportSuppressed)
-                    {
-                        return this.WithIsSuppressed(true);
-                    }
-                    else
-                    {
-                        return null;
-                    }
+                    return reportSuppressedDiagnostics ? WithIsSuppressed(true) : null;
                 case ReportDiagnostic.Error:
                     return this.WithSeverity(DiagnosticSeverity.Error);
                 case ReportDiagnostic.Default:

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -490,13 +490,19 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal Diagnostic WithReportDiagnostic(ReportDiagnostic reportAction)
+        internal Diagnostic WithReportDiagnostic(ReportDiagnostic reportAction, bool reportSuppressed)
         {
             switch (reportAction)
             {
                 case ReportDiagnostic.Suppress:
-                    // Suppressed diagnostic.
-                    return null;
+                    if (reportSuppressed)
+                    {
+                        return this.WithIsSuppressed(true);
+                    }
+                    else
+                    {
+                        return null;
+                    }
                 case ReportDiagnostic.Error:
                     return this.WithSeverity(DiagnosticSeverity.Error);
                 case ReportDiagnostic.Default:

--- a/src/Compilers/Core/Portable/InternalUtilities/KeyValuePair.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/KeyValuePair.cs
@@ -16,5 +16,8 @@ namespace Roslyn.Utilities
             key = keyValuePair.Key;
             value = keyValuePair.Value;
         }
+
+        public static KeyValuePair<TKey, TValue> ToKeyValuePair<TKey, TValue>(this (TKey key, TValue value) tuple)
+            => Create(tuple.key, tuple.value);
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicDiagnosticFilter.vb
@@ -23,7 +23,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="generalDiagnosticOption">How warning diagnostics should be reported</param>
         ''' <param name="specificDiagnosticOptions">How specific diagnostics should be reported</param>
         ''' <returns>A diagnostic updated to reflect the options, or null if it has been filtered out</returns>
-        Public Shared Function Filter(diagnostic As Diagnostic, generalDiagnosticOption As ReportDiagnostic, specificDiagnosticOptions As IDictionary(Of String, ReportDiagnostic)) As Diagnostic
+        Public Shared Function Filter(diagnostic As Diagnostic,
+                                      generalDiagnosticOption As ReportDiagnostic,
+                                      specificDiagnosticOptions As IDictionary(Of String, ReportDiagnostic),
+                                      reportSuppressed As Boolean) As Diagnostic
             ' Diagnostic ids must be processed in case-insensitive fashion in VB.
             Dim caseInsensitiveSpecificDiagnosticOptions =
             ImmutableDictionary.Create(Of String, ReportDiagnostic)(CaseInsensitiveComparison.Comparer).AddRange(specificDiagnosticOptions)
@@ -55,7 +58,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' We don't permit configuring 1607 and independently configuring the new warnings.
 
             Dim report As ReportDiagnostic
-            Dim hasSourceSuppression As Boolean = False
 
             If (s_alinkWarnings.Contains(CType(diagnostic.Code, ERRID)) AndAlso
                 caseInsensitiveSpecificDiagnosticOptions.Keys.Contains(VisualBasic.MessageProvider.Instance.GetIdForErrorCode(ERRID.WRN_AssemblyGeneration1))) Then
@@ -65,23 +67,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 diagnostic.Location,
                 diagnostic.Category,
                 generalDiagnosticOption,
-                caseInsensitiveSpecificDiagnosticOptions,
-                hasSourceSuppression)
+                caseInsensitiveSpecificDiagnosticOptions)
             Else
                 report = GetDiagnosticReport(diagnostic.Severity, diagnostic.IsEnabledByDefault, diagnostic.Id, diagnostic.Location,
-                    diagnostic.Category, generalDiagnosticOption, caseInsensitiveSpecificDiagnosticOptions, hasSourceSuppression)
+                    diagnostic.Category, generalDiagnosticOption, caseInsensitiveSpecificDiagnosticOptions)
             End If
 
-            If hasSourceSuppression Then
-                diagnostic = diagnostic.WithIsSuppressed(True)
-            End If
-
-            Return diagnostic.WithReportDiagnostic(report)
+            Return diagnostic.WithReportDiagnostic(report, reportSuppressed)
         End Function
 
-        Friend Shared Function GetDiagnosticReport(severity As DiagnosticSeverity, isEnabledByDefault As Boolean, id As String, location As Location, category As String, generalDiagnosticOption As ReportDiagnostic, caseInsensitiveSpecificDiagnosticOptions As IDictionary(Of String, ReportDiagnostic), <Out> ByRef hasDisableDirectiveSuppression As Boolean) As ReportDiagnostic
-            hasDisableDirectiveSuppression = False
-
+        Friend Shared Function GetDiagnosticReport(severity As DiagnosticSeverity,
+                                                   isEnabledByDefault As Boolean,
+                                                   id As String,
+                                                   location As Location,
+                                                   category As String,
+                                                   generalDiagnosticOption As ReportDiagnostic,
+                                                   caseInsensitiveSpecificDiagnosticOptions As IDictionary(Of String, ReportDiagnostic)) As ReportDiagnostic
             ' Read options (e.g., /nowarn or /warnaserror)
             Dim report As ReportDiagnostic = ReportDiagnostic.Default
             Dim isSpecified = caseInsensitiveSpecificDiagnosticOptions.TryGetValue(id, report)
@@ -97,7 +98,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' If location is available, check warning directive state.
             If location IsNot Nothing AndAlso location.SourceTree IsNot Nothing AndAlso
                 location.SourceTree.GetWarningState(id, location.SourceSpan.Start) = ReportDiagnostic.Suppress Then
-                hasDisableDirectiveSuppression = True
+                Return ReportDiagnostic.Suppress
             End If
 
             ' check options (/nowarn)

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -116,15 +116,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overrides Function GetDiagnosticReport(diagnosticInfo As DiagnosticInfo, options As CompilationOptions) As ReportDiagnostic
-            Dim hasSourceSuppression = False
             Return VisualBasicDiagnosticFilter.GetDiagnosticReport(diagnosticInfo.Severity,
                                                                    True,
                                                                    diagnosticInfo.MessageIdentifier,
                                                                    Location.None,
                                                                    diagnosticInfo.Category,
                                                                    options.GeneralDiagnosticOption,
-                                                                   options.SpecificDiagnosticOptions,
-                                                                   hasSourceSuppression)
+                                                                   options.SpecificDiagnosticOptions)
         End Function
 
 

--- a/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
@@ -1109,7 +1109,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Function FilterDiagnostic(diagnostic As Diagnostic) As Diagnostic
-            Return VisualBasicDiagnosticFilter.Filter(diagnostic, GeneralDiagnosticOption, SpecificDiagnosticOptions)
+            Return VisualBasicDiagnosticFilter.Filter(
+                diagnostic,
+                GeneralDiagnosticOption,
+                SpecificDiagnosticOptions,
+                ReportSuppressedDiagnostics)
         End Function
 
         '' 1.1 BACKCOMPAT OVERLOAD -- DO NOT TOUCH

--- a/src/Test/Utilities/Portable/TestHelpers.cs
+++ b/src/Test/Utilities/Portable/TestHelpers.cs
@@ -2,17 +2,28 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
+using KeyValuePair = Roslyn.Utilities.KeyValuePair;
 
 namespace Roslyn.Test.Utilities
 {
     public static class TestHelpers
     {
+        public static ImmutableDictionary<TKey, TValue> CreateImmutableDictionary<TKey, TValue>(
+            IEqualityComparer<TKey> comparer,
+            params (TKey, TValue)[] entries)
+            => ImmutableDictionary.CreateRange(comparer, entries.Select(KeyValuePair.ToKeyValuePair));
+
+        public static ImmutableDictionary<TKey, TValue> CreateImmutableDictionary<TKey, TValue>(params (TKey, TValue)[] entries)
+            => ImmutableDictionary.CreateRange(entries.Select(KeyValuePair.ToKeyValuePair));
+
         public static IEnumerable<Type> GetAllTypesWithStaticFieldsImplementingType(Assembly assembly, Type type)
         {
             return assembly.GetTypes().Where(t =>


### PR DESCRIPTION
Right now the compilation API for diagnostic filtering returns
null for a given diagnostic if it is suppressed, unless it is
suppressed by a pragma and wouldn't have otherwise been suppressed,
in which case it returns the original diagnostic, but marked as
suppressed.

This logic is already complex, but it gets even worse as we add
more ways to suppress diagnostics. As far as I can tell, the only
reason why we would want to return a suppressed diagnostic instead
of a null diagnostic is if the compilation wants to report suppressed
diagnostics, as it does in /errorlog and in some IDE scenarios. In
these cases, it's much simpler to pass in the requested behavior instead
of have special behavior around #pragmas and suppression, which is
already questionable.