### PR TITLE
Fix possible stack overflow in IntegrationHelper (#25313)

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
@@ -214,7 +214,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         {
             foreach (var process in Process.GetProcessesByName(processName))
             {
-                KillProcess(processName);
+                KillProcess(process);
             }
         }
 


### PR DESCRIPTION
Hi, this is my first pull request. I tried to fill the ask mode template as good as i could.

This should fix a possible stack overflow exception in the KillProcess method in IntegrationHelper.cs as reported in #25313 

<details><summary>Ask Mode template completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Calling KillProcess could result in a StackOverflowException.

### Bugs this fixes
Fixes #25313 

### Workarounds, if any

None

### Risk

Low risk

### Performance impact

Low performance impact. No extra allocations and no extra complexity

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

Reported via #25313 

### Test documentation updated?

No

</details>
