### PR TITLE
Fix in optimizer to always respect refkind of vararg arguments

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -827,34 +827,43 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             for (int i = 0; i < arguments.Length; i++)
             {
-                RefKind argRefKind;
+                RefKind argRefKind = GetArgumentRefKind(arguments, parameters, argRefKindsOpt, i);
+                EmitArgument(arguments[i], argRefKind);
+            }
+        }
 
-                if (i < parameters.Length)
+        /// <summary>
+        /// Computes the desired refkind of the argument.
+        /// Consiuders all the cases where ref kinds are explicit, omitted, vararg cases.
+        /// </summary>
+        internal static RefKind GetArgumentRefKind(ImmutableArray<BoundExpression> arguments, ImmutableArray<ParameterSymbol> parameters, ImmutableArray<RefKind> argRefKindsOpt, int i)
+        {
+            RefKind argRefKind;
+            if (i < parameters.Length)
+            {
+                if (!argRefKindsOpt.IsDefault && i < argRefKindsOpt.Length)
                 {
-                    if (!argRefKindsOpt.IsDefault && i < argRefKindsOpt.Length)
-                    {
-                        // if we have an explicit refKind for the given argument, use that
-                        argRefKind = argRefKindsOpt[i];
+                    // if we have an explicit refKind for the given argument, use that
+                    argRefKind = argRefKindsOpt[i];
 
-                        Debug.Assert(argRefKind == parameters[i].RefKind ||
-                                argRefKind == RefKindExtensions.StrictIn && parameters[i].RefKind == RefKind.In,
-                                "in Emit the argument RefKind must be compatible with the corresponding parameter");
-                    }
-                    else
-                    {
-                        // otherwise fallback to the refKind of the parameter
-                        argRefKind = parameters[i].RefKind;
-                    }
+                    Debug.Assert(argRefKind == parameters[i].RefKind ||
+                            argRefKind == RefKindExtensions.StrictIn && parameters[i].RefKind == RefKind.In,
+                            "in Emit the argument RefKind must be compatible with the corresponding parameter");
                 }
                 else
                 {
-                    // vararg case
-                    Debug.Assert(arguments[i].Kind == BoundKind.ArgListOperator);
-                    argRefKind = RefKind.None;
+                    // otherwise fallback to the refKind of the parameter
+                    argRefKind = parameters[i].RefKind;
                 }
-
-                EmitArgument(arguments[i], argRefKind);
             }
+            else
+            {
+                // vararg case
+                Debug.Assert(arguments[i].Kind == BoundKind.ArgListOperator);
+                argRefKind = RefKind.None;
+            }
+
+            return argRefKind;
         }
 
         private void EmitArrayElementLoad(BoundArrayAccess arrayAccess, bool used)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -834,7 +834,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         /// <summary>
         /// Computes the desired refkind of the argument.
-        /// Consiuders all the cases where ref kinds are explicit, omitted, vararg cases.
+        /// Considers all the cases - where ref kinds are explicit, omitted, vararg cases.
         /// </summary>
         internal static RefKind GetArgumentRefKind(ImmutableArray<BoundExpression> arguments, ImmutableArray<ParameterSymbol> parameters, ImmutableArray<RefKind> argRefKindsOpt, int i)
         {

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1179,7 +1179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             for (int i = 0; i < arguments.Length; i++)
             {
-                RefKind refKind = argRefKindsOpt.IsDefaultOrEmpty ? RefKind.None : node.ArgumentRefKindsOpt[i];
+                RefKind refKind = argRefKindsOpt.IsDefaultOrEmpty ? RefKind.None : argRefKindsOpt[i];
                 VisitArgument(arguments, ref rewrittenArguments, i, refKind);
             }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1101,7 +1101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
 
             MethodSymbol method = node.Method;
-            var rewrittenArguments = VisitArguments(node.Arguments, method.Parameters);
+            var rewrittenArguments = VisitArguments(node.Arguments, method.Parameters, node.ArgumentRefKindsOpt);
 
             return node.Update(receiver, method, rewrittenArguments);
         }
@@ -1134,7 +1134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return receiver;
         }
 
-        private ImmutableArray<BoundExpression> VisitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<ParameterSymbol> parameters)
+        private ImmutableArray<BoundExpression> VisitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<ParameterSymbol> parameters, ImmutableArray<RefKind> argRefKindsOpt)
         {
             Debug.Assert(!arguments.IsDefault);
             Debug.Assert(!parameters.IsDefault);
@@ -1144,26 +1144,46 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             ArrayBuilder<BoundExpression> rewrittenArguments = null;
             for (int i = 0; i < arguments.Length; i++)
             {
-                var arg = arguments[i];
-                BoundExpression rewrittenArg;
-
-                // Treat the __arglist() as a value parameter.
-                ExprContext context = (i == parameters.Length || parameters[i].RefKind == RefKind.None) ? ExprContext.Value : ExprContext.Address;
-
-                rewrittenArg = VisitExpression(arg, context);
-                if (rewrittenArguments == null && arg != rewrittenArg)
-                {
-                    rewrittenArguments = ArrayBuilder<BoundExpression>.GetInstance();
-                    rewrittenArguments.AddRange(arguments, i);
-                }
-
-                if (rewrittenArguments != null)
-                {
-                    rewrittenArguments.Add(rewrittenArg);
-                }
+                RefKind argRefKind = CodeGenerator.GetArgumentRefKind(arguments, parameters, argRefKindsOpt, i);
+                VisitArgument(arguments, ref rewrittenArguments, i, argRefKind);
             }
 
             return rewrittenArguments != null ? rewrittenArguments.ToImmutableAndFree() : arguments;
+        }
+
+        private void VisitArgument(ImmutableArray<BoundExpression> arguments, ref ArrayBuilder<BoundExpression> rewrittenArguments, int i, RefKind argRefKind)
+        {
+            ExprContext context = (argRefKind == RefKind.None) ? ExprContext.Value : ExprContext.Address;
+
+            var arg = arguments[i];
+            BoundExpression rewrittenArg = VisitExpression(arg, context);
+
+            if (rewrittenArguments == null && arg != rewrittenArg)
+            {
+                rewrittenArguments = ArrayBuilder<BoundExpression>.GetInstance();
+                rewrittenArguments.AddRange(arguments, i);
+            }
+
+            if (rewrittenArguments != null)
+            {
+                rewrittenArguments.Add(rewrittenArg);
+            }
+        }
+
+        public override BoundNode VisitArgListOperator(BoundArgListOperator node)
+        {
+
+            ArrayBuilder<BoundExpression> rewrittenArguments = null;
+            ImmutableArray<BoundExpression> arguments = node.Arguments;
+            ImmutableArray<RefKind> argRefKindsOpt = node.ArgumentRefKindsOpt;
+
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                RefKind refKind = argRefKindsOpt.IsDefaultOrEmpty ? RefKind.None : node.ArgumentRefKindsOpt[i];
+                VisitArgument(arguments, ref rewrittenArguments, i, refKind);
+            }
+
+            return node.Update(rewrittenArguments?.ToImmutableAndFree() ?? arguments, argRefKindsOpt, node.Type);
         }
 
         public override BoundNode VisitMakeRefOperator(BoundMakeRefOperator node)
@@ -1178,7 +1198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         public override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node)
         {
             var constructor = node.Constructor;
-            var rewrittenArguments = VisitArguments(node.Arguments, constructor.Parameters);
+            var rewrittenArguments = VisitArguments(node.Arguments, constructor.Parameters, node.ArgumentRefKindsOpt);
             Debug.Assert(node.InitializerExpressionOpt == null);
 
             return node.Update(constructor, rewrittenArguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -13331,7 +13331,7 @@ public static class P
         }
 
         [WorkItem(26113, "https://github.com/dotnet/roslyn/issues/26113")]
-        [Fact()]
+        [ConditionalFact(typeof(DesktopOnly))]
         public void VarargByRef()
         {
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -13330,6 +13330,71 @@ public static class P
             var compilation = CompileAndVerifyWithMscorlib40(code, expectedOutput: "4");
         }
 
+        [WorkItem(26113, "https://github.com/dotnet/roslyn/issues/26113")]
+        [Fact()]
+        public void VarargByRef()
+        {
+
+            var code = @"
+using System;
+class A
+{
+    static void Test(__arglist)
+    {
+        var args = new ArgIterator(__arglist);
+        ref int a = ref __refvalue(args.GetNextArg(), int);
+        a = 5;
+    }
+    static void Main()
+    {
+        int a = 0;
+        Test(__arglist(ref a));
+        Console.WriteLine(a);
+    }
+}
+";
+
+            var comp = CompileAndVerify(code, expectedOutput: "5", options: TestOptions.DebugExe);
+
+            comp.VerifyIL("A.Main",
+@"
+{
+  // Code size       19 (0x13)
+  .maxstack  1
+  .locals init (int V_0) //a
+  IL_0000:  nop
+  IL_0001:  ldc.i4.0
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  call       ""void A.Test(__arglist) with __arglist( ref int)""
+  IL_000a:  nop
+  IL_000b:  ldloc.0
+  IL_000c:  call       ""void System.Console.WriteLine(int)""
+  IL_0011:  nop
+  IL_0012:  ret
+}
+");
+
+            comp = CompileAndVerify(code, expectedOutput: "5", options: TestOptions.ReleaseExe);
+
+            comp.VerifyIL("A.Main",
+@"
+{
+  // Code size       16 (0x10)
+  .maxstack  1
+  .locals init (int V_0) //a
+  IL_0000:  ldc.i4.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  call       ""void A.Test(__arglist) with __arglist( ref int)""
+  IL_0009:  ldloc.0
+  IL_000a:  call       ""void System.Console.WriteLine(int)""
+  IL_000f:  ret
+}
+");
+
+        }
+
         [WorkItem(24348, "https://github.com/dotnet/roslyn/issues/24348")]
         [ConditionalFact(typeof(DesktopOnly))]
         public void VarargBridgeMeta()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -13334,7 +13334,6 @@ public static class P
         [ConditionalFact(typeof(DesktopOnly))]
         public void VarargByRef()
         {
-
             var code = @"
 using System;
 class A
@@ -13353,9 +13352,7 @@ class A
     }
 }
 ";
-
             var comp = CompileAndVerify(code, expectedOutput: "5", options: TestOptions.DebugExe);
-
             comp.VerifyIL("A.Main",
 @"
 {
@@ -13376,7 +13373,6 @@ class A
 ");
 
             comp = CompileAndVerify(code, expectedOutput: "5", options: TestOptions.ReleaseExe);
-
             comp.VerifyIL("A.Main",
 @"
 {
@@ -13392,7 +13388,6 @@ class A
   IL_000f:  ret
 }
 ");
-
         }
 
         [WorkItem(24348, "https://github.com/dotnet/roslyn/issues/24348")]


### PR DESCRIPTION
Optimizer has all the information about refkinds, but chooses not to use it for `__arglist` . As a result vararg arguments are treated as always byval, which may allow optimizing them to stack values. That, in turns, result in byref arguments being effectively passed by value (and triggering an assert in codegen).

This change makes optimizer use the refkinds of vararg arguments.

The bug is not recent, and the feature is not extremely popular, so fixing in v.Next / master seems appropriate.

Fixes:#26113