### PR TITLE
Fix for ValidateBreakpointLocationWorker NFW

### DIFF
--- a/src/EditorFeatures/Test/Extensions/ITextSnapshotExtensionsTests.cs
+++ b/src/EditorFeatures/Test/Extensions/ITextSnapshotExtensionsTests.cs
@@ -159,10 +159,17 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
         }
 
         [Fact]
-        public void GetPointTest()
+        public void TryGetPointValueTest()
         {
             var snapshot = GetSampleCodeSnapshot();
-            Assert.Equal(new SnapshotPoint(snapshot, 15), snapshot.GetPoint(3, 0));
+            Assert.Equal(new SnapshotPoint(snapshot, 15), snapshot.TryGetPoint(3, 0).Value);
+        }
+
+        [Fact]
+        public void TryGetPointNullTest()
+        {
+            var snapshot = GetSampleCodeSnapshot();
+            Assert.Null(snapshot.TryGetPoint(3000, 0));
         }
 
         [Fact]

--- a/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotExtensions.cs
@@ -11,8 +11,18 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         public static SnapshotPoint GetPoint(this ITextSnapshot snapshot, int position)
             => new SnapshotPoint(snapshot, position);
 
-        public static SnapshotPoint GetPoint(this ITextSnapshot snapshot, int lineNumber, int columnIndex)
-            => new SnapshotPoint(snapshot, snapshot.GetPosition(lineNumber, columnIndex));
+        public static SnapshotPoint? TryGetPoint(this ITextSnapshot snapshot, int lineNumber, int columnIndex)
+        {
+            var position = snapshot.TryGetPosition(lineNumber, columnIndex);
+            if (position.HasValue)
+            {
+                return new SnapshotPoint(snapshot, position.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
 
         /// <summary>
         /// Convert a <see cref="LinePositionSpan"/> to <see cref="TextSpan"/>.

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -290,7 +290,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     if (document != null)
                     {
                         var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
-                        if (!nullablePoint.HasValue)
+                        if (nullablePoint == null)
                         {
                             // The point disappeared between sessions. Do not allow a breakpoint here.
                             return VSConstants.E_FAIL;

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -150,11 +150,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                         if (textBuffer != null)
                         {
                             var snapshot = textBuffer.CurrentSnapshot;
-                            Document document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
-                            if (document != null)
+                            var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
+                            if (nullablePoint.HasValue)
                             {
-                                var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
-                                if (nullablePoint.HasValue)
+                                Document document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
+                                if (document != null)
                                 {
                                     var point = nullablePoint.Value;
                                     var proximityExpressions = _proximityExpressionsService.GetProximityExpressionsAsync(document, point.Position, waitContext.CancellationToken).WaitAndGetResult(waitContext.CancellationToken);
@@ -286,16 +286,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 if (textBuffer != null)
                 {
                     var snapshot = textBuffer.CurrentSnapshot;
+                    var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
+                    if (nullablePoint == null)
+                    {
+                        // The point disappeared between sessions. Do not allow a breakpoint here.
+                        return VSConstants.E_FAIL;
+                    }
+
                     Document document = snapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
                     if (document != null)
                     {
-                        var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
-                        if (nullablePoint == null)
-                        {
-                            // The point disappeared between sessions. Do not allow a breakpoint here.
-                            return VSConstants.E_FAIL;
-                        }
-
                         var point = nullablePoint.Value;
                         var length = 0;
                         if (pCodeSpan != null && pCodeSpan.Length > 0)

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -92,21 +92,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                             var textBuffer = _languageService.EditorAdaptersFactoryService.GetDataBuffer(pBuffer);
                             if (textBuffer != null)
                             {
-                                var point = textBuffer.CurrentSnapshot.GetPoint(iLine, iCol);
-                                var document = point.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
-
-                                if (document != null)
+                                var nullablePoint = textBuffer.CurrentSnapshot.TryGetPoint(iLine, iCol);
+                                if (nullablePoint.HasValue)
                                 {
-                                    // NOTE(cyrusn): We have to wait here because the debuggers' 
-                                    // GetNameOfLocation is a blocking call.  In the future, it 
-                                    // would be nice if they could make it async.
-                                    var debugLocationInfo = _languageDebugInfo.GetLocationInfoAsync(document, point, cancellationToken).WaitAndGetResult(cancellationToken);
+                                    var point = nullablePoint.Value;
+                                    var document = point.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
 
-                                    if (!debugLocationInfo.IsDefault)
+                                    if (document != null)
                                     {
-                                        succeeded = true;
-                                        name = debugLocationInfo.Name;
-                                        lineOffset = debugLocationInfo.LineOffset;
+                                        // NOTE(cyrusn): We have to wait here because the debuggers' 
+                                        // GetNameOfLocation is a blocking call.  In the future, it 
+                                        // would be nice if they could make it async.
+                                        var debugLocationInfo = _languageDebugInfo.GetLocationInfoAsync(document, point, cancellationToken).WaitAndGetResult(cancellationToken);
+
+                                        if (!debugLocationInfo.IsDefault)
+                                        {
+                                            succeeded = true;
+                                            name = debugLocationInfo.Name;
+                                            lineOffset = debugLocationInfo.LineOffset;
+                                        }
                                     }
                                 }
                             }
@@ -149,13 +153,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                             Document document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
                             if (document != null)
                             {
-                                var point = snapshot.GetPoint(iLine, iCol);
-                                var proximityExpressions = _proximityExpressionsService.GetProximityExpressionsAsync(document, point.Position, waitContext.CancellationToken).WaitAndGetResult(waitContext.CancellationToken);
-
-                                if (proximityExpressions != null)
+                                var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
+                                if (nullablePoint.HasValue)
                                 {
-                                    enumBSTR = new VsEnumBSTR(proximityExpressions);
-                                    succeeded = true;
+                                    var point = nullablePoint.Value;
+                                    var proximityExpressions = _proximityExpressionsService.GetProximityExpressionsAsync(document, point.Position, waitContext.CancellationToken).WaitAndGetResult(waitContext.CancellationToken);
+
+                                    if (proximityExpressions != null)
+                                    {
+                                        enumBSTR = new VsEnumBSTR(proximityExpressions);
+                                        succeeded = true;
+                                    }
                                 }
                             }
                         }
@@ -281,7 +289,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     Document document = snapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
                     if (document != null)
                     {
-                        var point = snapshot.GetPoint(iLine, iCol);
+                        var nullablePoint = snapshot.TryGetPoint(iLine, iCol);
+                        if (!nullablePoint.HasValue)
+                        {
+                            // The point disappeared between sessions. Do not allow a breakpoint here.
+                            return VSConstants.E_FAIL;
+                        }
+
+                        var point = nullablePoint.Value;
                         var length = 0;
                         if (pCodeSpan != null && pCodeSpan.Length > 0)
                         {


### PR DESCRIPTION
### Customer scenario

1. Create a solution VS
2. Set a breakpoint somewhere in the end of a long CS file
3. Close the solution in VS
4. Reduce the file out of VS such that the line with breakpoint does not exist anymore
5. Open the solution again

Observed:
NFW happened. Should not be other further effects.

### Bugs this fixes
Fixes VSO [555744](https://devdiv.visualstudio.com/DevDiv/_queries?id=555744)
This is one of highly ranked NFW.

### Workarounds, if any
None

### Risk
Low. Just extended interface from Get to TryGet.

### Performance impact
Should be an improvement by reducing resources for processing the NFW

### Is this a regression from a previous update?
No

### How was the bug found?
NFW