### PR TITLE
Don't try to create a XamlProject for a null hierarchy.

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
@@ -95,6 +95,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             string filePath = monikerObj as string;
 
             _rdt.Value.FindDocument(filePath, out var hierarchy, out var itemId, out var docCookie);
+            if (hierarchy == null)
+            {
+                return;
+            }
 
             AbstractProject project = GetXamlProject(hierarchy);
             if (project == null)


### PR DESCRIPTION
Finally got around to submitting this. It has been reported via email for diffing scenarios in VS with XAML files under source code control. I can see how this could null ref but I have not been able to repro it. Fix is trivial - bail out if the IVsHierarchy for the text view is null so we don't attempt to create a XamlProject for a null hierarchy - which is why I have submitted it for dev15.7.x. But if that's too late I would be fine with moving it to 15.8 too.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
