### PR TITLE
recursive-patterns(21) Add hidden sequence points for switch statement.

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -699,21 +699,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             EmitSequencePoint(node);
 
-            if (node.Expression != null)
-            {
-                // used is true to ensure that something is emitted
-                EmitExpression(node.Expression, used: true);
-                EmitPopIfUnused(used);
-            }
-            else
-            {
-                if (node.Syntax != null && _ilEmitStyle == ILEmitStyle.Debug)
-                {
-                    // if there was no code emitted, then emit nop 
-                    // otherwise this point could get associated with some random statement, possibly in a wrong scope
-                    _builder.EmitOpCode(ILOpCode.Nop);
-                }
-            }
+            // used is true to ensure that something is emitted
+            EmitExpression(node.Expression, used: true);
+            EmitPopIfUnused(used);
         }
 
         private void EmitSequencePoint(BoundSequencePointExpression node)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -699,9 +699,21 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             EmitSequencePoint(node);
 
-            // used is true to ensure that something is emitted
-            EmitExpression(node.Expression, used: true);
-            EmitPopIfUnused(used);
+            if (node.Expression != null)
+            {
+                // used is true to ensure that something is emitted
+                EmitExpression(node.Expression, used: true);
+                EmitPopIfUnused(used);
+            }
+            else
+            {
+                if (node.Syntax != null && _ilEmitStyle == ILEmitStyle.Debug)
+                {
+                    // if there was no code emitted, then emit nop 
+                    // otherwise this point could get associated with some random statement, possibly in a wrong scope
+                    _builder.EmitOpCode(ILOpCode.Nop);
+                }
+            }
         }
 
         private void EmitSequencePoint(BoundSequencePointExpression node)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchExpression.cs
@@ -42,12 +42,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _factory.Syntax = node.Syntax;
                 var result = ArrayBuilder<BoundStatement>.GetInstance();
                 var loweredSwitchGoverningExpression = _localRewriter.VisitExpression(node.Expression);
-
-                // Note that a when-clause can contain an assignment to a
-                // pattern variable declared in a different when-clause (e.g. in the same section, or
-                // in a different section via the use of a local function), so we need to analyze all
-                // of the when clauses to see if they are all simple enough to conclude that they do
-                // not mutate pattern variables.
                 BoundDecisionDag decisionDag = ShareTempsIfPossibleAndEvaluateInput(node.DecisionDag, loweredSwitchGoverningExpression, result);
 
                 // lower the decision dag.

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -965,9 +965,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundSequencePointWithSpan(syntax, statement, span);
         }
 
-        public BoundStatement HiddenSequencePoint()
+        public BoundStatement HiddenSequencePoint(BoundStatement statementOpt = null)
         {
-            return new BoundSequencePoint(null, null) { WasCompilerGenerated = true };
+            return new BoundSequencePoint(null, statementOpt) { WasCompilerGenerated = true };
         }
 
         public BoundStatement ThrowNull()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -9276,24 +9276,40 @@ public class Program
         <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""19"" document=""1"" />
         <entry offset=""0x4"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8"" hidden=""true"" document=""1"" />
+        <entry offset=""0x19"" hidden=""true"" document=""1"" />
         <entry offset=""0x1b"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x22"" hidden=""true"" document=""1"" />
         <entry offset=""0x24"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""38"" document=""1"" />
         <entry offset=""0x26"" startLine=""13"" startColumn=""24"" endLine=""13"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x2d"" hidden=""true"" document=""1"" />
         <entry offset=""0x2f"" startLine=""13"" startColumn=""24"" endLine=""13"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x36"" hidden=""true"" document=""1"" />
         <entry offset=""0x38"" startLine=""13"" startColumn=""32"" endLine=""13"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x3a"" hidden=""true"" document=""1"" />
         <entry offset=""0x3c"" startLine=""14"" startColumn=""24"" endLine=""14"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x43"" hidden=""true"" document=""1"" />
         <entry offset=""0x45"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""38"" document=""1"" />
         <entry offset=""0x47"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x4e"" hidden=""true"" document=""1"" />
         <entry offset=""0x50"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x57"" hidden=""true"" document=""1"" />
         <entry offset=""0x59"" startLine=""15"" startColumn=""32"" endLine=""15"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""1"" />
         <entry offset=""0x5d"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x64"" hidden=""true"" document=""1"" />
         <entry offset=""0x66"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""38"" document=""1"" />
         <entry offset=""0x68"" startLine=""17"" startColumn=""24"" endLine=""17"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x6f"" hidden=""true"" document=""1"" />
         <entry offset=""0x71"" startLine=""17"" startColumn=""24"" endLine=""17"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x78"" hidden=""true"" document=""1"" />
         <entry offset=""0x7a"" startLine=""17"" startColumn=""32"" endLine=""17"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x7c"" hidden=""true"" document=""1"" />
         <entry offset=""0x7e"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x85"" hidden=""true"" document=""1"" />
         <entry offset=""0x87"" startLine=""18"" startColumn=""32"" endLine=""18"" endColumn=""38"" document=""1"" />
         <entry offset=""0x89"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x90"" hidden=""true"" document=""1"" />
         <entry offset=""0x92"" startLine=""19"" startColumn=""32"" endLine=""19"" endColumn=""38"" document=""1"" />
         <entry offset=""0x94"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
       </sequencePoints>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2181,7 +2181,7 @@ class C
   IL_0006:  stloc.1
  ~IL_0007:  ldloc.1
   IL_0008:  stloc.0
-  IL_0009:  ldloc.0
+ ~IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_003a
   IL_000c:  ldloc.0
   IL_000d:  ldstr      ""a""
@@ -2223,7 +2223,7 @@ class C
   IL_0006:  stloc.1
  ~IL_0007:  ldloc.1
   IL_0008:  stloc.0
-  IL_0009:  ldloc.0
+ ~IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_003c
   IL_000c:  ldloc.0
   IL_000d:  ldstr      ""a""
@@ -2330,6 +2330,7 @@ class C
         <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""21"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0x9"" hidden=""true"" document=""1"" />
         <entry offset=""0x15"" startLine=""9"" startColumn=""21"" endLine=""9"" endColumn=""49"" document=""1"" />
         <entry offset=""0x1c"" startLine=""9"" startColumn=""50"" endLine=""9"" endColumn=""56"" document=""1"" />
         <entry offset=""0x1e"" startLine=""10"" startColumn=""21"" endLine=""10"" endColumn=""49"" document=""1"" />
@@ -3833,8 +3834,7 @@ class C
   IL_002f:  br.s       IL_0031
  -IL_0031:  ldloc.s    V_4
   IL_0033:  ret
-}
-", methodToken: diff1.UpdatedMethods.Single());
+}", methodToken: diff1.UpdatedMethods.Single());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -1269,6 +1269,7 @@ class C
         <entry offset=""0xe"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""21"" document=""1"" />
         <entry offset=""0x21"" hidden=""true"" document=""1"" />
         <entry offset=""0x2e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
         <entry offset=""0x3c"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""28"" document=""1"" />
         <entry offset=""0x43"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""29"" document=""1"" />
         <entry offset=""0x56"" startLine=""20"" startColumn=""17"" endLine=""20"" endColumn=""23"" document=""1"" />

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLocalFunctionTests.cs
@@ -350,6 +350,7 @@ class C
         <entry offset=""0xf"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""15"" document=""1"" />
         <entry offset=""0x22"" hidden=""true"" document=""1"" />
         <entry offset=""0x2f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x31"" hidden=""true"" document=""1"" />
         <entry offset=""0x3d"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""28"" document=""1"" />
         <entry offset=""0x45"" startLine=""21"" startColumn=""17"" endLine=""21"" endColumn=""23"" document=""1"" />
         <entry offset=""0x58"" startLine=""22"" startColumn=""17"" endLine=""22"" endColumn=""23"" document=""1"" />

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -2802,6 +2802,7 @@ class Program
         <entry offset=""0x1b"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""14"" document=""1"" />
         <entry offset=""0x1c"" startLine=""14"" startColumn=""17"" endLine=""14"" endColumn=""33"" document=""1"" />
         <entry offset=""0x23"" hidden=""true"" document=""1"" />
+        <entry offset=""0x25"" hidden=""true"" document=""1"" />
         <entry offset=""0x2b"" startLine=""17"" startColumn=""25"" endLine=""17"" endColumn=""31"" document=""1"" />
         <entry offset=""0x2d"" startLine=""20"" startColumn=""25"" endLine=""20"" endColumn=""42"" document=""1"" />
         <entry offset=""0x38"" hidden=""true"" document=""1"" />
@@ -3029,9 +3030,15 @@ class Student : Person { public double GPA; }
         <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" document=""1"" />
         <entry offset=""0x4"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" hidden=""true"" document=""1"" />
+        <entry offset=""0x18"" hidden=""true"" document=""1"" />
         <entry offset=""0x1d"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x2e"" hidden=""true"" document=""1"" />
         <entry offset=""0x30"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""57"" document=""1"" />
+        <entry offset=""0x4f"" hidden=""true"" document=""1"" />
         <entry offset=""0x53"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""57"" document=""1"" />
+        <entry offset=""0x72"" hidden=""true"" document=""1"" />
         <entry offset=""0x74"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""59"" document=""1"" />
         <entry offset=""0x8e"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""43"" document=""1"" />
         <entry offset=""0xa2"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" document=""1"" />
@@ -3125,9 +3132,15 @@ class Student : Person { public double GPA; }
         <entry offset=""0xd"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
         <entry offset=""0xe"" hidden=""true"" document=""1"" />
         <entry offset=""0x1b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3d"" hidden=""true"" document=""1"" />
         <entry offset=""0x47"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x5d"" hidden=""true"" document=""1"" />
         <entry offset=""0x5f"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""63"" document=""1"" />
+        <entry offset=""0x6f"" hidden=""true"" document=""1"" />
         <entry offset=""0x7d"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""63"" document=""1"" />
+        <entry offset=""0x8d"" hidden=""true"" document=""1"" />
         <entry offset=""0x8f"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""65"" document=""1"" />
         <entry offset=""0x9f"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""49"" document=""1"" />
         <entry offset=""0xaf"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" document=""1"" />
@@ -3220,10 +3233,17 @@ class Student : Person { public double GPA; }
         <entry offset=""0xd"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
         <entry offset=""0xe"" hidden=""true"" document=""1"" />
         <entry offset=""0x1b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3d"" hidden=""true"" document=""1"" />
         <entry offset=""0x47"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x5d"" hidden=""true"" document=""1"" />
         <entry offset=""0x60"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x70"" hidden=""true"" document=""1"" />
         <entry offset=""0x7f"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x8f"" hidden=""true"" document=""1"" />
         <entry offset=""0x92"" startLine=""30"" startColumn=""17"" endLine=""30"" endColumn=""27"" document=""1"" />
+        <entry offset=""0xa2"" hidden=""true"" document=""1"" />
         <entry offset=""0xa3"" startLine=""33"" startColumn=""17"" endLine=""33"" endColumn=""27"" document=""1"" />
         <entry offset=""0xb3"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" document=""1"" />
       </sequencePoints>
@@ -3300,6 +3320,7 @@ expectedIL: @"{
   IL_0002:  stloc.1
   IL_0003:  ldc.i4.1
   IL_0004:  stloc.0
+  // sequence point: <hidden>
   IL_0005:  br.s       IL_0007
   // sequence point: Console.Write(1);
   IL_0007:  ldc.i4.1
@@ -3323,6 +3344,7 @@ expectedIL: @"{
   IL_0006:  stloc.1
   IL_0007:  ldstr      ""M2""
   IL_000c:  stloc.0
+  // sequence point: <hidden>
   IL_000d:  br.s       IL_000f
   // sequence point: Console.Write(nameof(M2));
   IL_000f:  ldstr      ""M2""
@@ -3420,6 +3442,7 @@ expectedIL: @"{
   IL_0002:  stloc.2
   IL_0003:  ldc.i4.1
   IL_0004:  stloc.1
+  // sequence point: <hidden>
   IL_0005:  ldloc.1
   IL_0006:  box        ""int""
   IL_000b:  isinst     ""T""
@@ -3429,7 +3452,9 @@ expectedIL: @"{
   IL_0018:  isinst     ""T""
   IL_001d:  unbox.any  ""T""
   IL_0022:  stloc.0
+  // sequence point: <hidden>
   IL_0023:  br.s       IL_0025
+  // sequence point: <hidden>
   IL_0025:  br.s       IL_0027
   // sequence point: Console.Write(1);
   IL_0027:  ldc.i4.1
@@ -3437,6 +3462,7 @@ expectedIL: @"{
   IL_002d:  nop
   // sequence point: break;
   IL_002e:  br.s       IL_003b
+  // sequence point: <hidden>
   IL_0030:  br.s       IL_0032
   // sequence point: Console.Write(2);
   IL_0032:  ldc.i4.2
@@ -3461,6 +3487,7 @@ expectedIL: @"{
   IL_0006:  stloc.2
   IL_0007:  ldstr      ""M2""
   IL_000c:  stloc.1
+  // sequence point: <hidden>
   IL_000d:  ldloc.1
   IL_000e:  isinst     ""T""
   IL_0013:  brfalse.s  IL_002e
@@ -3468,7 +3495,9 @@ expectedIL: @"{
   IL_0016:  isinst     ""T""
   IL_001b:  unbox.any  ""T""
   IL_0020:  stloc.0
+  // sequence point: <hidden>
   IL_0021:  br.s       IL_0023
+  // sequence point: <hidden>
   IL_0023:  br.s       IL_0025
   // sequence point: Console.Write(3);
   IL_0025:  ldc.i4.3
@@ -3476,6 +3505,7 @@ expectedIL: @"{
   IL_002b:  nop
   // sequence point: break;
   IL_002c:  br.s       IL_0039
+  // sequence point: <hidden>
   IL_002e:  br.s       IL_0030
   // sequence point: Console.Write(4);
   IL_0030:  ldc.i4.4
@@ -3578,6 +3608,7 @@ expectedIL: @"{
   IL_0002:  stloc.3
   IL_0003:  ldnull
   IL_0004:  stloc.2
+  // sequence point: <hidden>
   IL_0005:  br.s       IL_0007
   // sequence point: Console.Write(6);
   IL_0007:  ldc.i4.6
@@ -8401,20 +8432,29 @@ partial class C
         <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""19"" document=""1"" />
         <entry offset=""0x3"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5"" hidden=""true"" document=""1"" />
+        <entry offset=""0x14"" hidden=""true"" document=""1"" />
         <entry offset=""0x32"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x35"" hidden=""true"" document=""1"" />
         <entry offset=""0x37"" startLine=""9"" startColumn=""20"" endLine=""9"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x3a"" hidden=""true"" document=""1"" />
         <entry offset=""0x3c"" startLine=""10"" startColumn=""17"" endLine=""10"" endColumn=""23"" document=""1"" />
         <entry offset=""0x3e"" startLine=""11"" startColumn=""20"" endLine=""11"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x41"" hidden=""true"" document=""1"" />
         <entry offset=""0x43"" startLine=""13"" startColumn=""20"" endLine=""13"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x46"" hidden=""true"" document=""1"" />
         <entry offset=""0x48"" startLine=""14"" startColumn=""17"" endLine=""14"" endColumn=""23"" document=""1"" />
         <entry offset=""0x4a"" startLine=""16"" startColumn=""17"" endLine=""16"" endColumn=""23"" document=""1"" />
         <entry offset=""0x4c"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""23"" document=""1"" />
         <entry offset=""0x4e"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" document=""1"" />
         <entry offset=""0x51"" hidden=""true"" document=""1"" />
+        <entry offset=""0x54"" hidden=""true"" document=""1"" />
+        <entry offset=""0x64"" hidden=""true"" document=""1"" />
         <entry offset=""0x6b"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""23"" document=""1"" />
         <entry offset=""0x6d"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" document=""1"" />
         <entry offset=""0x6f"" startLine=""27"" startColumn=""9"" endLine=""27"" endColumn=""19"" document=""1"" />
         <entry offset=""0x72"" hidden=""true"" document=""1"" />
+        <entry offset=""0x76"" hidden=""true"" document=""1"" />
         <entry offset=""0x78"" startLine=""30"" startColumn=""17"" endLine=""30"" endColumn=""23"" document=""1"" />
         <entry offset=""0x7a"" startLine=""32"" startColumn=""5"" endLine=""32"" endColumn=""6"" document=""1"" />
       </sequencePoints>
@@ -8544,6 +8584,7 @@ class Program
     // sequence point: <hidden>
     IL_0017:  ldloc.1
     IL_0018:  stfld      ""int Program.<Test>d__0.<>s__2""
+    // sequence point: <hidden>
     IL_001d:  ldc.i4.1
     IL_001e:  ldarg.0
     IL_001f:  ldfld      ""int Program.<Test>d__0.<>s__2""

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -3031,8 +3031,6 @@ class Student : Person { public double GPA; }
         <entry offset=""0x1"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" document=""1"" />
         <entry offset=""0x4"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xe"" hidden=""true"" document=""1"" />
-        <entry offset=""0x18"" hidden=""true"" document=""1"" />
         <entry offset=""0x1d"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
         <entry offset=""0x2e"" hidden=""true"" document=""1"" />
         <entry offset=""0x30"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""57"" document=""1"" />
@@ -3133,8 +3131,6 @@ class Student : Person { public double GPA; }
         <entry offset=""0xe"" hidden=""true"" document=""1"" />
         <entry offset=""0x1b"" hidden=""true"" document=""1"" />
         <entry offset=""0x1d"" hidden=""true"" document=""1"" />
-        <entry offset=""0x29"" hidden=""true"" document=""1"" />
-        <entry offset=""0x3d"" hidden=""true"" document=""1"" />
         <entry offset=""0x47"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
         <entry offset=""0x5d"" hidden=""true"" document=""1"" />
         <entry offset=""0x5f"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""63"" document=""1"" />
@@ -3234,8 +3230,6 @@ class Student : Person { public double GPA; }
         <entry offset=""0xe"" hidden=""true"" document=""1"" />
         <entry offset=""0x1b"" hidden=""true"" document=""1"" />
         <entry offset=""0x1d"" hidden=""true"" document=""1"" />
-        <entry offset=""0x29"" hidden=""true"" document=""1"" />
-        <entry offset=""0x3d"" hidden=""true"" document=""1"" />
         <entry offset=""0x47"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
         <entry offset=""0x5d"" hidden=""true"" document=""1"" />
         <entry offset=""0x60"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""27"" document=""1"" />


### PR DESCRIPTION
- [X] There should be a hidden sequence point at the start of the code to handle the decision dag. This is necessary so that jumps back from a `when` clause into the decision dag do not appear to jump back up to the switch statement.
- [X] After an evaluation that calls out to user code, the decision dag already saves it to a temp. We should add a hidden sequence point there when the stack is empty.
- [X] Temps that are used in lowering the decision dag and that need to survive across calls out to user code (i.e. pretty much all of them) should be classified as long-lived. (Done previously)
- [X] Those temps need to be associated with the switch statement's syntax node. (Done previously)

We also add hidden sequence points before the code that assigns the pattern variables in a switch section and after evaluating a *when-clause*.

Part of #25547

Note that we do not introduce sequence points (hidden or otherwise)...
- following calls out to language-supported operations (such as equality of language-supported types including decimal and string), some of which are produced during code gen rather than lowering.
- for the *is-pattern-expression*. It is treated like any other expression, as it does not have the subtleties caused by the switch's *when-clause* (the *when-clause* in a switch expression doesn't get a sequence point).
