### PR TITLE
Fix for UseDeconstruction with default literal

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseDeconstruction/UseDeconstructionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseDeconstruction/UseDeconstructionTests.cs
@@ -619,7 +619,7 @@ class C
 {
     void M()
     {
-        (object name, double age) [|person|] = (string.Empty, 0);
+        (object name, double age) [|person|] = (null, 0);
         Console.WriteLine(person.name + "" "" + person.age);
     }
 }",
@@ -627,7 +627,7 @@ class C
 {
     void M()
     {
-        (object name, double age) = (string.Empty, 0);
+        (object name, double age) = (null, 0);
         Console.WriteLine(name + "" "" + age);
     }
 }");

--- a/src/EditorFeatures/CSharpTest/UseDeconstruction/UseDeconstructionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseDeconstruction/UseDeconstructionTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.UseDeconstruction;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
@@ -481,7 +482,7 @@ class C
         (string name, int age) [|person|] = default;
         Console.WriteLine(person.name + "" "" + person.age);
     }
-}");
+}", new TestParameters(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseDeconstruction)]
@@ -606,6 +607,28 @@ class C
     {
         foreach ((string name, int age) in new Person[] { }.Cast<(string, int)>())
             Console.WriteLine(name + "" "" + age);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseDeconstruction)]
+        public async Task TestWithTupleLiteralConversion()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        (object name, double age) [|person|] = (string.Empty, 0);
+        Console.WriteLine(person.name + "" "" + person.age);
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        (object name, double age) = (string.Empty, 0);
+        Console.WriteLine(name + "" "" + age);
     }
 }");
         }

--- a/src/Features/CSharp/Portable/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
@@ -176,6 +176,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
                 !conversion.IsTupleConversion &&
                 !conversion.IsTupleLiteralConversion)
             {
+                // If there is any other conversion, we bail out because the source type might not be a tuple
+                // or it is a tuple but only thanks to target type inference, which won't occur in a deconstruction.
+                // Interesting case that illustrates this is initialization with a default literal:
+                // (int a, int b) t = default;
+                // This is classified as conversion.IsNullLiteral.
                 return false;
             }
 

--- a/src/Features/CSharp/Portable/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
@@ -125,10 +125,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
             }
 
             var local = (ILocalSymbol)semanticModel.GetDeclaredSymbol(declarator, cancellationToken);
-            var expressionType = semanticModel.GetTypeInfo(declarator.Initializer.Value, cancellationToken).Type;
+            var initializerConversion = semanticModel.GetConversion(declarator.Initializer.Value, cancellationToken);
 
             return TryAnalyze(
-                semanticModel, local, variableDeclaration.Type, declarator.Identifier, expressionType,
+                semanticModel, local, variableDeclaration.Type, declarator.Identifier, initializerConversion,
                 variableDeclaration.Parent.Parent, out tupleType, out memberAccessExpressions, cancellationToken);
         }
 
@@ -140,10 +140,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
             CancellationToken cancellationToken)
         {
             var local = semanticModel.GetDeclaredSymbol(forEachStatement, cancellationToken);
-            var elementType = semanticModel.GetForEachStatementInfo(forEachStatement).ElementType;
+            var elementConversion = semanticModel.GetForEachStatementInfo(forEachStatement).ElementConversion;
 
             return TryAnalyze(
-                semanticModel, local, forEachStatement.Type, forEachStatement.Identifier, elementType,
+                semanticModel, local, forEachStatement.Type, forEachStatement.Identifier, elementConversion,
                 forEachStatement, out tupleType, out memberAccessExpressions, cancellationToken);
         }
 
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
             ILocalSymbol local,
             TypeSyntax typeNode,
             SyntaxToken identifier,
-            ITypeSymbol initializerType,
+            Conversion conversion,
             SyntaxNode searchScope,
             out INamedTypeSymbol tupleType,
             out ImmutableArray<MemberAccessExpressionSyntax> memberAccessExpressions,
@@ -171,9 +171,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
                 return false;
             }
 
+            if (conversion.Exists &&
+                !conversion.IsIdentity &&
+                !conversion.IsTupleConversion &&
+                !conversion.IsTupleLiteralConversion)
+            {
+                return false;
+            }
+
             var type = semanticModel.GetTypeInfo(typeNode, cancellationToken).Type;
-            if (type == null || !type.IsTupleType ||
-                initializerType == null || !initializerType.IsTupleType)
+            if (type == null || !type.IsTupleType)
             {
                 return false;
             }


### PR DESCRIPTION
fixes #25260

The previous PR #25282 didn't actually fix the issue with a default literal. The test (which asserts that "use deconstruction" isn't offered) actually passes because it is using the default language version - 7.0, which doesn't allow default literals, therefore the code is incorrect. With C# 7.1 enabled, it *is* offered (and shouldn't be). The implementation is wrong. It is currently checking the type of the expression but a default literal does have an inferred type.

The failure was discovered in #26115 where the test fails when default language version is changed to 8.0.