### PR TITLE
Support pointers of unmanaged type parameters in method type inference

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -524,7 +524,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 BoundExpression argument = _arguments[arg];
                 TypeSymbol target = _formalParameterTypes[arg];
-                bool isExactInference = GetRefKind(arg).IsManagedReference() || argument.Type.IsPointerType() || target.IsPointerType();
+                bool isExactInference = GetRefKind(arg).IsManagedReference() || target.IsPointerType();
 
                 MakeExplicitParameterTypeInferences(binder, argument, target, isExactInference, ref useSiteDiagnostics);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -522,11 +522,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: For each of the method arguments Ei:
             for (int arg = 0, length = this.NumberArgumentsToProcess; arg < length; arg++)
             {
-                var argument = _arguments[arg];
-
-                bool isExactInference = GetRefKind(arg) != RefKind.None;
-
+                BoundExpression argument = _arguments[arg];
                 TypeSymbol target = _formalParameterTypes[arg];
+                bool isExactInference = GetRefKind(arg).IsManagedReference() || argument.Type.IsPointerType() || target.IsPointerType();
+
                 MakeExplicitParameterTypeInferences(binder, argument, target, isExactInference, ref useSiteDiagnostics);
             }
         }
@@ -1486,6 +1485,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
+            // This can be valid via (where T : unmanaged) constraints
+            if (ExactPointerInference(source, target, ref useSiteDiagnostics))
+            {
+                return;
+            }
+
             // SPEC: * Otherwise no inferences are made.
         }
 
@@ -1596,6 +1601,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ExactTypeArgumentInference(namedSource, namedTarget, ref useSiteDiagnostics);
             return true;
+        }
+
+        private bool ExactPointerInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            if (source is PointerTypeSymbol sourcePointer && target is PointerTypeSymbol targetPointer)
+            {
+                ExactInference(sourcePointer.PointedAtType, targetPointer.PointedAtType, ref useSiteDiagnostics);
+                return true;
+            }
+
+            return false;
         }
 
         private void ExactTypeArgumentInference(NamedTypeSymbol source, NamedTypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1605,9 +1605,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactPointerInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            if (source is PointerTypeSymbol sourcePointer && target is PointerTypeSymbol targetPointer)
+            if (source.TypeKind == TypeKind.Pointer && target.TypeKind == TypeKind.Pointer)
             {
-                ExactInference(sourcePointer.PointedAtType, targetPointer.PointedAtType, ref useSiteDiagnostics);
+                ExactInference(((PointerTypeSymbol)source).PointedAtType, ((PointerTypeSymbol)target).PointedAtType, ref useSiteDiagnostics);
                 return true;
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -3115,5 +3115,75 @@ Unmanaged: 1
 Object: 2
 Unmanaged: 3");
         }
+
+        [Fact]
+        [WorkItem(25654, "https://github.com/dotnet/roslyn/issues/25654")]
+        public void UnmanagedConstraint_PointersTypeInference()
+        {
+            var compilation = CreateCompilation(@"
+class C
+{
+    unsafe void M<T>(T* a) where T : unmanaged
+    {
+        var p = stackalloc T[10];
+        M(p);
+    }
+}", options: TestOptions.UnsafeReleaseDll);
+
+            compilation.VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            var inferredMethod = (MethodSymbol)model.GetSymbolInfo(call).Symbol;
+            var declaredMethod = compilation.GlobalNamespace.GetTypeMember("C").GetMethod("M");
+
+            Assert.Equal(declaredMethod, inferredMethod);
+            Assert.Equal(declaredMethod.TypeParameters.Single(), inferredMethod.TypeArguments.Single());
+        }
+
+        [Fact]
+        [WorkItem(25654, "https://github.com/dotnet/roslyn/issues/25654")]
+        public void UnmanagedConstraint_PointersTypeInference_Errors()
+        {
+            CreateCompilation(@"
+unsafe class C
+{
+    void Unmanaged<T>(T* a) where T : unmanaged
+    {
+    }
+    void UnmanagedWithInterface<T>(T* a) where T : unmanaged, System.IDisposable
+    {
+    }
+    void Test()
+    {
+        int a = 0;
+
+        Unmanaged(0);                       // fail (type inference)
+        Unmanaged(a);                       // fail (type inference)
+        Unmanaged(&a);                      // succeed (unmanaged type pointer)
+
+        UnmanagedWithInterface(0);          // fail (type inference)
+        UnmanagedWithInterface(a);          // fail (type inference)
+        UnmanagedWithInterface(&a);         // fail (does not match interface)
+    }
+}", options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                // (14,9): error CS0411: The type arguments for method 'C.Unmanaged<T>(T*)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Unmanaged(0);                       // fail (type inference)
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Unmanaged").WithArguments("C.Unmanaged<T>(T*)").WithLocation(14, 9),
+                // (15,9): error CS0411: The type arguments for method 'C.Unmanaged<T>(T*)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Unmanaged(a);                       // fail (type inference)
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Unmanaged").WithArguments("C.Unmanaged<T>(T*)").WithLocation(15, 9),
+                // (18,9): error CS0411: The type arguments for method 'C.UnmanagedWithInterface<T>(T*)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         UnmanagedWithInterface(0);          // fail (type inference)
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "UnmanagedWithInterface").WithArguments("C.UnmanagedWithInterface<T>(T*)").WithLocation(18, 9),
+                // (19,9): error CS0411: The type arguments for method 'C.UnmanagedWithInterface<T>(T*)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         UnmanagedWithInterface(a);          // fail (type inference)
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "UnmanagedWithInterface").WithArguments("C.UnmanagedWithInterface<T>(T*)").WithLocation(19, 9),
+                // (20,9): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'C.UnmanagedWithInterface<T>(T*)'. There is no boxing conversion from 'int' to 'System.IDisposable'.
+                //         UnmanagedWithInterface(&a);         // fail (does not match interface)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "UnmanagedWithInterface").WithArguments("C.UnmanagedWithInterface<T>(T*)", "System.IDisposable", "T", "int").WithLocation(20, 9));
+        }
     }
 }


### PR DESCRIPTION
Fixes #25654 

@dotnet/roslyn-compiler for review.