### PR TITLE
Build NuPkg on Unix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,8 @@ usage()
     echo "  --release             Build Release"
     echo "  --restore             Restore projects required to build"
     echo "  --build               Build all projects"
+    echo "  --pack                Build prerelease nuget packages"
+    echo "  --packall             Build all nuget packages"
     echo "  --test                Run unit tests"
     echo "  --mono                Run unit tests with mono"
     echo "  --build-bootstrap     Build the bootstrap compilers"
@@ -32,6 +34,8 @@ build_configuration=Debug
 restore=false
 build=false
 test_=false
+pack=false
+pack_all=false
 use_mono=false
 build_bootstrap=false
 use_bootstrap=false
@@ -93,6 +97,13 @@ do
         --stop-vbcscompiler)
             stop_vbcscompiler=true
             ;;
+        --pack)
+            pack=true
+            ;;
+        --packall)
+            pack_all=true
+            pack=true
+            ;;
         *)
             echo "$1"
             usage
@@ -108,6 +119,32 @@ logs_path=${config_path}/Logs
 mkdir -p ${binaries_path}
 mkdir -p ${config_path}
 mkdir -p ${logs_path}
+
+function pack_all_kind() {
+    pushd "${root_path}/src/NuGet"
+
+    echo Packing $1
+
+    local nupkg_path="${config_path}/NuGet/PreRelease"
+    local nuspec_files=("Microsoft.CodeAnalysis.CSharp.nuspec" "Microsoft.CodeAnalysis.Compilers.nuspec" "Microsoft.CodeAnalysis.VisualBasic.nuspec" "Microsoft.CodeAnalysis.Common.nuspec" "Microsoft.NETCore.Compilers.nuspec")
+    mkdir -p ${nupkg_path}
+    for i in "${nuspec_files[@]}" 
+    do
+        dotnet pack -nologo --no-build NuGetProjectPackUtil.csproj -p:NuSpecFile=$i -p:NuGetPackageKind=$1 -p:NuspecBasePath=${binaries_path}/Debug -o ${nupkg_path}
+    done
+
+    popd
+}
+
+function pack_all() {
+    pack_all_kind PreRelease
+
+    if [[ "$pack_all" = true ]]
+    then
+        pack_all_kind Release
+        pack_all_kind PerBuildPreRelease
+    fi
+}
 
 if [[ "$build_in_docker" = true ]]
 then
@@ -165,6 +202,11 @@ if [[ "${build}" == true ]]
 then
     echo "Building Compilers.sln"
     dotnet build "${root_path}"/Compilers.sln ${build_args} "/bl:${binaries_path}/Build.binlog"
+fi
+
+if [[ "${pack}" == true ]]
+then
+    pack_all
 fi
 
 if [[ "${stop_vbcscompiler}" == true ]]

--- a/build/scripts/cibuild.sh
+++ b/build/scripts/cibuild.sh
@@ -24,4 +24,4 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 echo "Building this commit:"
 git show --no-patch --pretty=raw HEAD
 
-"${root_path}"/build.sh --restore --bootstrap --build --stop-vbcscompiler --test "$@"
+"${root_path}"/build.sh --restore --bootstrap --build --packall --stop-vbcscompiler --test "$@"


### PR DESCRIPTION
Change our Unix builds to create the set of NuGet packages that are needed for
source build.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
