### PR TITLE
In Object serialization, do not keep track of non-reusable green nodes.

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             // write nothing, always read/deserialized as global Instance

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
+++ b/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         // From what I see in our own codebase, tokens longer then 40-50 chars are 
         // not very common. 
         // So it seems reasonable to limit the sizes to some round number like 42.
-        private const int MaxCachedTokenSize = 42;
+        internal const int MaxCachedTokenSize = 42;
 
         private enum QuickScanState : byte
         {

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
@@ -66,6 +66,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             this.flags |= NodeFlags.IsNotMissing;  //note: cleared by subclasses representing missing tokens
         }
 
+        internal override bool ShouldReuseInSerialization => base.ShouldReuseInSerialization && 
+                                                             FullWidth < Lexer.MaxCachedTokenSize;
+
         //====================
 
         public override bool IsToken => true;

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxTrivia.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxTrivia.cs
@@ -34,6 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         public override bool IsTrivia => true;
 
+        internal override bool ShouldReuseInSerialization => this.Kind == SyntaxKind.WhitespaceTrivia &&
+                                                             FullWidth < Lexer.MaxCachedTokenSize;
+
         internal override void WriteTo(ObjectWriter writer)
         {
             base.WriteTo(writer);

--- a/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
@@ -149,6 +149,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             private T _member;
 
+
             public TypeWithOneMember(T value)
             {
                 _member = value;
@@ -160,6 +161,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     ? (T)Enum.ToObject(typeof(T), reader.ReadInt64())
                     : (T)reader.ReadValue();
             }
+
+            bool IObjectWritable.IsReusable => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -218,6 +221,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 _member2 = (S)reader.ReadValue();
             }
 
+            bool IObjectWritable.IsReusable => true;
+
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
                 writer.WriteValue(_member1);
@@ -275,6 +280,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     _members[i] = (T)reader.ReadValue();
                 }
             }
+
+            bool IObjectWritable.IsReusable => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -510,6 +517,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 TestReadingPrimitiveArrays(reader);
             }
+
+            bool IObjectWritable.IsReusable => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -804,6 +813,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 TestReadingPrimitiveAPIs(reader);
             }
 
+            bool IObjectWritable.IsReusable => true;
+
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
                 TestWritingPrimitiveAPIs(writer);
@@ -885,6 +896,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 TestReadingPrimitiveValues(reader);
             }
+
+            bool IObjectWritable.IsReusable => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -1147,6 +1160,30 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void TestReuse()
+        {
+            var oneNode = new Node("one");
+            var n1 = new Node("x", oneNode, oneNode, oneNode, oneNode);
+            var n2 = RoundTripValue(n1, recursive: true);
+
+            Assert.Same(n2.Children[0], n2.Children[1]);
+            Assert.Same(n2.Children[1], n2.Children[2]);
+            Assert.Same(n2.Children[2], n2.Children[3]);
+        }
+
+        [Fact]
+        public void TestReuseNegative()
+        {
+            var oneNode = new Node("one", isReusable: false);
+            var n1 = new Node("x", oneNode, oneNode, oneNode, oneNode);
+            var n2 = RoundTripValue(n1, recursive: true);
+
+            Assert.NotSame(n2.Children[0], n2.Children[1]);
+            Assert.NotSame(n2.Children[1], n2.Children[2]);
+            Assert.NotSame(n2.Children[2], n2.Children[3]);
+        }
+
+        [Fact]
         public void TestWideObjectGraph()
         {
             int id = 0;
@@ -1197,11 +1234,18 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             internal readonly string Name;
             internal readonly Node[] Children;
+            private readonly bool _isReusable = true;
 
             public Node(string name, params Node[] children)
             {
                 this.Name = name;
                 this.Children = children;
+            }
+
+            public Node(string name, bool isReusable)
+                : this(name)
+            {
+                this._isReusable = isReusable;
             }
 
             private Node(ObjectReader reader)
@@ -1211,6 +1255,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
 
             private static readonly Func<ObjectReader, object> s_createInstance = r => new Node(r);
+
+            bool IObjectWritable.IsReusable => _isReusable;
 
             public void WriteTo(ObjectWriter writer)
             {

--- a/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     : (T)reader.ReadValue();
             }
 
-            bool IObjectWritable.IsReusable => true;
+            bool IObjectWritable.ShouldReuseInSerialization => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 _member2 = (S)reader.ReadValue();
             }
 
-            bool IObjectWritable.IsReusable => true;
+            bool IObjectWritable.ShouldReuseInSerialization => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 }
             }
 
-            bool IObjectWritable.IsReusable => true;
+            bool IObjectWritable.ShouldReuseInSerialization => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -517,7 +517,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 TestReadingPrimitiveArrays(reader);
             }
 
-            bool IObjectWritable.IsReusable => true;
+            bool IObjectWritable.ShouldReuseInSerialization => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -812,7 +812,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 TestReadingPrimitiveAPIs(reader);
             }
 
-            bool IObjectWritable.IsReusable => true;
+            bool IObjectWritable.ShouldReuseInSerialization => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -896,7 +896,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 TestReadingPrimitiveValues(reader);
             }
 
-            bool IObjectWritable.IsReusable => true;
+            bool IObjectWritable.ShouldReuseInSerialization => true;
 
             void IObjectWritable.WriteTo(ObjectWriter writer)
             {
@@ -1255,7 +1255,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             private static readonly Func<ObjectReader, object> s_createInstance = r => new Node(r);
 
-            bool IObjectWritable.IsReusable => _isReusable;
+            bool IObjectWritable.ShouldReuseInSerialization => _isReusable;
 
             public void WriteTo(ObjectWriter writer)
             {

--- a/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
@@ -149,7 +149,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             private T _member;
 
-
             public TypeWithOneMember(T value)
             {
                 _member = value;

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis
 
         #region Serialization
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
@@ -138,6 +138,8 @@ namespace Microsoft.CodeAnalysis
 
         #region Serialization
 
+        bool IObjectWritable.IsReusable => true;
+
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             this.WriteTo(writer);

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis
 
         #region Serialization
 
-        bool IObjectWritable.ShouldReuseInSerialization => true;
+        bool IObjectWritable.ShouldReuseInSerialization => false;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
@@ -93,6 +93,8 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             writer.WriteType(_resourceSource);

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        bool IObjectWritable.ShouldReuseInSerialization => true;
+        bool IObjectWritable.ShouldReuseInSerialization => false;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Compilers/Core/Portable/Serialization/IObjectWritable.cs
+++ b/src/Compilers/Core/Portable/Serialization/IObjectWritable.cs
@@ -12,8 +12,8 @@ namespace Roslyn.Utilities
 
         /// <summary>
         /// Returns `true` when the same instance could be used more than once.
-        /// In this is not a case and, there is no point in tracking the instance 
-        /// for the purpose of de-duplication while serializing/deserializing.
+        /// Instances that return "false" should not be tracked or the purpose 
+        /// of de-duplication while serializing/deserializing.
         /// </summary>
         bool IsReusable { get; }
     }

--- a/src/Compilers/Core/Portable/Serialization/IObjectWritable.cs
+++ b/src/Compilers/Core/Portable/Serialization/IObjectWritable.cs
@@ -9,5 +9,12 @@ namespace Roslyn.Utilities
     internal interface IObjectWritable
     {
         void WriteTo(ObjectWriter writer);
+
+        /// <summary>
+        /// Returns `true` when the same instance could be used more than once.
+        /// In this is not a case and, there is no point in tracking the instance 
+        /// for the purpose of de-duplication while serializing/deserializing.
+        /// </summary>
+        bool IsReusable { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Serialization/IObjectWritable.cs
+++ b/src/Compilers/Core/Portable/Serialization/IObjectWritable.cs
@@ -11,8 +11,8 @@ namespace Roslyn.Utilities
         void WriteTo(ObjectWriter writer);
 
         /// <summary>
-        /// Returns `true` when the same instance could be used more than once.
-        /// Instances that return "false" should not be tracked or the purpose 
+        /// Returns 'true' when the same instance could be used more than once.
+        /// Instances that return 'false' should not be tracked for the purpose 
         /// of de-duplication while serializing/deserializing.
         /// </summary>
         bool ShouldReuseInSerialization { get; }

--- a/src/Compilers/Core/Portable/Serialization/IObjectWritable.cs
+++ b/src/Compilers/Core/Portable/Serialization/IObjectWritable.cs
@@ -15,6 +15,6 @@ namespace Roslyn.Utilities
         /// Instances that return "false" should not be tracked or the purpose 
         /// of de-duplication while serializing/deserializing.
         /// </summary>
-        bool IsReusable { get; }
+        bool ShouldReuseInSerialization { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Serialization/ObjectBinder.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectBinder.cs
@@ -32,7 +32,7 @@ namespace Roslyn.Utilities
         /// </summary>
         private static readonly Dictionary<Type, int> s_typeToIndex = new Dictionary<Type, int>();
         private static readonly List<Type> s_types = new List<Type>();
-        private static readonly List<Func<ObjectReader, object>> s_typeReaders = new List<Func<ObjectReader, object>>();
+        private static readonly List<Func<ObjectReader, IObjectWritable>> s_typeReaders = new List<Func<ObjectReader, IObjectWritable>>();
 
         /// <summary>
         /// Gets an immutable copy of the state of this binder.  This copy does not need to be
@@ -51,7 +51,7 @@ namespace Roslyn.Utilities
             }
         }
 
-        public static void RegisterTypeReader(Type type, Func<ObjectReader, object> typeReader)
+        public static void RegisterTypeReader(Type type, Func<ObjectReader, IObjectWritable> typeReader)
         {
             lock (s_gate)
             {

--- a/src/Compilers/Core/Portable/Serialization/ObjectBinderSnapshot.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectBinderSnapshot.cs
@@ -10,12 +10,12 @@ namespace Roslyn.Utilities
     {
         private readonly Dictionary<Type, int> _typeToIndex;
         private readonly ImmutableArray<Type> _types;
-        private readonly ImmutableArray<Func<ObjectReader, object>> _typeReaders;
+        private readonly ImmutableArray<Func<ObjectReader, IObjectWritable>> _typeReaders;
 
         public ObjectBinderSnapshot(
             Dictionary<Type, int> typeToIndex,
             List<Type> types,
-            List<Func<ObjectReader, object>> typeReaders)
+            List<Func<ObjectReader, IObjectWritable>> typeReaders)
         {
             _typeToIndex = new Dictionary<Type, int>(typeToIndex);
             _types = types.ToImmutableArray();
@@ -28,7 +28,7 @@ namespace Roslyn.Utilities
         public Type GetTypeFromId(int typeId)
             => _types[typeId];
 
-        public Func<ObjectReader, object> GetTypeReaderFromId(int typeId)
+        public Func<ObjectReader, IObjectWritable> GetTypeReaderFromId(int typeId)
             => _typeReaders[typeId];
     }
 }

--- a/src/Compilers/Core/Portable/Serialization/ObjectBinderSnapshot.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectBinderSnapshot.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 
 namespace Roslyn.Utilities
 {
-    internal struct ObjectBinderSnapshot
+    internal readonly struct ObjectBinderSnapshot
     {
         private readonly Dictionary<Type, int> _typeToIndex;
         private readonly ImmutableArray<Type> _types;

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -607,7 +607,12 @@ namespace Roslyn.Utilities
 
             // recursive: read and construct instance immediately from member elements encoding next in the stream
             var instance = typeReader(this);
-            _objectReferenceMap.AddValue(objectId, instance);
+
+            if (instance.IsReusable)
+            {
+                _objectReferenceMap.AddValue(objectId, instance);
+            }
+
             return instance;
         }
 

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -608,7 +608,7 @@ namespace Roslyn.Utilities
             // recursive: read and construct instance immediately from member elements encoding next in the stream
             var instance = typeReader(this);
 
-            if (instance.IsReusable)
+            if (instance.ShouldReuseInSerialization)
             {
                 _objectReferenceMap.AddValue(objectId, instance);
             }

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -361,10 +361,14 @@ namespace Roslyn.Utilities
             public bool TryGetReferenceId(object value, out int referenceId)
                 => _valueToIdMap.TryGetValue(value, out referenceId);
 
-            public void Add(object value)
+            public void Add(object value, bool isReusable = true)
             {
                 var id = _nextId++;
-                _valueToIdMap.Add(value, id);
+
+                if (isReusable)
+                {
+                    _valueToIdMap.Add(value, id);
+                }
             }
         }
 
@@ -801,9 +805,9 @@ namespace Roslyn.Utilities
 
         private void WriteObjectWorker(IObjectWritable writable)
         {
-            // emit object header up front
-            _objectReferenceMap.Add(writable);
+            _objectReferenceMap.Add(writable, writable.IsReusable);
 
+            // emit object header up front
             _writer.Write((byte)EncodingKind.Object);
 
             // Directly write out the type-id for this object.  i.e. no need to write out the 'Type'

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -361,7 +361,7 @@ namespace Roslyn.Utilities
             public bool TryGetReferenceId(object value, out int referenceId)
                 => _valueToIdMap.TryGetValue(value, out referenceId);
 
-            public void Add(object value, bool isReusable = true)
+            public void Add(object value, bool isReusable)
             {
                 var id = _nextId++;
 
@@ -436,7 +436,7 @@ namespace Roslyn.Utilities
                 }
                 else
                 {
-                    _stringReferenceMap.Add(value);
+                    _stringReferenceMap.Add(value, isReusable: true);
 
                     if (value.IsValidUnicodeString())
                     {
@@ -805,7 +805,7 @@ namespace Roslyn.Utilities
 
         private void WriteObjectWorker(IObjectWritable writable)
         {
-            _objectReferenceMap.Add(writable, writable.IsReusable);
+            _objectReferenceMap.Add(writable, writable.ShouldReuseInSerialization);
 
             // emit object header up front
             _writer.Write((byte)EncodingKind.Object);

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -437,7 +437,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        bool IObjectWritable.IsReusable => this.IsCacheable;
+        bool IObjectWritable.IsReusable => ShouldReuseInSerialization;
+
+        internal virtual bool ShouldReuseInSerialization => this.IsCacheable;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -437,6 +437,8 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        bool IObjectWritable.IsReusable => this.IsCacheable;
+
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             this.WriteTo(writer);

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        bool IObjectWritable.IsReusable => ShouldReuseInSerialization;
+        bool IObjectWritable.ShouldReuseInSerialization => ShouldReuseInSerialization;
 
         internal virtual bool ShouldReuseInSerialization => this.IsCacheable;
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxAnnotation.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxAnnotation.cs
@@ -57,6 +57,8 @@ namespace Microsoft.CodeAnalysis
             this.Data = reader.ReadString();
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             writer.WriteInt64(_id);

--- a/src/Compilers/Core/Portable/Syntax/SyntaxAnnotation.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxAnnotation.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis
             this.Data = reader.ReadString();
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -18,6 +18,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Sub New()
         End Sub
 
+        Private ReadOnly Property IsReausable As Boolean Implements IObjectWritable.IsReusable
+            Get
+                Return True
+            End Get
+        End Property
+
         Private Sub WriteTo(writer As ObjectWriter) Implements IObjectWritable.WriteTo
             ' don't write anything since we always return the shared 'Instance' when read.
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Sub New()
         End Sub
 
-        Private ReadOnly Property IsReausable As Boolean Implements IObjectWritable.IsReusable
+        Private ReadOnly Property IsReausable As Boolean Implements IObjectWritable.ShouldReuseInSerialization
             Get
                 Return True
             End Get

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Sub New()
         End Sub
 
-        Private ReadOnly Property IsReausable As Boolean Implements IObjectWritable.ShouldReuseInSerialization
+        Private ReadOnly Property IObjectWritable_ShouldReuseInSerialization As Boolean Implements IObjectWritable.ShouldReuseInSerialization
             Get
                 Return True
             End Get

--- a/src/Compilers/VisualBasic/Portable/Scanner/QuickTokenAccumulator.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/QuickTokenAccumulator.vb
@@ -134,7 +134,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Const s_CHARPROP_LENGTH = &H180
 
         ' Maximum length of a token to scan
-        Friend Const MAXTOKENSIZE = 42
+        Friend Const MAX_CACHED_TOKENSIZE = 42
 
         Shared Sub New()
             Debug.Assert(s_charProperties.Length = s_CHARPROP_LENGTH)
@@ -183,7 +183,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim index = _lineBufferOffset And s_PAGE_MASK
             Dim qtStart = index
 
-            Dim limit = index + Math.Min(MAXTOKENSIZE, _bufferLen - offset)
+            Dim limit = index + Math.Min(MAX_CACHED_TOKENSIZE, _bufferLen - offset)
             limit = Math.Min(limit, pageArr.Length)
 
             Dim hashCode As Integer = Hash.FnvOffsetBias

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
@@ -89,6 +89,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Me._trailingTrivia = DirectCast(reader.ReadValue(), GreenNode)
             End Sub
 
+            Private ReadOnly Property IsReausable As Boolean Implements IObjectWritable.IsReusable
+                Get
+                    Return _leadingTrivia IsNot Nothing AndAlso
+                        ShouldCacheTriviaInfo(_leadingTrivia, _trailingTrivia)
+                End Get
+            End Property
+
             Public Sub WriteTo(writer As ObjectWriter) Implements IObjectWritable.WriteTo
                 writer.WriteValue(_leadingTrivia)
                 writer.WriteValue(_trailingTrivia)

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
@@ -197,6 +197,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End If
         End Sub
 
+        Friend Overrides ReadOnly Property ShouldReuseInSerialization As Boolean
+            Get
+                Return MyBase.ShouldReuseInSerialization AndAlso
+                    Me.FullWidth < Scanner.MAX_CACHED_TOKENSIZE
+            End Get
+        End Property
+
         Friend Overrides Sub WriteTo(writer As ObjectWriter)
             MyBase.WriteTo(writer)
             writer.WriteString(Me._text)

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Me._trailingTrivia = DirectCast(reader.ReadValue(), GreenNode)
             End Sub
 
-            Private ReadOnly Property IsReausable As Boolean Implements IObjectWritable.ShouldReuseInSerialization
+            Private ReadOnly Property IObjectWritable_ShouldReuseInSerialization As Boolean Implements IObjectWritable.ShouldReuseInSerialization
                 Get
                     Return ShouldCacheTriviaInfo(_leadingTrivia, _trailingTrivia)
                 End Get

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
@@ -89,10 +89,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Me._trailingTrivia = DirectCast(reader.ReadValue(), GreenNode)
             End Sub
 
-            Private ReadOnly Property IsReausable As Boolean Implements IObjectWritable.IsReusable
+            Private ReadOnly Property IsReausable As Boolean Implements IObjectWritable.ShouldReuseInSerialization
                 Get
-                    Return _leadingTrivia IsNot Nothing AndAlso
-                        ShouldCacheTriviaInfo(_leadingTrivia, _trailingTrivia)
+                    Return ShouldCacheTriviaInfo(_leadingTrivia, _trailingTrivia)
                 End Get
             End Property
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxTrivia.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxTrivia.vb
@@ -49,6 +49,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ObjectBinder.RegisterTypeReader(GetType(SyntaxTrivia), Function(r) New SyntaxTrivia(r))
         End Sub
 
+        Friend Overrides ReadOnly Property ShouldReuseInSerialization As Boolean
+            Get
+                Select Case Me.Kind
+                    Case SyntaxKind.WhitespaceTrivia,
+                        SyntaxKind.EndOfLineTrivia,
+                        SyntaxKind.LineContinuationTrivia,
+                        SyntaxKind.DocumentationCommentExteriorTrivia,
+                        SyntaxKind.ColonTrivia
+
+                        Return True
+                    Case Else
+                        Return False
+                End Select
+            End Get
+        End Property
+
         Friend Overrides Sub WriteTo(writer As ObjectWriter)
             MyBase.WriteTo(writer)
             writer.WriteString(Me._text)

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return result;
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         public void WriteTo(ObjectWriter writer)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -113,6 +113,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return result;
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         public void WriteTo(ObjectWriter writer)
         {
             writer.WriteString(SerializationFormat);

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return false;
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         public void WriteTo(ObjectWriter writer)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -143,6 +143,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return false;
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         public void WriteTo(ObjectWriter writer)
         {
             _literalInfo.WriteTo(writer);

--- a/src/Workspaces/Core/Portable/Shared/Utilities/BloomFilter_Serialization.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/BloomFilter_Serialization.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
     {
         private const string SerializationFormat = "2";
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         public void WriteTo(ObjectWriter writer)
         {

--- a/src/Workspaces/Core/Portable/Shared/Utilities/BloomFilter_Serialization.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/BloomFilter_Serialization.cs
@@ -10,6 +10,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
     {
         private const string SerializationFormat = "2";
 
+        bool IObjectWritable.IsReusable => true;
+
         public void WriteTo(ObjectWriter writer)
         {
             writer.WriteString(SerializationFormat);

--- a/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
@@ -15,6 +15,7 @@ namespace Roslyn.Utilities
         private const string SerializationFormat = "3";
 
         public Checksum Checksum { get; }
+
         private readonly BKTree _bkTree;
 
         public SpellChecker(Checksum checksum, BKTree bKTree)
@@ -41,6 +42,8 @@ namespace Roslyn.Utilities
 
             return array;
         }
+
+        bool IObjectWritable.IsReusable => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
@@ -43,7 +43,7 @@ namespace Roslyn.Utilities
             return array;
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -88,6 +88,8 @@ namespace Microsoft.CodeAnalysis
             return !(left == right);
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         public void WriteTo(ObjectWriter writer)
             => _checkSum.WriteTo(writer);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis
             return !(left == right);
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         public void WriteTo(ObjectWriter writer)
             => _checkSum.WriteTo(writer);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -98,6 +98,8 @@ namespace Microsoft.CodeAnalysis
             return !(left == right);
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             ProjectId.WriteTo(writer);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis
             return !(left == right);
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -204,6 +204,8 @@ namespace Microsoft.CodeAnalysis
                 return new DocumentAttributes(newId, newName, newFolders, newSourceCodeKind, newFilePath, newIsGenerated);
             }
 
+            bool IObjectWritable.IsReusable => true;
+
             public void WriteTo(ObjectWriter writer)
             {
                 Id.WriteTo(writer);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis
                 return new DocumentAttributes(newId, newName, newFolders, newSourceCodeKind, newFilePath, newIsGenerated);
             }
 
-            bool IObjectWritable.IsReusable => true;
+            bool IObjectWritable.ShouldReuseInSerialization => true;
 
             public void WriteTo(ObjectWriter writer)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -84,6 +84,8 @@ namespace Microsoft.CodeAnalysis
             return this.Id.GetHashCode();
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             writer.WriteGuid(Id);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis
             return this.Id.GetHashCode();
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -486,7 +486,7 @@ namespace Microsoft.CodeAnalysis
                     newHasAllInformation);
             }
 
-            bool IObjectWritable.IsReusable => true;
+            bool IObjectWritable.ShouldReuseInSerialization => true;
 
             public void WriteTo(ObjectWriter writer)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -486,6 +486,8 @@ namespace Microsoft.CodeAnalysis
                     newHasAllInformation);
             }
 
+            bool IObjectWritable.IsReusable => true;
+
             public void WriteTo(ObjectWriter writer)
             {
                 Id.WriteTo(writer);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis
             return this.Id.GetHashCode();
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
@@ -81,6 +81,8 @@ namespace Microsoft.CodeAnalysis
             return this.Id.GetHashCode();
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             writer.WriteGuid(Id);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -112,6 +112,8 @@ namespace Microsoft.CodeAnalysis
                 FilePath = filePath;
             }
 
+            bool IObjectWritable.IsReusable => true;
+
             public void WriteTo(ObjectWriter writer)
             {
                 Id.WriteTo(writer);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis
                 FilePath = filePath;
             }
 
-            bool IObjectWritable.IsReusable => true;
+            bool IObjectWritable.ShouldReuseInSerialization => true;
 
             public void WriteTo(ObjectWriter writer)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis
             return baseVersion._utcLastModified == persistedVersion._utcLastModified;
         }
 
-        bool IObjectWritable.IsReusable => true;
+        bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
@@ -193,6 +193,8 @@ namespace Microsoft.CodeAnalysis
             return baseVersion._utcLastModified == persistedVersion._utcLastModified;
         }
 
+        bool IObjectWritable.IsReusable => true;
+
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             WriteTo(writer);


### PR DESCRIPTION
### Reducing chances of OutOfMemory crash upon serialization/deserialization of syntax trees.

Serialization/deserialization allocates temporary tables to track potentially reused objects - to reduce the size of serialized streams and to avoid completely expanding de-duplicated nodes after the round-trip.
The additional memory requirements are proportional to the size of the tree and generally not a problem. However when running close to limits it was reported to cause crashes.

The current algorithm is very conservative and tries to keep track of _every_ node in the tree. There is a good degree of redundancy here since some nodes are clearly not reusable.

The fix here checks for common and easily detectable cases where nodes are not reusable - when nodes have diagnostics or doc comments or the size of tokens exceeds the limits when scanner will not consider them reusable, and so on - just a number of known and simple criteria.

NOTE: precise separation on not-reusable and reusable is not a goal here as that could be hard to do and going beyond common cases will yield diminishing benefits. 
We only need to remove the most common redundancies. Being very precise would just result in scenarios where we can deserialize successfully and then OOM on the next operation that works with the tree and needs some memory anyways.

### Bugs this fixes

Fixes:#22659

### Workarounds, if any

No workarounds. When working close to OOM limits, any operation that may trigger serialization (closing/opening file views for example) may become source of instability.

### Risk

Risk is low, since the fix does not interfere with overall serialization process, it only uses conservative checks to omit clearly not reusable nodes from filling up the object reference tables. 

### Performance impact

Perf impact is low. 
Next to the whole serialization/deserialization process, the additional checks should be very cheap. 
In fact, not filling up the tables with redundant objects may have positive impact on the performance, depending on a scenario.

### Is this a regression from a previous update?

N/A

### Root cause analysis

Serialization/deserialization by design require additional memory. To a degree any such action a would be dangerous when close to the limits and nothing can be done to completely eliminate that. 
It is also somewhat hard to estimate the hazard.

We are acting on this since there are known crashes and since there are fairly easy ways to reduce the transient memory consumption for this scenario.

### How was the bug found?

Crash reports, WER.

### Test documentation updated?

N/A