### PR TITLE
Fix connection leaking on cancellation

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -136,7 +136,8 @@ End Class";
 
                 var source = new CancellationTokenSource();
                 var connection = new InvokeThrowsCancellationConnection(source);
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => SessionWithSolution.CreateAsync(connection, solution, source.Token));
+                var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => SessionWithSolution.CreateAsync(connection, solution, source.Token));
+                Assert.Equal(exception.CancellationToken, source.Token);
 
                 // make sure things that should have been cleaned up are cleaned up
                 var service = (RemotableDataServiceFactory.Service)solution.Workspace.Services.GetService<IRemotableDataService>();

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -140,11 +140,12 @@ End Class";
                 }
                 catch (OperationCanceledException)
                 {
-                    // make sure things that should have been cleaned up are cleaned up
-                    var service = (RemotableDataServiceFactory.Service)solution.Workspace.Services.GetService<IRemotableDataService>();
-                    Assert.Null(service.GetRemotableData_TestOnly(solutionChecksum, CancellationToken.None));
-                    Assert.True(connection.Disposed);
                 }
+                
+                // make sure things that should have been cleaned up are cleaned up
+                var service = (RemotableDataServiceFactory.Service)solution.Workspace.Services.GetService<IRemotableDataService>();
+                Assert.Null(service.GetRemotableData_TestOnly(solutionChecksum, CancellationToken.None));
+                Assert.True(connection.Disposed);
             }
         }
 

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -134,13 +134,7 @@ End Class";
 
                 var source = new CancellationTokenSource();
                 var connection = new MyConnection(source);
-                try
-                {
-                    await SessionWithSolution.CreateAsync(connection, solution, source.Token);
-                }
-                catch (OperationCanceledException)
-                {
-                }
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => SessionWithSolution.CreateAsync(connection, solution, source.Token));
                 
                 // make sure things that should have been cleaned up are cleaned up
                 var service = (RemotableDataServiceFactory.Service)solution.Workspace.Services.GetService<IRemotableDataService>();

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -131,18 +131,22 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
 #if DEBUG
-            private string _creationCallStack;
-
+            private readonly string _creationCallStack;
+#endif
             ~Connection()
             {
                 // this can happen if someone kills OOP. 
                 // when that happen, we don't want to crash VS, so this is debug only check
                 if (!Environment.HasShutdownStarted)
                 {
-                    Contract.Requires(false, $"Should have been disposed!\r\n {_creationCallStack}");
+#if DEBUG
+                    Contract.Fail($"Should have been disposed!\r\n {_creationCallStack}");
+#else
+                    Contract.Fail($"Should have been disposed!");
+#endif
                 }
             }
-#endif
+
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -101,6 +101,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
             protected Connection()
             {
+#if DEBUG
+                _creationCallStack = Environment.StackTrace;
+#endif
                 _disposed = false;
             }
 
@@ -128,13 +131,15 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
 #if DEBUG
+            private string _creationCallStack;
+
             ~Connection()
             {
                 // this can happen if someone kills OOP. 
                 // when that happen, we don't want to crash VS, so this is debug only check
                 if (!Environment.HasShutdownStarted)
                 {
-                    Contract.Requires(false, $@"Should have been disposed!");
+                    Contract.Requires(false, $"Should have been disposed!\r\n {_creationCallStack}");
                 }
             }
 #endif

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -45,14 +45,13 @@ namespace Microsoft.CodeAnalysis.Remote
         public static async Task<SessionWithSolution> TryCreateSessionAsync(
             this RemoteHostClient client, string serviceName, Solution solution, object callbackTarget, CancellationToken cancellationToken)
         {
-            var session = await client.TryCreateConnectionAsync(serviceName, callbackTarget, cancellationToken).ConfigureAwait(false);
-            if (session == null)
+            var connection = await client.TryCreateConnectionAsync(serviceName, callbackTarget, cancellationToken).ConfigureAwait(false);
+            if (connection == null)
             {
                 return null;
             }
 
-            var scope = await GetPinnedScopeAsync(solution, cancellationToken).ConfigureAwait(false);
-            return await SessionWithSolution.CreateAsync(session, scope, cancellationToken).ConfigureAwait(false);
+            return await SessionWithSolution.CreateAsync(connection, solution, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
### Customer scenario

While users are using VS. Connections to servicehub can be leaked and number of connections get increased overtime.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/26183

### Workarounds, if any

there is no workaround

### Risk

I don't see any risk

### Performance impact

It should remove connection leaks.

### Is this a regression from a previous update?

No

### Root cause analysis

when we create certain type of connection, if cancellation happens at right time, we didn't dispose connection before exception escapes current call.

### How was the bug found?

dogfooding and unit testing.
