### PR TITLE
GoToImplementation: only include abstract symbols if they are types

### DIFF
--- a/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
+++ b/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 symbol, project, cancellationToken).ConfigureAwait(false);
 
             var filteredSymbols = implementations.WhereAsArray(
-                s => s.Locations.Any(l => l.IsInSource));
+                s => (!s.IsAbstract || s is ITypeSymbol) && s.Locations.Any(l => l.IsInSource));
 
             return filteredSymbols.Length == 0
                 ? (symbol, project, filteredSymbols, EditorFeaturesResources.The_symbol_has_no_implementations)

--- a/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
+++ b/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToImplementation
 
                     expectedDefinitions.Sort()
 
-                    Assert.Equal(actualDefinitions.Count, expectedDefinitions.Count)
+                    Assert.Equal(expectedDefinitions.Count, actualDefinitions.Count)
 
                     For i = 0 To actualDefinitions.Count - 1
                         Dim actual = actualDefinitions(i)
@@ -104,6 +104,33 @@ class [|D|] : C
 interface $$I { }
 abstract class [|C|] : I { }
 class [|D|] : C { }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <WorkItem(26167, "https://github.com/dotnet/roslyn/issues/26167")>
+        Public Async Function TestWithAbstracProperty() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+
+public abstract class Base
+{
+    public abstract int P { get; set; }
+    void N()
+    {
+        _ = this.P$$;
+    }
+}
+public class C : Base
+{
+    public override int [|P|] { get; set; }
+}
         </Document>
     </Project>
 </Workspace>
@@ -327,12 +354,13 @@ interface I { void $$M(); }
 
         <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         <WorkItem(6752, "https://github.com/dotnet/roslyn/issues/6752")>
+        <WorkItem(26167, "https://github.com/dotnet/roslyn/issues/26167")>
         Public Async Function TestWithAbstractMethodImplementation() As Task
             Dim workspace =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
         <Document>
-class C : I { public abstract void [|M|]() { } }
+class C : I { public abstract void M() { } }
 class D : C { public override void [|M|]() { } }}
 interface I { void $$M(); }
         </Document>
@@ -439,7 +467,7 @@ class D : C
         public virtual void $$[|M|]() { }
     }
     abstract class B : A {
-        public abstract override void [|M|]();
+        public abstract override void M();
     }
     sealed class C1 : B {
         public override void [|M|]() { }


### PR DESCRIPTION
### Customer scenario
Invoke GoToImplementation on a method declared as abstract and with one implementation. The current behavior (since 15.6) is to list both the declaration and the implementation.
Such behavior makes sense for types, but not for methods/properties/etc.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/26167

### Workarounds, if any
You can still use GoToImplementation, but, in simple cases with a single implementation, you will have to click on a listing of two symbols, instead of directly being taken to the implementation.

### Risk & Performance impact
Low. This is adding a simple check when filtering down the list of implementation symbols.

### Is this a regression from a previous update?
Yes. In 15.6, the rule for GoToImplementation was relaxed to include abstract symbols (https://github.com/dotnet/roslyn/pull/23360). This makes sense for type symbols, but as a customer reported, this doesn't make as much sense for other symbols, such as methods.
The impact is that in simple cases (where there is only one implementation), we're listing two locations, when one location is really not an implementation. Filtering down to just one location allows to jump directly to the implementation.

### How was the bug found?
Reported by customer.

Tagging @CyrusNajmabadi @dotnet/roslyn-ide for review.
Tagging @jinujoseph for bar check. Any chance to fit this in 15.7? If not, I'll retarget to 15.8.