### PR TITLE
Support Lazy type for smart variable completion provider

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -256,6 +256,46 @@ public class C
             await VerifyItemExistsAsync(markup, "builder");
         }
 
+        [WorkItem(25214, "https://github.com/dotnet/roslyn/issues/25214")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeImplementsLazyOfType1()
+        {
+            var markup = @"
+using System;
+using System.Collections.Generic;
+
+internal class Example
+{
+    public Lazy<Item> $$
+}
+
+public class Item { }
+";
+            await VerifyItemExistsAsync(markup, "item");
+            await VerifyItemExistsAsync(markup, "Item");
+            await VerifyItemExistsAsync(markup, "GetItem");
+        }
+
+        [WorkItem(25214, "https://github.com/dotnet/roslyn/issues/25214")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeImplementsLazyOfType2()
+        {
+            var markup = @"
+using System;
+using System.Collections.Generic;
+
+internal class Example
+{
+    public List<Lazy<Item>> $$
+}
+
+public class Item { }
+";
+            await VerifyItemExistsAsync(markup, "items");
+            await VerifyItemExistsAsync(markup, "Items");
+            await VerifyItemExistsAsync(markup, "GetItems");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void NoSuggestionsForInt()
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -196,9 +196,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 var taskOfTType = compilation.TaskOfTType();
                 var valueTaskType = compilation.ValueTaskOfTType();
+                var lazyOfTType = compilation.LazyOfTType();
 
                 if (originalDefinition == taskOfTType ||
                     originalDefinition == valueTaskType ||
+                    originalDefinition == lazyOfTType ||
                     originalDefinition.SpecialType == SpecialType.System_Nullable_T)
                 {
                     return UnwrapType(namedType.TypeArguments[0], compilation, wasPlural: wasPlural, seenTypes: seenTypes);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
@@ -117,5 +117,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static INamedTypeSymbol DynamicAttributeType(this Compilation compilation)
             => compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.DynamicAttribute");
+
+        public static INamedTypeSymbol LazyOfTType(this Compilation compilation)
+            => compilation.GetTypeByMetadataName(typeof(Lazy<>).FullName);
     }
 }


### PR DESCRIPTION
Fixes #25214

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
