### PR TITLE
EnC does not work in .NET Core async methods

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -1174,7 +1174,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             Debug.Assert(Thread.CurrentThread.GetApartmentState() == ApartmentState.MTA);
 
             var symMethod = (ISymUnmanagedMethod2)_pdbReader.Value.GetMethodByVersion(MetadataTokens.GetToken(methodHandle), methodVersion: 1);
-            return MetadataTokens.StandaloneSignatureHandle(symMethod.GetLocalSignatureToken());
+
+            // async methods do not have debug info.
+            return symMethod == null ? default : MetadataTokens.StandaloneSignatureHandle(symMethod.GetLocalSignatureToken());
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -1175,7 +1175,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
 
             var symMethod = (ISymUnmanagedMethod2)_pdbReader.Value.GetMethodByVersion(MetadataTokens.GetToken(methodHandle), methodVersion: 1);
 
-            // async methods do not have debug info.
+            // Compiler generated methods (e.g. async kick-off methods) might not have debug information.
             return symMethod == null ? default : MetadataTokens.StandaloneSignatureHandle(symMethod.GetLocalSignatureToken());
         }
 


### PR DESCRIPTION
### Customer scenario

create a console project targeting .net core 2.0 in visual studio 2017 15.6.5, and paste this code

```
using System;
using System.Threading.Tasks;
namespace EditAndContinueIssue
{
    class Program
    {
        static void Main(string[] args)
        {
            AsyncMethod().Wait();
        }
        private static async Task AsyncMethod()
        {
            var msg = "Hello world";
            //msg = "Edited message";
            await Task.Delay(TimeSpan.FromSeconds(1));
            Console.WriteLine(msg);
        }
    }
}
```

1. ensure 'edit and continue' is enabled from tools > options > debugging
2. put a breakpoint on line 13
3. run the project in debug mode
4. when the breakpoint is hit, uncomment line 14
5. resume execution
6. expected behavior
7. the edits are applied and "Edited message" is written to the console

actual behavior
"Edits were made which cannot be compiled. Execution cannot continue until the compile errors are fixed." is displayed

### Bugs this fixes
https://developercommunity.visualstudio.com/content/problem/231199/edit-and-continue-does-not-work-with-async-methods.html
and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/602104

### Workarounds, if any
none

### Risk
very low

### Performance impact
none

### Is this a regression from a previous update?
no

### How was the bug found?
customer reported it