### PR TITLE
Make sure we always subscribe to shared hierarchy eventing

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -316,10 +316,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         if (document.IsOpen)
                         {
                             NotifyWorkspace(workspace =>
+                            {
                                 workspace.OnDocumentOpened(
                                     document.Id,
                                     document.GetOpenTextBuffer().AsTextContainer(),
-                                    isCurrentContext: LinkedFileUtilities.IsCurrentContextHierarchy(document, _runningDocumentTable)));
+                                    isCurrentContext: LinkedFileUtilities.IsCurrentContextHierarchy(document, _runningDocumentTable));
+                                (workspace as VisualStudioWorkspaceImpl)?.ConnectToSharedHierarchyEvents(document);
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
In d9e300215 I restored the code that was subscribing to IVsHierarchy event notifications to know when shared contexts change. Unfortunately it was put in the event handler for IVisualStudioHostDocument.Opened, which only runs when the document is being opened that was already part of the workspace. If the reverse order happens: a file is already open, and only _then_ added to the workspace, the code was skipped.

Curiously, Workspace has an overridable method OnDocumentClosing which you can use to hook calls, but not an equivalent OnDocumentOpening. It's unclear to me if this design was something we want to extend (it's a bit strange) and so I'm not touching that for now.

Fixes dotnet/project-system#3467.

<details><summary>Ask Mode template</summary>

### Customer scenario

Open a CPS-based project in 15.7 that does multitargeting, or uses shared projects. If you open a file prior to the project system having fully updated the language (an operation that happens asynchronously), the project switcher won't work.

### Bugs this fixes

https://github.com/dotnet/project-system/issues/3467

### Workarounds, if any

Close and reopen the affected file. There's no hint to the user that this workaround would work.

### Risk

Low: just moving some code around to cover some missed cases.

### Performance impact

None: code just moving around.

### Is this a regression from a previous update?

Yes, code was refactored since 15.6 and this was introduced.

### Root cause analysis

We connect to an open text buffer through two different codepaths:

1. The user opened a file that we knew was in a project.
2. A file is added to a project that was already opened.

We ran some additional connection code only in the first case, but not the second. The second now happens regularly in CPS, because CPS is now deferring informing the language service about files until much later in the load process, so it's easy to open a file before the project information has been wired up.

For preventing regressions, this area of code is being entirely refactored to address a number of issues; I'm not going to write tests that would soon be deleted.

### How was the bug found?

Customer reported.

</details>
