### PR TITLE
Fixes mapping of active statement when changing ctor body from block to expression

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -158,6 +158,21 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             return false;
         }
 
+        /// <summary>
+        /// Report a non-fatal error like <see cref="ReportWithoutCrash"/> but propagates the exception.
+        /// </summary>
+        /// <returns>False to propagate the exception.</returns>
+        [DebuggerHidden]
+        public static bool ReportWithoutCrashUnlessCanceledAndPropagate(Exception exception)
+        {
+            if (!(exception is OperationCanceledException))
+            {
+                Report(exception, s_nonFatalHandler);
+            }
+
+            return false;
+        }
+
         private static object s_reportedMarker = new object();
 
         private static void Report(Exception exception, Action<Exception> handler)

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.Methods.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.Methods.cs
@@ -435,6 +435,58 @@ class C
 
         #endregion
 
+        #region Constuctors
+
+        [Fact]
+        public void Constructor_ExpressionBodyToBlockBody1()
+        {
+            var src1 = "class C { int x; C() => <AS:0>x = 1</AS:0>; }";
+            var src2 = "class C { int x; <AS:0>C()</AS:0> { x = 1; } }";
+
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void Constructor_BlockBodyToExpressionBody1()
+        {
+            var src1 = "class C { int x; C() <AS:0>{</AS:0> x = 1; } }";
+            var src2 = "class C { int x; C() => <AS:0>x = 1</AS:0>; }";
+
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void Constructor_BlockBodyToExpressionBody2()
+        {
+            var src1 = "class C { int x; <AS:0>C()</AS:0> { x = 1; } }";
+            var src2 = "class C { int x; C() => <AS:0>x = 1</AS:0>; }";
+
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void Constructor_BlockBodyToExpressionBody3()
+        {
+            var src1 = "class C { int x; C() : <AS:0>base()</AS:0> { x = 1; } }";
+            var src2 = "class C { int x; C() => <AS:0>x = 1</AS:0>; }";
+
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        #endregion
+
         #region Properties
 
         [Fact]

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -566,7 +566,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.ThisConstructorInitializer:
                 case SyntaxKind.BaseConstructorInitializer:
                 case SyntaxKind.ConstructorDeclaration:
-                    var newConstructor = (ConstructorDeclarationSyntax)newBody.Parent;
+                    var newConstructor = (ConstructorDeclarationSyntax)(newBody.Parent.IsKind(SyntaxKind.ArrowExpressionClause) ? newBody.Parent.Parent : newBody.Parent);
                     newStatement = (SyntaxNode)newConstructor.Initializer ?? newConstructor;
                     return true;
 

--- a/src/Features/Core/Portable/EditAndContinue/DocumentAnalysisResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DocumentAnalysisResults.cs
@@ -13,19 +13,19 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Spans of active statements in the document, or null if the document has syntax errors.
         /// </summary>
-        public readonly ImmutableArray<ActiveStatement> ActiveStatements;
+        public ImmutableArray<ActiveStatement> ActiveStatements { get; }
 
         /// <summary>
         /// Diagnostics for rude edits in the document, or null if the document is unchanged or has syntax errors.
         /// If the compilation has semantic errors only syntactic rude edits are calculated.
         /// </summary>
-        public readonly ImmutableArray<RudeEditDiagnostic> RudeEditErrors;
+        public ImmutableArray<RudeEditDiagnostic> RudeEditErrors { get; }
 
         /// <summary>
         /// Edits made in the document, or null if the document is unchanged, has syntax errors, has rude edits,
         /// or if the compilation has semantic errors.
         /// </summary>
-        public readonly ImmutableArray<SemanticEdit> SemanticEdits;
+        public ImmutableArray<SemanticEdit> SemanticEdits { get; }
 
         /// <summary>
         /// Exception regions -- spans of catch and finally handlers that surround the active statements.
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ///   try { } |finally { try { } catch { ... AS ... } }|
         ///   try { try { } |finally { ... AS ... }| } |catch { } catch { } finally { }|
         /// </remarks>
-        public readonly ImmutableArray<ImmutableArray<LinePositionSpan>> ExceptionRegions;
+        public ImmutableArray<ImmutableArray<LinePositionSpan>> ExceptionRegions { get; }
 
         /// <summary>
         /// Line edits in the document, or null if the document has syntax errors or rude edits, 
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <remarks>
         /// Sorted by <see cref="LineChange.OldLine"/>
         /// </remarks>
-        public readonly ImmutableArray<LineChange> LineEdits;
+        public ImmutableArray<LineChange> LineEdits { get; }
 
         /// <summary>
         /// The compilation has compilation errors (syntactic or semantic), 


### PR DESCRIPTION
### Customer scenario

VS crashes when program is stopped at a breakpoint placed on the constructor declaration (not on its body) and the constructor body is changed from a block to an expression.

Harden GetAllAddedSymbolsAsync to avoid VS crash on an unexpected exception.

### Bugs this fixes

[VSO 590387](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/590387)

### Workarounds, if any

None.

### Risk

Small.

### Performance impact

Small.

### Is this a regression from a previous update?

### Root cause analysis

Missing unit test.

### How was the bug found?

Customer reported.

### Test documentation updated?
