### PR TITLE
Update Roslyn snapshot when editorconfig is updated. for now, it only…

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProviderFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProviderFactory.cs
@@ -3,15 +3,25 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.CodingConventions;
 
 namespace Microsoft.CodeAnalysis.Editor.Options
 {
     [Export(typeof(IDocumentOptionsProviderFactory))]
     class EditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
     {
+        private readonly ICodingConventionsManager _codingConventionsManager;
+
+        [ImportingConstructor]
+        [Obsolete("Never call this directly")]
+        public EditorConfigDocumentOptionsProviderFactory(ICodingConventionsManager codingConventionsManager)
+        {
+            _codingConventionsManager = codingConventionsManager;
+        }
+
         public IDocumentOptionsProvider Create(Workspace workspace)
         {
-            return new EditorConfigDocumentOptionsProvider(workspace);
+            return new EditorConfigDocumentOptionsProvider(workspace, _codingConventionsManager);
         }
     }
 }

--- a/src/EditorFeatures/Core/Shared/Utilities/ResettableDelay.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ResettableDelay.cs
@@ -9,6 +9,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 {
     internal class ResettableDelay
     {
+        public static readonly ResettableDelay CompletedDelay = new ResettableDelay();
+
         private readonly int _delayInMilliseconds;
         private readonly TaskCompletionSource<object> _taskCompletionSource;
 
@@ -37,6 +39,16 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             {
                 StartTimer(continueOnCapturedContext: false);
             }
+        }
+
+        private ResettableDelay()
+        {
+            // create resettableDelay with completed state
+            _delayInMilliseconds = 0;
+            _taskCompletionSource = new TaskCompletionSource<object>();
+            _taskCompletionSource.SetResult(null);
+
+            Reset();
         }
 
         public Task Task => _taskCompletionSource.Task;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1051,5 +1051,17 @@ namespace Microsoft.CodeAnalysis
                 return this.Workspace.Options;
             }
         }
+
+        /// <summary>
+        /// Update current solution as a result of option changes.
+        /// 
+        /// this is a temporary workaround until editorconfig becomes real part of roslyn solution snapshot.
+        /// until then, this will explicitly fork current solution snapshot
+        /// </summary>
+        internal Solution WithOptionChanged()
+        {
+            // just create new snapshot
+            return new Solution(_state);
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1060,7 +1060,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal Solution WithOptionChanged()
         {
-            // just create new snapshot
+            // options are associated with solution snapshot. creating new snapshot
+            // will cause us to retrieve new options
             return new Solution(_state);
         }
     }


### PR DESCRIPTION
… updates when editorconfig is saved.

### Customer scenario

User updates editorconfig and save the file but the change doesn't get picked up by other files opened in VS until files are closed and reopened.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/15003

### Workarounds, if any

modify the file or close and reopen the file.

### Risk

Low.

### Performance impact

Low

### Is this a regression from a previous update?

No

### Root cause analysis

We consider options as a part of snapshot. but we didn't update snapshots when editorconfig options are changed. for now, we support it for opened files, but for full experience, it require editorconfig work from compiler.

### How was the bug found?

Dogfooding, Feedbacks

