### PR TITLE
Avoid stealing focus from the active output window pane

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/WorkspaceFailureOutputPane.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/WorkspaceFailureOutputPane.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             return Guid.Empty;
         }
 
-        public void ActivatePane(IVsOutputWindow outputWindow, Guid paneGuid)
+        private void ActivatePane(IVsOutputWindow outputWindow, Guid paneGuid)
         {
             AssertIsForeground();
 

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/WorkspaceFailureOutputPane.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/WorkspaceFailureOutputPane.cs
@@ -58,7 +58,9 @@ namespace Microsoft.VisualStudio.LanguageServices
                     _doNotAccessDirectlyOutputPane = CreateOutputPane(outputWindow);
 
                     if (lastActivePane != Guid.Empty)
+                    {
                         ActivatePane(outputWindow, lastActivePane);
+                    }
                 }
 
                 return _doNotAccessDirectlyOutputPane;

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/WorkspaceFailureOutputPane.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/WorkspaceFailureOutputPane.cs
@@ -69,6 +69,8 @@ namespace Microsoft.VisualStudio.LanguageServices
 
         private IVsOutputWindowPane CreateOutputPane(IVsOutputWindow outputWindow)
         {
+            AssertIsForeground();
+
             // Try to get the workspace pane if it has already been registered
             var workspacePaneGuid = s_workspacePaneGuid;
 
@@ -82,8 +84,10 @@ namespace Microsoft.VisualStudio.LanguageServices
             return null;
         }
 
-        private static Guid GetActivePane(IVsOutputWindow outputWindow)
+        private Guid GetActivePane(IVsOutputWindow outputWindow)
         {
+            AssertIsForeground();
+
             if (outputWindow is IVsOutputWindow2 outputWindow2)
             {
                 if (ErrorHandler.Succeeded(outputWindow2.GetActivePaneGUID(out var activePaneGuid)))
@@ -95,8 +99,10 @@ namespace Microsoft.VisualStudio.LanguageServices
             return Guid.Empty;
         }
 
-        public static void ActivatePane(IVsOutputWindow outputWindow, Guid paneGuid)
+        public void ActivatePane(IVsOutputWindow outputWindow, Guid paneGuid)
         {
+            AssertIsForeground();
+
             if (ErrorHandler.Succeeded(outputWindow.GetPane(ref paneGuid, out var pane)))
             {
                 pane.Activate();

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/WorkspaceFailureOutputPane.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/WorkspaceFailureOutputPane.cs
@@ -49,26 +49,26 @@ namespace Microsoft.VisualStudio.LanguageServices
                 {
                     var outputWindow = (IVsOutputWindow)_serviceProvider.GetService(typeof(SVsOutputWindow));
 
-                    // Try to get the workspace pane if it has already been registered
-                    var workspacePaneGuid = s_workspacePaneGuid;
-                    var hr = outputWindow.GetPane(ref workspacePaneGuid, out _doNotAccessDirectlyOutputPane);
-
-                    // If the workspace pane has not been registered before, create it
-                    if (_doNotAccessDirectlyOutputPane == null || hr != VSConstants.S_OK)
-                    {
-                        if (ErrorHandler.Failed(outputWindow.CreatePane(ref workspacePaneGuid, ServicesVSResources.IntelliSense, fInitVisible: 1, fClearWithSolution: 1)) ||
-                            ErrorHandler.Failed(outputWindow.GetPane(ref workspacePaneGuid, out _doNotAccessDirectlyOutputPane)))
-                        {
-                            return null;
-                        }
-
-                        // Must activate the workspace pane for it to show up in the output window
-                        _doNotAccessDirectlyOutputPane.Activate();
-                    }
+                    _doNotAccessDirectlyOutputPane = CreateOutputPane(outputWindow);
                 }
 
                 return _doNotAccessDirectlyOutputPane;
             }
+        }
+
+        private IVsOutputWindowPane CreateOutputPane(IVsOutputWindow outputWindow)
+        {
+            // Try to get the workspace pane if it has already been registered
+            var workspacePaneGuid = s_workspacePaneGuid;
+
+            // If the pane has already been created, CreatePane returns it
+            if (ErrorHandler.Succeeded(outputWindow.CreatePane(ref workspacePaneGuid, ServicesVSResources.IntelliSense, fInitVisible: 1, fClearWithSolution: 1)) &&
+                ErrorHandler.Succeeded(outputWindow.GetPane(ref workspacePaneGuid, out var pane)))
+            {
+                return pane;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Avoid stealing focus when creating our output window pane.

Fixes part of #12202.

~NOTE: I've spent three hours trying to test this but failed miserably due to a number of issues. I'm not going to spend anymore time on it but others are welcome to take my changes, test and merge.~ I've since tested this and it works.