### PR TITLE
Add editorconfig parser and unit tests

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -79,8 +80,18 @@ my_PROP = my_VAL");
             var properties = config.GlobalSection.Properties;
 
             Assert.True(properties.TryGetValue("my_PrOp", out var val));
-            Assert.Equal(val, "my_val");
+            Assert.Equal(val, "my_VAL");
             Assert.Equal("my_prop", properties.Keys.Single());
+        }
+
+        [Fact]
+        public void NonReservedKeyPreservedCaseVal()
+        {
+            var config = ParseConfigFile(string.Join(Environment.NewLine,
+                EditorConfig.ReservedKeys.Select(k => "MY_" + k + " = MY_VAL")));
+            AssertEx.SetEqual(
+                EditorConfig.ReservedKeys.Select(k => KeyValuePair.Create("my_" + k, "MY_VAL")).ToList(),
+                config.GlobalSection.Properties);
         }
 
         [Fact]
@@ -219,6 +230,28 @@ long: this value continues
             var config = ParseConfigFile(@"
 RoOt = TruE");
             Assert.True(config.IsRoot);
+        }
+
+        [Fact]
+        public void ReservedValues()
+        {
+            int index = 0;
+            var config = ParseConfigFile(string.Join(Environment.NewLine,
+                EditorConfig.ReservedValues.Select(v => "MY_KEY" + (index++) + " = " + v.ToUpperInvariant())));
+            index = 0;
+            AssertEx.SetEqual(
+                EditorConfig.ReservedValues.Select(v => KeyValuePair.Create("my_key" + (index++), v)).ToList(),
+                config.GlobalSection.Properties);
+        }
+
+        [Fact]
+        public void ReservedKeys()
+        {
+            var config = ParseConfigFile(string.Join(Environment.NewLine,
+                EditorConfig.ReservedKeys.Select(k => k + " = MY_VAL")));
+            AssertEx.SetEqual(
+                EditorConfig.ReservedKeys.Select(k => KeyValuePair.Create(k, "my_val")).ToList(),
+                config.GlobalSection.Properties);
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
@@ -37,7 +37,7 @@ my_prop = my_val
                 properties);
 
             var namedSections = config.NamedSections;
-            Assert.Equal(1, namedSections.Count);
+            Assert.Equal(1, namedSections.Length);
             Assert.Equal("*.cs", namedSections[0].Name);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my_prop", "my_val")},
@@ -59,7 +59,20 @@ my_prop = my_val");
                 new[] { KeyValuePair.Create("my_prop", "my_val")},
                 properties);
 
-            Assert.Equal(0, config.NamedSections.Count);
+            Assert.Equal(0, config.NamedSections.Length);
+        }
+
+        [Fact]
+        public void EmptySection()
+        {
+            var config = EditorConfig.Parse(@"
+[]
+my_prop = my_val", "");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+            Assert.Equal(new[] { KeyValuePair.Create("my_prop", "my_val")}, properties);
+            Assert.Equal(0, config.NamedSections.Length);
         }
 
         [Fact]
@@ -70,9 +83,9 @@ my_PROP = my_VAL");
             var properties = config.GlobalSection.Properties;
             Assert.Equal(1, properties.Count);
 
-            Assert.True(properties.TryGetValue("my_prop", out var val));
-            Assert.Equal(val, "my_VAL");
-            Assert.Equal("my_PROP", properties.Keys.Single());
+            Assert.True(properties.TryGetValue("my_PrOp", out var val));
+            Assert.Equal(val, "my_val");
+            Assert.Equal("my_prop", properties.Keys.Single());
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
@@ -226,5 +226,13 @@ long: this value continues
                 new[] { KeyValuePair.Create("long", "this value continues")},
                 properties);
         }
+
+        [Fact]
+        public void CaseInsensitiveRoot()
+        {
+            var config = ParseConfigFile(@"
+RoOt = TruE");
+            Assert.True(config.IsRoot);
+        }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class EditorConfigTests
+    {
+        private static EditorConfig ParseConfigFile(string text) => EditorConfig.Parse(text, "");
+
+        [Fact]
+        public void SimpleCase()
+        {
+            var config = EditorConfig.Parse(@"
+root = true
+
+# Comment1
+# Comment2
+##################################
+
+my_global_prop = my_global_val
+
+[*.cs]
+my_prop = my_val
+
+", "Z:\\bogus");
+
+            Assert.Equal("", config.GlobalSection.Name);
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(2, properties.Count);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("my_global_prop", "my_global_val"),
+                        KeyValuePair.Create("root", "true") },
+                properties);
+
+            var namedSections = config.NamedSections;
+            Assert.Equal(1, namedSections.Count);
+            Assert.Equal("*.cs", namedSections[0].Name);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("my_prop", "my_val")},
+                namedSections[0].Properties);
+            
+            Assert.True(config.IsRoot);
+            Assert.Equal("Z:\\bogus", config.Directory);
+        }
+
+        [Fact]
+        public void MissingClosingBracket()
+        {
+            var config = ParseConfigFile(@"
+[*.cs
+my_prop = my_val");
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("my_prop", "my_val")},
+                properties);
+
+            Assert.Equal(0, config.NamedSections.Count);
+        }
+
+        [Fact]
+        public void CaseInsensitivePropKey()
+        {
+            var config = ParseConfigFile(@"
+my_PROP = my_VAL");
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+
+            Assert.True(properties.TryGetValue("my_prop", out var val));
+            Assert.Equal(val, "my_VAL");
+            Assert.Equal("my_PROP", properties.Keys.Single());
+        }
+
+        [Fact]
+        public void DuplicateKeys()
+        {
+            var config = ParseConfigFile(@"
+my_prop = my_val
+my_prop = my_other_val");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+            Assert.Equal(new[] { KeyValuePair.Create("my_prop", "my_other_val") }, properties);
+        }
+
+        [Fact]
+        public void DuplicateKeysCasing()
+        {
+            var config = ParseConfigFile(@"
+my_prop = my_val
+my_PROP = my_other_val");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+            Assert.Equal(new[] { KeyValuePair.Create("my_prop", "my_other_val") }, properties);
+        }
+
+        [Fact]
+        public void MissingKey()
+        {
+            var config = ParseConfigFile(@"
+= my_val1
+my_prop = my_val2");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("my_prop", "my_val2") },
+                properties);
+        }
+
+        [Fact]
+        public void MissingVal()
+        {
+            var config = ParseConfigFile(@"
+my_prop1 =
+my_prop2 = my_val");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(2, properties.Count);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("my_prop1", ""),
+                        KeyValuePair.Create("my_prop2", "my_val") },
+                properties);
+        }
+
+        [Fact]
+        public void SpacesInProperties()
+        {
+            var config = ParseConfigFile(@"
+my prop1 = my_val1
+my_prop2 = my val2");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("my_prop2", "my val2") },
+                properties);
+        }
+
+        [Fact]
+        public void EndOfLineComments()
+        {
+            var config = ParseConfigFile(@"
+my_prop2 = my val2 # Comment");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("my_prop2", "my val2") },
+                properties);
+        }
+
+        [Fact]
+        public void SymbolsStartKeys()
+        {
+            var config = ParseConfigFile(@"
+@!$abc = my_val1
+@!$\# = my_val2");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(0, properties.Count);
+        }
+
+        [Fact]
+        public void EqualsAndColon()
+        {
+            var config = ParseConfigFile(@"
+my:key1 = my_val
+my_key2 = my:val");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(2, properties.Count);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("my", "key1 = my_val"),
+                        KeyValuePair.Create("my_key2", "my:val")},
+                properties);
+        }
+
+        [Fact]
+        public void SymbolsInProperties()
+        {
+            var config = ParseConfigFile(@"
+my@key1 = my_val
+my_key2 = my@val");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("my_key2", "my@val")},
+                properties);
+        }
+
+        [Fact]
+        public void LongLines()
+        {
+            // PROTOTYPE(editorconfig): This example is described in the Python ConfigParser as
+            // allowing line continuation via the RFC 822 specification, section 3.1.1 LONG
+            // HEADER FIELDS. It's unclear whether it's intended for editorconfig to permit
+            // this interpretation. The VS parser does not. We should probably check other
+            // parsers for completeness.
+            var config = ParseConfigFile(@"
+long: this value continues
+   in the next line");
+
+            var properties = config.GlobalSection.Properties;
+            Assert.Equal(1, properties.Count);
+            AssertEx.SetEqual(
+                new[] { KeyValuePair.Create("long", "this value continues")},
+                properties);
+        }
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
@@ -30,14 +30,12 @@ my_prop = my_val
 
             Assert.Equal("", config.GlobalSection.Name);
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(2, properties.Count);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my_global_prop", "my_global_val"),
                         KeyValuePair.Create("root", "true") },
                 properties);
 
             var namedSections = config.NamedSections;
-            Assert.Equal(1, namedSections.Length);
             Assert.Equal("*.cs", namedSections[0].Name);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my_prop", "my_val")},
@@ -54,7 +52,6 @@ my_prop = my_val
 [*.cs
 my_prop = my_val");
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my_prop", "my_val")},
                 properties);
@@ -70,7 +67,6 @@ my_prop = my_val");
 my_prop = my_val", "");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
             Assert.Equal(new[] { KeyValuePair.Create("my_prop", "my_val")}, properties);
             Assert.Equal(0, config.NamedSections.Length);
         }
@@ -81,7 +77,6 @@ my_prop = my_val", "");
             var config = ParseConfigFile(@"
 my_PROP = my_VAL");
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
 
             Assert.True(properties.TryGetValue("my_PrOp", out var val));
             Assert.Equal(val, "my_val");
@@ -96,7 +91,6 @@ my_prop = my_val
 my_prop = my_other_val");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
             Assert.Equal(new[] { KeyValuePair.Create("my_prop", "my_other_val") }, properties);
         }
 
@@ -108,7 +102,6 @@ my_prop = my_val
 my_PROP = my_other_val");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
             Assert.Equal(new[] { KeyValuePair.Create("my_prop", "my_other_val") }, properties);
         }
 
@@ -120,7 +113,6 @@ my_PROP = my_other_val");
 my_prop = my_val2");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my_prop", "my_val2") },
                 properties);
@@ -134,7 +126,6 @@ my_prop1 =
 my_prop2 = my_val");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(2, properties.Count);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my_prop1", ""),
                         KeyValuePair.Create("my_prop2", "my_val") },
@@ -149,7 +140,6 @@ my prop1 = my_val1
 my_prop2 = my val2");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my_prop2", "my val2") },
                 properties);
@@ -162,7 +152,6 @@ my_prop2 = my val2");
 my_prop2 = my val2 # Comment");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my_prop2", "my val2") },
                 properties);
@@ -187,7 +176,6 @@ my:key1 = my_val
 my_key2 = my:val");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(2, properties.Count);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my", "key1 = my_val"),
                         KeyValuePair.Create("my_key2", "my:val")},
@@ -202,7 +190,6 @@ my@key1 = my_val
 my_key2 = my@val");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("my_key2", "my@val")},
                 properties);
@@ -221,7 +208,6 @@ long: this value continues
    in the next line");
 
             var properties = config.GlobalSection.Properties;
-            Assert.Equal(1, properties.Count);
             AssertEx.SetEqual(
                 new[] { KeyValuePair.Create("long", "this value continues")},
                 properties);

--- a/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
+++ b/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
@@ -223,21 +223,33 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Returns a StringComparer that compares strings according the VB identifier comparison rules.
+        /// Returns a StringComparer that compares strings according to Unicode rules for case-insensitive
+        /// identifier comparison (lower-case mapping).
         /// </summary>
+        /// <remarks>
+        /// These are also the rules used for VB identifier comparison.
+        /// </remarks>
         private static readonly OneToOneUnicodeComparer s_comparer = new OneToOneUnicodeComparer();
 
         /// <summary>
-        /// Returns a StringComparer that compares strings according the VB identifier comparison rules.
+        /// Returns a StringComparer that compares strings according to Unicode rules for case-insensitive
+        /// identifier comparison (lower-case mapping).
         /// </summary>
+        /// <remarks>
+        /// These are also the rules used for VB identifier comparison.
+        /// </remarks>
         public static StringComparer Comparer => s_comparer;
 
         /// <summary>
-        /// Determines if two VB identifiers are equal according to the VB identifier comparison rules.
+        /// Determines if two strings are equal according to Unicode rules for case-insensitive
+        /// identifier comparison (lower-case mapping).
         /// </summary>
         /// <param name="left">First identifier to compare</param>
         /// <param name="right">Second identifier to compare</param>
         /// <returns>true if the identifiers should be considered the same.</returns>
+        /// <remarks>
+        /// These are also the rules used for VB identifier comparison.
+        /// </remarks>
         public static bool Equals(string left, string right) => s_comparer.Equals(left, right);
 
         /// <summary>
@@ -257,18 +269,25 @@ namespace Microsoft.CodeAnalysis
         public static bool StartsWith(string value, string possibleStart) => OneToOneUnicodeComparer.StartsWith(value, possibleStart);
 
         /// <summary>
-        /// Compares two VB identifiers according to the VB identifier comparison rules.
+        /// Compares two strings according to the Unicode rules for case-insensitive
+        /// identifier comparison (lower-case mapping).
         /// </summary>
         /// <param name="left">First identifier to compare</param>
         /// <param name="right">Second identifier to compare</param>
         /// <returns>-1 if <paramref name="left"/> &lt; <paramref name="right"/>, 1 if <paramref name="left"/> &gt; <paramref name="right"/>, 0 if they are equal.</returns>
+        /// <remarks>
+        /// These are also the rules used for VB identifier comparison.
+        /// </remarks>
         public static int Compare(string left, string right) => s_comparer.Compare(left, right);
 
         /// <summary>
-        /// Gets a case-insensitive hash code for VB identifiers.
+        /// Gets a case-insensitive hash code for Unicode identifiers.
         /// </summary>
         /// <param name="value">identifier to get the hash code for</param>
         /// <returns>The hash code for the given identifier</returns>
+        /// <remarks>
+        /// These are also the rules used for VB identifier comparison.
+        /// </remarks>
         public static int GetHashCode(string value)
         {
             Debug.Assert(value != null);

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -54,6 +54,8 @@
     <PackageReference Include="System.Text.Encoding" Version="$(SystemTextEncodingVersion)" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
     <PackageReference Include="System.Text.Encoding.Extensions" Version="$(SystemTextEncodingExtensionsVersion)" />
+    <!-- PROTOTYPE(editorconfig) Confirm that we want to reference regular expressions before shipping -->
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="$(SystemXmlReaderWriterVersion)" />
     <PackageReference Include="System.Xml.XDocument" Version="$(SystemXmlXDocumentVersion)" />
     <PackageReference Include="System.Xml.XmlDocument" Version="$(SystemXmlXmlDocumentVersion)" />
@@ -62,7 +64,6 @@
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
     <PackageReference Include="System.Xml.XPath.XDocument" Version="$(SystemXmlXPathXDocumentVersion)" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp" />

--- a/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
@@ -100,10 +100,13 @@ namespace Microsoft.CodeAnalysis
                     {
                         var key = propMatches[0].Groups[1].Value;
                         var value = propMatches[0].Groups[2].Value;
-                        Debug.Assert(!string.IsNullOrEmpty(key));
 
-                        key = CaseInsensitiveComparison.ToLower(key.Trim());
-                        value = CaseInsensitiveComparison.ToLower(value?.Trim());
+                        Debug.Assert(!string.IsNullOrEmpty(key));
+                        Debug.Assert(key == key.Trim());
+                        Debug.Assert(value == value?.Trim());
+
+                        key = CaseInsensitiveComparison.ToLower(key);
+                        value = CaseInsensitiveComparison.ToLower(value);
 
                         activeSectionProperties[key] = value ?? "";
                         continue;

--- a/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Represents a single EditorConfig file, see http://editorconfig.org for details about the format.
+    /// </summary>
+    internal class EditorConfig
+    {
+        // Matches EditorConfig section header such as "[*.{js,py}]", see http://editorconfig.org for details
+        private static Regex _sectionMatcher = new Regex(@"^\s*\[(([^#;]|\\#|\\;)+)\]\s*([#;].*)?$", RegexOptions.Compiled);
+        // Matches EditorConfig property such as "indent_style = space", see http://editorconfig.org for details
+        private static Regex _propertyMatcher = new Regex(@"^\s*([\w\.\-_]+)\s*[=:]\s*(.*?)\s*([#;].*)?$", RegexOptions.Compiled);
+
+        public Section GlobalSection = new Section(string.Empty);
+
+        public string Directory { get; private set; }
+
+        public IList<Section> NamedSections = new List<Section>();
+
+        private EditorConfig()
+        {
+        }
+
+        /// <summary>
+        /// Gets whether this editorconfig is a the topmost editorconfig.
+        /// </summary>
+        public bool IsRoot
+        {
+            get
+            {
+                return this.GlobalSection.Properties.ContainsKey("root") && this.GlobalSection.Properties["root"] == "true";
+            }
+        }
+
+        public static EditorConfig Parse(string text, string editorConfigParentDirectory)
+        {
+            var editorConfig = new EditorConfig();
+            editorConfig.Directory = editorConfigParentDirectory;
+            var activeSection = editorConfig.GlobalSection;
+            using(var reader = new StringReader(text))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    if (IsComment(line))
+                    {
+                        continue;
+                    }
+
+                    var sectionMatches = _sectionMatcher.Matches(line);
+                    if (sectionMatches.Count > 0 && sectionMatches[0].Groups.Count > 0)
+                    {
+                        var sectionName = sectionMatches[0].Groups[1].Value;
+                        if (!string.IsNullOrEmpty(sectionName))
+                        {
+                            activeSection = new Section(sectionName);
+                            editorConfig.NamedSections.Add(activeSection);
+                        }
+                        continue;
+                    }
+
+                    var propMatches = _propertyMatcher.Matches(line);
+                    if (propMatches.Count > 0 && propMatches[0].Groups.Count > 1)
+                    {
+                        var key = propMatches[0].Groups[1].Value;
+                        var value = propMatches[0].Groups[2].Value;
+                        if (!string.IsNullOrEmpty(key))
+                        {
+                            activeSection.Properties[key.Trim()] = value?.Trim();
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            return editorConfig;
+        }
+
+        private static bool IsComment(string line)
+        {
+            for (int i = 0; i < line.Length; i++)
+            {
+                char c = line[i];
+                if (!Char.IsWhiteSpace(c))
+                {
+                    return c == '#' || c == ';';
+                }
+            }
+
+            return false;
+        }
+
+        internal class Section
+        {
+            public Section(string name)
+            {
+                this.Name = name;
+                // N.B. The editorconfig documentation is quite loose on property interpretation.
+                // Specifically, it says:
+                //      Currently all properties and values are case-insensitive.
+                //      They are lowercased when parsed.
+                // This is not a mandate for case-insensitive parsing, but a strong suggestion.
+                // As for *which* case-insensitive comparison, we use CaseInsensitiveComparison.Comparer,
+                // which is the recommended Unicode comparison for case-insensitive identifiers. The
+                // implementation performs the equivalent of a lower-case comparsion. The
+                // editorconfig file is defined as using a UTF-8 encoding, making Unicode comparison
+                // relevant.
+                this.Properties = new Dictionary<string, string>(CaseInsensitiveComparison.Comparer);
+            }
+
+            public string Name { get; }
+
+            public IDictionary<string, string> Properties { get; }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
@@ -20,9 +20,6 @@ namespace Microsoft.CodeAnalysis
         // Matches EditorConfig property such as "indent_style = space", see http://editorconfig.org for details
         private static readonly Regex s_propertyMatcher = new Regex(@"^\s*([\w\.\-_]+)\s*[=:]\s*(.*?)\s*([#;].*)?$", RegexOptions.Compiled);
 
-        private static ImmutableHashSet<string> s_lazyReservedKeys;
-        private static ImmutableHashSet<string> s_lazyReservedValues;
-
         /// <summary>
         /// A set of keys that are reserved for special interpretation for the editorconfig specification.
         /// All values corresponding to reserved keys in a (key,value) property pair are always lowercased
@@ -33,52 +30,24 @@ namespace Microsoft.CodeAnalysis
         /// at 2018-04-21 19:37:05Z. New keys may be added to this list in newer versions, but old ones will
         /// not be removed.
         /// </remarks>
-        public static ImmutableHashSet<string> ReservedKeys
-        {
-            get
-            {
-                if (s_lazyReservedKeys == null)
-                {
-                    var reservedKeys = new[] { 
-                        "root",
-                        "indent_style",
-                        "indent_size",
-                        "tab_width",
-                        "end_of_line",
-                        "charset",
-                        "trim_trailing_whitespace",
-                        "insert_final_newline",
-                    };
-                    Interlocked.CompareExchange(
-                        ref s_lazyReservedKeys,
-                        ImmutableHashSet.CreateRange(CaseInsensitiveComparison.Comparer, reservedKeys),
-                        null);
-                }
-
-                return  s_lazyReservedKeys;
-            }
-        }
+        public static ImmutableHashSet<string> ReservedKeys { get; }
+            = ImmutableHashSet.CreateRange(CaseInsensitiveComparison.Comparer, new[] {
+                "root",
+                "indent_style",
+                "indent_size",
+                "tab_width",
+                "end_of_line",
+                "charset",
+                "trim_trailing_whitespace",
+                "insert_final_newline",
+            });
 
         /// <summary>
         /// A set of values that are reserved for special use for the editorconfig specification
         /// and will always be lower-cased by the parser.
         /// </summary>
-        public static ImmutableHashSet<string> ReservedValues
-        {
-            get
-            {
-                if (s_lazyReservedValues == null)
-                {
-                    var reservedValues = new[] { "unset" };
-                    Interlocked.CompareExchange(
-                        ref s_lazyReservedValues,
-                        ImmutableHashSet.CreateRange(CaseInsensitiveComparison.Comparer, reservedValues),
-                        null);
-                }
-
-                return  s_lazyReservedValues;
-            }
-        }
+        public static ImmutableHashSet<string> ReservedValues { get; }
+            = ImmutableHashSet.CreateRange(CaseInsensitiveComparison.Comparer, new[] { "unset" });
 
         public Section GlobalSection { get; }
 
@@ -215,8 +184,8 @@ namespace Microsoft.CodeAnalysis
         {
             public Section(string name, ImmutableDictionary<string, string> properties)
             {
-                this.Name = name;
-                this.Properties = properties;
+                Name = name;
+                Properties = properties;
             }
 
             /// <summary>
@@ -227,8 +196,8 @@ namespace Microsoft.CodeAnalysis
             /// <summary>
             /// Keys and values for this section. All keys are lower-cased according to the
             /// EditorConfig specification and keys are compared case-insensitively. Values are
-            /// lower-cased if the value appears in <see href="EditorConfig.ReservedValues" />
-            /// or if the corresponding key is in <see href="EditorConfig.ReservedKeys" />. Otherwise,
+            /// lower-cased if the value appears in <see cref="EditorConfig.ReservedValues" />
+            /// or if the corresponding key is in <see cref="EditorConfig.ReservedKeys" />. Otherwise,
             /// the values are the literal values present in the source.
             /// </summary>
             public ImmutableDictionary<string, string> Properties { get; }

--- a/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
@@ -69,7 +69,8 @@ namespace Microsoft.CodeAnalysis
             => GlobalSection.Properties.TryGetValue("root", out string val) && val == "true";
 
         /// <summary>
-        /// Parses an editor config file text located within the given parent directory.
+        /// Parses an editor config file text located within the given parent directory. No parsing
+        /// errors are reported. If any line contains a parse error, it is dropped.
         /// </summary>
         public static EditorConfig Parse(string text, string parentDirectory)
         {

--- a/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
@@ -140,6 +140,10 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
+        /// <summary>
+        /// Represents a named section of the editorconfig file, which consists of a name followed by a set
+        /// of key-value pairs.
+        /// </summary>
         internal sealed class Section
         {
             public Section(string name, ImmutableDictionary<string, string> properties)
@@ -148,8 +152,15 @@ namespace Microsoft.CodeAnalysis
                 this.Properties = properties;
             }
 
+            /// <summary>
+            /// The name as present directly in the section specification of the editorconfig file.
+            /// </summary>
             public string Name { get; }
 
+            /// <summary>
+            /// Keys and values for this section. All keys and values are lower-cased according to the
+            /// EditorConfig specification and keys are compared case-insensitively.
+            /// </summary>
             public ImmutableDictionary<string, string> Properties { get; }
         }
     }


### PR DESCRIPTION
This is the same parser used by Visual Studio for editorconfig with a
minor modification to use case-insensitive comparison for property keys.

Right now the parser is unused, but unit tests have been added in preparation for later use.