### PR TITLE
move back to debug assert.

### DIFF
--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -132,21 +132,17 @@ namespace Microsoft.CodeAnalysis.Remote
 
 #if DEBUG
             private readonly string _creationCallStack;
-#endif
+
             ~Connection()
             {
                 // this can happen if someone kills OOP. 
                 // when that happen, we don't want to crash VS, so this is debug only check
                 if (!Environment.HasShutdownStarted)
                 {
-#if DEBUG
-                    Contract.Fail($"Should have been disposed!\r\n {_creationCallStack}");
-#else
-                    Contract.Fail($"Should have been disposed!");
-#endif
+                    Contract.Requires(false, $"Should have been disposed!\r\n {_creationCallStack}");
                 }
             }
-
+#endif
         }
     }
 }


### PR DESCRIPTION
realized why this was debug assert. if user kills OOP explicitly, connection can disconnect without us explicitly disposing it. especially for connection that kept alive (KeepAliveConnection). that is why this was debug assert.

moving back to debug assert.

this is following PR of https://github.com/dotnet/roslyn/pull/26178
