### PR TITLE
Defer loading of SQLite binaries until they will be used

### DIFF
--- a/src/VisualStudio/CSharp/Test/PersistentStorage/SQLitePersistentStorageTests.cs
+++ b/src/VisualStudio/CSharp/Test/PersistentStorage/SQLitePersistentStorageTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.SolutionSize;
 using Microsoft.CodeAnalysis.SQLite;
@@ -17,11 +15,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
     /// </remarks>
     public class SQLitePersistentStorageTests : AbstractPersistentStorageTests
     {
-        static SQLitePersistentStorageTests()
-        {
-            Assert.True(SQLitePersistentStorageService.TryInitializeLibraries());
-        }
-
         internal override IPersistentStorageService GetStorageService(IPersistentStorageLocationService locationService, ISolutionSizeTracker solutionSizeTracker, IPersistentStorageFaultInjector faultInjector)
             => new SQLitePersistentStorageService(_persistentEnabledOptionService, locationService, solutionSizeTracker, faultInjector);
 

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorageService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.SQLite
         [DllImport("kernel32.dll")]
         private static extern IntPtr LoadLibrary(string dllToLoad);
 
-        internal static bool TryInitializeLibraries() => s_initialized.Value;
+        private static bool TryInitializeLibraries() => s_initialized.Value;
 
         private static readonly Lazy<bool> s_initialized = new Lazy<bool>(() => TryInitializeLibrariesLazy());
 
@@ -88,6 +88,13 @@ namespace Microsoft.CodeAnalysis.SQLite
         protected override bool TryOpenDatabase(
             Solution solution, string workingFolderPath, string databaseFilePath, out IPersistentStorage storage)
         {
+            if (!TryInitializeLibraries())
+            {
+                // SQLite is not supported on the current platform
+                storage = null;
+                return false;
+            }
+
             // try to get db ownership lock. if someone else already has the lock. it will throw
             var dbOwnershipLock = TryGetDatabaseOwnership(databaseFilePath);
             if (dbOwnershipLock == null)

--- a/src/Workspaces/Core/Desktop/Workspace/Storage/PersistenceStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Storage/PersistenceStorageServiceFactory.cs
@@ -28,13 +28,7 @@ namespace Microsoft.CodeAnalysis.Storage
             switch (database)
             {
                 case StorageDatabase.SQLite:
-                    if (!SQLitePersistentStorageService.TryInitializeLibraries())
-                    {
-                        break;
-                    }
-
                     var locationService = workspaceServices.GetService<IPersistentStorageLocationService>();
-
                     if (locationService != null)
                     {
                         return new SQLitePersistentStorageService(optionService, locationService, _solutionSizeTracker);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/594591

### Customer scenario

When opening a small solution, SQLite assemblies are loaded by Visual Studio even though they are not used. In aggregate, assembly loads like this cause delays for users trying to simply open their solution for editing.¹

¹ We don't have evidence of the assemblies here being a direct problem, but this is a general explanation for why we look for the total number of assembly loads as part of the product performance regression test suite.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/594591

### Workarounds, if any

None needed (no functional/behavioral change).

### Risk

Low. The initialization code is the same as before and only runs once, but is relocated to follow some fast-path checks for small solutions.

### Performance impact

Improves performance when opening solutions that do not exceed the solution size threshold for persisting data.

### Is this a regression from a previous update?

Yes. Introduced by #25590.

### Root cause analysis

Caught by RPS.

### How was the bug found?

RPS.

### Test documentation updated?

N/A