### PR TITLE
Now that we have only one kind of switch statement, rename bound nodes to recognize that fact.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2725,8 +2725,8 @@ moreArguments:
 //                case BoundKind.BreakStatement:
 //                case BoundKind.LocalFunctionStatement:
 //                case BoundKind.ContinueStatement:
-//                case BoundKind.PatternSwitchStatement:
-//                case BoundKind.PatternSwitchSection:
+//                case BoundKind.SwitchStatement:
+//                case BoundKind.SwitchSection:
 //                case BoundKind.PatternSwitchLabel:
 //                case BoundKind.IfStatement:
 //                case BoundKind.DoStatement:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -471,7 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // SPEC:    If the goto case statement is not enclosed by a switch statement, a compile-time error occurs.
                     // SPEC:    If the goto default statement is not enclosed by a switch statement, a compile-time error occurs.
 
-                    PatternSwitchBinder binder = GetSwitchBinder(this);
+                    SwitchBinder binder = GetSwitchBinder(this);
                     if (binder == null)
                     {
                         Error(diagnostics, ErrorCode.ERR_InvalidGotoCase, node);
@@ -2415,13 +2415,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundContinueStatement(node, target);
         }
 
-        private static PatternSwitchBinder GetSwitchBinder(Binder binder)
+        private static SwitchBinder GetSwitchBinder(Binder binder)
         {
-            PatternSwitchBinder switchBinder = binder as PatternSwitchBinder;
+            SwitchBinder switchBinder = binder as SwitchBinder;
             while (binder != null && switchBinder == null)
             {
                 binder = binder.Next;
-                switchBinder = binder as PatternSwitchBinder;
+                switchBinder = binder as SwitchBinder;
             }
             return switchBinder;
         }

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// <see cref="BoundDecisionDagNode"/> for each of them, containing
     /// the state transitions (including the test to perform at each node and the successor nodes) but
     /// not the state descriptions. A <see cref="BoundDecisionDag"/> containing this
-    /// set of nodes becomes part of the bound nodes (e.g. in <see cref="BoundPatternSwitchStatement"/> and
+    /// set of nodes becomes part of the bound nodes (e.g. in <see cref="BoundSwitchStatement"/> and
     /// <see cref="BoundSwitchExpression"/>) and is used for semantic analysis and lowering.
     /// </para>
     /// </summary>
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             CSharpCompilation compilation,
             SyntaxNode syntax,
             BoundExpression switchGoverningExpression,
-            ImmutableArray<BoundPatternSwitchSection> switchSections,
+            ImmutableArray<BoundSwitchSection> switchSections,
             LabelSymbol defaultLabel,
             DiagnosticBag diagnostics)
         {
@@ -128,12 +128,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundDecisionDag CreateDecisionDagForSwitchStatement(
             SyntaxNode syntax,
             BoundExpression switchGoverningExpression,
-            ImmutableArray<BoundPatternSwitchSection> switchSections)
+            ImmutableArray<BoundSwitchSection> switchSections)
         {
             var rootIdentifier = new BoundDagTemp(switchGoverningExpression.Syntax, switchGoverningExpression.Type, source: null, index: 0);
             int i = 0;
             var builder = ArrayBuilder<RemainingTestsForCase>.GetInstance(switchSections.Length);
-            foreach (BoundPatternSwitchSection section in switchSections)
+            foreach (BoundSwitchSection section in switchSections)
             {
                 foreach (BoundPatternSwitchLabel label in section.SwitchLabels)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -519,7 +519,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AddToMap(node.Expression, _enclosing);
             Visit(node.Expression, _enclosing);
 
-            var switchBinder = PatternSwitchBinder.Create(_enclosing, node);
+            var switchBinder = SwitchBinder.Create(_enclosing, node);
             AddToMap(node, switchBinder);
 
             foreach (SwitchSectionSyntax section in node.Sections)

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -13,7 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal partial class PatternSwitchBinder : LocalScopeBinder
+    internal partial class SwitchBinder : LocalScopeBinder
     {
         protected readonly SwitchStatementSyntax SwitchSyntax;
 
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression _switchGoverningExpression;
         private DiagnosticBag _switchGoverningDiagnostics;
 
-        private PatternSwitchBinder(Binder next, SwitchStatementSyntax switchSyntax)
+        private SwitchBinder(Binder next, SwitchStatementSyntax switchSyntax)
             : base(next)
         {
             SwitchSyntax = switchSyntax;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -304,10 +304,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            public override BoundNode VisitPatternSwitchStatement(BoundPatternSwitchStatement node)
+            public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
             {
                 AddAll(node.InnerLocals);
-                base.VisitPatternSwitchStatement(node);
+                base.VisitSwitchStatement(node);
                 RemoveAll(node.InnerLocals);
                 return null;
             }
@@ -320,10 +320,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            public override BoundNode VisitPatternSwitchSection(BoundPatternSwitchSection node)
+            public override BoundNode VisitSwitchSection(BoundSwitchSection node)
             {
                 AddAll(node.Locals);
-                base.VisitPatternSwitchSection(node);
+                base.VisitSwitchSection(node);
                 RemoveAll(node.Locals);
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -779,13 +779,13 @@
     <Field Name="Label" Type="GeneratedLabelSymbol" />
   </Node>
 
-  <Node Name="BoundPatternSwitchStatement" Base="BoundStatement">
+  <Node Name="BoundSwitchStatement" Base="BoundStatement">
     <Field Name="Expression" Type="BoundExpression"/>
 
     <!-- Locals declared immediately within the switch block. -->
     <Field Name="InnerLocals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
     <Field Name="InnerLocalFunctions" Type="ImmutableArray&lt;LocalFunctionSymbol&gt;"/>
-    <Field Name="SwitchSections" Type="ImmutableArray&lt;BoundPatternSwitchSection&gt;"/>
+    <Field Name="SwitchSections" Type="ImmutableArray&lt;BoundSwitchSection&gt;"/>
     <Field Name="DecisionDag" Type="BoundDecisionDag" Null="disallow" SkipInVisitor="true"/>
     <Field Name="DefaultLabel" Type="BoundPatternSwitchLabel" Null="allow"/>
     <Field Name="BreakLabel" Type="GeneratedLabelSymbol"/>
@@ -1178,7 +1178,7 @@
     <Field Name="Property" Type="PropertySymbol" Null="disallow"/>
   </Node>
 
-  <Node Name="BoundPatternSwitchSection" Base="BoundStatementList">
+  <Node Name="BoundSwitchSection" Base="BoundStatementList">
     <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
     <Field Name="SwitchLabels" Type="ImmutableArray&lt;BoundPatternSwitchLabel&gt;"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundStatementExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundStatementExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case BoundKind.LabelStatement:
                 case BoundKind.LabeledStatement:
-                case BoundKind.PatternSwitchSection:
+                case BoundKind.SwitchSection:
                     break;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(node.Kind);
@@ -38,8 +38,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(((BoundLabeledStatement)node).Label == label);
                     break;
 
-                case BoundKind.PatternSwitchSection:
-                    foreach (var boundPatternSwitchLabel in ((BoundPatternSwitchSection)node).SwitchLabels)
+                case BoundKind.SwitchSection:
+                    foreach (var boundPatternSwitchLabel in ((BoundSwitchSection)node).SwitchLabels)
                     {
                         if (boundPatternSwitchLabel.Label == label)
                         {

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -657,7 +657,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             CheckSyntaxNode(declarationSyntax);
 
             var binder = this.GetEnclosingBinder(GetAdjustedNodePosition(declarationSyntax));
-            while (binder != null && !(binder is PatternSwitchBinder))
+            while (binder != null && !(binder is SwitchBinder))
             {
                 binder = binder.Next;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitGotoStatement(node);
         }
 
-        protected override void VisitPatternSwitchSection(BoundPatternSwitchSection node, bool isLastSection)
+        protected override void VisitPatternSwitchSection(BoundSwitchSection node, bool isLastSection)
         {
             base.VisitPatternSwitchSection(node, isLastSection);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1614,16 +1614,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public override BoundNode VisitPatternSwitchStatement(BoundPatternSwitchStatement node)
+        public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
             DeclareVariables(node.InnerLocals);
-            var result = base.VisitPatternSwitchStatement(node);
+            var result = base.VisitSwitchStatement(node);
             ReportUnusedVariables(node.InnerLocals);
             ReportUnusedVariables(node.InnerLocalFunctions);
             return result;
         }
 
-        protected override void VisitPatternSwitchSection(BoundPatternSwitchSection node, bool isLastSection)
+        protected override void VisitPatternSwitchSection(BoundSwitchSection node, bool isLastSection)
         {
             DeclareVariables(node.Locals);
             base.VisitPatternSwitchSection(node, isLastSection);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -848,9 +848,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             stateChangedAfterUse |= ResolveBranches(label.Label, label);
                         }
                         break;
-                    case BoundKind.PatternSwitchSection:
+                    case BoundKind.SwitchSection:
                         {
-                            var sec = (BoundPatternSwitchSection)node;
+                            var sec = (BoundSwitchSection)node;
                             foreach (var label in sec.SwitchLabels)
                             {
                                 stateChangedAfterUse |= ResolveBranches(label.Label, sec);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass_Switch.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass_Switch.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal abstract partial class PreciseAbstractFlowPass<LocalState>
     {
-        public override BoundNode VisitPatternSwitchStatement(BoundPatternSwitchStatement node)
+        public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
             // visit switch header
             VisitRvalue(node.Expression);
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        private void VisitPatternSwitchBlock(BoundPatternSwitchStatement node)
+        private void VisitPatternSwitchBlock(BoundSwitchStatement node)
         {
             var initialState = State.Clone();
             HashSet<LabelSymbol> reachableLabels = node.DecisionDag.ReachableLabels;
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ResolveBreaks(afterSwitchState, node.BreakLabel);
         }
 
-        protected virtual void VisitPatternSwitchSection(BoundPatternSwitchSection node, bool isLastSection)
+        protected virtual void VisitPatternSwitchSection(BoundSwitchSection node, bool isLastSection)
         {
             SetState(UnreachableState());
             foreach (var label in node.SwitchLabels)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             NoteDeclaredPatternVariables(pattern);
         }
 
-        protected override void VisitPatternSwitchSection(BoundPatternSwitchSection node, bool isLastSection)
+        protected override void VisitPatternSwitchSection(BoundSwitchSection node, bool isLastSection)
         {
             foreach (var label in node.SwitchLabels)
             {

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ExpressionStatement,
         BreakStatement,
         ContinueStatement,
-        PatternSwitchStatement,
+        SwitchStatement,
         SwitchDispatch,
         IfStatement,
         DoStatement,
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         DagTypeEvaluation,
         DagFieldEvaluation,
         DagPropertyEvaluation,
-        PatternSwitchSection,
+        SwitchSection,
         PatternSwitchLabel,
         SequencePointExpression,
         Sequence,
@@ -2730,10 +2730,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundPatternSwitchStatement : BoundStatement
+    internal sealed partial class BoundSwitchStatement : BoundStatement
     {
-        public BoundPatternSwitchStatement(SyntaxNode syntax, BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundPatternSwitchSection> switchSections, BoundDecisionDag decisionDag, BoundPatternSwitchLabel defaultLabel, GeneratedLabelSymbol breakLabel, bool hasErrors = false)
-            : base(BoundKind.PatternSwitchStatement, syntax, hasErrors || expression.HasErrors() || switchSections.HasErrors() || decisionDag.HasErrors() || defaultLabel.HasErrors())
+        public BoundSwitchStatement(SyntaxNode syntax, BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag decisionDag, BoundPatternSwitchLabel defaultLabel, GeneratedLabelSymbol breakLabel, bool hasErrors = false)
+            : base(BoundKind.SwitchStatement, syntax, hasErrors || expression.HasErrors() || switchSections.HasErrors() || decisionDag.HasErrors() || defaultLabel.HasErrors())
         {
 
             Debug.Assert(expression != null, "Field 'expression' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
@@ -2759,7 +2759,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public ImmutableArray<LocalFunctionSymbol> InnerLocalFunctions { get; }
 
-        public ImmutableArray<BoundPatternSwitchSection> SwitchSections { get; }
+        public ImmutableArray<BoundSwitchSection> SwitchSections { get; }
 
         public BoundDecisionDag DecisionDag { get; }
 
@@ -2769,14 +2769,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
-            return visitor.VisitPatternSwitchStatement(this);
+            return visitor.VisitSwitchStatement(this);
         }
 
-        public BoundPatternSwitchStatement Update(BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundPatternSwitchSection> switchSections, BoundDecisionDag decisionDag, BoundPatternSwitchLabel defaultLabel, GeneratedLabelSymbol breakLabel)
+        public BoundSwitchStatement Update(BoundExpression expression, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundSwitchSection> switchSections, BoundDecisionDag decisionDag, BoundPatternSwitchLabel defaultLabel, GeneratedLabelSymbol breakLabel)
         {
             if (expression != this.Expression || innerLocals != this.InnerLocals || innerLocalFunctions != this.InnerLocalFunctions || switchSections != this.SwitchSections || decisionDag != this.DecisionDag || defaultLabel != this.DefaultLabel || breakLabel != this.BreakLabel)
             {
-                var result = new BoundPatternSwitchStatement(this.Syntax, expression, innerLocals, innerLocalFunctions, switchSections, decisionDag, defaultLabel, breakLabel, this.HasErrors);
+                var result = new BoundSwitchStatement(this.Syntax, expression, innerLocals, innerLocalFunctions, switchSections, decisionDag, defaultLabel, breakLabel, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -4514,10 +4514,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundPatternSwitchSection : BoundStatementList
+    internal sealed partial class BoundSwitchSection : BoundStatementList
     {
-        public BoundPatternSwitchSection(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundPatternSwitchLabel> switchLabels, ImmutableArray<BoundStatement> statements, bool hasErrors = false)
-            : base(BoundKind.PatternSwitchSection, syntax, statements, hasErrors || switchLabels.HasErrors() || statements.HasErrors())
+        public BoundSwitchSection(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundPatternSwitchLabel> switchLabels, ImmutableArray<BoundStatement> statements, bool hasErrors = false)
+            : base(BoundKind.SwitchSection, syntax, statements, hasErrors || switchLabels.HasErrors() || statements.HasErrors())
         {
 
             Debug.Assert(!locals.IsDefault, "Field 'locals' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
@@ -4535,14 +4535,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
-            return visitor.VisitPatternSwitchSection(this);
+            return visitor.VisitSwitchSection(this);
         }
 
-        public BoundPatternSwitchSection Update(ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundPatternSwitchLabel> switchLabels, ImmutableArray<BoundStatement> statements)
+        public BoundSwitchSection Update(ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundPatternSwitchLabel> switchLabels, ImmutableArray<BoundStatement> statements)
         {
             if (locals != this.Locals || switchLabels != this.SwitchLabels || statements != this.Statements)
             {
-                var result = new BoundPatternSwitchSection(this.Syntax, locals, switchLabels, statements, this.HasErrors);
+                var result = new BoundSwitchSection(this.Syntax, locals, switchLabels, statements, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -7130,8 +7130,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitBreakStatement(node as BoundBreakStatement, arg);
                 case BoundKind.ContinueStatement: 
                     return VisitContinueStatement(node as BoundContinueStatement, arg);
-                case BoundKind.PatternSwitchStatement: 
-                    return VisitPatternSwitchStatement(node as BoundPatternSwitchStatement, arg);
+                case BoundKind.SwitchStatement: 
+                    return VisitSwitchStatement(node as BoundSwitchStatement, arg);
                 case BoundKind.SwitchDispatch: 
                     return VisitSwitchDispatch(node as BoundSwitchDispatch, arg);
                 case BoundKind.IfStatement: 
@@ -7218,8 +7218,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitDagFieldEvaluation(node as BoundDagFieldEvaluation, arg);
                 case BoundKind.DagPropertyEvaluation: 
                     return VisitDagPropertyEvaluation(node as BoundDagPropertyEvaluation, arg);
-                case BoundKind.PatternSwitchSection: 
-                    return VisitPatternSwitchSection(node as BoundPatternSwitchSection, arg);
+                case BoundKind.SwitchSection: 
+                    return VisitSwitchSection(node as BoundSwitchSection, arg);
                 case BoundKind.PatternSwitchLabel: 
                     return VisitPatternSwitchLabel(node as BoundPatternSwitchLabel, arg);
                 case BoundKind.SequencePointExpression: 
@@ -7608,7 +7608,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return this.DefaultVisit(node, arg);
         }
-        public virtual R VisitPatternSwitchStatement(BoundPatternSwitchStatement node, A arg)
+        public virtual R VisitSwitchStatement(BoundSwitchStatement node, A arg)
         {
             return this.DefaultVisit(node, arg);
         }
@@ -7784,7 +7784,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return this.DefaultVisit(node, arg);
         }
-        public virtual R VisitPatternSwitchSection(BoundPatternSwitchSection node, A arg)
+        public virtual R VisitSwitchSection(BoundSwitchSection node, A arg)
         {
             return this.DefaultVisit(node, arg);
         }
@@ -8292,7 +8292,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return this.DefaultVisit(node);
         }
-        public virtual BoundNode VisitPatternSwitchStatement(BoundPatternSwitchStatement node)
+        public virtual BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
             return this.DefaultVisit(node);
         }
@@ -8468,7 +8468,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return this.DefaultVisit(node);
         }
-        public virtual BoundNode VisitPatternSwitchSection(BoundPatternSwitchSection node)
+        public virtual BoundNode VisitSwitchSection(BoundSwitchSection node)
         {
             return this.DefaultVisit(node);
         }
@@ -9038,7 +9038,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return null;
         }
-        public override BoundNode VisitPatternSwitchStatement(BoundPatternSwitchStatement node)
+        public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
             this.Visit(node.Expression);
             this.VisitList(node.SwitchSections);
@@ -9277,7 +9277,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Visit(node.Input);
             return null;
         }
-        public override BoundNode VisitPatternSwitchSection(BoundPatternSwitchSection node)
+        public override BoundNode VisitSwitchSection(BoundSwitchSection node)
         {
             this.VisitList(node.SwitchLabels);
             this.VisitList(node.Statements);
@@ -9975,10 +9975,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return node;
         }
-        public override BoundNode VisitPatternSwitchStatement(BoundPatternSwitchStatement node)
+        public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundPatternSwitchSection> switchSections = (ImmutableArray<BoundPatternSwitchSection>)this.VisitList(node.SwitchSections);
+            ImmutableArray<BoundSwitchSection> switchSections = (ImmutableArray<BoundSwitchSection>)this.VisitList(node.SwitchSections);
             BoundDecisionDag decisionDag = node.DecisionDag;
             BoundPatternSwitchLabel defaultLabel = (BoundPatternSwitchLabel)this.Visit(node.DefaultLabel);
             return node.Update(expression, node.InnerLocals, node.InnerLocalFunctions, switchSections, decisionDag, defaultLabel, node.BreakLabel);
@@ -10231,7 +10231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             return node.Update(node.Property, input);
         }
-        public override BoundNode VisitPatternSwitchSection(BoundPatternSwitchSection node)
+        public override BoundNode VisitSwitchSection(BoundSwitchSection node)
         {
             ImmutableArray<BoundPatternSwitchLabel> switchLabels = (ImmutableArray<BoundPatternSwitchLabel>)this.VisitList(node.SwitchLabels);
             ImmutableArray<BoundStatement> statements = (ImmutableArray<BoundStatement>)this.VisitList(node.Statements);
@@ -11271,9 +11271,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             );
         }
-        public override TreeDumperNode VisitPatternSwitchStatement(BoundPatternSwitchStatement node, object arg)
+        public override TreeDumperNode VisitSwitchStatement(BoundSwitchStatement node, object arg)
         {
-            return new TreeDumperNode("patternSwitchStatement", null, new TreeDumperNode[]
+            return new TreeDumperNode("switchStatement", null, new TreeDumperNode[]
             {
                 new TreeDumperNode("expression", null, new TreeDumperNode[] { Visit(node.Expression, null) }),
                 new TreeDumperNode("innerLocals", node.InnerLocals, null),
@@ -11712,9 +11712,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             );
         }
-        public override TreeDumperNode VisitPatternSwitchSection(BoundPatternSwitchSection node, object arg)
+        public override TreeDumperNode VisitSwitchSection(BoundSwitchSection node, object arg)
         {
-            return new TreeDumperNode("patternSwitchSection", null, new TreeDumperNode[]
+            return new TreeDumperNode("switchSection", null, new TreeDumperNode[]
             {
                 new TreeDumperNode("locals", node.Locals, null),
                 new TreeDumperNode("switchLabels", null, from x in node.SwitchLabels select Visit(x, null)),

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Previous.InstrumentReturnStatement(original, rewritten);
         }
 
-        public override BoundStatement InstrumentPatternSwitchStatement(BoundPatternSwitchStatement original, BoundStatement rewritten)
+        public override BoundStatement InstrumentPatternSwitchStatement(BoundSwitchStatement original, BoundStatement rewritten)
         {
             return Previous.InstrumentPatternSwitchStatement(original, rewritten);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundSequencePoint(original.Syntax, rewritten);
         }
 
-        public override BoundStatement InstrumentPatternSwitchStatement(BoundPatternSwitchStatement original, BoundStatement rewritten)
+        public override BoundStatement InstrumentPatternSwitchStatement(BoundSwitchStatement original, BoundStatement rewritten)
         {
             SwitchStatementSyntax switchSyntax = (SwitchStatementSyntax)original.Syntax;
             TextSpan switchSequencePointSpan = TextSpan.FromBounds(

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -433,7 +433,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        public override BoundStatement InstrumentPatternSwitchStatement(BoundPatternSwitchStatement original, BoundStatement rewritten)
+        public override BoundStatement InstrumentPatternSwitchStatement(BoundSwitchStatement original, BoundStatement rewritten)
         {
             return AddDynamicAnalysis(original, base.InstrumentPatternSwitchStatement(original, rewritten));
         }
@@ -554,8 +554,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.LockStatement:
                     syntaxForSpan = ((BoundLockStatement)statement).Argument.Syntax;
                     break;
-                case BoundKind.PatternSwitchStatement:
-                    syntaxForSpan = ((BoundPatternSwitchStatement)statement).Expression.Syntax;
+                case BoundKind.SwitchStatement:
+                    syntaxForSpan = ((BoundSwitchStatement)statement).Expression.Syntax;
                     break;
                 default:
                     syntaxForSpan = statement.Syntax;

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return rewritten;
         }
 
-        public virtual BoundStatement InstrumentPatternSwitchStatement(BoundPatternSwitchStatement original, BoundStatement rewritten)
+        public virtual BoundStatement InstrumentPatternSwitchStatement(BoundSwitchStatement original, BoundStatement rewritten)
         {
             Debug.Assert(original.Syntax.Kind() == SyntaxKind.SwitchStatement);
             return InstrumentStatement(original, rewritten);
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public virtual BoundExpression InstrumentSwitchStatementExpression(BoundStatement original, BoundExpression rewrittenExpression, SyntheticBoundNodeFactory factory)
         {
-            Debug.Assert(original.Kind == BoundKind.PatternSwitchStatement);
+            Debug.Assert(original.Kind == BoundKind.SwitchStatement);
             Debug.Assert(!original.WasCompilerGenerated);
             Debug.Assert(original.Syntax.Kind() == SyntaxKind.SwitchStatement);
             Debug.Assert(factory != null);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
@@ -14,14 +14,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class LocalRewriter
     {
-        public override BoundNode VisitPatternSwitchStatement(BoundPatternSwitchStatement node)
+        public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
             return PatternSwitchLocalRewriter.Rewrite(this, node);
         }
 
         private class PatternSwitchLocalRewriter : BasePatternSwitchLocalRewriter
         {
-            public static BoundStatement Rewrite(LocalRewriter localRewriter, BoundPatternSwitchStatement node)
+            public static BoundStatement Rewrite(LocalRewriter localRewriter, BoundSwitchStatement node)
             {
                 var rewriter = new PatternSwitchLocalRewriter(node, localRewriter);
                 BoundStatement result = rewriter.LowerPatternSwitchStatement(node);
@@ -62,12 +62,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return result;
             }
 
-            private PatternSwitchLocalRewriter(BoundPatternSwitchStatement node, LocalRewriter localRewriter)
+            private PatternSwitchLocalRewriter(BoundSwitchStatement node, LocalRewriter localRewriter)
                 : base(node.Syntax, localRewriter, node.SwitchSections.SelectAsArray(section => section.Syntax), isSwitchStatement: true)
             {
             }
 
-            private BoundStatement LowerPatternSwitchStatement(BoundPatternSwitchStatement node)
+            private BoundStatement LowerPatternSwitchStatement(BoundSwitchStatement node)
             {
                 _factory.Syntax = node.Syntax;
                 var result = ArrayBuilder<BoundStatement>.GetInstance();
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // decision dag, so the code in `result` is unreachable at this point.
 
                 // Lower each switch section.
-                foreach (BoundPatternSwitchSection section in node.SwitchSections)
+                foreach (BoundSwitchSection section in node.SwitchSections)
                 {
                     _factory.Syntax = section.Syntax;
                     var sectionBuilder = ArrayBuilder<BoundStatement>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -227,8 +227,8 @@ namespace Microsoft.CodeAnalysis.Operations
                     return CreateBoundRecursivePatternOperation((BoundRecursivePattern)boundNode);
                 case BoundKind.DiscardPattern:
                     return CreateBoundDiscardPatternOperation((BoundDiscardPattern)boundNode);
-                case BoundKind.PatternSwitchStatement:
-                    return CreateBoundPatternSwitchStatementOperation((BoundPatternSwitchStatement)boundNode);
+                case BoundKind.SwitchStatement:
+                    return CreateBoundPatternSwitchStatementOperation((BoundSwitchStatement)boundNode);
                 case BoundKind.PatternSwitchLabel:
                     return CreateBoundPatternSwitchLabelOperation((BoundPatternSwitchLabel)boundNode);
                 case BoundKind.IsPatternExpression:
@@ -1801,7 +1801,7 @@ namespace Microsoft.CodeAnalysis.Operations
             return new RecursivePattern(variable, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
-        private ISwitchOperation CreateBoundPatternSwitchStatementOperation(BoundPatternSwitchStatement boundPatternSwitchStatement)
+        private ISwitchOperation CreateBoundPatternSwitchStatementOperation(BoundSwitchStatement boundPatternSwitchStatement)
         {
             Lazy<IOperation> value = new Lazy<IOperation>(() => Create(boundPatternSwitchStatement.Expression));
             Lazy<ImmutableArray<ISwitchCaseOperation>> cases = new Lazy<ImmutableArray<ISwitchCaseOperation>>(() => GetPatternSwitchStatementCases(boundPatternSwitchStatement));

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Operations
             return builder.ToImmutableAndFree();
         }
 
-        private ImmutableArray<ISwitchCaseOperation> GetPatternSwitchStatementCases(BoundPatternSwitchStatement statement)
+        private ImmutableArray<ISwitchCaseOperation> GetPatternSwitchStatementCases(BoundSwitchStatement statement)
         {
             return statement.SwitchSections.SelectAsArray(switchSection =>
             {


### PR DESCRIPTION
@cston @agocke @dotnet/roslyn-compiler Please review.

This is JUST a rename. No semantic changes.
