### PR TITLE
EE doesn't recognize property in generic if declaration is an interface

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override ImmutableArray<NamedTypeSymbol> GetInterfaces(ConsList<TypeParameterSymbol> inProgress)
         {
             var interfaces = _sourceTypeParameter.GetInterfaces(inProgress);
-            return this.TypeMap.SubstituteNamedTypes(InterfacesNoUseSiteDiagnostics()); // It looks like there is a bug on this line https://github.com/dotnet/roslyn/issues/23886
+            return this.TypeMap.SubstituteNamedTypes(interfaces);
         }
 
         private TypeMap TypeMap

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -2108,6 +2108,56 @@ class C<T>
         }
 
         [Fact]
+        public void GenericWithInterfaceConstraint()
+        {
+            var source =
+@"public interface IFoo
+{
+    string Key { get; set; }
+}
+
+public class Foo : IFoo
+{
+    public string Key { get; set; }
+}
+
+class C
+{
+    public static void M<T>(T foo) where T : IFoo
+    {
+    }
+}";
+            var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression(
+                    expr: "foo.Key",
+                    error: out error,
+                    testData: testData);
+
+                var methodData = testData.GetMethodData("<>x.<>m0<T>(T)");
+                var method = methodData.Method;
+                Assert.Equal(1, method.Parameters.Length);
+                var eeTypeParameterSymbol = (EETypeParameterSymbol)method.Parameters[0].Type;
+                Assert.Equal(1, eeTypeParameterSymbol.AllEffectiveInterfacesNoUseSiteDiagnostics.Length);
+                Assert.Equal("IFoo", eeTypeParameterSymbol.AllEffectiveInterfacesNoUseSiteDiagnostics[0].Name);
+
+                methodData.VerifyIL(
+@"{
+  // Code size       14 (0xe)
+  .maxstack  1
+  IL_0000:  ldarga.s   V_0
+  IL_0002:  constrained. ""T""
+  IL_0008:  callvirt   ""string IFoo.Key.get""
+  IL_000d:  ret
+}");
+            });
+        }
+
+        [Fact]
         public void AssignEmitError()
         {
             var longName = new string('P', 1100);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -2111,19 +2111,14 @@ class C<T>
         public void GenericWithInterfaceConstraint()
         {
             var source =
-@"public interface IFoo
+@"public interface I
 {
     string Key { get; set; }
 }
 
-public class Foo : IFoo
-{
-    public string Key { get; set; }
-}
-
 class C
 {
-    public static void M<T>(T foo) where T : IFoo
+    public static void M<T>(T t) where T : I
     {
     }
 }";
@@ -2134,7 +2129,7 @@ class C
                 string error;
                 var testData = new CompilationTestData();
                 context.CompileExpression(
-                    expr: "foo.Key",
+                    expr: "t.Key",
                     error: out error,
                     testData: testData);
 
@@ -2143,7 +2138,7 @@ class C
                 Assert.Equal(1, method.Parameters.Length);
                 var eeTypeParameterSymbol = (EETypeParameterSymbol)method.Parameters[0].Type;
                 Assert.Equal(1, eeTypeParameterSymbol.AllEffectiveInterfacesNoUseSiteDiagnostics.Length);
-                Assert.Equal("IFoo", eeTypeParameterSymbol.AllEffectiveInterfacesNoUseSiteDiagnostics[0].Name);
+                Assert.Equal("I", eeTypeParameterSymbol.AllEffectiveInterfacesNoUseSiteDiagnostics[0].Name);
 
                 methodData.VerifyIL(
 @"{
@@ -2151,7 +2146,7 @@ class C
   .maxstack  1
   IL_0000:  ldarga.s   V_0
   IL_0002:  constrained. ""T""
-  IL_0008:  callvirt   ""string IFoo.Key.get""
+  IL_0008:  callvirt   ""string I.Key.get""
   IL_000d:  ret
 }");
             });

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -170,6 +170,45 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub GenericWithInterfaceConstraint()
+            Const source = "
+Public Interface I
+    Property Key As String
+End Interface
+
+Class C
+    Public Shared Sub M(Of T As I)(tt As T)
+    End Sub
+End Class
+"
+            Dim compilation0 = CreateCompilationWithMscorlib40(source, options:=TestOptions.DebugDll)
+            WithRuntimeInstance(
+                compilation0,
+                Sub(runtime)
+                    Dim context = CreateMethodContext(runtime, "C.M")
+                    Dim errorMessage As String = Nothing
+                    Dim testData = New CompilationTestData()
+                    Dim result = context.CompileExpression(expr:="tt.Key", error:=errorMessage, testData:=testData)
+                    Dim methodData = testData.GetMethodData("<>x.<>m0(Of T)(T)")
+                    Dim method = methodData.Method
+                    Assert.Equal(1, method.Parameters.Length)
+                    Dim eeTypeParameterSymbol = DirectCast(method.Parameters(0).Type, EETypeParameterSymbol)
+                    Assert.Equal(1, eeTypeParameterSymbol.ConstraintTypesNoUseSiteDiagnostics.Length)
+                    Assert.Equal("I", eeTypeParameterSymbol.ConstraintTypesNoUseSiteDiagnostics(0).Name)
+
+                    methodData.VerifyIL(
+"{
+  // Code size       14 (0xe)
+  .maxstack  1
+  IL_0000:  ldarga.s   V_0
+  IL_0002:  constrained. ""T""
+  IL_0008:  callvirt   ""Function I.get_Key() As String""
+  IL_000d:  ret
+}")
+                End Sub)
+        End Sub
+
+        <Fact>
         Public Sub EmitError()
             Const source = "
 Class C


### PR DESCRIPTION
### Customer scenario
```
public interface I
{
    string Key { get; set; }
}

public class C: I
{
    public string Key { get; set; }
}

class Program
{
    static void Main(string[] args)
    {
        PrintC(new C() { Key = "Hello World" });
        Console.ReadLine();
    }

    private static void PrintC<T>(T t) where T : 
    {
        //set breakpoint here and try to look at t.Key
        Console.WriteLine(t.Key);
    }
}
```

set a breakpoint and try to evaluate `t.Key` in the watch window
**Expected**
`"Hello World"`
**Actual**
`error CS1061: 'T' does not contain a definition for 'Key' and no extension method 'Key' accepting a first argument of type 'T' could be found (are you missing a using directive or an assembly reference?)`

### Bugs this fixes

- https://github.com/dotnet/roslyn/issues/23886
- https://developercommunity.visualstudio.com/content/problem/216341/compiler-doesnt-recognise-property-in-generic-if-d.html

### Workarounds, if any
none

### Risk
very low

### Performance impact
none

### Is this a regression from a previous update?
no

### How was the bug found?
customer reported it