### PR TITLE
Fix path to Microsoft.Build.Tasks.CodeAnalysis.dll in Microsoft.Managed.Core.targets

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -4,7 +4,7 @@
   <!--
     Common targets for managed compilers.
   -->
-  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.MapSourceRoots" AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.MapSourceRoots" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll" />
 
   <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
           BeforeTargets="CoreCompile"


### PR DESCRIPTION
### Customer scenario

Use Microsoft.NetCore.Compilers package in a project that is built by a .NET CLI that has different version of the C# compiler than the one in the package.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/604343

### Workarounds, if any

None

### Risk

Low

### Performance impact

None

### Is this a regression from a previous update?

### Root cause analysis

Test was testing incorrect behavior.

### How was the bug found?

Dogfooding

### Test documentation updated?

