### PR TITLE
fix test hang.

### DIFF
--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -851,7 +851,8 @@ End Class";
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26244")]
+        [Fact]
+        [WorkItem(26244, "https://github.com/dotnet/roslyn/issues/26244")]
         public async Task FileFromSameProjectTogetherTest()
         {
             var projectId1 = ProjectId.CreateNewId();
@@ -900,6 +901,11 @@ End Class";
                 var globalOperation = workspace.Services.GetService<IGlobalOperationNotificationService>();
                 using (var operation = globalOperation.Start("Block SolutionCrawler"))
                 {
+                    // make sure global operaiton is actually started
+                    // otherwise, solution crawler might processed event we are later waiting for
+                    var operationWaiter = GetListenerProvider(workspace.ExportProvider).GetWaiter(FeatureAttribute.GlobalOperation);
+                    await operationWaiter.CreateWaitTask();
+
                     // mutate solution
                     workspace.OnSolutionAdded(solution);
 

--- a/src/Workspaces/Core/Portable/Notification/GlobalOperationNotificationService.cs
+++ b/src/Workspaces/Core/Portable/Notification/GlobalOperationNotificationService.cs
@@ -52,38 +52,34 @@ namespace Microsoft.CodeAnalysis.Notification
 
         protected virtual Task RaiseGlobalOperationStarted()
         {
-            using (_listener.BeginAsyncOperation("GlobalOperationStarted"))
+            var ev = _eventMap.GetEventHandlers<EventHandler>(GlobalOperationStartedEventName);
+            if (ev.HasHandlers)
             {
-                var ev = _eventMap.GetEventHandlers<EventHandler>(GlobalOperationStartedEventName);
-                if (ev.HasHandlers)
+                var asyncToken = _listener.BeginAsyncOperation("GlobalOperationStarted");
+                return _eventQueue.ScheduleTask(() =>
                 {
-                    return _eventQueue.ScheduleTask(() =>
-                    {
-                        ev.RaiseEvent(handler => handler(this, EventArgs.Empty));
-                    });
-                }
-
-                return SpecializedTasks.EmptyTask;
+                    ev.RaiseEvent(handler => handler(this, EventArgs.Empty));
+                }).CompletesAsyncOperation(asyncToken);
             }
+
+            return SpecializedTasks.EmptyTask;
         }
 
         protected virtual Task RaiseGlobalOperationStopped(IReadOnlyList<string> operations, bool cancelled)
         {
-            using (_listener.BeginAsyncOperation("GlobalOperationStopped"))
+            var ev = _eventMap.GetEventHandlers<EventHandler<GlobalOperationEventArgs>>(GlobalOperationStoppedEventName);
+            if (ev.HasHandlers)
             {
-                var ev = _eventMap.GetEventHandlers<EventHandler<GlobalOperationEventArgs>>(GlobalOperationStoppedEventName);
-                if (ev.HasHandlers)
+                var asyncToken = _listener.BeginAsyncOperation("GlobalOperationStopped");
+                var args = new GlobalOperationEventArgs(operations, cancelled);
+
+                return _eventQueue.ScheduleTask(() =>
                 {
-                    var args = new GlobalOperationEventArgs(operations, cancelled);
-
-                    return _eventQueue.ScheduleTask(() =>
-                    {
-                        ev.RaiseEvent(handler => handler(this, args));
-                    });
-                }
-
-                return SpecializedTasks.EmptyTask;
+                    ev.RaiseEvent(handler => handler(this, args));
+                }).CompletesAsyncOperation(asyncToken);
             }
+
+            return SpecializedTasks.EmptyTask;
         }
 
         public override event EventHandler Started


### PR DESCRIPTION
if solution cralwer runs before global operation raised start event (which is async event), then we can get into state where events we are blocking for is already processed and we get into a hang.

..

this is test only fix.
