### PR TITLE
removed back pointer to document from DocumentSpecficiOptionSet

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProvider.DocumentOptions.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProvider.DocumentOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.Options
                 _errorLogger = errorLogger;
             }
 
-            public bool TryGetDocumentOption(Document document, OptionKey option, OptionSet underlyingOptions, out object value)
+            public bool TryGetDocumentOption(OptionKey option, OptionSet underlyingOptions, out object value)
             {
                 var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
                 if (editorConfigPersistence == null)

--- a/src/Workspaces/Core/Portable/Options/IDocumentOptions.cs
+++ b/src/Workspaces/Core/Portable/Options/IDocumentOptions.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.Options
     /// </summary>
     interface IDocumentOptions
     {
-        bool TryGetDocumentOption(Document document, OptionKey option, OptionSet underlyingOptions, out object value);
+        bool TryGetDocumentOption(OptionKey option, OptionSet underlyingOptions, out object value);
     }
 }

--- a/src/Workspaces/Core/Portable/Options/OptionServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionServiceFactory.cs
@@ -154,25 +154,23 @@ namespace Microsoft.CodeAnalysis.Options
                     }
                 }
 
-                return new DocumentSpecificOptionSet(document, realizedDocumentOptions, optionSet);
+                return new DocumentSpecificOptionSet(realizedDocumentOptions, optionSet);
             }
 
             private class DocumentSpecificOptionSet : OptionSet
             {
-                private readonly Document _document;
                 private readonly OptionSet _underlyingOptions;
                 private readonly List<IDocumentOptions> _documentOptions;
                 private readonly object _gate = new object();
                 private ImmutableDictionary<OptionKey, object> _values;
 
-                public DocumentSpecificOptionSet(Document document, List<IDocumentOptions> documentOptions, OptionSet underlyingOptions)
-                    : this(document, documentOptions, underlyingOptions, ImmutableDictionary<OptionKey, object>.Empty)
+                public DocumentSpecificOptionSet(List<IDocumentOptions> documentOptions, OptionSet underlyingOptions)
+                    : this(documentOptions, underlyingOptions, ImmutableDictionary<OptionKey, object>.Empty)
                 {
                 }
 
-                public DocumentSpecificOptionSet(Document document, List<IDocumentOptions> documentOptions, OptionSet underlyingOptions, ImmutableDictionary<OptionKey, object> values)
+                public DocumentSpecificOptionSet(List<IDocumentOptions> documentOptions, OptionSet underlyingOptions, ImmutableDictionary<OptionKey, object> values)
                 {
-                    _document = document;
                     _documentOptions = documentOptions;
                     _underlyingOptions = underlyingOptions;
                     _values = values;
@@ -188,7 +186,7 @@ namespace Microsoft.CodeAnalysis.Options
 
                     foreach (var documentOptionSource in _documentOptions)
                     {
-                        if (documentOptionSource.TryGetDocumentOption(_document, optionKey, _underlyingOptions, out value))
+                        if (documentOptionSource.TryGetDocumentOption(optionKey, _underlyingOptions, out value))
                         {
                             // Cache and return
                             lock (_gate)
@@ -206,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Options
 
                 public override OptionSet WithChangedOption(OptionKey optionAndLanguage, object value)
                 {
-                    return new DocumentSpecificOptionSet(_document, _documentOptions, _underlyingOptions, _values.Add(optionAndLanguage, value));
+                    return new DocumentSpecificOptionSet(_documentOptions, _underlyingOptions, _values.Add(optionAndLanguage, value));
                 }
 
                 internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)


### PR DESCRIPTION
OptionSet used to be small data users can hold onto without worrying about holding onto whole solution snapshot.

looking at other optionSet implementation (http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Options/OptionSet.cs,1f3f91e655cd75cf,references), it looks like only DocumentSpecificOptionSet does that. all others are just data.

and DocumentSpecificOptionSet also doesn't actually use document it is holding onto for anything.

now, this optionset will behave same as others. it will not pin roslyn solution snapshot while the optionset is held onto.
