### PR TITLE
MakeMethodAsync: don't rename entry point methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -47,7 +47,7 @@ class Program
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
         [WorkItem(26312, "https://github.com/dotnet/roslyn/issues/26312")]
-        public async Task AwaitInVoidMainMethodWithModifiers()
+        public async Task AwaitInTaskMainMethodWithModifiers()
         {
             var initial =
 @"using System;
@@ -67,13 +67,16 @@ using System.Threading.Tasks;
 
 class Program
 {
-    public static async void Main()
+    public static async Task Main()
     {
         await Task.Delay(1);
     }
 }";
-            await TestAsync(initial, expected, index: 1, parseOptions: CSharpParseOptions.Default,
+            await TestAsync(initial, expected, parseOptions: CSharpParseOptions.Default,
                 compilationOptions: new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+
+            // no option offered to keep void
+            await TestActionCountAsync(initial, count: 1, new TestParameters(compilationOptions: new CSharpCompilationOptions(OutputKind.ConsoleApplication)));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -22,9 +23,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.MakeMethodA
 @"using System;
 using System.Threading.Tasks;
 
-class Program 
+class Program
 {
-    public static void Test() 
+    public static void Test()
     {
         [|await Task.Delay(1);|]
     }
@@ -34,15 +35,77 @@ class Program
 @"using System;
 using System.Threading.Tasks;
 
-class Program 
+class Program
 {
-    public static async void TestAsync() 
+    public static async void TestAsync()
     {
         await Task.Delay(1);
     }
 }";
             await TestInRegularAndScriptAsync(initial, expected, index: 1);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        [WorkItem(26312, "https://github.com/dotnet/roslyn/issues/26312")]
+        public async Task AwaitInVoidMainMethodWithModifiers()
+        {
+            var initial =
+@"using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    public static void Main()
+    {
+        [|await Task.Delay(1);|]
+    }
+}";
+
+            var expected =
+@"using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    public static async void Main()
+    {
+        await Task.Delay(1);
+    }
+}";
+            await TestAsync(initial, expected, index: 1, parseOptions: CSharpParseOptions.Default,
+                compilationOptions: new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        [WorkItem(26312, "https://github.com/dotnet/roslyn/issues/26312")]
+        public async Task AwaitInVoidMainMethodWithModifiers_NotEntryPoint()
+        {
+            var initial =
+@"using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    public void Main()
+    {
+        [|await Task.Delay(1);|]
+    }
+}";
+
+            var expected =
+@"using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    public async void MainAsync()
+    {
+        await Task.Delay(1);
+    }
+}";
+            await TestInRegularAndScriptAsync(initial, expected, index: 1);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
         public async Task AwaitInVoidMethodWithModifiers2()
         {

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
@@ -59,6 +59,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private const string AliasAttributeName = "Alias";
         private const string ProjectNameAttribute = "Name";
         private const string CheckOverflowAttributeName = "CheckOverflow";
+        private const string OutputKindName = "OutputKind";
 
         /// <summary>
         /// Creates a single buffer in a workspace.

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -466,6 +466,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var strongNameProvider = default(StrongNameProvider);
             var delaySign = default(bool?);
             var checkOverflow = false;
+            var outputKind = OutputKind.DynamicallyLinkedLibrary;
 
             if (compilationOptionsElement != null)
             {
@@ -475,6 +476,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 if (rootNamespaceAttribute != null)
                 {
                     rootNamespace = rootNamespaceAttribute.Value;
+                }
+
+                var outputKindAttribute = compilationOptionsElement.Attribute(OutputKindName);
+                if (outputKindAttribute != null)
+                {
+                    outputKind = (OutputKind)Enum.Parse(typeof(OutputKind), (string)outputKindAttribute.Value);
                 }
 
                 var checkOverflowAttribute = compilationOptionsElement.Attribute(CheckOverflowAttributeName);
@@ -546,7 +553,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var languageServices = workspace.Services.GetLanguageServices(language);
             var metadataService = workspace.Services.GetService<IMetadataService>();
             var compilationOptions = languageServices.GetService<ICompilationFactoryService>().GetDefaultCompilationOptions();
-            compilationOptions = compilationOptions.WithOutputKind(OutputKind.DynamicallyLinkedLibrary)
+            compilationOptions = compilationOptions.WithOutputKind(outputKind)
                                                    .WithGeneralDiagnosticOption(reportDiagnostic)
                                                    .WithSourceReferenceResolver(SourceFileResolver.Default)
                                                    .WithXmlReferenceResolver(XmlFileResolver.Default)

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlCreation.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlCreation.cs
@@ -94,6 +94,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 element.SetAttributeValue(CheckOverflowAttributeName, true);
             }
 
+            if (options.OutputKind != OutputKind.DynamicallyLinkedLibrary)
+            {
+                element = element ?? new XElement(CompilationOptionsElementName);
+                element.SetAttributeValue(OutputKindName, options.OutputKind);
+            }
+
             return element;
         }
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.vb
@@ -389,6 +389,34 @@ End Module
             Await TestAsync(initial, expected)
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)>
+        <WorkItem(26312, "https://github.com/dotnet/roslyn/issues/26312")>
+        Public Async Function TestTaskPlacementOnEntryPoint_CaseInsensitive() As Task
+            Dim initial =
+<File>
+Imports System
+Imports System.Threading.Tasks
+
+Module Module1
+    Sub mAiN()
+        [|Await Task.Run(Sub() Console.WriteLine())|]
+    End Sub
+End Module
+</File>
+            Dim expected =
+<File>
+Imports System
+Imports System.Threading.Tasks
+
+Module Module1
+    Async Function mAiN() As Task
+        Await Task.Run(Sub() Console.WriteLine())
+    End Function
+End Module
+</File>
+            Await TestAsync(initial, expected)
+        End Function
+
         <WorkItem(17368, "https://github.com/dotnet/roslyn/issues/17368")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)>
         Public Async Function TestWithMissingParameterList() As Task

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.vb
@@ -362,8 +362,8 @@ End Module
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)>
-        <WorkItem(13356, "https://github.com/dotnet/roslyn/issues/13356")>
-        Public Async Function TestTaskPlacement() As Task
+        <WorkItem(26312, "https://github.com/dotnet/roslyn/issues/26312")>
+        Public Async Function TestTaskPlacementOnEntryPoint() As Task
             Dim initial =
 <File>
 Imports System
@@ -381,7 +381,7 @@ Imports System
 Imports System.Threading.Tasks
 
 Module Module1
-    Async Function MainAsync() As Task
+    Async Function Main() As Task
         Await Task.Run(Sub() Console.WriteLine())
     End Function
 End Module

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -37,9 +37,6 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
         protected override bool IsAsyncSupportingFunctionSyntax(SyntaxNode node)
             => node.IsAsyncSupportingFunctionSyntax();
 
-        protected override bool IsLikelyEntryPointName(string methodName)
-            => string.Equals(methodName, "Main", StringComparison.Ordinal);
-
         protected override SyntaxNode AddAsyncTokenAndFixReturnType(
             bool keepVoid, IMethodSymbol methodSymbolOpt, SyntaxNode node,
             INamedTypeSymbol taskType, INamedTypeSymbol taskOfTType, INamedTypeSymbol valueTaskOfTType)

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -35,6 +36,9 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
 
         protected override bool IsAsyncSupportingFunctionSyntax(SyntaxNode node)
             => node.IsAsyncSupportingFunctionSyntax();
+
+        protected override bool IsLikelyEntryPointName(string methodName)
+            => string.Equals(methodName, "Main", StringComparison.Ordinal);
 
         protected override SyntaxNode AddAsyncTokenAndFixReturnType(
             bool keepVoid, IMethodSymbol methodSymbolOpt, SyntaxNode node,

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
@@ -15,9 +15,12 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
     internal abstract class AbstractMakeMethodAsynchronousCodeFixProvider : CodeFixProvider
     {
         protected abstract bool IsAsyncSupportingFunctionSyntax(SyntaxNode node);
+
         protected abstract SyntaxNode AddAsyncTokenAndFixReturnType(
             bool keepVoid, IMethodSymbol methodSymbolOpt, SyntaxNode node,
             INamedTypeSymbol taskType, INamedTypeSymbol taskOfTType, INamedTypeSymbol valueTaskOfTType);
+
+        protected abstract bool IsLikelyEntryPointName(string methodName);
 
         public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -47,7 +50,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             }
 
             var symbol = semanticModel.GetDeclaredSymbol(node, cancellationToken) as IMethodSymbol;
-            bool isEntryPoint = symbol != null && symbol.IsStatic && string.Equals(symbol.Name, "Main", StringComparison.Ordinal);
+            bool isEntryPoint = symbol != null && symbol.IsStatic && IsLikelyEntryPointName(symbol.Name);
 
             // Offer to convert to a Task return type.
             context.RegisterCodeFix(

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
@@ -49,6 +49,8 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             }
 
             var symbol = semanticModel.GetDeclaredSymbol(node, cancellationToken) as IMethodSymbol;
+
+            // Heuristic to recognize the common case for entry point method
             var isEntryPoint = symbol != null && symbol.IsStatic && IsLikelyEntryPointName(symbol.Name, context.Document);
 
             // Offer to convert to a Task return type.
@@ -132,7 +134,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             // Store the path to this node.  That way we can find it post rename.
             var syntaxPath = new SyntaxPath(node);
 
-            // Rename the method to add the 'Async' suffix (except if it's the entry point), then add the 'async' keyword.
+            // Rename the method to add the 'Async' suffix, then add the 'async' keyword.
             var newSolution = await Renamer.RenameSymbolAsync(solution, methodSymbol, newName, solution.Options, cancellationToken).ConfigureAwait(false);
 
             var newDocument = newSolution.GetDocument(document.Id);

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
@@ -50,29 +50,19 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             var entryPoint = compilation.GetEntryPoint(cancellationToken);
             bool isEntryPoint = entryPoint?.Equals(symbol) == true;
 
-            // If it's a void returning method, offer to keep the void return type, or convert to 
-            // a Task return type.
-            bool isOrdinaryOrLocalFunction = symbol.IsOrdinaryMethodOrLocalFunction();
-            if (isOrdinaryOrLocalFunction && symbol.ReturnsVoid)
-            {
-                context.RegisterCodeFix(
-                    new MyCodeAction(GetMakeAsyncTaskFunctionResource(), c => FixNodeAsync(
-                        context.Document, diagnostic, keepVoid: false, isEntryPoint, cancellationToken: c)),
-                    context.Diagnostics);
+            // Offer to convert to a Task return type.
+            context.RegisterCodeFix(
+                new MyCodeAction(GetMakeAsyncTaskFunctionResource(), c => FixNodeAsync(
+                    context.Document, diagnostic, keepVoid: false, isEntryPoint, cancellationToken: c)),
+                context.Diagnostics);
 
-                if (!isEntryPoint)
-                {
-                    context.RegisterCodeFix(
-                        new MyCodeAction(GetMakeAsyncVoidFunctionResource(), c => FixNodeAsync(
-                            context.Document, diagnostic, keepVoid: true, isEntryPoint: false, cancellationToken: c)),
-                        context.Diagnostics);
-                }
-            }
-            else
+            // If it's a void returning method (and not an entry point), also offer to keep the void return type
+            bool isOrdinaryOrLocalFunction = symbol.IsOrdinaryMethodOrLocalFunction();
+            if (isOrdinaryOrLocalFunction && symbol.ReturnsVoid && !isEntryPoint)
             {
                 context.RegisterCodeFix(
-                    new MyCodeAction(GetMakeAsyncTaskFunctionResource(), c => FixNodeAsync(
-                        context.Document, diagnostic, keepVoid: false, isEntryPoint, cancellationToken: c)),
+                    new MyCodeAction(GetMakeAsyncVoidFunctionResource(), c => FixNodeAsync(
+                        context.Document, diagnostic, keepVoid: true, isEntryPoint: false, cancellationToken: c)),
                     context.Diagnostics);
             }
         }

--- a/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
@@ -39,10 +39,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
             Return node.IsAsyncSupportedFunctionSyntax()
         End Function
 
-        Protected Overrides Function IsLikelyEntryPointName(methodName As String) As Boolean
-            Return CaseInsensitiveComparison.Compare(methodName, "Main") = 0
-        End Function
-
         Protected Overrides Function AddAsyncTokenAndFixReturnType(
                 keepVoid As Boolean, methodSymbolOpt As IMethodSymbol, node As SyntaxNode,
                 taskType As INamedTypeSymbol, taskOfTType As INamedTypeSymbol, valueTaskOfTType As INamedTypeSymbol) As SyntaxNode

--- a/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
@@ -39,6 +39,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
             Return node.IsAsyncSupportedFunctionSyntax()
         End Function
 
+        Protected Overrides Function IsLikelyEntryPointName(methodName As String) As Boolean
+            Return CaseInsensitiveComparison.Compare(methodName, "Main") = 0
+        End Function
+
         Protected Overrides Function AddAsyncTokenAndFixReturnType(
                 keepVoid As Boolean, methodSymbolOpt As IMethodSymbol, node As SyntaxNode,
                 taskType As INamedTypeSymbol, taskOfTType As INamedTypeSymbol, valueTaskOfTType As INamedTypeSymbol) As SyntaxNode


### PR DESCRIPTION
### Customer scenario
Invoked MakeMethodAsync fixer on `Main` method. The method should be left as `Main` rather than renamed to `MainAync`.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/26312

### Workarounds, if any
Edit the name back.

### Risk
### Performance impact
Low. The fix is limited to the MakeMethodAsync fixer.

### Is this a regression from a previous update?
No.

### How was the bug found?
Reported by customer.