### PR TITLE
[WIP] OwnedDisposable<T>

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -76,14 +76,14 @@ namespace Roslyn.Test.Utilities.Remote
             _inprocServices.RegisterService(name, serviceCreator);
         }
 
-        public override async Task<Connection> TryCreateConnectionAsync(
+        public override async Task<OwnedDisposable<Connection>> TryCreateConnectionAsync(
             string serviceName, object callbackTarget, CancellationToken cancellationToken)
         {
             // get stream from service hub to communicate service specific information 
             // this is what consumer actually use to communicate information
             var serviceStream = await _inprocServices.RequestServiceAsync(serviceName, cancellationToken).ConfigureAwait(false);
 
-            return new JsonRpcConnection(_inprocServices.Logger, callbackTarget, serviceStream, _remotableDataRpc.TryAddReference());
+            return new OwnedDisposable<Connection>(new JsonRpcConnection(_inprocServices.Logger, callbackTarget, serviceStream, _remotableDataRpc.TryAddReference()));
         }
 
         protected override void OnStarted()

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.ConnectionManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.ConnectionManager.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 {
                     try
                     {
-                        return new OwnedDisposable<Connection>(new PooledConnection(this, serviceName, ref connection));
+                        return new OwnedDisposable<Connection>(() => new PooledConnection(this, serviceName, ref connection));
                     }
                     finally
                     {
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                         return default;
                     }
 
-                    return new OwnedDisposable<Connection>(new PooledConnection(this, serviceName, ref newConnection));
+                    return new OwnedDisposable<Connection>(() => new PooledConnection(this, serviceName, ref newConnection));
                 }
                 finally
                 {
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 // this is what consumer actually use to communicate information
                 var serviceStream = await Connections.RequestServiceAsync(dataRpc.Target.Workspace, _hubClient, serviceName, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
 
-                return new OwnedDisposable<Connection>(new JsonRpcConnection(_hubClient.Logger, callbackTarget, serviceStream, dataRpc));
+                return new OwnedDisposable<Connection>(() => new JsonRpcConnection(_hubClient.Logger, callbackTarget, serviceStream, dataRpc));
             }
 
             private void Free(string serviceName, ref OwnedDisposable<Connection> connection)

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.ConnectionManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.ConnectionManager.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             private readonly int _maxPoolConnections;
 
             // keyed to serviceName. each connection is for specific service such as CodeAnalysisService
-            private readonly ConcurrentDictionary<string, ConcurrentQueue<JsonRpcConnection>> _pools;
+            private readonly ConcurrentDictionary<string, ConcurrentQueue<OwnedDisposable<Connection>>> _pools;
 
             // indicate whether pool should be used.
             private readonly bool _enableConnectionPool;
@@ -51,13 +51,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                 // initial value 4 is chosen to stop concurrent dictionary creating too many locks.
                 // and big enough for all our services such as codeanalysis, remotehost, snapshot and etc services
-                _pools = new ConcurrentDictionary<string, ConcurrentQueue<JsonRpcConnection>>(concurrencyLevel: 4, capacity: 4);
+                _pools = new ConcurrentDictionary<string, ConcurrentQueue<OwnedDisposable<Connection>>>(concurrencyLevel: 4, capacity: 4);
 
                 _enableConnectionPool = enableConnectionPool;
                 _shutdownLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
             }
 
-            public Task<Connection> TryCreateConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
+            public Task<OwnedDisposable<Connection>> TryCreateConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
             {
                 // pool is not enabled by option
                 if (!_enableConnectionPool)
@@ -87,25 +87,39 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 return TryGetConnectionFromPoolAsync(serviceName, cancellationToken);
             }
 
-            private async Task<Connection> TryGetConnectionFromPoolAsync(string serviceName, CancellationToken cancellationToken)
+            private async Task<OwnedDisposable<Connection>> TryGetConnectionFromPoolAsync(string serviceName, CancellationToken cancellationToken)
             {
-                var queue = _pools.GetOrAdd(serviceName, _ => new ConcurrentQueue<JsonRpcConnection>());
+                var queue = _pools.GetOrAdd(serviceName, _ => new ConcurrentQueue<OwnedDisposable<Connection>>());
                 if (queue.TryDequeue(out var connection))
                 {
-                    return new PooledConnection(this, serviceName, connection);
+                    try
+                    {
+                        return new OwnedDisposable<Connection>(new PooledConnection(this, serviceName, ref connection));
+                    }
+                    finally
+                    {
+                        connection.Dispose();
+                    }
                 }
 
-                var newConnection = (JsonRpcConnection)await TryCreateNewConnectionAsync(serviceName, callbackTarget: null, cancellationToken).ConfigureAwait(false);
-                if (newConnection == null)
+                var newConnection = await TryCreateNewConnectionAsync(serviceName, callbackTarget: null, cancellationToken).ConfigureAwait(false);
+                try
                 {
-                    // we might not get new connection if we are either shutdown explicitly or due to OOP terminated
-                    return null;
-                }
+                    if (newConnection == null)
+                    {
+                        // we might not get new connection if we are either shutdown explicitly or due to OOP terminated
+                        return default;
+                    }
 
-                return new PooledConnection(this, serviceName, newConnection);
+                    return new OwnedDisposable<Connection>(new PooledConnection(this, serviceName, ref newConnection));
+                }
+                finally
+                {
+                    newConnection.Dispose();
+                }
             }
 
-            private async Task<Connection> TryCreateNewConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
+            private async Task<OwnedDisposable<Connection>> TryCreateNewConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
             {
                 var dataRpc = _remotableDataRpc.TryAddReference();
                 if (dataRpc == null)
@@ -114,17 +128,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     // no other one holding the data connection.
                     // in those error case, don't crash but return null. this method is TryCreate since caller expects it to return null
                     // on such error situation.
-                    return null;
+                    return default;
                 }
 
                 // get stream from service hub to communicate service specific information
                 // this is what consumer actually use to communicate information
                 var serviceStream = await Connections.RequestServiceAsync(dataRpc.Target.Workspace, _hubClient, serviceName, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
 
-                return new JsonRpcConnection(_hubClient.Logger, callbackTarget, serviceStream, dataRpc);
+                return new OwnedDisposable<Connection>(new JsonRpcConnection(_hubClient.Logger, callbackTarget, serviceStream, dataRpc));
             }
 
-            private void Free(string serviceName, JsonRpcConnection connection)
+            private void Free(string serviceName, ref OwnedDisposable<Connection> connection)
             {
                 using (_shutdownLock.DisposableRead())
                 {
@@ -146,7 +160,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     }
 
                     // pool the connection
-                    queue.Enqueue(connection);
+                    queue.Enqueue(connection.Move());
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             _rpc.StartListening();
         }
 
-        public override Task<Connection> TryCreateConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
+        public override Task<OwnedDisposable<Connection>> TryCreateConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
         {
             return _connectionManager.TryCreateConnectionAsync(serviceName, callbackTarget, cancellationToken);
         }

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// Creating session could fail if remote host is not available. one of example will be user killing
         /// remote host.
         /// </summary>
-        public abstract Task<Connection> TryCreateConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken);
+        public abstract Task<OwnedDisposable<Connection>> TryCreateConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken);
 
         protected abstract void OnStarted();
 
@@ -74,9 +74,9 @@ namespace Microsoft.CodeAnalysis.Remote
             {
             }
 
-            public override Task<Connection> TryCreateConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
+            public override Task<OwnedDisposable<Connection>> TryCreateConnectionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
             {
-                return SpecializedTasks.Default<Connection>();
+                return SpecializedTasks.Default<OwnedDisposable<Connection>>();
             }
 
             protected override void OnStarted()

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostSessionHelpers.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostSessionHelpers.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private SessionWithSolution(ref OwnedDisposable<RemoteHostClient.Connection> connection, PinnedRemotableDataScope scope)
         {
-            _connection = connection;
+            _connection = connection.Move();
             _scope = scope;
         }
 

--- a/src/Workspaces/Core/Portable/Utilities/OwnedDisposable`1.cs
+++ b/src/Workspaces/Core/Portable/Utilities/OwnedDisposable`1.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Roslyn.Utilities
+{
+    internal struct OwnedDisposable<T> : IDisposable, IEquatable<OwnedDisposable<T>>
+        where T : class, IDisposable
+    {
+        private T _resource;
+
+        public OwnedDisposable(T resource)
+        {
+            _resource = resource;
+        }
+
+        public T Target => _resource;
+
+        public T Claim()
+        {
+            return Interlocked.Exchange(ref _resource, null);
+        }
+
+        public OwnedDisposable<T> Move()
+        {
+            return new OwnedDisposable<T>(Claim());
+        }
+
+        public Boxed Box()
+        {
+            return new Boxed(ref this);
+        }
+
+        public void Dispose()
+        {
+            Claim()?.Dispose();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is OwnedDisposable<T> other
+                && Equals(other);
+        }
+
+        public bool Equals(OwnedDisposable<T> other)
+        {
+            return EqualityComparer<T>.Default.Equals(_resource, other._resource);
+        }
+
+        public override int GetHashCode()
+        {
+            return EqualityComparer<T>.Default.GetHashCode(_resource);
+        }
+
+        public static bool operator ==(OwnedDisposable<T> disposable1, OwnedDisposable<T> disposable2)
+        {
+            return disposable1.Equals(disposable2);
+        }
+
+        public static bool operator !=(OwnedDisposable<T> disposable1, OwnedDisposable<T> disposable2)
+        {
+            return !(disposable1 == disposable2);
+        }
+
+        public static bool operator ==(OwnedDisposable<T> disposable1, T y)
+        {
+            return EqualityComparer<T>.Default.Equals(disposable1._resource, y);
+        }
+
+        public static bool operator !=(OwnedDisposable<T> disposable1, T y)
+        {
+            return !(disposable1 == y);
+        }
+
+        internal sealed class Boxed : IDisposable
+        {
+            private OwnedDisposable<T> _resource;
+
+            internal Boxed(ref OwnedDisposable<T> resource)
+            {
+                _resource = resource.Move();
+            }
+
+            public ref OwnedDisposable<T> Resource => ref _resource;
+
+            public T Target => _resource.Target;
+
+            public void Dispose()
+            {
+                Resource.Dispose();
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/OwnedDisposable`1.cs
+++ b/src/Workspaces/Core/Portable/Utilities/OwnedDisposable`1.cs
@@ -16,6 +16,11 @@ namespace Roslyn.Utilities
             _resource = resource;
         }
 
+        public OwnedDisposable(Func<T> resource)
+        {
+            _resource = resource();
+        }
+
         public T Target => _resource;
 
         public T Claim()


### PR DESCRIPTION
* Implement transferable disposables with `OwnedDisposable<T>`
* Apply `OwnedDisposable<T>` to `RemoteHostClient.Connection`

The types and patterns provided in this change work towards a design goal of addressing https://github.com/dotnet/roslyn/issues/25880#issuecomment-377967573 in a world where the following hold:

* The `IDisposable` analyzers are enabled with severity Error
* Warnings for the analyzers must not be suppressed

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
