### PR TITLE
Use ITextBufferCloneService if available in AsText

### DIFF
--- a/src/EditorFeatures/Text/Extensions.cs
+++ b/src/EditorFeatures/Text/Extensions.cs
@@ -37,7 +37,10 @@ namespace Microsoft.CodeAnalysis.Text
             => line.Snapshot.AsText().Lines[line.LineNumber];
 
         public static SourceText AsText(this ITextSnapshot textSnapshot)
-            => SnapshotSourceText.From(textBufferCloneServiceOpt: null, textSnapshot);
+        {
+            textSnapshot.TextBuffer.Properties.TryGetProperty<ITextBufferCloneService>(typeof(ITextBufferCloneService), out var textBufferCloneServiceOpt);
+            return SnapshotSourceText.From(textBufferCloneServiceOpt, textSnapshot);
+        }
 
         internal static SourceText AsRoslynText(this ITextSnapshot textSnapshot, ITextBufferCloneService textBufferCloneServiceOpt, Encoding encoding)
             => new SnapshotSourceText.ClosedSnapshotSourceText(textBufferCloneServiceOpt, ((ITextSnapshot2)textSnapshot).TextImage, encoding);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio.LanguageServices.Utilities;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Projection;
 using Roslyn.Utilities;
 using VSLangProj;
 using VSLangProj140;
@@ -39,6 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private const string AppCodeFolderName = "App_Code";
 
         private readonly ITextBufferFactoryService _textBufferFactoryService;
+        private readonly IProjectionBufferFactoryService _projectionBufferFactoryService;
         private readonly ITextBufferCloneService _textBufferCloneService;
 
         // document worker coordinator
@@ -64,7 +66,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             _textBufferCloneService = exportProvider.GetExportedValue<ITextBufferCloneService>();
             _textBufferFactoryService = exportProvider.GetExportedValue<ITextBufferFactoryService>();
+            _projectionBufferFactoryService = exportProvider.GetExportedValue<IProjectionBufferFactoryService>();
             _textBufferFactoryService.TextBufferCreated += AddTextBufferCloneServiceToBuffer;
+            _projectionBufferFactoryService.ProjectionBufferCreated += AddTextBufferCloneServiceToBuffer;
             exportProvider.GetExportedValue<PrimaryWorkspace>().Register(this);
         }
 
@@ -1096,6 +1100,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (!finalize)
             {
                 _textBufferFactoryService.TextBufferCreated -= AddTextBufferCloneServiceToBuffer;
+                _projectionBufferFactoryService.ProjectionBufferCreated -= AddTextBufferCloneServiceToBuffer;
             }
 
             // workspace is going away. unregister this workspace from work coordinator


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/604150

/cc @minestarks

### Customer scenario

A customer attempts to reformat an HTML document, and Visual Studio crashes. Pasting the following into an HTML document will reproduce the issue.

```html
<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
<head>
    <meta charset="utf-8" />
    <title></title>
    <script>    
        function foo() {}
    </script>
</head>
<body>

</body>
</html>
```

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/604150

### Workarounds, if any

None.

### Risk

Low. Of multiple possible places to fix the sequence of events leading to a product crash, this one provides the strongest assurances that 15.7 release will continue to behave like 15.6 w.r.t. text differencing.

### Performance impact

Aside from fixing a possible crash, performance is improved in the impacted scenarios by allowing the use of `ITextBufferCloneService` rather than falling back to the slower path.

### Is this a regression from a previous update?

Yes, introduced by #25558.

### Root cause analysis

Two changes in the causal PR resulted in a behavior change:

* The `AsText(ITextSnapshot)` extension method failed to use the `ITextBufferCloneService` assigned to the source text buffer for the snapshot.
* Roslyn only uses text buffers created by `ITextBufferFactoryService`. The TypeScript implementation, on the other hand, uses projection buffers created by `IProjectionBufferFactoryService`. The events notifying extension code that a buffer is created differs for these two services.

While the fallback behavior of Roslyn was intended to be slower but functionally equivalent, the text differencing algorithm differed between the two approaches - the one used when `ITextBufferCloneService` was not available threw an exception if the set of changes made to a buffer were not ordered.

### How was the bug found?

Dogfooding / reported by TypeScript team

### Test documentation updated?

N/A