### PR TITLE
Handle completion items with leading/trailing decorative text

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -498,7 +498,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             private static int GetRecentItemIndex(ImmutableArray<string> recentItems, CompletionItem item)
             {
-                var index = recentItems.IndexOf(item.DisplayText);
+                var index = recentItems.IndexOf(CompletionHelper.GetDisplayTextForMatching(item));
                 return -index;
             }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             }
 
             // Let the completion rules know that this item was committed.
-            this.MakeMostRecentItem(item.DisplayText);
+            this.MakeMostRecentItem(CompletionHelper.GetDisplayTextForMatching(item));
         }
 
         private void SetCaretPosition(int desiredCaretPosition)

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -19,6 +19,11 @@ namespace Microsoft.CodeAnalysis.Completion
         private static readonly CultureInfo EnUSCultureInfo = new CultureInfo("en-US");
         private readonly bool _isCaseSensitive;
 
+        // Support for completion items with extra decorative characters in their DisplayText.
+        // This allows bolding and MRU to operate on the "real" display text (without text
+        // decorations). This should be a substring of the corresponding DisplayText.
+        private static string DisplayTextForMatching = nameof(DisplayTextForMatching);
+
         public CompletionHelper(bool isCaseSensitive)
         {
             _isCaseSensitive = isCaseSensitive;
@@ -252,5 +257,8 @@ namespace Microsoft.CodeAnalysis.Completion
 
             return 0;
         }
+
+        internal static string GetDisplayTextForMatching(CompletionItem item)
+            => item.Properties.TryGetValue(DisplayTextForMatching, out var displayText) ? displayText : item.DisplayText;
     }
 }


### PR DESCRIPTION
Leading/trailing decorative text can interfere with the pattern
matcher's ability to find/bold matching spans and add redundant items to
the MRU list.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
