### PR TITLE
Fix bad codegen for fixed buffer access

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -964,7 +964,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 // - i.e assigns int value to a short local.
                 // in that case we should force lhs to be a real local.
                 Debug.Assert(
-                    node.Left.Type.Equals(node.Right.Type, TypeCompareKind.AllIgnoreOptions),
+                    node.Left.Type.Equals(node.Right.Type, TypeCompareKind.AllIgnoreOptions) ||
+                    IsFixedBufferAssignmentToRefLocal(node.Left, node.Right, node.IsRef),
                     @"type of the assignment value is not the same as the type of assignment target. 
                 This is not expected by the optimizer and is typically a result of a bug somewhere else.");
 
@@ -997,6 +998,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             return node.Update(left, right, node.IsRef, node.Type);
         }
+
+        /// <summary>
+        /// Fixed-sized buffers are lowered as field accesses with pointer type, but
+        /// we want to assign them to pinned ref locals before creating the pointer
+        /// type, so this results in an assignment with mismatched types (pointer to managed
+        /// ref). This is legal according to the CLR, but not how we usually represent things
+        /// in lowering.
+        /// </summary>
+        internal static bool IsFixedBufferAssignmentToRefLocal(BoundExpression left, BoundExpression right, bool isRef)
+            => isRef &&
+               right is BoundFieldAccess fieldAccess &&
+               fieldAccess.FieldSymbol.IsFixed &&
+               left.Type.Equals(((PointerTypeSymbol)right.Type).PointedAtType, TypeCompareKind.AllIgnoreOptions);
 
         // indirect assignment is assignment to a value referenced indirectly
         // it may only happen if 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -246,25 +246,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // either should lower into addressof
             Debug.Assert(initializerExpr.Kind == BoundKind.AddressOfOperator);
 
+            TypeSymbol initializerType = ((PointerTypeSymbol)initializerExpr.Type).PointedAtType;
+
             // initializer expressions are bound/lowered right into addressof operators here
             // that is a bit too far
             // we need to pin the underlying field, and only then take the address.
             initializerExpr = ((BoundAddressOfOperator)initializerExpr).Operand;
-
-            TypeSymbol initializerType = initializerExpr.Type;
-
-            // If this is a fixed buffer, the type is a pointer, but we need
-            // the underlying type, since we're turning a pointer into a managed ref
-            if (initializerExpr is BoundFieldAccess fieldAccess && fieldAccess.FieldSymbol.IsFixed)
-            {
-                initializerType = ((PointerTypeSymbol)initializerType).PointedAtType;
-                initializerExpr = fieldAccess.Update(
-                    fieldAccess.ReceiverOpt,
-                    fieldAccess.FieldSymbol,
-                    fieldAccess.ConstantValueOpt,
-                    fieldAccess.ResultKind,
-                    initializerType);
-            }
 
             // intervening parens may have been skipped by the binder; find the declarator
             VariableDeclaratorSyntax declarator = fixedInitializer.Syntax.FirstAncestorOrSelf<VariableDeclaratorSyntax>();

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -376,6 +377,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundAssignmentOperator AssignmentExpression(BoundExpression left, BoundExpression right, bool isRef = false)
         {
             Debug.Assert(left.Type.Equals(right.Type, TypeCompareKind.AllIgnoreOptions) ||
+                    StackOptimizerPass1.IsFixedBufferAssignmentToRefLocal(left, right, isRef) ||
                     right.Type.IsErrorType() || left.Type.IsErrorType());
 
             return new BoundAssignmentOperator(Syntax, left, right, left.Type, isRef: isRef) { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
@@ -15,6 +15,73 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class FixedSizeBufferTests : EmitMetadataTestBase
     {
         [Fact]
+        public void NestedStructFixed()
+        {
+            var verifier = CompileAndVerify(@"
+class  X {
+    internal struct CaseRange {
+        public int Lo, Hi;
+        public unsafe fixed int Delta [3];
+
+        public CaseRange (int lo, int hi, int d1, int d2, int d3)
+        {
+            Lo = lo;
+            Hi = hi;
+            unsafe {
+                fixed (int *p = Delta) {
+                    p [0] = d1;
+                    p [1] = d2;
+                    p [2] = d3;
+                }
+            }
+        }
+    }
+
+    static void Main ()
+    {
+        var a = new CaseRange (0, 0, 0, 0, 0);
+    }
+}", options: TestOptions.UnsafeReleaseExe, verify: Verification.Fails);
+            verifier.VerifyIL("X.CaseRange..ctor", @"
+{
+  // Code size       49 (0x31)
+  .maxstack  3
+  .locals init (pinned int& V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  stfld      ""int X.CaseRange.Lo""
+  IL_0007:  ldarg.0
+  IL_0008:  ldarg.2
+  IL_0009:  stfld      ""int X.CaseRange.Hi""
+  IL_000e:  ldarg.0
+  IL_000f:  ldflda     ""int* X.CaseRange.Delta""
+  IL_0014:  ldflda     ""int X.CaseRange.<Delta>e__FixedBuffer.FixedElementField""
+  IL_0019:  stloc.0
+  IL_001a:  ldloc.0
+  IL_001b:  conv.u
+  IL_001c:  dup
+  IL_001d:  ldarg.3
+  IL_001e:  stind.i4
+  IL_001f:  dup
+  IL_0020:  ldc.i4.4
+  IL_0021:  add
+  IL_0022:  ldarg.s    V_4
+  IL_0024:  stind.i4
+  IL_0025:  ldc.i4.2
+  IL_0026:  conv.i
+  IL_0027:  ldc.i4.4
+  IL_0028:  mul
+  IL_0029:  add
+  IL_002a:  ldarg.s    V_5
+  IL_002c:  stind.i4
+  IL_002d:  ldc.i4.0
+  IL_002e:  conv.u
+  IL_002f:  stloc.0
+  IL_0030:  ret
+}");
+        }
+
+        [Fact]
         public void SimpleFixedBuffer()
         {
             var text =
@@ -368,7 +435,7 @@ class Program
 {
   // Code size       62 (0x3e)
   .maxstack  4
-  .locals init (pinned int*& V_0)
+  .locals init (pinned int& V_0)
   IL_0000:  newobj     ""S1..ctor()""
   IL_0005:  dup
   IL_0006:  ldflda     ""S S1.field""
@@ -435,7 +502,7 @@ class Program
   // Code size       47 (0x2f)
   .maxstack  2
   .locals init (int* V_0, //p
-                pinned int*& V_1)
+                pinned int& V_1)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  ldflda     ""S C.s""
   IL_000a:  ldflda     ""int* S.x""

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class FixedSizeBufferTests : EmitMetadataTestBase
     {
         [Fact]
+        [WorkItem(26351, "https://github.com/dotnet/roslyn/pull/26351")]
         public void NestedStructFixed()
         {
             var verifier = CompileAndVerify(@"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -10350,7 +10350,7 @@ unsafe public struct FixedStruct
 {
   // Code size       20 (0x14)
   .maxstack  1
-  .locals init (pinned char*& V_0)
+  .locals init (pinned char& V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""char* FixedStruct.c""
   IL_0006:  ldflda     ""char FixedStruct.<c>e__FixedBuffer.FixedElementField""
@@ -10403,7 +10403,7 @@ unsafe public struct FixedStruct
 {
   // Code size       45 (0x2d)
   .maxstack  3
-  .locals init (pinned char*& V_0)
+  .locals init (pinned char& V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""char* FixedStruct.c""
   IL_0006:  ldflda     ""char FixedStruct.<c>e__FixedBuffer.FixedElementField""

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -15554,7 +15554,7 @@ unsafe class Test
 {
   // Code size       25 (0x19)
   .maxstack  3
-  .locals init (pinned int*& V_0,
+  .locals init (pinned int& V_0,
                 int V_1)
   IL_0000:  ldarg.0
   IL_0001:  ldflda     ""S Test.field""

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -8256,7 +8256,7 @@ class Program
 {
   // Code size       34 (0x22)
   .maxstack  3
-  .locals init (pinned bool*& V_0)
+  .locals init (pinned bool& V_0)
   IL_0000:  ldsflda    ""s Program._fixedBufferExample""
   IL_0005:  ldflda     ""bool* s._buffer""
   IL_000a:  ldflda     ""bool s.<_buffer>e__FixedBuffer.FixedElementField""
@@ -8285,7 +8285,7 @@ class Program
 {
   // Code size       46 (0x2e)
   .maxstack  3
-  .locals init (pinned bool*& V_0)
+  .locals init (pinned bool& V_0)
   IL_0000:  ldsflda    ""s Program._fixedBufferExample""
   IL_0005:  ldflda     ""bool* s._buffer""
   IL_000a:  ldflda     ""bool s.<_buffer>e__FixedBuffer.FixedElementField""
@@ -8372,7 +8372,7 @@ class Program
 {
   // Code size       47 (0x2f)
   .maxstack  3
-  .locals init (pinned bool*& V_0)
+  .locals init (pinned bool& V_0)
   IL_0000:  ldsflda    ""s Program._fixedBufferExample""
   IL_0005:  ldflda     ""bool* s._buffer""
   IL_000a:  ldflda     ""bool s.<_buffer>e__FixedBuffer.FixedElementField""
@@ -8401,7 +8401,7 @@ class Program
 {
   // Code size       35 (0x23)
   .maxstack  3
-  .locals init (pinned bool*& V_0)
+  .locals init (pinned bool& V_0)
   IL_0000:  ldsflda    ""s Program._fixedBufferExample""
   IL_0005:  ldflda     ""bool* s._buffer""
   IL_000a:  ldflda     ""bool s.<_buffer>e__FixedBuffer.FixedElementField""


### PR DESCRIPTION
### Customer scenario

Very common usages of fixed buffers will cause failures in Mono and potentially other runtimes due to bad IL. The IL is rejected due to type system violations, but is semantically correct. This causes  the CLR to accept the IL and run it as expected. Mono is stricter, however, and other runtimes may also reject the program.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/26335
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/605434

### Workarounds, if any

For Mono, there are none.

### Risk

This is a change localized to fixed buffer field access in lowering.

### Performance impact

None, this is a minor change in logic.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

Unfortunately, the desktop CLR and CoreCLR both accept this IL and run it as expected. Type system violations like this are usually caught with PEVerify, but since this is unsafe code by definition, PEVerify cannot be used to find this violation.

### How was the bug found?

Mono reported this bug when they upgraded their baseline compiler.

