### PR TITLE
Reenable IDE test in features/recursive-patterns

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseDeconstruction/UseDeconstructionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseDeconstruction/UseDeconstructionTests.cs
@@ -471,7 +471,7 @@ class C
         }
 
         [WorkItem(25260, "https://github.com/dotnet/roslyn/issues/25260")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26115"), Trait(Traits.Feature, Traits.Features.CodeActionsUseDeconstruction)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseDeconstruction)]
         public async Task TestNotWithDefaultLiteralInitializer()
         {
             await TestMissingInRegularAndScriptAsync(


### PR DESCRIPTION
The failure revealed an actual bug which was fixed in #26140 
Originally, the test used C# 7.0 which made it ineffectual because C# 7.0 doesn't even have default literals. That was the real reason the test originally passed and didn't catch the bug (it's a negative test).

Tagging @gafter