### PR TITLE
deploy vsix packages on build

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -29,6 +29,7 @@ param (
     [switch]$packAll = $false,
     [switch]$binaryLog = $false,
     [switch]$noAnalyzers = $false,
+    [switch]$deployExtensions = $false,
     [string]$signType = "",
 
     # Test options 
@@ -61,6 +62,7 @@ function Print-Usage() {
     Write-Host "  -sign                     Sign our binaries"
     Write-Host "  -signType                 Type of sign: real, test, verify"
     Write-Host "  -pack                     Create our NuGet packages"
+    Write-Host "  -deployExtensions         Deploy built vsixes"
     Write-Host "  -binaryLog                Create binary log for every MSBuild invocation"
     Write-Host "" 
     Write-Host "Test options" 
@@ -246,7 +248,7 @@ function Build-Artifacts() {
         Run-MSBuild "Compilers.sln" -useDotnetBuild
     }
     elseif ($build) {
-        Run-MSBuild "Roslyn.sln" "/p:DeployExtension=false"
+        Run-MSBuild "Roslyn.sln" "/p:DeployExtension=$deployExtensions"
         Build-ExtraSignArtifacts
     }
 
@@ -447,12 +449,12 @@ function Test-Special() {
 }
 
 function Test-PerfCorrectness() {
-    Run-MSBuild "Roslyn.sln" "/p:DeployExtension=false" -logFileName "RoslynPerfCorrectness"
+    Run-MSBuild "Roslyn.sln" "/p:DeployExtension=$deployExtensions" -logFileName "RoslynPerfCorrectness"
     Exec-Block { & ".\Binaries\$buildConfiguration\Exes\Perf.Runner\Roslyn.Test.Performance.Runner.exe" --ci-test } | Out-Host
 }
 
 function Test-PerfRun() { 
-    Run-MSBuild "Roslyn.sln" "/p:DeployExtension=false" -logFileName "RoslynPerfRun"
+    Run-MSBuild "Roslyn.sln" "/p:DeployExtension=$deployExtensions" -logFileName "RoslynPerfRun"
 
     # Check if we have credentials to upload to benchview
     $extraArgs = @()


### PR DESCRIPTION
Currently if someone runs `Build.cmd` and then launches visual studio using `devenv /rootSuffix RoslynDev` none of the vsix packages will have been deployed.  Deployment *without opening Visual Studio* is pretty roundabout without this change.