### PR TITLE
Revert "Update Roslyn snapshot when editorconfig is updated

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProvider.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.ErrorLogger;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -16,8 +17,6 @@ namespace Microsoft.CodeAnalysis.Editor.Options
     // isn't yet available outside of Visual Studio.
     internal sealed partial class EditorConfigDocumentOptionsProvider : IDocumentOptionsProvider
     {
-        private const int EventDelayInMillisecond = 50;
-
         private readonly object _gate = new object();
 
         /// <summary>
@@ -26,20 +25,13 @@ namespace Microsoft.CodeAnalysis.Editor.Options
         /// </summary>
         private readonly Dictionary<DocumentId, Task<ICodingConventionContext>> _openDocumentContexts = new Dictionary<DocumentId, Task<ICodingConventionContext>>();
 
-        private readonly Workspace _workspace;
         private readonly ICodingConventionsManager _codingConventionsManager;
         private readonly IErrorLoggerService _errorLogger;
 
-        private ResettableDelay _resettableDelay;
-
-        internal EditorConfigDocumentOptionsProvider(Workspace workspace, ICodingConventionsManager codingConventionsManager)
+        internal EditorConfigDocumentOptionsProvider(Workspace workspace)
         {
-            _workspace = workspace;
-
-            _codingConventionsManager = codingConventionsManager;
+            _codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager();
             _errorLogger = workspace.Services.GetService<IErrorLoggerService>();
-
-            _resettableDelay = ResettableDelay.CompletedDelay;
 
             workspace.DocumentOpened += Workspace_DocumentOpened;
             workspace.DocumentClosed += Workspace_DocumentClosed;
@@ -55,13 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.Options
 
                     // Ensure we dispose the context, which we'll do asynchronously
                     contextTask.ContinueWith(
-                        t =>
-                        {
-                            var context = t.Result;
-
-                            context.CodingConventionsChangedAsync -= OnCodingConventionsChangedAsync;
-                            context.Dispose();
-                        },
+                        t => t.Result.Dispose(),
                         CancellationToken.None,
                         TaskContinuationOptions.OnlyOnRanToCompletion,
                         TaskScheduler.Default);
@@ -73,14 +59,7 @@ namespace Microsoft.CodeAnalysis.Editor.Options
         {
             lock (_gate)
             {
-                var contextTask = Task.Run(async () =>
-                {
-                    var context = await GetConventionContextAsync(e.Document.FilePath, CancellationToken.None).ConfigureAwait(false);
-                    context.CodingConventionsChangedAsync += OnCodingConventionsChangedAsync;
-                    return context;
-                });
-
-                _openDocumentContexts.Add(e.Document.Id, contextTask);
+                _openDocumentContexts.Add(e.Document.Id, Task.Run(() => GetConventionContextAsync(e.Document.FilePath, CancellationToken.None)));
             }
         }
 
@@ -142,40 +121,6 @@ namespace Microsoft.CodeAnalysis.Editor.Options
             return IOUtilities.PerformIOAsync(
                 () => _codingConventionsManager.GetConventionContextAsync(path, cancellationToken),
                 defaultValue: EmptyCodingConventionContext.Instance);
-        }
-
-        private Task OnCodingConventionsChangedAsync(object sender, CodingConventionsChangedEventArgs arg)
-        {
-            // this is a temporary workaround. once we finish the work to put editorconfig file as a part of roslyn solution snapshot,
-            // that system will automatically pick up option changes and update snapshot. and it will work regardless
-            // whether a file is opened in editor or not.
-            // 
-            // but until then, we need to explicitly touch workspace to update snapshot. and 
-            // only works for open files. it is not easy to track option changes for closed files with current model.
-            // related tracking issue - https://github.com/dotnet/roslyn/issues/26250
-
-            lock (_gate)
-            {
-                if (!_resettableDelay.Task.IsCompleted)
-                {
-                    _resettableDelay.Reset();
-                }
-                else
-                {
-                    // since this event gets raised for all documents that are affected by 1 editconfig file,
-                    // and since for now we make that event as whole solution changed event, we don't need to update
-                    // snapshot for each events. aggregate all events to 1.
-                    var delay = new ResettableDelay(EventDelayInMillisecond);
-                    delay.Task.ContinueWith(_ => _workspace.OnOptionChanged(),
-                        CancellationToken.None,
-                        TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default);
-
-                    _resettableDelay = delay;
-                }
-            }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProviderFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProviderFactory.cs
@@ -3,25 +3,15 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.VisualStudio.CodingConventions;
 
 namespace Microsoft.CodeAnalysis.Editor.Options
 {
     [Export(typeof(IDocumentOptionsProviderFactory))]
     class EditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
     {
-        private readonly ICodingConventionsManager _codingConventionsManager;
-
-        [ImportingConstructor]
-        [Obsolete("Never call this directly")]
-        public EditorConfigDocumentOptionsProviderFactory(ICodingConventionsManager codingConventionsManager)
-        {
-            _codingConventionsManager = codingConventionsManager;
-        }
-
         public IDocumentOptionsProvider Create(Workspace workspace)
         {
-            return new EditorConfigDocumentOptionsProvider(workspace, _codingConventionsManager);
+            return new EditorConfigDocumentOptionsProvider(workspace);
         }
     }
 }

--- a/src/EditorFeatures/Core/Shared/Utilities/ResettableDelay.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ResettableDelay.cs
@@ -9,8 +9,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 {
     internal class ResettableDelay
     {
-        public static readonly ResettableDelay CompletedDelay = new ResettableDelay();
-
         private readonly int _delayInMilliseconds;
         private readonly TaskCompletionSource<object> _taskCompletionSource;
 
@@ -39,16 +37,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             {
                 StartTimer(continueOnCapturedContext: false);
             }
-        }
-
-        private ResettableDelay()
-        {
-            // create resettableDelay with completed state
-            _delayInMilliseconds = 0;
-            _taskCompletionSource = new TaskCompletionSource<object>();
-            _taskCompletionSource.SetResult(null);
-
-            Reset();
         }
 
         public Task Task => _taskCompletionSource.Task;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1051,18 +1051,5 @@ namespace Microsoft.CodeAnalysis
                 return this.Workspace.Options;
             }
         }
-
-        /// <summary>
-        /// Update current solution as a result of option changes.
-        /// 
-        /// this is a temporary workaround until editorconfig becomes real part of roslyn solution snapshot.
-        /// until then, this will explicitly fork current solution snapshot
-        /// </summary>
-        internal Solution WithOptionChanged()
-        {
-            // options are associated with solution snapshot. creating new snapshot
-            // will cause us to retrieve new options
-            return new Solution(_state);
-        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -725,27 +725,5 @@ namespace Microsoft.CodeAnalysis
 
             return newSolution.GetProject(oldProject.Id);
         }
-
-        /// <summary>
-        /// Update current solution as a result of option changes.
-        /// 
-        /// this is a temporary workaround until editorconfig becomes real part of roslyn solution snapshot.
-        /// until then, this will explicitly move current solution forward when such event happened
-        /// </summary>
-        internal void OnOptionChanged()
-        {
-            using (_serializationLock.DisposableWait())
-            {
-                var oldSolution = this.CurrentSolution;
-                var newSolution = this.SetCurrentSolution(oldSolution.WithOptionChanged());
-
-                // for now, this says whole solution is changed.
-                // in future, we probably going to just raise additional file changed event (for editconfig file) and then 
-                // let IOptionService.OptionChanged event to raise what option has changed.
-                // currently, since editorconfig file is not part of solution, we can't say which file is changed.
-                // 1 editorconfig file can affect multiple files in multiple projects so solution changed is easiest options for now.
-                this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.SolutionChanged, oldSolution, newSolution);
-            }
-        }
     }
 }


### PR DESCRIPTION
This reverts commit f56d67a6afcc8e4fe4cee41cf7ef301b55e4f5b8. We are seeing deadlocks where our code tries to fetch the options for a file, and that code runs on the background thread. The background thread is trying to hop back to the foreground thread to apply file watchers for .editorconfig files.