### PR TITLE
Optimize VB lookup

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -1470,7 +1470,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 LookupInInterfaces(lookupResult, container, lookIn, processed, name, arity, options, binder, methodsOnly, useSiteDiagnostics)
 
                 ' If no viable or ambiguous results, look in Object.
-                If lookupResult?.IsGoodOrAmbiguous <> True AndAlso (options And LookupOptions.NoSystemObjectLookupForInterfaces) = 0 Then
+                If (lookupResult Is Nothing OrElse Not lookupResult.IsGoodOrAmbiguous) AndAlso (options And LookupOptions.NoSystemObjectLookupForInterfaces) = 0 Then
                     Dim currentResult = LookupResult.GetInstance()
                     Dim obj As NamedTypeSymbol = binder.SourceModule.ContainingAssembly.GetSpecialType(SpecialType.System_Object)
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -498,7 +498,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Lookup(currentResult, containedModule, name, arity, options, binder, useSiteDiagnostics)
 
                         ' Symbols in source take priority over symbols in a referenced assembly.
-                        If currentResult IsNot Nothing AndAlso currentResult.StopFurtherLookup AndAlso currentResult.Symbols.Count > 0 AndAlso
+                        If currentResult?.StopFurtherLookup AndAlso currentResult.Symbols.Count > 0 AndAlso
                            lookupResult.StopFurtherLookup AndAlso lookupResult.Symbols.Count > 0 Then
 
                             Dim currentFromSource = currentResult.Symbols(0).ContainingModule Is sourceModule
@@ -676,7 +676,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Exit Do ' still do extension methods.
                     End If
 
-                    If result IsNot Nothing AndAlso result.StopFurtherLookup Then
+                    If result?.StopFurtherLookup Then
                         ' If we found a non-overloadable symbol, we can stop now. Note that even if we find a method without the Overloads
                         ' modifier, we cannot stop because we need to check for extension methods.
                         If result.HasSymbol Then
@@ -1139,7 +1139,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 binder As Binder,
                 <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
             )
-                If result IsNot Nothing AndAlso result.IsGood AndAlso
+                If result?.IsGood AndAlso
                     ((options And LookupOptions.EagerlyLookupExtensionMethods) = 0 OrElse
                      result.Symbols(0).Kind <> SymbolKind.Method) Then
                     Return
@@ -1532,7 +1532,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         leaveEventsOnly = isEventsOnlySpecified
                     End If
 
-                    If lookupResult IsNot Nothing AndAlso lookupResult.IsGood AndAlso currentResult.IsGood Then
+                    If lookupResult?.IsGood AndAlso currentResult.IsGood Then
                         ' We have _another_ viable result while lookupResult is already viable. Use special interface merging rules.
                         MergeInterfaceLookupResults(lookupResult, currentResult, basesBeingResolved, leaveEventsOnly, useSiteDiagnostics)
                     Else
@@ -1552,7 +1552,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 currentResult.Free()
 
-                If methodsOnly AndAlso lookupResult IsNot Nothing AndAlso lookupResult.IsGood Then
+                If methodsOnly AndAlso lookupResult?.IsGood Then
                     ' We need to filter out non-method symbols from 'currentResult' 
                     ' before merging with 'lookupResult'
                     FilterSymbolsInLookupResult(lookupResult, SymbolKind.Method, leaveInsteadOfRemoving:=True)
@@ -1560,7 +1560,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' it may look like a Good result, but it may have ambiguities inside
                 ' so we need to check that to be sure.
-                If lookupResult IsNot Nothing AndAlso lookupResult.IsGood Then
+                If lookupResult?.IsGood Then
                     Dim ambiguityDiagnostics As AmbiguousSymbolDiagnostic = Nothing
                     Dim symbols As ArrayBuilder(Of Symbol) = lookupResult.Symbols
 
@@ -1696,10 +1696,9 @@ ExitForFor:
             End Function
 
             Private Shared Sub ClearLookupResultIfNotMethods(methodsOnly As Boolean, lookupResult As LookupResult)
-                If lookupResult IsNot Nothing AndAlso
-                    methodsOnly AndAlso
-                    lookupResult.HasSymbol AndAlso
-                    lookupResult.Symbols(0).Kind <> SymbolKind.Method Then
+                If methodsOnly AndAlso
+                   lookupResult?.HasSymbol AndAlso
+                   lookupResult.Symbols(0).Kind <> SymbolKind.Method Then
                     lookupResult.Clear()
                 End If
             End Sub

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -643,18 +643,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Dim currentResult As LookupResult = Nothing
                     LookupWithoutInheritance(currentResult, currentType, name, arity, options, accessThroughType, binder, useSiteDiagnostics)
-                    If result IsNot Nothing AndAlso result.IsGoodOrAmbiguous AndAlso currentResult IsNot Nothing AndAlso currentResult.IsGoodOrAmbiguous AndAlso Not LookupResult.CanOverload(result.Symbols(0), currentResult.Symbols(0)) Then
-                        ' We hit another good symbol that can't overload this one. That doesn't affect the lookup result, but means we have to stop
-                        ' looking for more members. See bug #14078 for example.
-                        hitNonoverloadingSymbol = True
-                    End If
+                    If currentResult IsNot Nothing Then
+                        If result Is Nothing Then
+                            result = LookupResult.GetInstance()
+                        End If
 
-                    If result Is Nothing AndAlso currentResult IsNot Nothing Then
-                        result = LookupResult.GetInstance()
-                    End If
+                        If result.IsGoodOrAmbiguous AndAlso currentResult.IsGoodOrAmbiguous AndAlso Not LookupResult.CanOverload(result.Symbols(0), currentResult.Symbols(0)) Then
+                            ' We hit another good symbol that can't overload this one. That doesn't affect the lookup result, but means we have to stop
+                            ' looking for more members. See bug #14078 for example.
+                            hitNonoverloadingSymbol = True
+                        End If
 
-                    result?.MergeOverloadedOrPrioritized(currentResult, True)
-                    currentResult?.Free()
+                        result.MergeOverloadedOrPrioritized(currentResult, True)
+                        currentResult.Free()
+                    End If
 
                     ' If the type is from a winmd file and implements any of the special WinRT collection
                     ' projections, then we may need to add projected interface members
@@ -1147,12 +1149,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 LookupForExtensionMethods(currentResult, container, name, arity, options, binder, useSiteDiagnostics)
                 MergeInternalXmlHelperValueIfNecessary(currentResult, container, name, arity, options, binder, useSiteDiagnostics)
 
-                If result Is Nothing AndAlso currentResult IsNot Nothing Then
-                    result = LookupResult.GetInstance()
-                End If
+                If currentResult IsNot Nothing Then
+                    If result Is Nothing Then
+                        result = LookupResult.GetInstance()
+                    End If
 
-                result?.MergeOverloadedOrPrioritized(currentResult, checkIfCurrentHasOverloads:=False)
-                currentResult?.Free()
+                    result.MergeOverloadedOrPrioritized(currentResult, checkIfCurrentHasOverloads:=False)
+                    currentResult.Free()
+                End If
             End Sub
 
             Private Shared Function ShouldLookupExtensionMethods(options As LookupOptions, container As TypeSymbol) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -741,7 +741,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim conflictingMembers = New HashSet(Of Symbol)(comparer)
 
                 ' Add all viable members from type lookup
-                If result IsNot Nothing AndAlso result.IsGood Then
+                If result?.IsGood Then
                     For Each sym In result.Symbols
                         ' Fields can't be present in the HashSet because they can't be compared
                         ' with a MemberSignatureComparer
@@ -788,7 +788,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
 
                 tmp.Free()
-                If result IsNot Nothing AndAlso result.IsGood Then
+                If result?.IsGood Then
                     For Each sym In result.Symbols
                         If sym.Kind <> SymbolKind.Field Then
                             allMembers.Remove(sym)
@@ -1470,7 +1470,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 LookupInInterfaces(lookupResult, container, lookIn, processed, name, arity, options, binder, methodsOnly, useSiteDiagnostics)
 
                 ' If no viable or ambiguous results, look in Object.
-                If lookupResult Is Nothing OrElse (Not lookupResult.IsGoodOrAmbiguous AndAlso (options And LookupOptions.NoSystemObjectLookupForInterfaces) = 0) Then
+                If lookupResult?.IsGoodOrAmbiguous <> True AndAlso (options And LookupOptions.NoSystemObjectLookupForInterfaces) = 0 Then
                     Dim currentResult = LookupResult.GetInstance()
                     Dim obj As NamedTypeSymbol = binder.SourceModule.ContainingAssembly.GetSpecialType(SpecialType.System_Object)
 
@@ -1589,10 +1589,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 ExitForFor:
 
                     If ambiguityDiagnostics IsNot Nothing Then
-                        If lookupResult Is Nothing Then
-                            lookupResult = LookupResult.GetInstance()
-                        End If
-
                         lookupResult.SetFrom(New SingleLookupResult(LookupResultKind.Ambiguous, symbols.First, ambiguityDiagnostics))
                     End If
                 End If
@@ -1655,7 +1651,7 @@ ExitForFor:
                 Dim constraintClass = typeParameter.GetClassConstraint(useSiteDiagnostics)
                 If constraintClass IsNot Nothing Then
                     LookupInClass(result, constraintClass, name, arity, options, constraintClass, binder, useSiteDiagnostics)
-                    If result IsNot Nothing AndAlso result.StopFurtherLookup Then
+                    If result?.StopFurtherLookup Then
                         Return
                     End If
                 End If

--- a/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
@@ -449,6 +449,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' multiple viable results, instead produce an ambiguity between all of them.
         Public Sub MergeAmbiguous(other As LookupResult,
                                   generateAmbiguityDiagnostic As Func(Of ImmutableArray(Of Symbol), AmbiguousSymbolDiagnostic))
+            If other Is Nothing Then
+                Return
+            End If
+
             If Me.IsGoodOrAmbiguous AndAlso other.IsGoodOrAmbiguous Then
                 ' Two viable or ambiguous results. Produce ambiguity.
                 Dim ambiguousResults = ArrayBuilder(Of Symbol).GetInstance()
@@ -552,6 +556,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' If the "checkIfCurrentHasOverloads" is True, then we only overload if every symbol in our current result has "Overloads" modifier; otherwise
         ' we overload regardless of the modifier.
         Public Sub MergeOverloadedOrPrioritized(other As LookupResult, checkIfCurrentHasOverloads As Boolean)
+            If other Is Nothing Then
+                Return
+            End If
+
             If Me.IsGoodOrAmbiguous AndAlso other.IsGoodOrAmbiguous Then
                 If Me.IsGood AndAlso other.IsGood Then
                     ' Two viable results. Either they can overload each other, or we need to produce an ambiguity.

--- a/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
@@ -556,10 +556,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' If the "checkIfCurrentHasOverloads" is True, then we only overload if every symbol in our current result has "Overloads" modifier; otherwise
         ' we overload regardless of the modifier.
         Public Sub MergeOverloadedOrPrioritized(other As LookupResult, checkIfCurrentHasOverloads As Boolean)
-            If other Is Nothing Then
-                Return
-            End If
-
             If Me.IsGoodOrAmbiguous AndAlso other.IsGoodOrAmbiguous Then
                 If Me.IsGood AndAlso other.IsGood Then
                     ' Two viable results. Either they can overload each other, or we need to produce an ambiguity.


### PR DESCRIPTION
This change defers the acquisition of LookupResult instances from the shared pool
to a point where they are known to be needed. In highly-concurrent compilation
scenarios (using AnalyzerRunner), this change was observed to reduce overall
allocations in the compiler by up to 50% (30GiB) when processing Roslyn.sln.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
