### PR TITLE
Update RoslynAnalyzers to fix diff churn with PublicAPI.Unshipped.txt files

### DIFF
--- a/build/Rulesets/Roslyn_BuildRules.ruleset
+++ b/build/Rulesets/Roslyn_BuildRules.ruleset
@@ -82,7 +82,7 @@
     <Rule Id="RS1012" Action="None" />
     <Rule Id="RS1013" Action="None" />
     <Rule Id="RS1014" Action="Warning" />
-    <Rule Id="RS1022" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
+    <Rule Id="RS1022" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26420: Enable rule RS1022 for Roslyn.sln -->
   </Rules>
   <Rules AnalyzerId="Microsoft.Composition.Analyzers" RuleNamespace="Microsoft.Composition.Analyzers">
     <Rule Id="RS0006" Action="Error" />

--- a/build/Rulesets/Roslyn_BuildRules.ruleset
+++ b/build/Rulesets/Roslyn_BuildRules.ruleset
@@ -82,6 +82,7 @@
     <Rule Id="RS1012" Action="None" />
     <Rule Id="RS1013" Action="None" />
     <Rule Id="RS1014" Action="Warning" />
+    <Rule Id="RS1022" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
   </Rules>
   <Rules AnalyzerId="Microsoft.Composition.Analyzers" RuleNamespace="Microsoft.Composition.Analyzers">
     <Rule Id="RS0006" Action="Error" />

--- a/build/Rulesets/Roslyn_BuildRules.ruleset
+++ b/build/Rulesets/Roslyn_BuildRules.ruleset
@@ -21,16 +21,16 @@
     <Rule Id="CA1055" Action="None" />
     <Rule Id="CA1056" Action="None" />
     <Rule Id="CA1061" Action="None" /> <!-- "do not hide base class methods": currently violations in the compiler -->
-    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1062" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
     <Rule Id="CA1063" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25134: Enable rule CA1063 (Implement IDisposable correctly) for Roslyn.sln -->
     <Rule Id="CA1064" Action="None" />
     <Rule Id="CA1065" Action="None" />
     <Rule Id="CA1066" Action="None" />
     <Rule Id="CA1067" Action="Warning" />
     <Rule Id="CA1068" Action="Warning" />
-    <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1303" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
     <Rule Id="CA1304" Action="None" />
-    <Rule Id="CA1508" Action="None" />
+    <Rule Id="CA1508" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
     <Rule Id="CA1707" Action="None" />
     <Rule Id="CA1710" Action="None" />
     <Rule Id="CA1714" Action="None" />
@@ -53,11 +53,11 @@
     <Rule Id="CA1824" Action="None" /> <!-- mark assemblies with NeutralResourcesLanguageAttribute -->
     <Rule Id="CA2000" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25880 -->
     <Rule Id="CA2007" Action="Warning" />
-    <Rule Id="CA2100" Action="None" />
+    <Rule Id="CA2100" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
     <Rule Id="CA2211" Action="None" />
     <Rule Id="CA2213" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25880 -->
     <Rule Id="CA2214" Action="None" /> <!-- do not call overridable methods in constructors: done in various places -->
-    <Rule Id="CA2215" Action="None" />
+    <Rule Id="CA2215" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/26400: Enable rules CA1062, CA1303, CA1508, CA2100 and CA2215 for Roslyn.sln -->
     <Rule Id="CA2218" Action="None" />
     <Rule Id="CA2222" Action="None" />
     <Rule Id="CA2224" Action="None" />

--- a/build/Rulesets/Roslyn_BuildRules.ruleset
+++ b/build/Rulesets/Roslyn_BuildRules.ruleset
@@ -21,13 +21,16 @@
     <Rule Id="CA1055" Action="None" />
     <Rule Id="CA1056" Action="None" />
     <Rule Id="CA1061" Action="None" /> <!-- "do not hide base class methods": currently violations in the compiler -->
+    <Rule Id="CA1062" Action="None" />
     <Rule Id="CA1063" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25134: Enable rule CA1063 (Implement IDisposable correctly) for Roslyn.sln -->
     <Rule Id="CA1064" Action="None" />
     <Rule Id="CA1065" Action="None" />
     <Rule Id="CA1066" Action="None" />
     <Rule Id="CA1067" Action="Warning" />
     <Rule Id="CA1068" Action="Warning" />
+    <Rule Id="CA1303" Action="None" />
     <Rule Id="CA1304" Action="None" />
+    <Rule Id="CA1508" Action="None" />
     <Rule Id="CA1707" Action="None" />
     <Rule Id="CA1710" Action="None" />
     <Rule Id="CA1714" Action="None" />
@@ -50,9 +53,11 @@
     <Rule Id="CA1824" Action="None" /> <!-- mark assemblies with NeutralResourcesLanguageAttribute -->
     <Rule Id="CA2000" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25880 -->
     <Rule Id="CA2007" Action="Warning" />
+    <Rule Id="CA2100" Action="None" />
     <Rule Id="CA2211" Action="None" />
     <Rule Id="CA2213" Action="None" /> <!-- https://github.com/dotnet/roslyn/issues/25880 -->
     <Rule Id="CA2214" Action="None" /> <!-- do not call overridable methods in constructors: done in various places -->
+    <Rule Id="CA2215" Action="None" />
     <Rule Id="CA2218" Action="None" />
     <Rule Id="CA2222" Action="None" />
     <Rule Id="CA2224" Action="None" />

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -56,7 +56,7 @@
     <!-- Using a private build of Microsoft.Net.Test.SDK to work around issue https://github.com/Microsoft/vstest/issues/373 -->
     <MicrosoftNETTestSdkVersion>15.6.0-dev</MicrosoftNETTestSdkVersion>
     <MicrosoftNetCompilersVersion>2.8.0-beta3</MicrosoftNetCompilersVersion>
-    <MicrosoftNetRoslynDiagnosticsVersion>2.6.1-beta1-62702-01</MicrosoftNetRoslynDiagnosticsVersion>
+    <MicrosoftNetRoslynDiagnosticsVersion>2.6.1-beta1-62824-01</MicrosoftNetRoslynDiagnosticsVersion>
     <MicrosoftNetCoreILAsmVersion>2.0.0</MicrosoftNetCoreILAsmVersion>
     <MicrosoftNETCoreCompilersVersion>2.8.0-beta3</MicrosoftNETCoreCompilersVersion>
     <MicrosoftNETCoreVersion>5.0.0</MicrosoftNETCoreVersion>

--- a/build/scripts/sort-unshipped.cmd
+++ b/build/scripts/sort-unshipped.cmd
@@ -1,0 +1,3 @@
+REM Sort the PublicAPI.Unshipped.txt files
+
+powershell -Command "Get-ChildItem -Path src\ -Recurse -Filter PublicAPI.Unshipped.txt | ForEach { Get-Content $($_.FullName) | Sort-Object | Set-Content $($_.FullName) }"

--- a/src/Workspaces/Core/Desktop/PublicAPI.Shipped.txt
+++ b/src/Workspaces/Core/Desktop/PublicAPI.Shipped.txt
@@ -1,10 +1,8 @@
 Microsoft.CodeAnalysis.CommandLineProject
 Microsoft.CodeAnalysis.FileTextLoader (forwarded, contained in Microsoft.CodeAnalysis.Workspaces)
 Microsoft.CodeAnalysis.FileTextLoader.DefaultEncoding.get -> System.Text.Encoding (forwarded, contained in Microsoft.CodeAnalysis.Workspaces)
-Microsoft.CodeAnalysis.FileTextLoader.DefaultEncoding { get; } -> System.Text.Encoding (forwarded, contained in Microsoft.CodeAnalysis.Workspaces)
 Microsoft.CodeAnalysis.FileTextLoader.FileTextLoader(string path, System.Text.Encoding defaultEncoding) -> void (forwarded, contained in Microsoft.CodeAnalysis.Workspaces)
 Microsoft.CodeAnalysis.FileTextLoader.Path.get -> string (forwarded, contained in Microsoft.CodeAnalysis.Workspaces)
-Microsoft.CodeAnalysis.FileTextLoader.Path { get; } -> string (forwarded, contained in Microsoft.CodeAnalysis.Workspaces)
 Microsoft.CodeAnalysis.Host.Mef.DesktopMefHostServices
 Microsoft.CodeAnalysis.Host.Mef.MefV1HostServices
 Microsoft.CodeAnalysis.Host.Mef.MefV1HostServices.GetExports<TExtension, TMetadata>() -> System.Collections.Generic.IEnumerable<System.Lazy<TExtension, TMetadata>>


### PR DESCRIPTION
This PR does two things:
- Pulls in the latest RoslynAnalyzers package, so that we get the new behavior for PublicAPI fixer. The new behavior is that inserting a new API does not sort the whole "unshipped" file. The purpose is to minimize diff churn.
- Adds a batch script that sorts the "unshipped" files (may be useful to Tiger or for API review).

Fixes https://github.com/dotnet/roslyn/issues/26285

Tagging @jaredpar @dotnet/roslyn-infrastructure for review. Thanks
