### PR TITLE
Have version come from %CurrentProject%;GetBuildVersion

### DIFF
--- a/src/Deployment/source.extension.vsixmanifest
+++ b/src/Deployment/source.extension.vsixmanifest
@@ -13,7 +13,7 @@
     
     <Dependency d:ProjectName="CompilerExtension" 
                 DisplayName="Roslyn Compilers" 
-                Version="[|CompilerExtension;GetBuildVersion|,)"
+                Version="[|%CurrentProject%;GetBuildVersion|,)"
                 d:Source="Project" 
                 d:InstallSource="Embed" 
                 d:VsixSubPath="Vsixes" 
@@ -22,7 +22,7 @@
     
     <Dependency d:ProjectName="VisualStudioSetup"
                 DisplayName="Roslyn Language Services"
-                Version="[|VisualStudioSetup;GetBuildVersion|,)"
+                Version="[|%CurrentProject%;GetBuildVersion|,)"
                 d:Source="Project"
                 d:InstallSource="Embed"
                 d:VsixSubPath="Vsixes"
@@ -31,7 +31,7 @@
     
     <Dependency d:ProjectName="VisualStudioInteractiveComponents" 
                 DisplayName="Roslyn Interactive Components" 
-                Version="[|VisualStudioInteractiveComponents;GetBuildVersion|,)"
+                Version="[|%CurrentProject%;GetBuildVersion|,)"
                 d:Source="Project"  
                 d:InstallSource="Embed" 
                 d:VsixSubPath="Vsixes" 
@@ -40,7 +40,7 @@
     
     <Dependency  d:ProjectName="ExpressionEvaluatorPackage" 
                  DisplayName="Roslyn Expression Evaluators" 
-                 Version="[|ExpressionEvaluatorPackage;GetBuildVersion|,)"
+                 Version="[|%CurrentProject%;GetBuildVersion|,)"
                  d:Source="Project" 
                  d:InstallSource="Embed" 
                  d:VsixSubPath="Vsixes" 


### PR DESCRIPTION
fixes #26403

**Before Change:**
```XML
  <Dependencies>
    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" Version="[4.5,)" />
    <Dependency DisplayName="Roslyn Compilers" Version="[Vsixes\42.42.42.42424,)" Location="Vsixes\Roslyn.Compilers.Extension.vsix" Id="7922692f-f018-45e7-8f3f-d3b7c0262841" />
    <Dependency DisplayName="Roslyn Language Services" Version="[Vsixes\42.42.42.42424,)" Location="Vsixes\Roslyn.VisualStudio.Setup.vsix" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
    <Dependency DisplayName="Roslyn Interactive Components" Version="[Vsixes\42.42.42.42424,)" Location="Vsixes\Roslyn.VisualStudio.InteractiveComponents.vsix" Id="500fff63-afcf-4195-8db4-3fa8a5180e79" />
    <Dependency DisplayName="Roslyn Expression Evaluators" Version="[Vsixes\42.42.42.42424,)" Location="Vsixes\ExpressionEvaluatorPackage.vsix" Id="21BAC26D-2935-4D0D-A282-AD647E2592B5" />
  </Dependencies>
```

**After Change**

```XML
  <Dependencies>
    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" Version="[4.5,)" />
    <Dependency DisplayName="Roslyn Compilers" Version="[42.42.42.42424,)" Location="Vsixes\Roslyn.Compilers.Extension.vsix" Id="7922692f-f018-45e7-8f3f-d3b7c0262841" />
    <Dependency DisplayName="Roslyn Language Services" Version="[42.42.42.42424,)" Location="Vsixes\Roslyn.VisualStudio.Setup.vsix" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
    <Dependency DisplayName="Roslyn Interactive Components" Version="[42.42.42.42424,)" Location="Vsixes\Roslyn.VisualStudio.InteractiveComponents.vsix" Id="500fff63-afcf-4195-8db4-3fa8a5180e79" />
    <Dependency DisplayName="Roslyn Expression Evaluators" Version="[42.42.42.42424,)" Location="Vsixes\ExpressionEvaluatorPackage.vsix" Id="21BAC26D-2935-4D0D-A282-AD647E2592B5" />
  </Dependencies>
```