### PR TITLE
Do not report unused using/imports if not processing doc comments.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1890,7 +1890,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     cancellationToken.ThrowIfCancellationRequested();
 
                     SyntaxTree infoTree = info.Tree;
-                    if (filterTree == null || filterTree == infoTree)
+                    if ((filterTree == null || filterTree == infoTree) && infoTree.Options.DocumentationMode != DocumentationMode.None)
                     {
                         TextSpan infoSpan = info.Span;
                         if (!this.IsImportDirectiveUsed(infoTree, infoSpan.Start))

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1883,7 +1883,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override void ReportUnusedImports(SyntaxTree filterTree, DiagnosticBag diagnostics, CancellationToken cancellationToken)
         {
-            if (_lazyImportInfos != null)
+            if (_lazyImportInfos != null && filterTree?.Options.DocumentationMode != DocumentationMode.None)
             {
                 foreach (ImportInfo info in _lazyImportInfos)
                 {

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -392,8 +392,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(!docCommentNodes.IsDefaultOrEmpty);
 
-            bool haveWriter = _writer != null;
-
             bool processedDocComment = false; // Even if there are DocumentationCommentTriviaSyntax, we may not need to process any of them.
 
             ArrayBuilder<CSharpSyntaxNode> includeElementNodesBuilder = null;
@@ -412,13 +410,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _cancellationToken.ThrowIfCancellationRequested();
 
                 bool reportDiagnosticsForCurrentTrivia = trivia.SyntaxTree.ReportDocumentationCommentDiagnostics();
-
-                // If we're writing XML or we need to report diagnostics (either in this particular piece of trivia,
-                // or concerning undocumented [type] parameters), then we need to process this trivia node.
-                if (!(haveWriter || reportDiagnosticsForCurrentTrivia || reportParameterOrTypeParameterDiagnostics))
-                {
-                    continue;
-                }
 
                 if (!processedDocComment)
                 {

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
@@ -329,12 +329,8 @@ using System;
 /// <see cref='Console'/>
 public class C { }
 ";
-
-            // Not binding doc comments.
-            CreateCompilation(source).VerifyDiagnostics(
-                // (2,1): info CS8019: Unnecessary using directive.
-                // using System;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;"));
+            // Not reporting doc comment diagnostics. It is still a use.
+            CreateCompilation(source).VerifyDiagnostics();
 
             // Binding doc comments.
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics();
@@ -429,6 +425,35 @@ partial class Program
                 //// using System.Runtime.InteropServices;
                 //Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Runtime.InteropServices;").WithLocation(1, 1)
                 );
+        }
+
+        [Fact, WorkItem(2773, "https://github.com/dotnet/roslyn/issues/2773")]
+        public void UsageInDocComment()
+        {
+            var source = @"using X;
+
+/// <summary/>
+public class Program
+{
+    /// <summary>
+    /// <see cref=""Q""/>
+    /// </summary>
+    static void Main(string[] args)
+    {
+    }
+}
+
+namespace X
+{
+    /// <summary/>
+    public class Q { }
+}
+";
+            foreach (DocumentationMode documentationMode in Enum.GetValues(typeof(DocumentationMode)))
+            {
+                var compilation = CreateCompilation(source, parseOptions: TestOptions.Regular.WithDocumentationMode(documentationMode));
+                compilation.VerifyDiagnostics();
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -4369,17 +4369,17 @@ public partial class D { }
 public partial class E { }
 ";
 
-            var tree1 = Parse(source1, options: TestOptions.RegularWithDocumentationComments.WithLanguageVersion(LanguageVersion.Latest));
-            var tree2 = Parse(source2, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
+            var tree1 = Parse(source1, options: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Diagnose).WithLanguageVersion(LanguageVersion.Latest));
+            var tree2 = Parse(source2, options: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None).WithLanguageVersion(LanguageVersion.Latest));
 
             // This scenario does not exist in dev11, but the diagnostics seem reasonable.
             CreateCompilation(new[] { tree1, tree2 }).VerifyDiagnostics(
                 // (5,22): warning CS1591: Missing XML comment for publicly visible type or member 'D'
                 // public partial class D { }
-                Diagnostic(ErrorCode.WRN_MissingXMLComment, "D").WithArguments("D"),
+                Diagnostic(ErrorCode.WRN_MissingXMLComment, "D").WithArguments("D").WithLocation(5, 22),
                 // (7,22): warning CS1591: Missing XML comment for publicly visible type or member 'E'
                 // public partial class E { }
-                Diagnostic(ErrorCode.WRN_MissingXMLComment, "E").WithArguments("E"));
+                Diagnostic(ErrorCode.WRN_MissingXMLComment, "E").WithArguments("E").WithLocation(7, 22));
         }
 
         [Fact]

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -8,9 +8,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 {
     public static class TestOptions
     {
-        // Disable documentation comments by default so that we don't need to
+        // Disable diagnosing documentation comments by default so that we don't need to
         // document every public member of every test input.
-        public static readonly CSharpParseOptions Regular = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.None).WithLanguageVersion(LanguageVersion.Latest);
+        public static readonly CSharpParseOptions Regular = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Parse).WithLanguageVersion(LanguageVersion.Latest);
         public static readonly CSharpParseOptions Script = Regular.WithKind(SourceCodeKind.Script);
         public static readonly CSharpParseOptions Regular6 = Regular.WithLanguageVersion(LanguageVersion.CSharp6);
         public static readonly CSharpParseOptions Regular7 = Regular.WithLanguageVersion(LanguageVersion.CSharp7);

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1578,7 +1578,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         Friend Overrides Sub ReportUnusedImports(filterTree As SyntaxTree, diagnostics As DiagnosticBag, cancellationToken As CancellationToken)
-            If _lazyImportInfos IsNot Nothing Then
+            If _lazyImportInfos IsNot Nothing AndAlso (filterTree Is Nothing OrElse filterTree.Options.DocumentationMode <> DocumentationMode.None) Then
                 Dim unusedBuilder As ArrayBuilder(Of TextSpan) = Nothing
 
                 For Each info As ImportInfo In _lazyImportInfos

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1585,7 +1585,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     cancellationToken.ThrowIfCancellationRequested()
 
                     Dim infoTree As SyntaxTree = info.Tree
-                    If filterTree Is Nothing OrElse filterTree Is infoTree Then
+                    If (filterTree Is Nothing OrElse filterTree Is infoTree) AndAlso infoTree.Options.DocumentationMode <> DocumentationMode.None Then
                         Dim clauseSpans = info.ClauseSpans
                         Dim numClauseSpans = clauseSpans.Length
 

--- a/src/EditorFeatures/CSharpTest/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests.cs
@@ -1307,19 +1307,23 @@ public class QueryExpressionTest
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public async Task TestReferenceInCref()
         {
-            // parsing doc comments as simple trivia; System is unnecessary
-            await TestInRegularAndScriptAsync(
+            // parsing doc comments as simple trivia; we don't know System is unnecessary
+            await TestMissingAsync(
 @"[|using System;
 /// <summary><see cref=""String"" /></summary>
 class C
 {
-}|]",
-@"/// <summary><see cref=""String"" /></summary>
-class C
-{
-}");
+}|]", new TestParameters(Options.Regular.WithDocumentationMode(DocumentationMode.None)));
 
             // fully parsing doc comments; System is necessary
+            await TestMissingAsync(
+@"[|using System;
+/// <summary><see cref=""String"" /></summary>
+class C
+{
+}|]", new TestParameters(Options.Regular.WithDocumentationMode(DocumentationMode.Parse)));
+
+            // fully parsing and diagnosing doc comments; System is necessary
             await TestMissingAsync(
 @"[|using System;
 /// <summary><see cref=""String"" /></summary>


### PR DESCRIPTION
Also silently process doc comments when parsing them so we can report unused usings.
Fixes #2773
