### PR TITLE
Avoid adding duplicate metadata references to AbstractProject reference list

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -624,6 +624,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             lock (_gate)
             {
+                if (_metadataReferences.Contains(r => StringComparer.OrdinalIgnoreCase.Equals(r.FilePath, reference.FilePath)))
+                {
+                    // TODO: Added in order to diagnose why duplicate references get added to the project. See https://github.com/dotnet/roslyn/issues/26437
+                    FatalError.ReportWithoutCrash(new InvalidOperationException($"Reference with path '{reference.FilePath}' already exists in project '{DisplayName}'."));
+                    return;
+                }
+
                 _metadataReferences.Add(reference);
             }
 


### PR DESCRIPTION
### Customer scenario

VS crashes due to a duplicate metadata reference added to the list of references the AbstractProject maintains. The root cause is unknown. This change prevents the crash and reports non-Fatal Watson at the point when the duplicate reference is being added, so that we can diagnose why it's happening.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/599686

### Workarounds, if any

None.

### Risk

Small.

### Performance impact

Small.

### Is this a regression from a previous update?

### Root cause analysis

Unknown.

### How was the bug found?

Watson report.

### Test documentation updated?
