### PR TITLE
Fix overflow with circular field definition

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1120,7 +1120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool typeHasErrors = type.IsErrorType();
 
-            if (!typeHasErrors && type.IsManagedType)
+            if (!typeHasErrors && type.IsManagedType(fieldsBeingBound: null))
             {
                 diagnostics.Add(ErrorCode.ERR_ManagedAddr, node.Location, type);
                 typeHasErrors = true;
@@ -2717,7 +2717,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bestType = CreateErrorType();
             }
 
-            if (!bestType.IsErrorType() && bestType.IsManagedType)
+            if (!bestType.IsErrorType() && bestType.IsManagedType(fieldsBeingBound: null))
             {
                 Error(diagnostics, ErrorCode.ERR_ManagedAddr, node, bestType);
             }
@@ -3070,7 +3070,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol elementType = BindType(elementTypeSyntax, diagnostics);
 
             TypeSymbol type = GetStackAllocType(node, elementType, diagnostics, out bool hasErrors);
-            if (!elementType.IsErrorType() && elementType.IsManagedType)
+            if (!elementType.IsErrorType() && elementType.IsManagedType(fieldsBeingBound: null))
             {
                 Error(diagnostics, ErrorCode.ERR_ManagedAddr, elementTypeSyntax, elementType);
                 hasErrors = true;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2107,7 +2107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol operandType = operand.Type;
             Debug.Assert((object)operandType != null, "BindValue should have caught a null operand type");
 
-            bool isManagedType = operandType.IsManagedType;
+            bool isManagedType = operandType.IsManagedType(fieldsBeingBound: null);
             bool allowManagedAddressOf = Flags.Includes(BinderFlags.AllowManagedAddressOf);
             if (!allowManagedAddressOf)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1139,7 +1139,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
             }
 
-            if (elementType.IsManagedType)
+            if (elementType.IsManagedType(fieldsBeingBound: null))
             {
                 Error(diagnostics, ErrorCode.ERR_ManagedAddr, initializerSyntax, elementType);
                 hasErrors = true;

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2780,6 +2780,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The definition of field &apos;{0}&apos; is circular.
+        /// </summary>
+        internal static string ERR_CircularField {
+            get {
+                return ResourceManager.GetString("ERR_CircularField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The class type constraint &apos;{0}&apos; must come before any other constraints.
         /// </summary>
         internal static string ERR_ClassBoundNotFirst {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -720,6 +720,9 @@
   <data name="ERR_CircularBase" xml:space="preserve">
     <value>Circular base class dependency involving '{0}' and '{1}'</value>
   </data>
+  <data name="ERR_CircularField" xml:space="preserve">
+    <value>The definition of field '{0}' is circular</value>
+  </data>
   <data name="ERR_BadDelegateConstructor" xml:space="preserve">
     <value>The delegate '{0}' does not have a valid constructor</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1577,6 +1577,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExprCannotBeFixed = 8385,
         ERR_InvalidObjectCreation = 8386,
         #endregion diagnostics introduced for C# 7.3
+
+        ERR_CircularField = 8387,
     }
     // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    Debug.Assert(!pinnedTemp.Type.IsManagedType);
+                    Debug.Assert(!pinnedTemp.Type.IsManagedType(fieldsBeingBound: null));
 
                     // temp = ref *default(T*);
                     cleanup[i] = _factory.Assignment(_factory.Local(pinnedTemp), new BoundPointerIndirectionOperator(

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -234,12 +234,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsManagedType
+        internal sealed override bool IsManagedType(ConsList<FieldSymbol> fieldsBeingBound)
         {
-            get
-            {
-                return true;
-            }
+            return true;
         }
 
         internal sealed override bool IsByRefLikeType

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -817,7 +817,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            if (typeParameter.HasUnmanagedTypeConstraint && (typeArgument.IsManagedType || !typeArgument.IsNonNullableValueType()))
+            if (typeParameter.HasUnmanagedTypeConstraint && (typeArgument.IsManagedType(fieldsBeingBound: null) || !typeArgument.IsNonNullableValueType()))
             {
                 // "The type '{2}' must be a non-nullable value type, along with all fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'"
                 diagnosticsBuilder.Add(new TypeParameterDiagnosticInfo(typeParameter, new CSDiagnosticInfo(ErrorCode.ERR_UnmanagedConstraintNotSatisfied, containingSymbol.ConstructedFrom(), typeParameter, typeArgument)));

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -107,12 +107,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsManagedType
+        internal sealed override bool IsManagedType(ConsList<FieldSymbol> fieldsBeingBound)
         {
-            get
-            {
-                return true;
-            }
+            return true;
         }
 
         internal sealed override bool IsByRefLikeType

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -414,15 +414,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool IsManagedType
+        internal override bool IsManagedType(ConsList<FieldSymbol> fieldsBeingBound = null)
         {
-            get
-            {
-                // CONSIDER: we could cache this, but it's only expensive for non-special struct types
-                // that are pointed to.  For now, only cache on SourceMemberContainerSymbol since it fits
-                // nicely into the flags variable.
-                return BaseTypeAnalysis.IsManagedType(this);
-            }
+            // CONSIDER: we could cache this, but it's only expensive for non-special struct types
+            // that are pointed to.  For now, only cache on SourceMemberContainerSymbol since it fits
+            // nicely into the flags variable.
+            return BaseTypeAnalysis.IsManagedType(this, fieldsBeingBound);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -120,12 +120,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsManagedType
+        internal sealed override bool IsManagedType(ConsList<FieldSymbol> fieldsBeingBound)
         {
-            get
-            {
-                return false;
-            }
+            return false;
         }
 
         internal sealed override bool IsByRefLikeType

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -682,19 +682,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool IsManagedType
+        internal override bool IsManagedType(ConsList<FieldSymbol> fieldsBeingBound)
         {
-            get
+            var isManagedType = _flags.IsManagedType;
+            if (!isManagedType.HasValue())
             {
-                var isManagedType = _flags.IsManagedType;
-                if (!isManagedType.HasValue())
-                {
-                    bool value = base.IsManagedType;
-                    _flags.SetIsManagedType(value);
-                    return value;
-                }
-                return isManagedType.Value();
+                bool value = base.IsManagedType(fieldsBeingBound);
+                _flags.SetIsManagedType(value);
+                return value;
             }
+            return isManagedType.Value();
         }
 
         public override bool IsStatic

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -673,12 +673,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved);
         }
 
-        internal sealed override bool IsManagedType
+        internal sealed override bool IsManagedType(ConsList<FieldSymbol> fieldsBeingBound)
         {
-            get
-            {
-                return _underlyingType.IsManagedType;
-            }
+            return _underlyingType.IsManagedType(fieldsBeingBound);
         }
 
         public override bool IsTupleType

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -461,12 +461,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsManagedType
+        internal sealed override bool IsManagedType(ConsList<FieldSymbol> fieldsBeingBound)
         {
-            get
-            {
-                return !this.HasUnmanagedTypeConstraint;
-            }
+            return !this.HasUnmanagedTypeConstraint;
         }
 
         internal sealed override bool IsByRefLikeType

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// See Type::computeManagedType.
         /// </remarks>
-        internal abstract bool IsManagedType { get; }
+        internal abstract bool IsManagedType(ConsList<FieldSymbol> fieldsBeingBound = null);
 
         /// <summary>
         /// Returns true if the type may contain embedded references

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;NULL&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;NULL&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;Null&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;Null&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;nulo&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;NULL&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CSharpResources.resx">
     <body>
+      <trans-unit id="ERR_CircularField">
+        <source>The definition of field '{0}' is circular</source>
+        <target state="new">The definition of field '{0}' is circular</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2979,6 +2979,20 @@ void f() { if () const int i = 0; }
         }
 
         [Fact]
+        [WorkItem(24978, "https://github.com/dotnet/roslyn/issues/24978")]
+        public void StructTypeWithArrayOfSelfPointers()
+        {
+            string source = @"unsafe public struct X { public X*[] Y; }";
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+
+            comp.VerifyDiagnostics(
+                // (1,38): error CS8387: The definition of field 'X.Y' is circular
+                // unsafe public struct X { public X*[] Y; }
+                Diagnostic(ErrorCode.ERR_CircularField, "Y").WithArguments("X.Y").WithLocation(1, 38)
+                );
+        }
+
+        [Fact]
         [WorkItem(24869, "https://github.com/dotnet/roslyn/issues/24869")]
         public void TestSelfReferencingViaLambda()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -2351,7 +2351,7 @@ class C
             var compilation = CreateCompilation(text);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2368,7 +2368,7 @@ unsafe class C
             var compilation = CreateCompilation(text, options: TestOptions.UnsafeReleaseDll);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => !field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => !field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2383,7 +2383,7 @@ class C
             var compilation = CreateCompilation(text);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2400,7 +2400,7 @@ class C<T>
             var compilation = CreateCompilation(text);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2416,7 +2416,7 @@ class C<T, U> where U : struct
             var compilation = CreateCompilation(text);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2437,7 +2437,7 @@ class C
             var model = compilation.GetSemanticModel(tree);
 
             Assert.True(tree.GetCompilationUnitRoot().DescendantNodes().OfType<AnonymousObjectCreationExpressionSyntax>().
-                Select(syntax => model.GetTypeInfo(syntax).Type).All(type => ((TypeSymbol)type).IsManagedType));
+                Select(syntax => model.GetTypeInfo(syntax).Type).All(type => ((TypeSymbol)type).IsManagedType()));
         }
 
         [Fact]
@@ -2456,7 +2456,7 @@ class Outer
             var compilation = CreateCompilation(text);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Outer");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2476,7 +2476,7 @@ class Outer<T>
             var compilation = CreateCompilation(text);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Outer");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2494,7 +2494,7 @@ class C
             var compilation = CreateCompilation(text);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2523,7 +2523,7 @@ class C
             var compilation = CreateCompilation(text);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => !field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => !field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2539,7 +2539,7 @@ class C
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
             var method = type.GetMember<MethodSymbol>("M");
 
-            Assert.False(method.ReturnType.IsManagedType);
+            Assert.False(method.ReturnType.IsManagedType());
         }
 
         [Fact]
@@ -2570,11 +2570,11 @@ struct R<T>
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("E").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<NamedTypeSymbol>("E").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("D").GetMember<NamedTypeSymbol>("E").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S").GetMember<NamedTypeSymbol>("E").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("R").GetMember<NamedTypeSymbol>("E").IsManagedType);
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("E").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<NamedTypeSymbol>("E").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("D").GetMember<NamedTypeSymbol>("E").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S").GetMember<NamedTypeSymbol>("E").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("R").GetMember<NamedTypeSymbol>("E").IsManagedType());
         }
 
         [Fact]
@@ -2607,12 +2607,12 @@ struct R<T>
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("P").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<NamedTypeSymbol>("S").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("D").GetMember<NamedTypeSymbol>("S").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("Q").GetMember<NamedTypeSymbol>("S").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("R").GetMember<NamedTypeSymbol>("S").IsManagedType);
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("P").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<NamedTypeSymbol>("S").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("D").GetMember<NamedTypeSymbol>("S").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("Q").GetMember<NamedTypeSymbol>("S").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("R").GetMember<NamedTypeSymbol>("S").IsManagedType());
         }
 
         [Fact]
@@ -2635,7 +2635,7 @@ struct S<T>
             var compilation = CreateCompilation(text);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
-            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType));
+            Assert.True(type.GetMembers().OfType<FieldSymbol>().All(field => field.Type.IsManagedType()));
         }
 
         [Fact]
@@ -2670,11 +2670,11 @@ struct S5
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S3").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S4").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S5").IsManagedType);
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S3").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S4").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S5").IsManagedType());
         }
 
         [Fact]
@@ -2714,11 +2714,11 @@ struct S5
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S3").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S4").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S5").IsManagedType);
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S3").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S4").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S5").IsManagedType());
         }
 
         [Fact]
@@ -2753,11 +2753,11 @@ struct S5
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S3").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S4").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S5").IsManagedType);
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S3").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S4").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S5").IsManagedType());
         }
 
         [Fact]
@@ -2797,11 +2797,11 @@ struct S5
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S3").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S4").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S5").IsManagedType);
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S3").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S4").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S5").IsManagedType());
         }
 
         [Fact]
@@ -2820,8 +2820,8 @@ struct S2
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType);
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("S1").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S2").IsManagedType());
         }
 
         [Fact]
@@ -2833,8 +2833,8 @@ struct W<T> { X<W<W<T>>> x; }
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("X").IsManagedType); // because of X.t
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("W").IsManagedType);
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("X").IsManagedType()); // because of X.t
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("W").IsManagedType());
         }
 
         [Fact]
@@ -2854,8 +2854,8 @@ struct R
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("R").IsManagedType);
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("R").IsManagedType());
         }
 
         [Fact]
@@ -2874,9 +2874,9 @@ struct D { A a; }
 ";
             var compilation = CreateCompilation(text);
             var globalNamespace = compilation.GlobalNamespace;
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("Q").IsManagedType);
-            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("R").IsManagedType);
-            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S").IsManagedType);
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("Q").IsManagedType());
+            Assert.True(globalNamespace.GetMember<NamedTypeSymbol>("R").IsManagedType());
+            Assert.False(globalNamespace.GetMember<NamedTypeSymbol>("S").IsManagedType());
         }
 
         [Fact]
@@ -2886,9 +2886,9 @@ struct D { A a; }
 class C { }
 ";
             var compilation = CreateCompilation(text);
-            Assert.False(compilation.GetSpecialType(SpecialType.System_ArgIterator).IsManagedType);
-            Assert.False(compilation.GetSpecialType(SpecialType.System_RuntimeArgumentHandle).IsManagedType);
-            Assert.False(compilation.GetSpecialType(SpecialType.System_TypedReference).IsManagedType);
+            Assert.False(compilation.GetSpecialType(SpecialType.System_ArgIterator).IsManagedType());
+            Assert.False(compilation.GetSpecialType(SpecialType.System_RuntimeArgumentHandle).IsManagedType());
+            Assert.False(compilation.GetSpecialType(SpecialType.System_TypedReference).IsManagedType());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -261,12 +261,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
-        internal sealed override bool IsManagedType
+        internal sealed override bool IsManagedType(ConsList<FieldSymbol> fieldsBeingBound)
         {
-            get
-            {
-                return true;
-            }
+            return true;
         }
 
         internal override bool ShouldAddWinRTMembers


### PR DESCRIPTION
For review of this fix, it's useful to look at the circular portion of the stack in overflow, which I documented below.

Sadly, it's a fairly long loop, so I have to thread a new parameter `fieldsBeingBound` through a number of those methods.

Note: I made this parameter non-optional to highlight the callers. Most callers where left as `null` because I could not find a scenario to hit them where `fieldsBeingBound` would matter. But there are a couple of places where we do have such a value available, so I could pass it anyways (speculatively). I could also make it optional, since most callers use `null`.

Note2: The additional check/diagnostic is in `SourceMemberFieldSymbol.GetFieldType`.

### Customer scenario
`unsafe struct X { public X*[] Y; }` crashes compiler and IDE.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24978

### Workarounds, if any
None

### Risk
### Performance impact

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?
Reported by customer


### Repeating portion of the overflow stack

- Symbols.FieldSymbol.Type.get() [Line 55](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/FieldSymbol.cs,55)
- Symbols.BaseTypeAnalysis.DependsOnDefinitelyManagedType(Symbols.NamedTypeSymbol type, System.Collections.Generic.HashSet<Symbol> partialClosure) [Line 167](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/BaseTypeAnalysis.cs,167)
- Symbols.BaseTypeAnalysis.IsManagedType(Symbols.NamedTypeSymbol type) [Line 122](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/BaseTypeAnalysis.cs,122)
- Symbols.NamedTypeSymbol.IsManagedType.get() [Line 424](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/NamedTypeSymbol.cs,424)
- Symbols.SourceMemberContainerTypeSymbol.IsManagedType.get() [Line 692](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/Source/SourceMemberContainerSymbol.cs,692)
- Binder.BindNamespaceOrTypeOrAliasSymbol(Syntax.ExpressionSyntax syntax, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, bool suppressUseSiteDiagnostics) [Line 374](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Binder/Binder_Symbols.cs,374)
- Binder.BindTypeOrAlias(Syntax.ExpressionSyntax syntax, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved) [Line 225](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Binder/Binder_Symbols.cs,225)
- Binder.BindType(Syntax.ExpressionSyntax syntax, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved) [Line 205](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Binder/Binder_Symbols.cs,205)
- Binder.BindNamespaceOrTypeOrAliasSymbol(Syntax.ExpressionSyntax syntax, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, bool suppressUseSiteDiagnostics) [Line 346](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Binder/Binder_Symbols.cs,346)
- Binder.BindTypeOrAlias(Syntax.ExpressionSyntax syntax, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved) [Line 225](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Binder/Binder_Symbols.cs,225)
- Binder.BindType(Syntax.ExpressionSyntax syntax, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved) [Line 205](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Binder/Binder_Symbols.cs,205)
- Symbols.SourceMemberFieldSymbolFromDeclarator.GetFieldType(Roslyn.Utilities.ConsList<Symbols.FieldSymbol> fieldsBeingBound) [Line 437](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/Source/SourceMemberFieldSymbol.cs,437)
- Symbols.FieldSymbol.Type.get() Line 55
