### PR TITLE
Hard code Roslyn-Signed as the definition name

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -80,7 +80,7 @@ steps:
 
 - task: PublishSymbols@1
   inputs:
-    SymbolsPath: '$(DropRoot)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\Symbols'
+    SymbolsPath: '$(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\Symbols'
     SearchPattern: '*.dll;*.exe;*.pdb;Dlls\**\*.dll;Dlls\**\*.exe;Dlls\**\*.pdb;Exes\**\*.dll;Exes\**\*.exe;Exes\**\*.pdb;Vsix\**\*.dll;Vsix\**\*.exe;Vsix\**\*.pdb'
     SymbolsFolder: '$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)'
     SkipIndexing: true
@@ -92,7 +92,7 @@ steps:
 
 - task: PublishSymbols@1
   inputs:
-    SymbolsPath: '$(DropRoot)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\Symbols'
+    SymbolsPath: '$(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\Symbols'
     SearchPattern: '**\*.dll;**\*.exe;**\*.pdb'
     SymbolsFolder: '$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\SymStore'
     SkipIndexing: true
@@ -104,14 +104,14 @@ steps:
 
 - task: CopyFiles@2
   inputs:
-    SourceFolder: '$(DropRoot)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\Symbols'
+    SourceFolder: '$(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\Symbols'
     TargetFolder: '$(Build.StagingDirectory)\SymbolsForPublish'
   condition: and(succeeded(), contains(variables['PB_PublishType'], 'vsts'))
 
 - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
-    requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
+    requestName: '$(system.teamProject)/Roslyn-Signed/$(Build.BuildNumber)/$(Build.BuildId)'
     sourcePath: '$(Build.StagingDirectory)\SymbolsForPublish'
     usePat: false
   continueOnError: true
@@ -137,7 +137,7 @@ steps:
     PathtoPublish: 'Binaries\$(BuildConfiguration)'
     ArtifactName: '$(Build.BuildNumber)'
     publishLocation: FilePath
-    TargetPath: '$(DropRoot)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(BuildConfiguration)'
+    TargetPath: '$(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)'
     Parallel: true
     ParallelCount: 64
 
@@ -149,7 +149,7 @@ steps:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)\MicroBuild\Output'
     ArtifactName: '$(Build.BuildNumber)'
     publishLocation: FilePath
-    TargetPath: '$(DropRoot)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(BuildConfiguration)'
+    TargetPath: '$(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)'
   condition: and(succeededOrFailed(), contains(variables['PB_PublishType'], 'vsts'))
 
 


### PR DESCRIPTION
Until Roslyn-Signed-Yaml is renamed to Roslyn-Signed then we need to
hard code Roslyn-Signed instead of using `$(Build.DefinitionName)` in
the YAML file.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
