### PR TITLE
MEF construction

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
-using Moq;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1668,12 +1667,7 @@ class C
 
                 var subjectDocument = workspace.Documents.Single();
 
-                var textUndoHistory = new Mock<ITextUndoHistoryRegistry>();
-                var editorOperationsFactory = new Mock<IEditorOperationsFactoryService>();
-                var editorOperations = new Mock<IEditorOperations>();
-                editorOperationsFactory.Setup(x => x.GetEditorOperations(subjectDocument.GetTextView())).Returns(editorOperations.Object);
-
-                var commandHandler = new FormatCommandHandler(textUndoHistory.Object, editorOperationsFactory.Object);
+                var commandHandler = workspace.GetService<FormatCommandHandler>();
                 var typedChar = subjectDocument.GetTextBuffer().CurrentSnapshot.GetText(subjectDocument.CursorPosition.Value - 1, 1);
                 commandHandler.ExecuteCommand(new TypeCharCommandArgs(subjectDocument.GetTextView(), subjectDocument.TextBuffer, typedChar[0]), () => { }, TestCommandExecutionContext.Create());
 

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -21,7 +21,6 @@ using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
-using Moq;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -3284,12 +3283,7 @@ class Program{
             {
                 var subjectDocument = workspace.Documents.Single();
 
-                var textUndoHistory = new Mock<ITextUndoHistoryRegistry>();
-                var editorOperationsFactory = new Mock<IEditorOperationsFactoryService>();
-                var editorOperations = new Mock<IEditorOperations>();
-                editorOperationsFactory.Setup(x => x.GetEditorOperations(subjectDocument.GetTextView())).Returns(editorOperations.Object);
-
-                var commandHandler = new FormatCommandHandler(textUndoHistory.Object, editorOperationsFactory.Object);
+                var commandHandler = workspace.GetService<FormatCommandHandler>();
                 var typedChar = subjectDocument.GetTextBuffer().CurrentSnapshot.GetText(subjectDocument.CursorPosition.Value - 1, 1);
                 commandHandler.ExecuteCommand(new TypeCharCommandArgs(subjectDocument.GetTextView(), subjectDocument.TextBuffer, typedChar[0]), () => { }, TestCommandExecutionContext.Create());
 

--- a/src/EditorFeatures/Core/CommandHandlers/CompletionCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/CompletionCommandHandler.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Utilities;
 using VSCommanding = Microsoft.VisualStudio.Commanding;
 
@@ -15,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
     internal sealed class CompletionCommandHandler : AbstractCompletionCommandHandler
     {
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CompletionCommandHandler(IAsyncCompletionService completionService)
             : base(completionService)
         {

--- a/src/EditorFeatures/Core/CommandHandlers/IntelliSenseCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/IntelliSenseCommandHandler.cs
@@ -1,17 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Utilities;
 using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
+    [Export]
     [Export(typeof(VSCommanding.ICommandHandler))]
     [ContentType(ContentTypeNames.RoslynContentType)]
     [Name(PredefinedCommandHandlerNames.IntelliSense)]
     internal sealed class IntelliSenseCommandHandler : AbstractIntelliSenseCommandHandler
     {
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public IntelliSenseCommandHandler(
                CompletionCommandHandler completionCommandHandler,
                SignatureHelpCommandHandler signatureHelpCommandHandler,

--- a/src/EditorFeatures/Core/CommandHandlers/SignatureHelpCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/SignatureHelpCommandHandler.cs
@@ -38,24 +38,15 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         public string DisplayName => EditorFeaturesResources.Signature_Help_Command_Handler;
 
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public SignatureHelpCommandHandler(
             [ImportMany] IEnumerable<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> signatureHelpProviders,
             [ImportMany] IEnumerable<Lazy<IIntelliSensePresenter<ISignatureHelpPresenterSession, ISignatureHelpSession>, OrderableMetadata>> signatureHelpPresenters,
             IAsynchronousOperationListenerProvider listenerProvider)
-            : this(ExtensionOrderer.Order(signatureHelpPresenters).Select(lazy => lazy.Value).FirstOrDefault(),
-                   signatureHelpProviders, listenerProvider)
-        {
-        }
-
-        // For testing purposes.
-        public SignatureHelpCommandHandler(
-            IIntelliSensePresenter<ISignatureHelpPresenterSession, ISignatureHelpSession> signatureHelpPresenter,
-            [ImportMany] IEnumerable<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> signatureHelpProviders,
-            IAsynchronousOperationListenerProvider listenerProvider)
         {
             _signatureHelpProviders = ExtensionOrderer.Order(signatureHelpProviders);
             _listener = listenerProvider.GetListener(FeatureAttribute.SignatureHelp);
-            _signatureHelpPresenter = signatureHelpPresenter;
+            _signatureHelpPresenter = ExtensionOrderer.Order(signatureHelpPresenters).Select(lazy => lazy.Value).FirstOrDefault();
         }
 
         private bool TryGetController(EditorCommandArgs args, out Controller controller)

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -22,6 +23,7 @@ using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 {
+    [Export]
     [Export(typeof(VSCommanding.ICommandHandler))]
     [ContentType(ContentTypeNames.RoslynContentType)]
     [Name(PredefinedCommandHandlerNames.FormatDocument)]
@@ -40,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
         public string DisplayName => EditorFeaturesResources.Format_Command_Handler;
 
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public FormatCommandHandler(
             ITextUndoHistoryRegistry undoHistoryRegistry,
             IEditorOperationsFactoryService editorOperationsFactoryService)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/AsyncCompletionService.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/AsyncCompletionService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense;
@@ -31,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         private readonly Dictionary<IContentType, ImmutableHashSet<char>> _autoBraceCompletionCharSet;
 
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public AsyncCompletionService(
             IEditorOperationsFactoryService editorOperationsFactoryService,
             ITextUndoHistoryRegistry undoHistoryRegistry,
@@ -38,24 +40,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             IAsynchronousOperationListenerProvider listenerProvider,
             [ImportMany] IEnumerable<Lazy<IIntelliSensePresenter<ICompletionPresenterSession, ICompletionSession>, OrderableMetadata>> completionPresenters,
             [ImportMany] IEnumerable<Lazy<IBraceCompletionSessionProvider, BraceCompletionMetadata>> autoBraceCompletionChars)
-            : this(editorOperationsFactoryService, undoHistoryRegistry, inlineRenameService, listenerProvider,
-                  ExtensionOrderer.Order(completionPresenters).Select(lazy => lazy.Value).FirstOrDefault(),
-                  autoBraceCompletionChars)
-        {
-        }
-
-        public AsyncCompletionService(
-            IEditorOperationsFactoryService editorOperationsFactoryService,
-            ITextUndoHistoryRegistry undoHistoryRegistry,
-            IInlineRenameService inlineRenameService,
-            IAsynchronousOperationListenerProvider listenerProvider,
-            IIntelliSensePresenter<ICompletionPresenterSession, ICompletionSession> completionPresenter,
-            IEnumerable<Lazy<IBraceCompletionSessionProvider, BraceCompletionMetadata>> autoBraceCompletionChars)
         {
             _editorOperationsFactoryService = editorOperationsFactoryService;
             _undoHistoryRegistry = undoHistoryRegistry;
             _inlineRenameService = inlineRenameService;
-            _completionPresenter = completionPresenter;
+            _completionPresenter = ExtensionOrderer.Order(completionPresenters).Select(lazy => lazy.Value).FirstOrDefault();
             _listener = listenerProvider.GetListener(FeatureAttribute.CompletionSet);
 
             _autoBraceCompletionChars = autoBraceCompletionChars;

--- a/src/EditorFeatures/TestUtilities2/Intellisense/IntelliSenseTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/IntelliSenseTestState.vb
@@ -1,0 +1,15 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.ComponentModel.Composition
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+    <Export(GetType(IIntelliSenseTestState))>
+    <PartNotDiscoverable>
+    Friend Class IntelliSenseTestState
+        Implements IIntelliSenseTestState
+
+        Public Property CurrentCompletionPresenterSession As TestCompletionPresenterSession Implements IIntelliSenseTestState.CurrentCompletionPresenterSession
+
+        Public Property CurrentSignatureHelpPresenterSession As TestSignatureHelpPresenterSession Implements IIntelliSenseTestState.CurrentSignatureHelpPresenterSession
+    End Class
+End Namespace

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenter.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenter.vb
@@ -1,16 +1,25 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.ComponentModel.Composition
+Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.VisualStudio.Language.Intellisense
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
+    <Export(GetType(IIntelliSensePresenter(Of ICompletionPresenterSession, ICompletionSession)))>
+    <PartNotDiscoverable>
+    <Name("Presenter")>
+    <ContentType(ContentTypeNames.RoslynContentType)>
     Friend Class TestCompletionPresenter
         Implements IIntelliSensePresenter(Of ICompletionPresenterSession, ICompletionSession)
 
         Private ReadOnly _testState As IIntelliSenseTestState
 
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New(testState As IIntelliSenseTestState)
             Me._testState = testState
         End Sub

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestSignatureHelpPresenter.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestSignatureHelpPresenter.vb
@@ -1,16 +1,25 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.ComponentModel.Composition
+Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.VisualStudio.Language.Intellisense
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
+    <Export(GetType(IIntelliSensePresenter(Of ISignatureHelpPresenterSession, ISignatureHelpSession)))>
+    <PartNotDiscoverable>
+    <Name("Test Signature Help Presenter")>
+    <ContentType(ContentTypeNames.RoslynContentType)>
     Friend Class TestSignatureHelpPresenter
         Implements IIntelliSensePresenter(Of ISignatureHelpPresenterSession, ISignatureHelpSession)
 
         Private ReadOnly _testState As IIntelliSenseTestState
 
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New(testState As IIntelliSenseTestState)
             Me._testState = testState
         End Sub

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.ComponentModel.Composition
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
@@ -26,33 +27,33 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
     Partial Friend Class TestState
         Inherits AbstractCommandHandlerTestState
-        Implements IIntelliSenseTestState
-
-        Private _currentCompletionPresenterSession As TestCompletionPresenterSession
 
         Friend ReadOnly AsyncCompletionService As IAsyncCompletionService
         Friend ReadOnly SignatureHelpCommandHandler As SignatureHelpCommandHandler
         Friend ReadOnly FormatCommandHandler As FormatCommandHandler
         Friend ReadOnly CompletionCommandHandler As CompletionCommandHandler
         Friend ReadOnly IntelliSenseCommandHandler As IntelliSenseCommandHandler
+        Private ReadOnly SessionTestState As IIntelliSenseTestState
 
-        Friend Property CurrentSignatureHelpPresenterSession As TestSignatureHelpPresenterSession Implements IIntelliSenseTestState.CurrentSignatureHelpPresenterSession
-        Friend Property CurrentCompletionPresenterSession As TestCompletionPresenterSession Implements IIntelliSenseTestState.CurrentCompletionPresenterSession
+        Friend ReadOnly Property CurrentSignatureHelpPresenterSession As TestSignatureHelpPresenterSession
             Get
-                Return _currentCompletionPresenterSession
+                Return SessionTestState.CurrentSignatureHelpPresenterSession
             End Get
-            Set(value As TestCompletionPresenterSession)
-                _currentCompletionPresenterSession = value
-            End Set
+        End Property
+
+        Friend ReadOnly Property CurrentCompletionPresenterSession As TestCompletionPresenterSession
+            Get
+                Return SessionTestState.CurrentCompletionPresenterSession
+            End Get
         End Property
 
         Private Sub New(workspaceElement As XElement,
                         extraCompletionProviders As IEnumerable(Of Lazy(Of CompletionProvider, OrderableLanguageAndRoleMetadata)),
-                        extraSignatureHelpProviders As IEnumerable(Of Lazy(Of ISignatureHelpProvider, OrderableLanguageMetadata)),
+                        Optional excludedTypes As List(Of Type) = Nothing,
                         Optional extraExportedTypes As List(Of Type) = Nothing,
                         Optional includeFormatCommandHandler As Boolean = False,
                         Optional workspaceKind As String = Nothing)
-            MyBase.New(workspaceElement, ExportProviderCache.CreateTypeCatalog(If(extraExportedTypes, New List(Of Type))), workspaceKind:=workspaceKind)
+            MyBase.New(workspaceElement, CombineExcludedTypes(excludedTypes, includeFormatCommandHandler), ExportProviderCache.CreateTypeCatalog(CombineExtraTypes(If(extraExportedTypes, New List(Of Type)))), workspaceKind:=workspaceKind)
 
             Dim languageServices = Me.Workspace.CurrentSolution.Projects.First().LanguageServices
             Dim language = languageServices.Language
@@ -62,34 +63,55 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 completionService.SetTestProviders(extraCompletionProviders.Select(Function(lz) lz.Value).ToList())
             End If
 
-            Me.AsyncCompletionService = New AsyncCompletionService(
-                GetService(Of IEditorOperationsFactoryService)(),
-                UndoHistoryRegistry,
-                GetService(Of IInlineRenameService)(),
-                GetExportedValue(Of IAsynchronousOperationListenerProvider),
-                {New Lazy(Of IIntelliSensePresenter(Of ICompletionPresenterSession, ICompletionSession), OrderableMetadata)(Function() New TestCompletionPresenter(Me), New OrderableMetadata("Presenter"))},
-                GetExports(Of IBraceCompletionSessionProvider, BraceCompletionMetadata)())
+            Me.SessionTestState = GetExportedValue(Of IIntelliSenseTestState)()
 
-            Me.CompletionCommandHandler = New CompletionCommandHandler(Me.AsyncCompletionService)
+            Me.AsyncCompletionService = GetExportedValue(Of IAsyncCompletionService)()
 
-            Me.SignatureHelpCommandHandler = New SignatureHelpCommandHandler(
-                New TestSignatureHelpPresenter(Me),
-                GetExports(Of ISignatureHelpProvider, OrderableLanguageMetadata)().Concat(extraSignatureHelpProviders),
-                GetExportedValue(Of IAsynchronousOperationListenerProvider)())
+            Me.CompletionCommandHandler = GetExportedValue(Of CompletionCommandHandler)()
 
-            Me.IntelliSenseCommandHandler = New IntelliSenseCommandHandler(CompletionCommandHandler, SignatureHelpCommandHandler, Nothing)
+            Me.SignatureHelpCommandHandler = GetExportedValue(Of SignatureHelpCommandHandler)()
+
+            Me.IntelliSenseCommandHandler = GetExportedValue(Of IntelliSenseCommandHandler)()
 
             Me.FormatCommandHandler = If(includeFormatCommandHandler,
-                New FormatCommandHandler(
-                    GetService(Of ITextUndoHistoryRegistry),
-                    GetService(Of IEditorOperationsFactoryService)),
+                GetExportedValue(Of FormatCommandHandler)(),
                 Nothing)
         End Sub
+
+        Private Shared Function CombineExcludedTypes(excludedTypes As IList(Of Type), includeFormatCommandHandler As Boolean) As IList(Of Type)
+            Dim result = New List(Of Type) From {
+                GetType(IIntelliSensePresenter(Of ICompletionPresenterSession, ICompletionSession)),
+                GetType(IIntelliSensePresenter(Of ISignatureHelpPresenterSession, ISignatureHelpSession))
+            }
+
+            If Not includeFormatCommandHandler Then
+                result.Add(GetType(FormatCommandHandler))
+            End If
+
+            If excludedTypes IsNot Nothing Then
+                result.AddRange(excludedTypes)
+            End If
+
+            Return result
+        End Function
+
+        Private Shared Function CombineExtraTypes(extraExportedTypes As IList(Of Type)) As IList(Of Type)
+            Dim result = New List(Of Type) From {
+                GetType(TestCompletionPresenter),
+                GetType(TestSignatureHelpPresenter),
+                GetType(IntelliSenseTestState)
+            }
+
+            If extraExportedTypes IsNot Nothing Then
+                result.AddRange(extraExportedTypes)
+            End If
+
+            Return result
+        End Function
 
         Public Shared Function CreateVisualBasicTestState(
                 documentElement As XElement,
                 Optional extraCompletionProviders As CompletionProvider() = Nothing,
-                Optional extraSignatureHelpProviders As ISignatureHelpProvider() = Nothing,
                 Optional extraExportedTypes As List(Of Type) = Nothing) As TestState
             Return New TestState(
                 <Workspace>
@@ -100,14 +122,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                     </Project>
                 </Workspace>,
                 CreateLazyProviders(extraCompletionProviders, LanguageNames.VisualBasic, roles:=Nothing),
-                CreateLazyProviders(extraSignatureHelpProviders, LanguageNames.VisualBasic),
+                excludedTypes:=Nothing,
                 extraExportedTypes)
         End Function
 
         Public Shared Function CreateCSharpTestState(
                 documentElement As XElement,
                 Optional extraCompletionProviders As CompletionProvider() = Nothing,
-                Optional extraSignatureHelpProviders As ISignatureHelpProvider() = Nothing,
+                Optional excludedTypes As List(Of Type) = Nothing,
                 Optional extraExportedTypes As List(Of Type) = Nothing,
                 Optional includeFormatCommandHandler As Boolean = False) As TestState
             Return New TestState(
@@ -119,7 +141,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                     </Project>
                 </Workspace>,
                 CreateLazyProviders(extraCompletionProviders, LanguageNames.CSharp, roles:=Nothing),
-                CreateLazyProviders(extraSignatureHelpProviders, LanguageNames.CSharp),
+                excludedTypes,
                 extraExportedTypes,
                 includeFormatCommandHandler)
         End Function
@@ -127,13 +149,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Shared Function CreateTestStateFromWorkspace(
                 workspaceElement As XElement,
                 Optional extraCompletionProviders As CompletionProvider() = Nothing,
-                Optional extraSignatureHelpProviders As ISignatureHelpProvider() = Nothing,
                 Optional extraExportedTypes As List(Of Type) = Nothing,
                 Optional workspaceKind As String = Nothing) As TestState
             Return New TestState(
                 workspaceElement,
                 CreateLazyProviders(extraCompletionProviders, LanguageNames.VisualBasic, roles:=Nothing),
-                CreateLazyProviders(extraSignatureHelpProviders, LanguageNames.VisualBasic),
+                excludedTypes:=Nothing,
                 extraExportedTypes,
                 workspaceKind:=workspaceKind)
         End Function

--- a/src/VisualStudio/CSharp/Test/EventHookup/EventHookupTestState.cs
+++ b/src/VisualStudio/CSharp/Test/EventHookup/EventHookupTestState.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EventHookup
         private Mutex _testSessionHookupMutex;
 
         public EventHookupTestState(XElement workspaceElement, IDictionary<OptionKey, object> options)
-            : base(workspaceElement, GetExtraParts(), false)
+            : base(workspaceElement, excludedTypes: null, GetExtraParts(), false)
         {
 #pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
             _commandHandler = new EventHookupCommandHandler(Workspace.GetService<IInlineRenameService>(), Workspace.GetService<IQuickInfoBroker>(),

--- a/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
@@ -111,7 +111,6 @@ class C
             Using state = TestState.CreateTestStateFromWorkspace(
                 workspaceXml,
                 New CompletionProvider() {New MockCompletionProvider()},
-                Nothing,
                 New List(Of Type) From {GetType(TestCSharpSnippetInfoService)},
                 WorkspaceKind.Interactive)
 
@@ -132,8 +131,7 @@ class C
             Dim state = TestState.CreateCSharpTestState(
                 xElement,
                 New CompletionProvider() {New MockCompletionProvider()},
-                Nothing,
-                New List(Of Type) From {GetType(TestCSharpSnippetInfoService)})
+                extraExportedTypes:=New List(Of Type) From {GetType(TestCSharpSnippetInfoService)})
 
             Dim testSnippetInfoService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService(Of ISnippetInfoService)(), TestCSharpSnippetInfoService)
             testSnippetInfoService.SetSnippetShortcuts(snippetShortcuts)

--- a/src/VisualStudio/Core/Test/Completion/VisualBasicCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/VisualBasicCompletionSnippetNoteTests.vb
@@ -81,7 +81,6 @@ End Class]]></document>
             Dim state = TestState.CreateVisualBasicTestState(
                 xElement,
                 New CompletionProvider() {New MockCompletionProvider()},
-                Nothing,
                 New List(Of Type) From {GetType(TestVisualBasicSnippetInfoService)})
 
             Dim testSnippetInfoService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.VisualBasic).GetService(Of ISnippetInfoService)(), TestVisualBasicSnippetInfoService)

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -16,6 +16,7 @@ Imports Microsoft.CodeAnalysis.SignatureHelp
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.Commanding
+Imports Microsoft.VisualStudio.Language.Intellisense
 Imports Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Extensions
@@ -32,7 +33,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
 
     Friend Class TestState
         Inherits AbstractCommandHandlerTestState
-        Implements IIntelliSenseTestState
 
         Friend ReadOnly AsyncCompletionService As IAsyncCompletionService
         Friend ReadOnly SignatureHelpCommandHandler As SignatureHelpCommandHandler
@@ -40,18 +40,28 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
         Friend ReadOnly IntelliSenseCommandHandler As IntelliSenseCommandHandler
 
         Private _context As AbstractDebuggerIntelliSenseContext
+        Private ReadOnly SessionTestState As IIntelliSenseTestState
 
-        Friend Property CurrentSignatureHelpPresenterSession As TestSignatureHelpPresenterSession Implements IIntelliSenseTestState.CurrentSignatureHelpPresenterSession
-        Friend Property CurrentCompletionPresenterSession As TestCompletionPresenterSession Implements IIntelliSenseTestState.CurrentCompletionPresenterSession
+        Friend ReadOnly Property CurrentSignatureHelpPresenterSession As TestSignatureHelpPresenterSession
+            Get
+                Return SessionTestState.CurrentSignatureHelpPresenterSession
+            End Get
+        End Property
+
+        Friend ReadOnly Property CurrentCompletionPresenterSession As TestCompletionPresenterSession
+            Get
+                Return SessionTestState.CurrentCompletionPresenterSession
+            End Get
+        End Property
 
         Private Sub New(workspaceElement As XElement,
                         extraCompletionProviders As IEnumerable(Of Lazy(Of CompletionProvider, OrderableLanguageAndRoleMetadata)),
-                        extraSignatureHelpProviders As IEnumerable(Of Lazy(Of ISignatureHelpProvider, OrderableLanguageMetadata)),
                         isImmediateWindow As Boolean)
 
             MyBase.New(
                 workspaceElement,
-                exportProvider:=VisualStudioTestExportProvider.Factory.CreateExportProvider(),
+                excludedTypes:=CombineExcludedTypes(),
+                extraParts:=ExportProviderCache.CreateTypeCatalog(CombineExtraTypes()),
                 workspaceKind:=WorkspaceKind.Debugger)
 
             Dim languageServices = Me.Workspace.CurrentSolution.Projects.First().LanguageServices
@@ -62,22 +72,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 completionService.SetTestProviders(extraCompletionProviders.Select(Function(lz) lz.Value).ToList())
             End If
 
-            Me.AsyncCompletionService = New AsyncCompletionService(
-                GetService(Of IEditorOperationsFactoryService)(),
-                UndoHistoryRegistry,
-                GetService(Of IInlineRenameService)(),
-                GetExportedValue(Of IAsynchronousOperationListenerProvider)(),
-                New TestCompletionPresenter(Me),
-                GetExports(Of IBraceCompletionSessionProvider, BraceCompletionMetadata)())
+            Me.SessionTestState = GetExportedValue(Of IIntelliSenseTestState)()
 
-            Me.CompletionCommandHandler = New CompletionCommandHandler(Me.AsyncCompletionService)
+            Me.AsyncCompletionService = Workspace.GetService(Of IAsyncCompletionService)
 
-            Me.SignatureHelpCommandHandler = New SignatureHelpCommandHandler(
-                New TestSignatureHelpPresenter(Me),
-                GetExports(Of ISignatureHelpProvider, OrderableLanguageMetadata)().Concat(extraSignatureHelpProviders),
-                GetExportedValue(Of IAsynchronousOperationListenerProvider)())
+            Me.CompletionCommandHandler = Workspace.GetService(Of CompletionCommandHandler)
 
-            Me.IntelliSenseCommandHandler = New IntelliSenseCommandHandler(CompletionCommandHandler, SignatureHelpCommandHandler, Nothing)
+            Me.SignatureHelpCommandHandler = Workspace.GetService(Of SignatureHelpCommandHandler)
+
+            Me.IntelliSenseCommandHandler = Workspace.GetService(Of IntelliSenseCommandHandler)
 
             Dim spanDocument = Workspace.Documents.First(Function(x) x.SelectedSpans.Any())
             Dim statementSpan = spanDocument.SelectedSpans.First()
@@ -105,6 +108,21 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             _context.TryInitialize()
         End Sub
 
+        Private Shared Function CombineExcludedTypes() As IList(Of Type)
+            Return New List(Of Type) From {
+                GetType(IIntelliSensePresenter(Of ICompletionPresenterSession, ICompletionSession)),
+                GetType(IIntelliSensePresenter(Of ISignatureHelpPresenterSession, ISignatureHelpSession))
+            }
+        End Function
+
+        Private Shared Function CombineExtraTypes() As IList(Of Type)
+            Return New List(Of Type) From {
+                GetType(TestCompletionPresenter),
+                GetType(TestSignatureHelpPresenter),
+                GetType(IntelliSenseTestState)
+            }
+        End Function
+
         Public Overrides ReadOnly Property TextView As ITextView
             Get
                 Return _context.DebuggerTextView
@@ -131,7 +149,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
 
             Return New TestState(documentElement,
                 CreateLazyProviders(extraCompletionProviders, LanguageNames.VisualBasic, roles:=Nothing),
-                CreateLazyProviders(extraSignatureHelpProviders, LanguageNames.VisualBasic),
                 isImmediateWindow)
         End Function
 
@@ -144,7 +161,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Return New TestState(
                 workspaceElement,
                 CreateLazyProviders(extraCompletionProviders, LanguageNames.CSharp, roles:=Nothing),
-                CreateLazyProviders(extraSignatureHelpProviders, LanguageNames.CSharp),
                 isImmediateWindow)
         End Function
 

--- a/src/Workspaces/Core/Portable/Execution/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Execution/SerializerService.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Execution;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -30,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Serialization
 
         private readonly ConcurrentDictionary<string, IOptionsSerializationService> _lazyLanguageSerializationService;
 
-        [Obsolete("This exported object must be obtained through the MEF export provider.", error: true)]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public SerializerService(HostWorkspaceServices workspaceServices)
         {
             _workspaceServices = workspaceServices;

--- a/src/Workspaces/Core/Portable/Execution/SerializerServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Execution/SerializerServiceFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Execution
     [ExportWorkspaceServiceFactory(typeof(ISerializerService), layer: ServiceLayer.Default), Shared]
     internal class SerializerServiceFactory : IWorkspaceServiceFactory
     {
-        [Obsolete("This is the factory method for " + nameof(SerializerService) + ".", error: true)]
+        [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
             return new SerializerService(workspaceServices);

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/IAsynchronousOperationListenerProvider.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/IAsynchronousOperationListenerProvider.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.TestHooks
@@ -77,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             s_enableDiagnosticTokens = diagnostics;
         }
 
-        [Obsolete("This exported object must be obtained through the MEF export provider.", error: true)]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public AsynchronousOperationListenerProvider()
         {
             _singletonListeners = new ConcurrentDictionary<string, AsynchronousOperationListener>(concurrencyLevel: 2, capacity: 20);

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefConstruction.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefConstruction.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Host.Mef
+{
+    internal static class MefConstruction
+    {
+        internal const string ImportingConstructorMessage = "This exported object must be obtained through the MEF export provider.";
+        internal const string FactoryMethodMessage = "This factory method only provides services for the MEF export provider.";
+    }
+}

--- a/src/Workspaces/CoreTestUtilities/ExportProviderCache.cs
+++ b/src/Workspaces/CoreTestUtilities/ExportProviderCache.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -136,6 +137,23 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public static ComposableCatalog WithPart(this ComposableCatalog catalog, Type t)
         {
             return catalog.WithParts(CreateTypeCatalog(SpecializedCollections.SingletonEnumerable(t)));
+        }
+
+        public static ComposableCatalog WithoutPartsOfType(this ComposableCatalog catalog, Type t)
+        {
+            return catalog.WithoutPartsOfTypes(SpecializedCollections.SingletonEnumerable(t));
+        }
+
+        public static ComposableCatalog WithoutPartsOfTypes(this ComposableCatalog catalog, IEnumerable<Type> types)
+        {
+            var parts = catalog.Parts.Where(composablePartDefinition => !IsExcludedPart(composablePartDefinition));
+            return ComposableCatalog.Create(Resolver.DefaultInstance).AddParts(parts);
+
+            // Local functions
+            bool IsExcludedPart(ComposablePartDefinition part)
+            {
+                return types.Any(excludedType => excludedType.IsAssignableFrom(part.Type));
+            }
         }
 
         public static IExportProviderFactory GetOrCreateExportProviderFactory(ComposableCatalog catalog)

--- a/src/Workspaces/CoreTestUtilities/ExportProviderCache.cs
+++ b/src/Workspaces/CoreTestUtilities/ExportProviderCache.cs
@@ -139,17 +139,24 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return catalog.WithParts(CreateTypeCatalog(SpecializedCollections.SingletonEnumerable(t)));
         }
 
+        /// <summary>
+        /// Creates a <see cref="ComposableCatalog"/> derived from <paramref name="catalog"/>, but with all exported
+        /// parts assignable to type <paramref name="t"/> removed from the catalog.
+        /// </summary>
         public static ComposableCatalog WithoutPartsOfType(this ComposableCatalog catalog, Type t)
         {
             return catalog.WithoutPartsOfTypes(SpecializedCollections.SingletonEnumerable(t));
         }
 
+        /// <summary>
+        /// Creates a <see cref="ComposableCatalog"/> derived from <paramref name="catalog"/>, but with all exported
+        /// parts assignable to any type in <paramref name="types"/> removed from the catalog.
+        /// </summary>
         public static ComposableCatalog WithoutPartsOfTypes(this ComposableCatalog catalog, IEnumerable<Type> types)
         {
             var parts = catalog.Parts.Where(composablePartDefinition => !IsExcludedPart(composablePartDefinition));
             return ComposableCatalog.Create(Resolver.DefaultInstance).AddParts(parts);
 
-            // Local functions
             bool IsExcludedPart(ComposablePartDefinition part)
             {
                 return types.Any(excludedType => excludedType.IsAssignableFrom(part.Type));


### PR DESCRIPTION
Use MEF to construct objects during tests rather than rely on constructor injection. Unused mocks are removed in favor of readily-available items from the MEF container.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
