### PR TITLE
Increase logging for unit tests

### DIFF
--- a/src/Tools/Source/RunTests/ConsoleUtil.cs
+++ b/src/Tools/Source/RunTests/ConsoleUtil.cs
@@ -1,23 +1,40 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RunTests
 {
+    /// <summary>
+    /// Used to write out to the Console. In addition to writing to the console this will output the same messages
+    /// to our log file. This ensures the log file can be used as our single point of diagnostics.
+    /// </summary>
     internal static class ConsoleUtil
     {
-        internal static void Write(ConsoleColor color, string format, params object[] args)
+        internal static void Write(string message)
         {
-            WithColor(color, () => Console.Write(format, args));
+            Console.Write(message);
+            Logger.Log(message + Environment.NewLine);
         }
 
-        internal static void WriteLine(ConsoleColor color, string format, params object[] args)
+        internal static void WriteLine()
         {
-            WithColor(color, () => Console.WriteLine(format, args));
+            Console.WriteLine();
+        }
+
+        internal static void WriteLine(string message)
+        {
+            Console.WriteLine(message);
+            Logger.Log(message);
+        }
+
+        internal static void Write(ConsoleColor color, string message)
+        {
+            WithColor(color, () => Write(message));
+        }
+
+        internal static void WriteLine(ConsoleColor color, string message)
+        {
+            WithColor(color, () => WriteLine(message));
         }
 
         private static void WithColor(ConsoleColor color, Action action)

--- a/src/Tools/Source/RunTests/ConsoleUtil.cs
+++ b/src/Tools/Source/RunTests/ConsoleUtil.cs
@@ -19,6 +19,7 @@ namespace RunTests
         internal static void WriteLine()
         {
             Console.WriteLine();
+            Logger.Log("");
         }
 
         internal static void WriteLine(string message)

--- a/src/Tools/Source/RunTests/ITestExecutor.cs
+++ b/src/Tools/Source/RunTests/ITestExecutor.cs
@@ -2,13 +2,14 @@
 
 using RunTests.Cache;
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace RunTests
 {
-    internal struct TestExecutionOptions
+    internal readonly struct TestExecutionOptions
     {
         internal string XunitPath { get; }
         internal ProcDumpInfo? ProcDumpInfo { get; }
@@ -40,7 +41,7 @@ namespace RunTests
     /// is specifically for the actual test execution results while the latter can contain extra metadata
     /// about the results.  For example whether it was cached, or had diagonstic, output, etc ...
     /// </remarks>
-    internal struct TestResultInfo
+    internal readonly struct TestResultInfo
     {
         internal int ExitCode { get; }
         internal TimeSpan Elapsed { get; }
@@ -64,13 +65,18 @@ namespace RunTests
         }
     }
 
-    internal struct TestResult
+    internal readonly struct TestResult
     {
         internal TestResultInfo TestResultInfo { get; }
         internal AssemblyInfo AssemblyInfo { get; }
         internal string CommandLine { get; }
         internal bool IsFromCache { get; }
         internal string Diagnostics { get; }
+
+        /// <summary>
+        /// Collection of processes the runner explicitly ran to get the result.
+        /// </summary>
+        internal ImmutableArray<ProcessResult> ProcessResults { get; }
 
         internal string AssemblyPath => AssemblyInfo.AssemblyPath;
         internal string AssemblyName => Path.GetFileName(AssemblyPath);
@@ -83,12 +89,13 @@ namespace RunTests
         internal string ResultsFilePath => TestResultInfo.ResultsFilePath;
         internal string ResultsDirectory => TestResultInfo.ResultsDirectory;
 
-        internal TestResult(AssemblyInfo assemblyInfo, TestResultInfo testResultInfo, string commandLine, bool isFromCache, string diagnostics = null)
+        internal TestResult(AssemblyInfo assemblyInfo, TestResultInfo testResultInfo, string commandLine, bool isFromCache, ImmutableArray<ProcessResult> processResults = default, string diagnostics = null)
         {
             AssemblyInfo = assemblyInfo;
             TestResultInfo = testResultInfo;
             CommandLine = commandLine;
             IsFromCache = isFromCache;
+            ProcessResults = processResults.IsDefault ? ImmutableArray<ProcessResult>.Empty : processResults;
             Diagnostics = diagnostics;
         }
     }

--- a/src/Tools/Source/RunTests/ProcDumpUtil.cs
+++ b/src/Tools/Source/RunTests/ProcDumpUtil.cs
@@ -52,6 +52,17 @@ namespace RunTests
             return AttachProcDump(procDumpInfo.ProcDumpFilePath, processId, procDumpInfo.DumpDirectory);
         }
 
+        internal static string GetProcDumpCommandLine(string procDumpFilePath, int processId, string dumpDirectory)
+        {
+            // /accepteula command line option to automatically accept the Sysinternals license agreement.
+            // -ma	Write a 'Full' dump file. Includes All the Image, Mapped and Private memory.
+            // -e	Write a dump when the process encounters an unhandled exception. Include the 1 to create dump on first chance exceptions.
+            // -f C00000FD.STACK_OVERFLOWC Dump when a stack overflow first chance exception is encountered. 
+            const string procDumpSwitches = "/accepteula -ma -e -f C00000FD.STACK_OVERFLOW";
+            dumpDirectory = dumpDirectory.TrimEnd('\\');
+            return $" {procDumpSwitches} {processId} \"{dumpDirectory}\"";
+        }
+
         /// <summary>
         /// Attaches a new procdump.exe against the specified process.
         /// </summary>
@@ -60,15 +71,8 @@ namespace RunTests
         /// <param name="dumpDirectory">destination directory for dumps</param>
         internal static Process AttachProcDump(string procDumpFilePath, int processId, string dumpDirectory)
         {
-            // /accepteula command line option to automatically accept the Sysinternals license agreement.
-            // -ma	Write a 'Full' dump file. Includes All the Image, Mapped and Private memory.
-            // -e	Write a dump when the process encounters an unhandled exception. Include the 1 to create dump on first chance exceptions.
-            // -f C00000FD.STACK_OVERFLOWC Dump when a stack overflow first chance exception is encountered. 
-            const string procDumpSwitches = "/accepteula -ma -e -f C00000FD.STACK_OVERFLOW";
             Directory.CreateDirectory(dumpDirectory);
-            dumpDirectory = dumpDirectory.TrimEnd('\\');
-
-            return Process.Start(procDumpFilePath, $" {procDumpSwitches} {processId} \"{dumpDirectory}\"");
+            return Process.Start(procDumpFilePath, GetProcDumpCommandLine(procDumpFilePath, processId, dumpDirectory));
         }
     }
 }

--- a/src/Tools/Source/RunTests/ProcDumpUtil.cs
+++ b/src/Tools/Source/RunTests/ProcDumpUtil.cs
@@ -52,7 +52,7 @@ namespace RunTests
             return AttachProcDump(procDumpInfo.ProcDumpFilePath, processId, procDumpInfo.DumpDirectory);
         }
 
-        internal static string GetProcDumpCommandLine(string procDumpFilePath, int processId, string dumpDirectory)
+        internal static string GetProcDumpCommandLine(int processId, string dumpDirectory)
         {
             // /accepteula command line option to automatically accept the Sysinternals license agreement.
             // -ma	Write a 'Full' dump file. Includes All the Image, Mapped and Private memory.
@@ -72,7 +72,7 @@ namespace RunTests
         internal static Process AttachProcDump(string procDumpFilePath, int processId, string dumpDirectory)
         {
             Directory.CreateDirectory(dumpDirectory);
-            return Process.Start(procDumpFilePath, GetProcDumpCommandLine(procDumpFilePath, processId, dumpDirectory));
+            return Process.Start(procDumpFilePath, GetProcDumpCommandLine(processId, dumpDirectory));
         }
     }
 }

--- a/src/Tools/Source/RunTests/ProcessRunner.cs
+++ b/src/Tools/Source/RunTests/ProcessRunner.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -9,17 +10,35 @@ using System.Threading.Tasks;
 
 namespace RunTests
 {
-    public sealed class ProcessOutput
+    public readonly struct ProcessResult
     {
+        public Process Process { get; }
         public int ExitCode { get; }
-        public IList<string> OutputLines { get; }
-        public IList<string> ErrorLines { get; }
+        public ReadOnlyCollection<string> OutputLines { get; }
+        public ReadOnlyCollection<string> ErrorLines { get; }
 
-        public ProcessOutput(int exitCode, IList<string> outputLines, IList<string> errorLines)
+        public ProcessResult(Process process, int exitCode, ReadOnlyCollection<string> outputLines, ReadOnlyCollection<string> errorLines)
         {
+            Process = process;
             ExitCode = exitCode;
             OutputLines = outputLines;
             ErrorLines = errorLines;
+        }
+    }
+
+    public readonly struct ProcessInfo
+    {
+        public Process Process { get; }
+        public ProcessStartInfo StartInfo { get; }
+        public Task<ProcessResult> Result { get; }
+
+        public int Id => Process.Id;
+
+        public ProcessInfo(Process process, ProcessStartInfo startInfo, Task<ProcessResult> result)
+        {
+            Process = process;
+            StartInfo = startInfo;
+            Result = result;
         }
     }
 
@@ -33,7 +52,7 @@ namespace RunTests
             }
         }
 
-        public static Task<ProcessOutput> RunProcessAsync(
+        public static ProcessInfo CreateProcess(
             string executable,
             string arguments,
             bool lowPriority = false,
@@ -42,25 +61,23 @@ namespace RunTests
             bool displayWindow = true,
             Dictionary<string, string> environmentVariables = null,
             Action<Process> onProcessStartHandler = null,
-            CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
+            CancellationToken cancellationToken = default) =>
+            CreateProcess(
+                CreateProcessStartInfo(executable, arguments, workingDirectory, captureOutput, displayWindow, environmentVariables),
+                lowPriority: lowPriority,
+                onProcessStartHandler: onProcessStartHandler,
+                cancellationToken: cancellationToken);
 
-            var taskCompletionSource = new TaskCompletionSource<ProcessOutput>();
-            var processStartInfo = CreateProcessStartInfo(executable, arguments, workingDirectory, captureOutput, displayWindow, environmentVariables);
-            return CreateProcessTask(processStartInfo, lowPriority, taskCompletionSource, onProcessStartHandler, cancellationToken);
-        }
-
-        private static Task<ProcessOutput> CreateProcessTask(
+        public static ProcessInfo CreateProcess(
             ProcessStartInfo processStartInfo,
-            bool lowPriority,
-            TaskCompletionSource<ProcessOutput> taskCompletionSource,
-            Action<Process> onProcessStartHandler,
-            CancellationToken cancellationToken)
+            bool lowPriority = false,
+            Action<Process> onProcessStartHandler = null,
+            CancellationToken cancellationToken = default)
         {
             var errorLines = new List<string>();
             var outputLines = new List<string>();
             var process = new Process();
+            var tcs = new TaskCompletionSource<ProcessResult>();
 
             process.EnableRaisingEvents = true;
             process.StartInfo = processStartInfo;
@@ -89,14 +106,18 @@ namespace RunTests
                     Task.Run(() =>
                     {
                         process.WaitForExit();
-                        var processOutput = new ProcessOutput(process.ExitCode, outputLines, errorLines);
-                        taskCompletionSource.TrySetResult(processOutput);
+                        var result = new ProcessResult(
+                            process,
+                            process.ExitCode,
+                            new ReadOnlyCollection<string>(outputLines),
+                            new ReadOnlyCollection<string>(errorLines));
+                        tcs.TrySetResult(result);
                     });
                 };
 
             var registration = cancellationToken.Register(() =>
                 {
-                    if (taskCompletionSource.TrySetCanceled())
+                    if (tcs.TrySetCanceled())
                     {
                         // If the underlying process is still running, we should kill it
                         if (!process.HasExited)
@@ -131,15 +152,15 @@ namespace RunTests
                 process.BeginErrorReadLine();
             }
 
-            return taskCompletionSource.Task;
+            return new ProcessInfo(process, processStartInfo, tcs.Task);
         }
 
-        private static ProcessStartInfo CreateProcessStartInfo(
+        public static ProcessStartInfo CreateProcessStartInfo(
             string executable,
             string arguments,
-            string workingDirectory,
-            bool captureOutput,
-            bool displayWindow,
+            string workingDirectory = null,
+            bool captureOutput = false,
+            bool displayWindow = true,
             Dictionary<string, string> environmentVariables = null)
         {
             var processStartInfo = new ProcessStartInfo(executable, arguments);

--- a/src/Tools/Source/RunTests/ProcessRunner.cs
+++ b/src/Tools/Source/RunTests/ProcessRunner.cs
@@ -36,13 +36,13 @@ namespace RunTests
         public static Task<ProcessOutput> RunProcessAsync(
             string executable,
             string arguments,
-            CancellationToken cancellationToken,
             bool lowPriority = false,
             string workingDirectory = null,
             bool captureOutput = false,
             bool displayWindow = true,
             Dictionary<string, string> environmentVariables = null,
-            Action<Process> onProcessStartHandler = null)
+            Action<Process> onProcessStartHandler = null,
+            CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -89,10 +89,14 @@ namespace RunTests
                 // unexepected crashes.
                 void onProcessStart(Process process)
                 {
+                    Logger.Log($"xunit process with id {process.Id} created for test {assemblyInfo.DisplayName}");
                     if (_options.ProcDumpInfo != null)
                     {
-                        ProcDumpUtil.AttachProcDump(_options.ProcDumpInfo.Value, process.Id);
+                        var procDumpProcess = ProcDumpUtil.AttachProcDump(_options.ProcDumpInfo.Value, process.Id);
+                        Logger.Log($"procdump with id {procDumpProcess.Id} attached to {process.Id}");
                     }
+
+                    process.Exited += delegate { Logger.Log($"xunit process with id {process.Id} exited with {process.ExitCode}"); };
                 }
 
                 var start = DateTime.UtcNow;

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -23,7 +23,7 @@ namespace RunTests
         internal const int ExitSuccess = 0;
         internal const int ExitFailure = 1;
 
-        private const long MaxTotalDumpSizeInMegabytes = 4096; 
+        private const long MaxTotalDumpSizeInMegabytes = 4096;
 
         internal static int Main(string[] args)
         {
@@ -100,14 +100,14 @@ namespace RunTests
             var start = DateTime.Now;
             var assemblyInfoList = GetAssemblyList(options);
 
-            Console.WriteLine($"Data Storage: {testExecutor.DataStorage.Name}");
-            Console.WriteLine($"Proc dump location: {options.ProcDumpDirectory}");
-            Console.WriteLine($"Running {options.Assemblies.Count()} test assemblies in {assemblyInfoList.Count} partitions");
+            ConsoleUtil.WriteLine($"Data Storage: {testExecutor.DataStorage.Name}");
+            ConsoleUtil.WriteLine($"Proc dump location: {options.ProcDumpDirectory}");
+            ConsoleUtil.WriteLine($"Running {options.Assemblies.Count()} test assemblies in {assemblyInfoList.Count} partitions");
 
             var result = await testRunner.RunAllAsync(assemblyInfoList, cancellationToken).ConfigureAwait(true);
             var elapsed = DateTime.Now - start;
 
-            Console.WriteLine($"Test execution time: {elapsed}");
+            ConsoleUtil.WriteLine($"Test execution time: {elapsed}");
 
             WriteLogFile(options);
             DisplayResults(options.Display, result.TestResults);
@@ -123,7 +123,7 @@ namespace RunTests
                 return ExitFailure;
             }
 
-            Console.WriteLine($"All tests passed");
+            ConsoleUtil.WriteLine($"All tests passed");
             return ExitSuccess;
         }
 
@@ -139,8 +139,8 @@ namespace RunTests
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error writing log file {logFilePath}");
-                Console.WriteLine(ex);
+                ConsoleUtil.WriteLine($"Error writing log file {logFilePath}");
+                ConsoleUtil.WriteLine(ex.ToString());
             }
 
             Logger.Clear();
@@ -165,7 +165,7 @@ namespace RunTests
                     return;
                 }
 
-                Console.Write($"Dumping {name} {targetProcess.Id} to {dumpFilePath} ... ");
+                ConsoleUtil.Write($"Dumping {name} {targetProcess.Id} to {dumpFilePath} ... ");
                 try
                 {
                     var args = $"-accepteula -ma {targetProcess.Id} {dumpFilePath}";
@@ -177,24 +177,24 @@ namespace RunTests
                     // backup is to test for the dump file being present.
                     if (File.Exists(dumpFilePath))
                     {
-                        Console.WriteLine("succeeded");
+                        ConsoleUtil.WriteLine("succeeded");
                     }
                     else
                     {
-                        Console.WriteLine($"FAILED with {processOutput.ExitCode}");
-                        Console.WriteLine($"{procDumpFilePath} {args}");
-                        Console.WriteLine(string.Join(Environment.NewLine, processOutput.OutputLines));
+                        ConsoleUtil.WriteLine($"FAILED with {processOutput.ExitCode}");
+                        ConsoleUtil.WriteLine($"{procDumpFilePath} {args}");
+                        ConsoleUtil.WriteLine(string.Join(Environment.NewLine, processOutput.OutputLines));
                     }
                 }
                 catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
                 {
-                    Console.WriteLine("FAILED");
-                    Console.WriteLine(ex.Message);
+                    ConsoleUtil.WriteLine("FAILED");
+                    ConsoleUtil.WriteLine(ex.Message);
                     Logger.Log("Failed to dump process", ex);
                 }
             }
 
-            Console.WriteLine("Roslyn Error: test timeout exceeded, dumping remaining processes");
+            ConsoleUtil.WriteLine("Roslyn Error: test timeout exceeded, dumping remaining processes");
             var procDumpInfo = GetProcDumpInfo(options);
             if (procDumpInfo != null)
             {
@@ -209,7 +209,7 @@ namespace RunTests
             }
             else
             {
-                Console.WriteLine("Could not locate procdump");
+                ConsoleUtil.WriteLine("Could not locate procdump");
             }
 
             WriteLogFile(options);
@@ -248,7 +248,7 @@ namespace RunTests
 
             if (options.Assemblies.Count == 0)
             {
-                Console.WriteLine("No test assemblies specified.");
+                ConsoleUtil.WriteLine("No test assemblies specified.");
                 return false;
             }
 
@@ -405,7 +405,7 @@ namespace RunTests
             var dumpFiles = Directory.EnumerateFiles(directory, "*.dmp", SearchOption.AllDirectories).ToArray();
             long currentTotalSize = 0;
 
-            foreach(var dumpFile in dumpFiles)
+            foreach (var dumpFile in dumpFiles)
             {
                 long fileSizeInMegabytes = (new FileInfo(dumpFile).Length / 1024) / 1024;
                 currentTotalSize += fileSizeInMegabytes;

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -169,7 +169,7 @@ namespace RunTests
                 try
                 {
                     var args = $"-accepteula -ma {targetProcess.Id} {dumpFilePath}";
-                    var processTask = ProcessRunner.RunProcessAsync(procDumpFilePath, args, cancellationToken);
+                    var processTask = ProcessRunner.RunProcessAsync(procDumpFilePath, args, cancellationToken: cancellationToken);
                     var processOutput = await processTask;
 
                     // The exit code for procdump doesn't obey standard windows rules.  It will return non-zero

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -109,6 +109,7 @@ namespace RunTests
 
             ConsoleUtil.WriteLine($"Test execution time: {elapsed}");
 
+            LogProcessResultDetails(result.ProcessResults);
             WriteLogFile(options);
             DisplayResults(options.Display, result.TestResults);
 
@@ -125,6 +126,32 @@ namespace RunTests
 
             ConsoleUtil.WriteLine($"All tests passed");
             return ExitSuccess;
+        }
+
+        private static void LogProcessResultDetails(ImmutableArray<ProcessResult> processResults)
+        {
+            Logger.Log("### Begin logging executed process details");
+            foreach (var processResult in processResults)
+            {
+                var process = processResult.Process;
+                var startInfo = process.StartInfo;
+                Logger.Log($"### Begin {process.Id}");
+                Logger.Log($"### {startInfo.FileName} {startInfo.Arguments}");
+                Logger.Log($"### Exit code {process.ExitCode}");
+                Logger.Log("### Standard Output");
+                foreach (var line in processResult.OutputLines)
+                {
+                    Logger.Log(line);
+                }
+                Logger.Log("### Standard Error");
+                foreach (var line in processResult.ErrorLines)
+                {
+                    Logger.Log(line);
+                }
+                Logger.Log($"### End {process.Id}");
+            }
+
+            Logger.Log("End logging executed process details");
         }
 
         private static void WriteLogFile(Options options)

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -169,8 +169,8 @@ namespace RunTests
                 try
                 {
                     var args = $"-accepteula -ma {targetProcess.Id} {dumpFilePath}";
-                    var processTask = ProcessRunner.RunProcessAsync(procDumpFilePath, args, cancellationToken: cancellationToken);
-                    var processOutput = await processTask;
+                    var processInfo = ProcessRunner.CreateProcess(procDumpFilePath, args, cancellationToken: cancellationToken);
+                    var processOutput = await processInfo.Result;
 
                     // The exit code for procdump doesn't obey standard windows rules.  It will return non-zero
                     // for succesful cases (possibly returning the count of dumps that were written).  Best 

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -77,7 +77,7 @@ namespace RunTests
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine($"Error: {ex.Message}");
+                            ConsoleUtil.WriteLine($"Error: {ex.Message}");
                             failures++;
                         }
 
@@ -97,12 +97,12 @@ namespace RunTests
 
                 // Display the current status of the TestRunner.
                 // Note: The { ... , 2 } is to right align the values, thus aligns sections into columns. 
-                Console.Write($"  {running.Count, 2} running, {waiting.Count, 2} queued, {completed.Count, 2} completed");
+                ConsoleUtil.Write($"  {running.Count, 2} running, {waiting.Count, 2} queued, {completed.Count, 2} completed");
                 if (failures > 0)
                 {
-                    Console.Write($", {failures, 2} failures");
+                    ConsoleUtil.Write($", {failures, 2} failures");
                 }
-                Console.WriteLine();
+                ConsoleUtil.WriteLine();
 
                 if (running.Count > 0)
                 {
@@ -124,7 +124,7 @@ namespace RunTests
                 PrintFailedTestResult(testResult);
             }
 
-            Console.WriteLine("================");
+            ConsoleUtil.WriteLine("================");
             var line = new StringBuilder();
             foreach (var testResult in testResults)
             {
@@ -138,15 +138,14 @@ namespace RunTests
 
                 var message = line.ToString();
                 ConsoleUtil.WriteLine(color, message);
-                Logger.Log(message);
             }
-            Console.WriteLine("================");
+            ConsoleUtil.WriteLine("================");
 
             // Print diagnostics out last so they are cleanly visible at the end of the test summary
-            Console.WriteLine("Extra run diagnostics for logging, did not impact run results");
+            ConsoleUtil.WriteLine("Extra run diagnostics for logging, did not impact run results");
             foreach (var testResult in testResults.Where(x => !string.IsNullOrEmpty(x.Diagnostics)))
             {
-                Console.WriteLine(testResult.Diagnostics);
+                ConsoleUtil.WriteLine(testResult.Diagnostics);
             }
         }
 
@@ -156,20 +155,20 @@ namespace RunTests
             var outputLogPath = Path.Combine(_options.LogsDirectory, $"{testResult.DisplayName}.out.log");
             File.WriteAllText(outputLogPath, testResult.StandardOutput ?? "");
 
-            Console.WriteLine("Errors {0}: ", testResult.AssemblyName);
-            Console.WriteLine(testResult.ErrorOutput);
+            ConsoleUtil.WriteLine($"Errors {testResult.AssemblyName}");
+            ConsoleUtil.WriteLine(testResult.ErrorOutput);
 
-            // TODO: Put this in the log and take it off the console output to keep it simple?
-            Console.WriteLine($"Command: {testResult.CommandLine}");
-            Console.WriteLine($"xUnit output log: {outputLogPath}");
+            // TODO: Put this in the log and take it off the ConsoleUtil output to keep it simple?
+            ConsoleUtil.WriteLine($"Command: {testResult.CommandLine}");
+            ConsoleUtil.WriteLine($"xUnit output log: {outputLogPath}");
 
             if (!string.IsNullOrEmpty(testResult.ErrorOutput))
             {
-                Console.WriteLine(testResult.ErrorOutput);
+                ConsoleUtil.WriteLine(testResult.ErrorOutput);
             }
             else
             {
-                Console.WriteLine($"xunit produced no error output but had exit code {testResult.ExitCode}");
+                ConsoleUtil.WriteLine($"xunit produced no error output but had exit code {testResult.ExitCode}");
             }
 
             // If the results are html, use Process.Start to open in the browser.

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -18,12 +18,14 @@ namespace RunTests
         internal bool Succeeded { get; }
         internal int CacheCount { get; }
         internal ImmutableArray<TestResult> TestResults { get; }
+        internal ImmutableArray<ProcessResult> ProcessResults { get; }
 
-        internal RunAllResult(bool succeeded, int cacheCount, ImmutableArray<TestResult> testResults)
+        internal RunAllResult(bool succeeded, int cacheCount, ImmutableArray<TestResult> testResults, ImmutableArray<ProcessResult> processResults)
         {
             Succeeded = succeeded;
             CacheCount = cacheCount;
             TestResults = testResults;
+            ProcessResults = processResults;
         }
     }
 
@@ -112,7 +114,13 @@ namespace RunTests
 
             Print(completed);
 
-            return new RunAllResult((failures == 0), cacheCount, completed.ToImmutableArray());
+            var processResults = ImmutableArray.CreateBuilder<ProcessResult>();
+            foreach (var c in completed)
+            {
+                processResults.AddRange(c.ProcessResults);
+            }
+
+            return new RunAllResult((failures == 0), cacheCount, completed.ToImmutableArray(), processResults.ToImmutable());
         }
 
         private void Print(List<TestResult> testResults)


### PR DESCRIPTION
This increases the amount of data when running unit tests. The runtests.log file will now include:

- All console output from runtests.exe
- Process details from explicitly executed processes: procdump and xunit 

This is the next step in order to help us track down #26432