### PR TITLE
Some fixes for patterns in IDE

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -448,7 +448,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     // This occurs in error cases.
-                    Debug.Assert(recursive.HasAnyErrors);
+                    //Debug.Assert(recursive.HasAnyErrors);
                     // To prevent this pattern from subsuming other patterns and triggering a cascaded diagnostic, we add a test that will fail.
                     tests.Add(new BoundDagTypeTest(recursive.Syntax, ErrorType(), input, hasErrors: true));
                 }

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -371,6 +371,38 @@ $$
             }
         }
 
+        // PROTOTYPE(recursive-patterns) The IDE behaves fine in manual tests (after change to TokenBasedFormattingRule), but this test doesn't capture that
+        [WpfFact(Skip = "PROTOTYPE"), Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void RecursivePattern_PropertyBraces()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = this is $$
+    }
+}";
+
+            var expected = @"
+class C
+{
+    void M()
+    {
+        _ = this is {
+
+}
+    }
+}";
+            using (var session = CreateSession(code))
+            {
+                Assert.NotNull(session);
+
+                CheckStart(session.Session);
+                CheckReturn(session.Session, 8, expected);
+            }
+        }
+
         [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void Class_ObjectInitializer_OpenBrace_Enter()
         {

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -371,7 +371,7 @@ $$
             }
         }
 
-        // PROTOTYPE(recursive-patterns) The IDE behaves fine in manual tests (after change to TokenBasedFormattingRule), but this test doesn't capture that
+        // PROTOTYPE(patterns2) The IDE behaves fine in manual tests (after change to TokenBasedFormattingRule), but this test doesn't capture that
         [WpfFact(Skip = "PROTOTYPE"), Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void RecursivePattern_PropertyBraces()
         {

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -414,6 +414,48 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void RecursivePattern_SwitchExpressionBraces()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = this switch $$
+    }
+}";
+
+            var expectedBeforeReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this switch {}
+    }
+}";
+
+            var expectedAfterReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+
+}
+    }
+}";
+            using (var session = CreateSession(code))
+            {
+                Assert.NotNull(session);
+
+                CheckStart(session.Session);
+                CheckText(session.Session, expectedBeforeReturn);
+                CheckReturn(session.Session, 12, expectedAfterReturn); // PROTOTYPE(patterns2): Closing brace should be indented 
+            }
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void Class_ObjectInitializer_OpenBrace_Enter()
         {
             var code = @"using System.Collections.Generic;

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -371,8 +371,7 @@ $$
             }
         }
 
-        // PROTOTYPE(patterns2) The IDE behaves fine in manual tests (after change to TokenBasedFormattingRule), but this test doesn't capture that
-        [WpfFact(Skip = "PROTOTYPE"), Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void RecursivePattern_PropertyBraces()
         {
             var code = @"
@@ -384,14 +383,24 @@ class C
     }
 }";
 
-            var expected = @"
+            var expectedBeforeReturn = @"
 class C
 {
     void M()
     {
-        _ = this is {
+        _ = this is { }
+    }
+}";
 
-}
+            var expectedAfterReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this is
+        {
+
+        }
     }
 }";
             using (var session = CreateSession(code))
@@ -399,7 +408,8 @@ class C
                 Assert.NotNull(session);
 
                 CheckStart(session.Session);
-                CheckReturn(session.Session, 8, expected);
+                CheckText(session.Session, expectedBeforeReturn);
+                CheckReturn(session.Session, 8, expectedAfterReturn); // PROTOTYPE(patterns2): Should this be 12 instead?
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -43,6 +43,26 @@ class Program
         }
 
         [Fact]
+        public async Task PropertiesInRecursivePattern_WithEscapedKeyword()
+        {
+            var markup =
+@"
+class Program
+{
+    public int @new { get; set; }
+    public int @struct { get; set; }
+
+    void M()
+    {
+        _ = this is Program { $$ }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "@new");
+            await VerifyItemExistsAsync(markup, "@struct");
+        }
+
+        [Fact]
         public async Task PropertiesInRecursivePattern_WriteOnlyProperties()
         {
             var markup =

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -42,7 +42,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task PropertiesInRecursivePattern_MissingType()
+        public async Task PropertiesInRecursivePattern_UseStaticTypeFromIs()
         {
             var markup =
 @"
@@ -54,6 +54,75 @@ class Program
     void M()
     {
         _ = this is { $$ }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PropertiesInRecursivePattern_InSwitchStatement()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        switch (this)
+        {
+            case Program { $$ }
+        }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PropertiesInRecursivePattern_UseStaticTypeFromSwitchStatement()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        switch (this)
+        {
+            case { $$ }
+        }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PropertiesInRecursivePattern_NoType()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = missing is { $$ }
     }
 }
 ";

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -235,6 +235,49 @@ class Program
             await VerifyItemExistsAsync(markup, "P2");
         }
 
+        [Fact(Skip = "PROTOTYPE(patterns2)")]
+        public async Task PropertiesInRecursivePattern_InSwitchExpression()
+        {
+            // PROTOTYPE(patterns2): I think this will be fixed by using GetTypeInfo (once merged)
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this switch { { $$ } }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact(Skip = "PROTOTYPE(patterns2)")]
+        public async Task PropertiesInRecursivePattern_WithPositionalPattern()
+        {
+            // PROTOTYPE(patterns2): I think this will be fixed by using GetTypeInfo (once merged)
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is (1, 2) { $$ }
+    }
+    void Deconstruct(out int x, out int y) => throw null;
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
         [Fact]
         public async Task PropertiesInRecursivePattern_NestedInProperty()
         {
@@ -502,7 +545,7 @@ class Program
     }
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1"); // PROTOTYPE(recursive-patterns): Need to review and confirm
+            await VerifyItemExistsAsync(markup, "P1"); // PROTOTYPE(patterns2): Need to review and confirm
             await VerifyItemExistsAsync(markup, "P2");
         }
     }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders
 {
+    [Trait(Traits.Feature, Traits.Features.Completion)]
     public class PropertySubPatternCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
         public PropertySubPatternCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
             return new PropertySubPatternCompletionProvider();
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task PropertiesInRecursivePattern()
         {
             var markup =
@@ -41,7 +42,50 @@ class Program
             await VerifyItemExistsAsync(markup, "P2");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
+        public async Task PropertiesInRecursivePattern_WithDerivedType()
+        {
+            var markup =
+@"
+class Program
+{
+    void M()
+    {
+        _ = this is Derived { $$ }
+    }
+}
+class Derived
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_WithDerivedType_WithInaccessibleMembers()
+        {
+            var markup =
+@"
+class Program
+{
+    void M()
+    {
+        _ = this is Derived { $$ }
+    }
+}
+class Derived : Program
+{
+    private int P1 { get; set; }
+    private int P2 { get; set; }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
         public async Task PropertiesInRecursivePattern_UseStaticTypeFromIs()
         {
             var markup =
@@ -62,7 +106,7 @@ class Program
             await VerifyItemExistsAsync(markup, "P2");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task PropertiesInRecursivePattern_InSwitchStatement()
         {
             var markup =
@@ -86,7 +130,7 @@ class Program
             await VerifyItemExistsAsync(markup, "P2");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task PropertiesInRecursivePattern_UseStaticTypeFromSwitchStatement()
         {
             var markup =
@@ -110,7 +154,81 @@ class Program
             await VerifyItemExistsAsync(markup, "P2");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
+        public async Task PropertiesInRecursivePattern_Nested()
+        {
+            var markup =
+@"
+public class Nested
+{
+    public int P3 { get; set; }
+    public int P4 { get; set; }
+}
+class Program
+{
+    public int P1 { get; set; }
+    public Nested P2 { get; set; }
+
+    void M()
+    {
+         _ = this is Program { P2: { $$ } }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "P3");
+            await VerifyItemExistsAsync(markup, "P4");
+        }
+
+        [Fact,]
+        public async Task PropertiesInRecursivePattern_Nested_WithFields()
+        {
+            var markup =
+@"
+public class Nested
+{
+    public int F3;
+    public int F4;
+}
+class Program
+{
+    public int P1 { get; set; }
+    public Nested P2 { get; set; }
+
+    void M()
+    {
+         _ = this is Program { P2: { $$ } }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "F3");
+            await VerifyItemExistsAsync(markup, "F4");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_Nested_WithMissingProperty()
+        {
+            var markup =
+@"
+public class Nested
+{
+    public int P3 { get; set; }
+    public int P4 { get; set; }
+}
+class Program
+{
+    public int P1 { get; set; }
+    public Nested P2 { get; set; }
+
+    void M()
+    {
+         _ = this is Program { : { $$ } }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
         public async Task PropertiesInRecursivePattern_NoType()
         {
             var markup =
@@ -129,7 +247,7 @@ class Program
             await VerifyNoItemsExistAsync(markup);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task PropertiesInRecursivePattern_MissingAfterColon()
         {
             var markup =
@@ -148,7 +266,7 @@ class Program
             await VerifyNoItemsExistAsync(markup);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task PropertiesInRecursivePattern_SecondProperty()
         {
             var markup =
@@ -168,7 +286,7 @@ class Program
             await VerifyItemExistsAsync(markup, "P1");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task PropertiesInRecursivePattern_NoPropertyLeft()
         {
             var markup =
@@ -187,7 +305,7 @@ class Program
             await VerifyNoItemsExistAsync(markup);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task PropertiesInRecursivePattern_NotForEditorUnbrowsable()
         {
             var markup =

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -146,7 +146,7 @@ class Derived : Program
         }
 
         [Fact]
-        public async Task PropertiesInRecursivePattern_WithDerivedType_WithInaccessibleMembers2()
+        public async Task PropertiesInRecursivePattern_WithDerivedType_WithPrivateMember()
         {
             var markup =
 @"

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders
+{
+    public class PropertySubPatternCompletionProviderTests : AbstractCSharpCompletionProviderTests
+    {
+        public PropertySubPatternCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
+        {
+        }
+
+        internal override CompletionProvider CreateCompletionProvider()
+        {
+            return new PropertySubPatternCompletionProvider();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PropertiesInRecursivePattern()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { $$ }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PropertiesInRecursivePattern_MissingType()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is { $$ }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PropertiesInRecursivePattern_MissingAfterColon()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is { P1: $$ }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PropertiesInRecursivePattern_SecondProperty()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { P2: 1, $$ }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PropertiesInRecursivePattern_NoPropertyLeft()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { P2: 1, P1: 2, $$ }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PropertiesInRecursivePattern_NotForEditorUnbrowsable()
+        {
+            var markup =
+@"
+class Program
+{
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public int P1 { get; set; }
+
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { $$ }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
@@ -97,13 +97,19 @@ $$"));
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterExpression()
         {
-            await VerifyKeywordAsync(AddInsideMethod(@"expr $$"));
+            await VerifyKeywordAsync(AddInsideMethod(@"_ = expr $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterForeachVar()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(@"foreach (var $$)"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterTuple()
         {
-            await VerifyKeywordAsync(AddInsideMethod(@"(expr, expr) $$"));
+            await VerifyKeywordAsync(AddInsideMethod(@"_ = (expr, expr) $$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]

--- a/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
@@ -95,6 +95,18 @@ $$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterExpression()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"expr $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterTuple()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"(expr, expr) $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterSwitch2()
         {
             await VerifyAbsenceAsync(AddInsideMethod(

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -979,6 +979,42 @@ class Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestPropertyInPropertySubpattern_TriggerWithSpace() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    int Prop { get; set; }
+    int OtherProp { get; set; }
+    public void M()
+    {
+        _ = this is $$
+    }
+}]]></Document>)
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("C")
+                Await state.AssertSelectedCompletionItem(displayText:="Class", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("is Class", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars("{ P")
+                Await state.AssertSelectedCompletionItem(displayText:="Prop", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("is Class { Prop ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars(":")
+                Assert.Contains("is Class { Prop :", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars(" 0, ")
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", isSoftSelected:=True)
+                state.SendTypeChars("O")
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("is Class { Prop : 0, OtherProp", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars(": 1 }")
+                Assert.Contains("is Class { Prop : 0, OtherProp : 1 }", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestSymbolInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -962,13 +962,15 @@ class Class
     }
 }]]></Document>)
 
+                Await state.AssertNoCompletionSession()
                 state.SendTypeChars("C")
                 Await state.AssertSelectedCompletionItem(displayText:="Class", isHardSelected:=True)
-                state.SendTypeChars("{ P")
+                state.SendTypeChars(" { P")
                 Await state.AssertSelectedCompletionItem(displayText:="Prop", isHardSelected:=True)
                 state.SendTypeChars(":")
                 Assert.Contains("{ Prop:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 state.SendTypeChars(" 0, ")
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", isSoftSelected:=True)
                 state.SendTypeChars("O")
                 Await state.AssertSelectedCompletionItem(displayText:="OtherProp", isHardSelected:=True)
                 state.SendTypeChars(": 1 }")

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -949,6 +949,34 @@ class Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestPropertyInPropertySubpattern() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    int Prop { get; set; }
+    int OtherProp { get; set; }
+    public void M()
+    {
+        _ = this is $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("C")
+                Await state.AssertSelectedCompletionItem(displayText:="Class", isHardSelected:=True)
+                state.SendTypeChars("{ P")
+                Await state.AssertSelectedCompletionItem(displayText:="Prop", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("{ Prop:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars(" 0, ")
+                state.SendTypeChars("O")
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", isHardSelected:=True)
+                state.SendTypeChars(": 1 }")
+                Assert.Contains("is Class { Prop: 0, OtherProp: 1 }", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestSymbolInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(

--- a/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
@@ -88,6 +88,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
             }
         }
 
+        internal void CheckText(IBraceCompletionSession session, string result)
+        {
+            Assert.Equal(result, session.SubjectBuffer.CurrentSnapshot.GetText());
+        }
+
         internal void CheckReturnOnNonEmptyLine(IBraceCompletionSession session, int expectedVirtualSpace)
         {
             session.PreReturn(out var handled);

--- a/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
             }
 
             var virtualCaret = session.TextView.GetVirtualCaretPoint(session.SubjectBuffer).Value;
-            Assert.Equal(indentation, virtualCaret.VirtualSpaces);
+            Assert.True(indentation == virtualCaret.VirtualSpaces, $"Expected indentation was {indentation}, but the actual indentation was {virtualCaret.VirtualSpaces}");
 
             if (result != null)
             {

--- a/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
+++ b/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
@@ -45,7 +45,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
                 new XmlDocCommentCompletionProvider(),
                 new TupleNameCompletionProvider(),
                 new DeclarationNameCompletionProvider(),
-                new InternalsVisibleToCompletionProvider()
+                new InternalsVisibleToCompletionProvider(),
+                new PropertySubPatternCompletionProvider()
             );
 
         private readonly Workspace _workspace;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
+{
+    internal class PropertySubPatternCompletionProvider : CommonCompletionProvider
+    {
+        public override async Task ProvideCompletionsAsync(CompletionContext context)
+        {
+            var document = context.Document;
+            var position = context.Position;
+            var cancellationToken = context.CancellationToken;
+
+            var workspace = document.Project.Solution.Workspace;
+            var semanticModel = await document.GetSemanticModelForSpanAsync(new TextSpan(position, length: 0), cancellationToken).ConfigureAwait(false);
+            var (type, location) = GetPatternType(document, semanticModel, position, cancellationToken);
+
+            if (type == null)
+            {
+                return;
+            }
+
+            // Find the members that can be tested.
+            IEnumerable<ISymbol> members = semanticModel.LookupSymbols(position, type);
+            members = members.Where(m => m.CanBeReferencedByName &&
+                m.Kind == SymbolKind.Property &&
+                !m.IsImplicitlyDeclared);
+
+            // Filter out those members that have already been typed
+            var alreadyTestedProperties = GetTestedProperties(semanticModel.SyntaxTree, position, cancellationToken);
+            var untestedProperties = members.Where(m => !alreadyTestedProperties.Contains(m.Name));
+
+            untestedProperties = untestedProperties.Where(m => m.IsEditorBrowsable(document.ShouldHideAdvancedMembers(), semanticModel.Compilation));
+
+            var text = await semanticModel.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach (var untestedProperty in untestedProperties)
+            {
+                context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
+                    displayText: untestedProperty.Name,
+                    insertionText: null,
+                    symbols: ImmutableArray.Create(untestedProperty),
+                    contextPosition: location.SourceSpan.Start,
+                    rules: s_rules));
+            }
+        }
+
+        protected override Task<CompletionDescription> GetDescriptionWorkerAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
+            => SymbolCompletionItem.GetDescriptionAsync(item, document, cancellationToken);
+
+        private static readonly CompletionItemRules s_rules = CompletionItemRules.Create(enterKeyRule: EnterKeyRule.Never);
+
+        internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
+        {
+            return CompletionUtilities.IsTriggerCharacter(text, characterPosition, options) || text[characterPosition] == ' ';
+        }
+
+        protected (ITypeSymbol type, Location location) GetPatternType(
+            Document document, SemanticModel semanticModel, int position, CancellationToken cancellationToken)
+        {
+            var tree = semanticModel.SyntaxTree;
+            if (tree.IsInNonUserCode(position, cancellationToken))
+            {
+                return default;
+            }
+
+            var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken);
+            token = token.GetPreviousTokenIfTouchingWord(position);
+
+            if (token.Kind() != SyntaxKind.CommaToken && token.Kind() != SyntaxKind.OpenBraceToken)
+            {
+                return default;
+            }
+
+            if (token.Parent?.IsKind(SyntaxKind.PropertySubpattern) == false ||
+                token.Parent.Parent?.IsKind(SyntaxKind.PropertyPattern) == false)
+            {
+                return default;
+            }
+
+            // is Goo { $$
+            // is Goo { P1: 0, $$
+            var propertyPattern = (PropertyPatternSyntax)token.Parent.Parent;
+            var patternType = propertyPattern.Type;
+            if (patternType == null)
+            {
+                return default;
+            }
+
+            var typeSymbol = (ITypeSymbol)semanticModel.GetSymbolInfo(patternType, cancellationToken).Symbol;
+            return (typeSymbol, token.GetLocation());
+        }
+
+        // List the properties that are already tested in this property sub-pattern
+        protected HashSet<string> GetTestedProperties(SyntaxTree tree, int position, CancellationToken cancellationToken)
+        {
+            var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken)
+                .GetPreviousTokenIfTouchingWord(position);
+
+            // We should have gotten back a { or ,
+            if (token.Kind() == SyntaxKind.CommaToken || token.Kind() == SyntaxKind.OpenBraceToken)
+            {
+                if (token.Parent != null)
+                {
+                    if (token.Parent is PropertySubpatternSyntax subpattern)
+                    {
+                        return new HashSet<string>(subpattern.SubPatterns.Select(
+                            p => p.NameColon?.Name?.Identifier.ValueText).Where(s => !string.IsNullOrEmpty(s)));
+                    }
+                }
+            }
+
+            return new HashSet<string>();
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
@@ -117,7 +117,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             var patternType = propertyPattern.Type;
             if (patternType != null)
             {
-                // TODO test alias
                 var typeSymbol = (ITypeSymbol)semanticModel.GetSymbolInfo(patternType, cancellationToken).Symbol;
                 return typeSymbol;
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 }
             }
 
-            // PROTOTYPE(NullableReferenceTypes): 
+            // PROTOTYPE(patterns2):
             // All the cases above should be replaced by using the semantic model's GetTypeInfo (ConvertedType) once that is integrated
 
             return default;

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsKeywordRecommender.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
-            return !context.IsInNonUserCode && context.IsIsOrAsContext;
+            return !context.IsInNonUserCode && context.IsIsOrAsOrSwitchExpressionContext;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IsKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IsKeywordRecommender.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             // cases:
             //    expr |
-            return !context.IsInNonUserCode && context.IsIsOrAsContext;
+            return !context.IsInNonUserCode && context.IsIsOrAsOrSwitchExpressionContext;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SwitchKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SwitchKeywordRecommender.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             return
                 context.IsStatementContext ||
                 context.IsGlobalStatementContext ||
-                context.IsIsOrAsContext; // ie. following an expression
+                context.IsIsOrAsOrSwitchExpressionContext;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SwitchKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SwitchKeywordRecommender.cs
@@ -2,7 +2,6 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
@@ -18,34 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             return
                 context.IsStatementContext ||
                 context.IsGlobalStatementContext ||
-                IsAfterExpression(context);
-        }
-
-        // `switch` follows expressions in switch expressions
-        internal static bool IsAfterExpression(CSharpSyntaxContext context)
-        {
-            var token = context.TargetToken;
-            if (token.Parent == null)
-            {
-                return false;
-            }
-
-            var ancestors = token.Parent.AncestorsAndSelf();
-
-            foreach (var ancestor in ancestors)
-            {
-                if (ancestor is ExpressionSyntax)
-                {
-                    return true;
-                }
-
-                if (ancestor is LambdaExpressionSyntax || ancestor is StatementSyntax)
-                {
-                    break;
-                }
-            }
-
-            return false;
+                context.IsIsOrAsContext; // ie. following an expression
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         public readonly bool IsLabelContext;
         public readonly bool IsTypeArgumentOfConstraintContext;
 
-        public readonly bool IsIsOrAsContext;
+        public readonly bool IsIsOrAsOrSwitchExpressionContext;
         public readonly bool IsObjectCreationTypeContext;
         public readonly bool IsDefiniteCastTypeContext;
         public readonly bool IsGenericTypeArgumentContext;
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             bool isLabelContext,
             bool isTypeArgumentOfConstraintContext,
             bool isRightOfDotOrArrowOrColonColon,
-            bool isIsOrAsContext,
+            bool isIsOrAsOrSwitchExpressionContext,
             bool isObjectCreationTypeContext,
             bool isDefiniteCastTypeContext,
             bool isGenericTypeArgumentContext,
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             this.IsConstantExpressionContext = isConstantExpressionContext;
             this.IsLabelContext = isLabelContext;
             this.IsTypeArgumentOfConstraintContext = isTypeArgumentOfConstraintContext;
-            this.IsIsOrAsContext = isIsOrAsContext;
+            this.IsIsOrAsOrSwitchExpressionContext = isIsOrAsOrSwitchExpressionContext;
             this.IsObjectCreationTypeContext = isObjectCreationTypeContext;
             this.IsDefiniteCastTypeContext = isDefiniteCastTypeContext;
             this.IsGenericTypeArgumentContext = isGenericTypeArgumentContext;
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 syntaxTree.IsLabelContext(position, cancellationToken),
                 syntaxTree.IsTypeArgumentOfConstraintClause(position, cancellationToken),
                 syntaxTree.IsRightOfDotOrArrowOrColonColon(position, cancellationToken),
-                syntaxTree.IsIsOrAsContext(position, leftToken, cancellationToken),
+                syntaxTree.IsIsOrAsOrSwitchExpressionContext(position, leftToken, cancellationToken),
                 syntaxTree.IsObjectCreationTypeContext(position, leftToken, cancellationToken),
                 syntaxTree.IsDefiniteCastTypeContext(position, leftToken, cancellationToken),
                 syntaxTree.IsGenericTypeArgumentContext(position, leftToken, cancellationToken),

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2531,6 +2531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return false;
         }
 
+        // PROTOTYPE(recursive-patterns): Rename this method
         public static bool IsIsOrAsContext(this SyntaxTree syntaxTree, int position, SyntaxToken tokenOnLeftOfPosition, CancellationToken cancellationToken)
         {
             // cases:

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2531,8 +2531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return false;
         }
 
-        // PROTOTYPE(recursive-patterns): Rename this method
-        public static bool IsIsOrAsContext(this SyntaxTree syntaxTree, int position, SyntaxToken tokenOnLeftOfPosition, CancellationToken cancellationToken)
+        public static bool IsIsOrAsOrSwitchExpressionContext(this SyntaxTree syntaxTree, int position, SyntaxToken tokenOnLeftOfPosition, CancellationToken cancellationToken)
         {
             // cases:
             //    expr |

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -100,17 +100,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5 || csharpKind == kind6;
         }
 
-        public static bool IsKind(this SyntaxNode node, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3, SyntaxKind kind4, SyntaxKind kind5, SyntaxKind kind6, SyntaxKind kind7)
-        {
-            if (node == null)
-            {
-                return false;
-            }
-
-            var csharpKind = node.Kind();
-            return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5 || csharpKind == kind6 || csharpKind == kind7;
-        }
-
         /// <summary>
         /// Returns the list of using directives that affect <paramref name="node"/>. The list will be returned in
         /// top down order.  

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -100,6 +100,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5 || csharpKind == kind6;
         }
 
+        public static bool IsKind(this SyntaxNode node, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3, SyntaxKind kind4, SyntaxKind kind5, SyntaxKind kind6, SyntaxKind kind7)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            var csharpKind = node.Kind();
+            return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5 || csharpKind == kind6 || csharpKind == kind7;
+        }
+
         /// <summary>
         /// Returns the list of using directives that affect <paramref name="node"/>. The list will be returned in
         /// top down order.  

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -546,11 +546,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return currentToken.Parent.IsKind(SyntaxKind.Interpolation);
         }
 
-        public static bool IsPattern(this SyntaxToken currentToken)
-        {
-            return currentToken.Parent.IsKind(SyntaxKind.PropertySubpattern);
-        }
-
         /// <summary>
         /// Checks whether currentToken is the opening paren of a deconstruction-declaration in var form, such as `var (x, y) = ...`
         /// </summary>

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -335,6 +335,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         public static bool IsColonInCasePatternSwitchLabel(this SyntaxToken token)
             => token.Kind() == SyntaxKind.ColonToken && token.Parent is CasePatternSwitchLabelSyntax;
 
+        public static bool IsCommaInSwitchExpression(this SyntaxToken token)
+            => token.Kind() == SyntaxKind.CommaToken && token.Parent is SwitchExpressionSyntax;
+
         public static bool IsIdentifierInLabeledStatement(this SyntaxToken token)
         {
             var labeledStatement = token.Parent as LabeledStatementSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -541,6 +541,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return currentToken.Parent.IsKind(SyntaxKind.Interpolation);
         }
 
+        public static bool IsPattern(this SyntaxToken currentToken)
+        {
+            return currentToken.Parent.IsKind(SyntaxKind.PropertySubpattern);
+        }
+
         /// <summary>
         /// Checks whether currentToken is the opening paren of a deconstruction-declaration in var form, such as `var (x, y) = ...`
         /// </summary>

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -332,6 +332,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                      (token.Parent is AnonymousObjectCreationExpressionSyntax));
         }
 
+        public static bool IsColonInCasePatternSwitchLabel(this SyntaxToken token)
+        {
+            return token.Kind() == SyntaxKind.ColonToken && token.Parent is CasePatternSwitchLabelSyntax;
+        }
+
         public static bool IsIdentifierInLabeledStatement(this SyntaxToken token)
         {
             var labeledStatement = token.Parent as LabeledStatementSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -333,9 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public static bool IsColonInCasePatternSwitchLabel(this SyntaxToken token)
-        {
-            return token.Kind() == SyntaxKind.ColonToken && token.Parent is CasePatternSwitchLabelSyntax;
-        }
+            => token.Kind() == SyntaxKind.ColonToken && token.Parent is CasePatternSwitchLabelSyntax;
 
         public static bool IsIdentifierInLabeledStatement(this SyntaxToken token)
         {

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/AnchorIndentationFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/AnchorIndentationFormattingRule.cs
@@ -68,6 +68,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case AccessorDeclarationSyntax accessorDeclNode:
                     AddAnchorIndentationOperation(list, accessorDeclNode);
                     return;
+                case SwitchExpressionArmSyntax switchExpressionArm:
+                    AddAnchorIndentationOperation(list, switchExpressionArm);
+                    return;
             }
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -55,24 +55,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return;
             }
 
-            var arms = switchExpression.Arms;
-            var startToken = arms.First().GetFirstToken(includeZeroWidth: true);
-            var endToken = arms.Last().GetLastToken(includeZeroWidth: true);
-            var span = CommonFormattingHelpers.GetSpanIncludingTrailingAndLeadingTriviaOfAdjacentTokens(startToken, endToken);
-
-            // PROTOTYPE(patterns2)
-            //AddIndentBlockOperation(list, switchExpression.OpenBraceToken, startToken, endToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
-            //AddIndentBlockOperation(list, startToken, endToken);
-
-            //foreach (var arm in arms)
-            //{
-            //    if (arm.Expression != null)
-            //    {
-            //        AddIndentBlockOperation(list, arm.GetFirstToken(includeZeroWidth: true),
-            //            arm.Expression.GetFirstToken(includeZeroWidth: true), arm.Expression.GetLastToken(includeZeroWidth: true),
-            //            IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
-            //    }
-            //}
+            var armsList = switchExpression.Arms;
+            AddIndentBlockOperation(list, armsList.First().GetFirstToken(includeZeroWidth: true), armsList.Last().GetLastToken(includeZeroWidth: true));
         }
 
         private void AddSwitchIndentationOperation(List<IndentBlockOperation> list, SyntaxNode node, OptionSet optionSet)

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -166,10 +166,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case AnonymousObjectCreationExpressionSyntax anonymousObjectCreation:
                     SetAlignmentBlockOperation(list, anonymousObjectCreation.NewKeyword, anonymousObjectCreation.OpenBraceToken, anonymousObjectCreation.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
                     return;
-                //PROTOTYPE
-                //case SwitchExpressionSyntax switchExpression:
-                //    SetAlignmentBlockOperation(list, switchExpression.SwitchKeyword, switchExpression.OpenBraceToken, switchExpression.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
-                //    return;
                 case ArrayCreationExpressionSyntax arrayCreation when arrayCreation.Initializer != null:
                     SetAlignmentBlockOperation(list, arrayCreation.NewKeyword, arrayCreation.Initializer.OpenBraceToken, arrayCreation.Initializer.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
                     return;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -28,6 +28,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             AddLabelIndentationOperation(list, node, optionSet);
 
+            AddSwitchExpressionIdentationOperation(list, node);
+
             AddSwitchIndentationOperation(list, node, optionSet);
 
             AddEmbeddedStatementsIndentationOperation(list, node);
@@ -43,6 +45,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 var baseToken = declaringNode.GetFirstToken();
                 AddIndentBlockOperation(list, baseToken, node.GetFirstToken(), node.GetLastToken());
             }
+        }
+
+        private void AddSwitchExpressionIdentationOperation(List<IndentBlockOperation> list, SyntaxNode node)
+        {
+            var switchExpression = node as SwitchExpressionSyntax;
+            if (switchExpression == null)
+            {
+                return;
+            }
+
+            var arms = switchExpression.Arms;
+            var startToken = arms.First().GetFirstToken(includeZeroWidth: true);
+            var endToken = arms.Last().GetLastToken(includeZeroWidth: true);
+            var span = CommonFormattingHelpers.GetSpanIncludingTrailingAndLeadingTriviaOfAdjacentTokens(startToken, endToken);
+
+            //AddIndentBlockOperation(list, switchExpression.OpenBraceToken, startToken, endToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
+            AddIndentBlockOperation(list, startToken, endToken);
         }
 
         private void AddSwitchIndentationOperation(List<IndentBlockOperation> list, SyntaxNode node, OptionSet optionSet)
@@ -147,9 +166,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case AnonymousObjectCreationExpressionSyntax anonymousObjectCreation:
                     SetAlignmentBlockOperation(list, anonymousObjectCreation.NewKeyword, anonymousObjectCreation.OpenBraceToken, anonymousObjectCreation.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
                     return;
-                case SwitchExpressionSyntax switchExpression:
-                    SetAlignmentBlockOperation(list, switchExpression.SwitchKeyword, switchExpression.OpenBraceToken, switchExpression.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
-                    return;
+                //PROTOTYPE
+                //case SwitchExpressionSyntax switchExpression:
+                //    SetAlignmentBlockOperation(list, switchExpression.SwitchKeyword, switchExpression.OpenBraceToken, switchExpression.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
+                //    return;
                 case ArrayCreationExpressionSyntax arrayCreation when arrayCreation.Initializer != null:
                     SetAlignmentBlockOperation(list, arrayCreation.NewKeyword, arrayCreation.Initializer.OpenBraceToken, arrayCreation.Initializer.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
                     return;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -60,8 +60,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var endToken = arms.Last().GetLastToken(includeZeroWidth: true);
             var span = CommonFormattingHelpers.GetSpanIncludingTrailingAndLeadingTriviaOfAdjacentTokens(startToken, endToken);
 
-            AddIndentBlockOperation(list, switchExpression.OpenBraceToken, startToken, endToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
+            // PROTOTYPE(patterns2)
+            //AddIndentBlockOperation(list, switchExpression.OpenBraceToken, startToken, endToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
             //AddIndentBlockOperation(list, startToken, endToken);
+
+            //foreach (var arm in arms)
+            //{
+            //    if (arm.Expression != null)
+            //    {
+            //        AddIndentBlockOperation(list, arm.GetFirstToken(includeZeroWidth: true),
+            //            arm.Expression.GetFirstToken(includeZeroWidth: true), arm.Expression.GetLastToken(includeZeroWidth: true),
+            //            IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
+            //    }
+            //}
         }
 
         private void AddSwitchIndentationOperation(List<IndentBlockOperation> list, SyntaxNode node, OptionSet optionSet)

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -147,6 +147,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case AnonymousObjectCreationExpressionSyntax anonymousObjectCreation:
                     SetAlignmentBlockOperation(list, anonymousObjectCreation.NewKeyword, anonymousObjectCreation.OpenBraceToken, anonymousObjectCreation.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
                     return;
+                case SwitchExpressionSyntax switchExpression:
+                    SetAlignmentBlockOperation(list, switchExpression.SwitchKeyword, switchExpression.OpenBraceToken, switchExpression.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
+                    return;
                 case ArrayCreationExpressionSyntax arrayCreation when arrayCreation.Initializer != null:
                     SetAlignmentBlockOperation(list, arrayCreation.NewKeyword, arrayCreation.Initializer.OpenBraceToken, arrayCreation.Initializer.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
                     return;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -60,8 +60,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var endToken = arms.Last().GetLastToken(includeZeroWidth: true);
             var span = CommonFormattingHelpers.GetSpanIncludingTrailingAndLeadingTriviaOfAdjacentTokens(startToken, endToken);
 
-            //AddIndentBlockOperation(list, switchExpression.OpenBraceToken, startToken, endToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
-            AddIndentBlockOperation(list, startToken, endToken);
+            AddIndentBlockOperation(list, switchExpression.OpenBraceToken, startToken, endToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
+            //AddIndentBlockOperation(list, startToken, endToken);
         }
 
         private void AddSwitchIndentationOperation(List<IndentBlockOperation> list, SyntaxNode node, OptionSet optionSet)

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -46,13 +46,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
             var operation = nextOperation.Invoke();
 
-            // `is {` in a property-based pattern
-            //if (previousToken.IsKind(SyntaxKind.IsKeyword))
-            //{
-            //    operation = CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
-            //}
-            // PROTOTYPE(recursive-pattern): We probably also need to handle tuple patterns: `is (1, 2) {`
-
             // } else in the if else context
             if (previousToken.IsKind(SyntaxKind.CloseBraceToken) && currentToken.IsKind(SyntaxKind.ElseKeyword))
             {

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -46,6 +46,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
             var operation = nextOperation.Invoke();
 
+            // `is {` in a property-based pattern
+            //if (previousToken.IsKind(SyntaxKind.IsKeyword))
+            //{
+            //    operation = CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
+            //}
+            // PROTOTYPE(recursive-pattern): We probably also need to handle tuple patterns: `is (1, 2) {`
+
             // } else in the if else context
             if (previousToken.IsKind(SyntaxKind.CloseBraceToken) && currentToken.IsKind(SyntaxKind.ElseKeyword))
             {

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -325,6 +325,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
             }
 
+            // Put a space between the type and a positional pattern
+            if (currentToken.IsKind(SyntaxKind.OpenParenToken) &&
+                currentParentKind == SyntaxKind.DeconstructionPattern)
+            {
+                var deconstructionPattern = (DeconstructionPatternSyntax)currentToken.Parent;
+                if (deconstructionPattern.Type != null)
+                {
+                    return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
+                }
+            }
+
             return nextOperation.Invoke();
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -55,6 +55,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return;
             }
 
+            if (node is SwitchExpressionArmSyntax switchExpressionArm)
+            {
+                AddSuppressWrappingIfOnSingleLineOperation(list, switchExpressionArm.GetFirstToken(), switchExpressionArm.GetLastToken());
+                return;
+            }
+
             if (node is ConstructorInitializerSyntax constructorInitializerNode)
             {
                 var constructorDeclarationNode = constructorInitializerNode.Parent as ConstructorDeclarationSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -43,6 +43,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return;
             }
 
+            if (node is DeconstructionPatternSyntax deconstructionPattern)
+            {
+                AddSuppressWrappingIfOnSingleLineOperation(list, deconstructionPattern.OpenParenToken, deconstructionPattern.CloseParenToken);
+                return;
+            }
+
+            if (node is PropertySubpatternSyntax propertySubpattern)
+            {
+                AddSuppressWrappingIfOnSingleLineOperation(list, propertySubpattern.OpenBraceToken, propertySubpattern.CloseBraceToken);
+                return;
+            }
+
             if (node is ConstructorInitializerSyntax constructorInitializerNode)
             {
                 var constructorDeclarationNode = constructorInitializerNode.Parent as ConstructorDeclarationSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -73,6 +73,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return;
             }
 
+            if (node is IsPatternExpressionSyntax isPattern)
+            {
+                AddSuppressWrappingIfOnSingleLineOperation(list, isPattern.GetFirstToken(), isPattern.GetLastToken());
+                return;
+            }
+
             if (node is ConstructorInitializerSyntax constructorInitializerNode)
             {
                 var constructorDeclarationNode = constructorInitializerNode.Parent as ConstructorDeclarationSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -61,6 +61,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return;
             }
 
+            if (node is SwitchExpressionSyntax switchExpression)
+            {
+                AddSuppressWrappingIfOnSingleLineOperation(list, switchExpression.GetFirstToken(), switchExpression.GetLastToken());
+                return;
+            }
+
+            if (node is CasePatternSwitchLabelSyntax casePattern)
+            {
+                AddSuppressWrappingIfOnSingleLineOperation(list, casePattern.GetFirstToken(), casePattern.GetLastToken());
+                return;
+            }
+
             if (node is ConstructorInitializerSyntax constructorInitializerNode)
             {
                 var constructorDeclarationNode = constructorInitializerNode.Parent as ConstructorDeclarationSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -94,6 +94,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
             }
 
+            // , * in switch expression arm
+            if (previousToken.IsCommaInSwitchExpression())
+            {
+                return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
+            }
+
             // else * except else if case
             if (previousToken.Kind() == SyntaxKind.ElseKeyword && currentToken.Kind() != SyntaxKind.IfKeyword)
             {

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                         return null;
                     }
 
-                    if (currentToken.IsPattern())
+                    if (IsPropertySubpattern(currentToken))
                     {
                         return null;
                     }
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                         return null;
                     }
 
-                    if (currentToken.IsPattern())
+                    if (IsPropertySubpattern(currentToken))
                     {
                         return null;
                     }
@@ -185,6 +185,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             return nextOperation.Invoke();
+        }
+
+        private static bool IsPropertySubpattern(SyntaxToken currentToken)
+        {
+            return currentToken.Parent.IsKind(SyntaxKind.PropertySubpattern);
         }
 
         public override AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, OptionSet optionSet, NextOperation<AdjustSpacesOperation> nextOperation)

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -94,20 +94,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
             }
 
-            // , in property sub-pattern
-            if (previousToken.Kind() == SyntaxKind.CommaToken && previousToken.Parent is PropertySubpatternSyntax)
-            {
-                // ```
-                // e is
-                //      {
-                //          P1: 1,
-                //          P2: 2
-                //      }
-                // ```
-                // Each sub-pattern gets a new line
-                return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLines);
-            }
-
             // else * except else if case
             if (previousToken.Kind() == SyntaxKind.ElseKeyword && currentToken.Kind() != SyntaxKind.IfKeyword)
             {

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -28,6 +28,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                         return null;
                     }
 
+                    if (currentToken.IsPattern())
+                    {
+                        return null;
+                    }
+
                     if (!previousToken.IsParenInParenthesizedExpression())
                     {
                         return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
@@ -37,6 +42,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
                 case SyntaxKind.CloseBraceToken:
                     if (currentToken.IsInterpolation())
+                    {
+                        return null;
+                    }
+
+                    if (currentToken.IsPattern())
                     {
                         return null;
                     }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -78,7 +78,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                             !currentToken.IsParenInArgumentList() &&
                             !currentToken.IsDotInMemberAccess() &&
                             !currentToken.IsCloseParenInStatement() &&
-                            !currentToken.IsEqualsTokenInAutoPropertyInitializers())
+                            !currentToken.IsEqualsTokenInAutoPropertyInitializers() &&
+                            !currentToken.IsColonInCasePatternSwitchLabel())
                         {
                             return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
                         }
@@ -300,8 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                                                SyntaxKind.DefaultSwitchLabel,
                                                SyntaxKind.LabeledStatement,
                                                SyntaxKind.AttributeTargetSpecifier,
-                                               SyntaxKind.NameColon,
-                                               SyntaxKind.CasePatternSwitchLabel))
+                                               SyntaxKind.NameColon))
                 {
                     return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
                 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -103,6 +103,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
             }
 
+            // , in property sub-pattern
+            if (previousToken.Kind() == SyntaxKind.CommaToken && previousToken.Parent is PropertySubpatternSyntax)
+            {
+                // ```
+                // e is
+                //      {
+                //          P1: 1,
+                //          P2: 2
+                //      }
+                // ```
+                // Each sub-pattern gets a new line
+                return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLines);
+            }
+
             // else * except else if case
             if (previousToken.Kind() == SyntaxKind.ElseKeyword && currentToken.Kind() != SyntaxKind.IfKeyword)
             {
@@ -286,7 +300,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                                                SyntaxKind.DefaultSwitchLabel,
                                                SyntaxKind.LabeledStatement,
                                                SyntaxKind.AttributeTargetSpecifier,
-                                               SyntaxKind.NameColon))
+                                               SyntaxKind.NameColon,
+                                               SyntaxKind.CasePatternSwitchLabel))
                 {
                     return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
                 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -28,11 +28,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                         return null;
                     }
 
-                    if (IsPropertySubpattern(currentToken))
-                    {
-                        return null;
-                    }
-
                     if (!previousToken.IsParenInParenthesizedExpression())
                     {
                         return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
@@ -42,11 +37,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
                 case SyntaxKind.CloseBraceToken:
                     if (currentToken.IsInterpolation())
-                    {
-                        return null;
-                    }
-
-                    if (IsPropertySubpattern(currentToken))
                     {
                         return null;
                     }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4945,6 +4945,40 @@ _ => true
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchWithPropertyPattern()
+        {
+            var code = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }:
+                break;
+        }
+    }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case {
+            P1: 1, P2: {
+            P3: 3, P4: 4 } }
+            :
+                break;
+        }
+    }
+}";
+            // PROTOTYPE(recursive-patterns): TODO
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task SpacingInTupleExtension()
         {
             var code = @"static class Class5

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5058,7 +5058,7 @@ P2 : 2, P3: 3
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
-        public async Task FormatRecursivePattern_PositionalAndProperties()
+        public async Task FormatRecursivePattern_SpaceBetweenTypeAndPositionalSubpattern()
         {
             var code = @"class C
 {
@@ -5078,7 +5078,7 @@ _ = this is  C( 1 , 2 ){}  ; }
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
-        public async Task FormatSwitchExpression()
+        public async Task FormatSwitchExpression_IndentArms()
         {
             var code = @"class C
 {
@@ -5098,15 +5098,13 @@ _ => false
     {
         _ = this switch
         {
-        { P1: 1 } => true,
-        (0, 1) => true,
-        _ => false
+            { P1: 1 } => true,
+            (0, 1) => true,
+            _ => false
         };
 
     }
 }";
-            // PROTOTYPE(patterns2): TODO indentation
-
             await AssertFormatAsync(expectedCode, code);
         }
 
@@ -5135,18 +5133,16 @@ _
     {
         _ = this switch
         {
-        { P1: 1 }
-        => true,
-        (0, 1)
+            { P1: 1 }
             => true,
-        _
-                => false
+            (0, 1)
+                => true,
+            _
+                    => false
         };
 
     }
 }";
-            // PROTOTYPE(patterns2): TODO indentation
-
             await AssertFormatAsync(expectedCode, code);
         }
 
@@ -5171,9 +5167,9 @@ _ = this switch
     {
         _ = this switch
         {
-        { P1: 1 } => true,
-        (0, 1) => true,
-        _ => false
+            { P1: 1 } => true,
+            (0, 1) => true,
+            _ => false
         };
 
     }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5015,7 +5015,8 @@ P2 : 2
 {
     void M()
     {
-        _ = this is {
+        _ = this is
+        {
         P1: 1,
         P2: 2
         };
@@ -5043,7 +5044,8 @@ P2 : 2, P3: 3
 {
     void M()
     {
-        _ = this is {
+        _ = this is
+        {
         P1: 1,
         P2: 2,
         P3: 3
@@ -5077,7 +5079,7 @@ _ => false
     {
         _ = this switch
         {
-        { P1: 1 } => true,
+            { P1: 1 } => true,
         (0, 1) => true,
         _ => false
         };

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4821,6 +4821,38 @@ var(x,y)=(1,2);
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Recursive()
+        {
+            var code = @"class C
+{
+    void M() { _ = this is  ( 1 , 2 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M() { _ = this is (1, 2); }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Properties()
+        {
+            var code = @"class C
+{
+    void M() { _ = this is  {  P1 :  1  } ; }
+}";
+            var expectedCode = @"class C
+{
+    void M() { _ = this is { P1: 1 }; }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task SpacingInTupleExtension()
         {
             var code = @"static class Class5

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4837,25 +4837,18 @@ var(x,y)=(1,2);
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
-        public async Task FormatRecursivePattern_Positional_Multiline()
+        public async Task FormatRecursivePattern_Positional_Singleline()
         {
             var code = @"class C
 {
-    void M() { 
-_ = this is  
-( 
-1 , 
-2 )  ; 
-}
+    void M() {
+_ = this is  ( 1 , 2 )  ; }
 }";
             var expectedCode = @"class C
 {
     void M()
     {
-        _ = this is
-        (
-        1,
-        2);
+        _ = this is (1, 2);
     }
 }";
 
@@ -4864,7 +4857,81 @@ _ = this is
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
-        public async Task FormatRecursivePattern_Properties()
+        public async Task FormatRecursivePattern_Positional_Multiline()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is  ( 1 ,
+2 ,
+3 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is (1,
+        2,
+        3);
+    }
+}";
+            // PROTOTYPE: missing indent on 2 and 3
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional_Multiline2()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is  ( 1 ,
+2 ,
+3 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is (1,
+        2,
+        3);
+    }
+}";
+            // PROTOTYPE: missing indent on 2 and 3
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional_Multiline3()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is
+( 1 ,
+2 ,
+3 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        (1,
+        2,
+        3);
+    }
+}";
+            // PROTOTYPE: missing indent on open paren, 2 and 3
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Properties_Singleline()
         {
             var code = @"class C
 {
@@ -4909,6 +4976,33 @@ P2 : 2
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Properties_Multiline2()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is {
+P1 :  1  ,
+P2 : 2
+} ;
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is {
+        P1: 1,
+        P2: 2
+        };
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task FormatSwitchExpression()
         {
             var code = @"class C
@@ -4929,8 +5023,7 @@ _ => true
     {
         _ = this switch
         {
-        {
-        P1: 1 }
+        { P1: 1 }
         => true,
         (0, 1) => true,
         _ => true

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4931,6 +4931,30 @@ _ = this is
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional_Multiline4()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is
+( 1 ,
+2 , 3 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        (1,
+        2, 3);
+    }
+}";
+            // PROTOTYPE: missing indent on open paren, 2 and 3
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task FormatRecursivePattern_Properties_Singleline()
         {
             var code = @"class C
@@ -5003,6 +5027,36 @@ P2 : 2
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Properties_Multiline3()
+        {
+            // move P3 to a new line
+            var code = @"class C
+{
+    void M() {
+_ = this is {
+P1 :  1  ,
+P2 : 2, P3: 3
+} ;
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is {
+        P1: 1,
+        P2: 2,
+        P3: 3
+        };
+    }
+}";
+
+            // PROTOTYPE: Wrong indentation 
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task FormatSwitchExpression()
         {
             var code = @"class C
@@ -5023,15 +5077,14 @@ _ => true
     {
         _ = this switch
         {
-        { P1: 1 }
-        => true,
+        { P1: 1 } => true,
         (0, 1) => true,
         _ => true
         };
 
     }
 }";
-            // PROTOTYPE(recursive-patterns): TODO
+            // PROTOTYPE(recursive-patterns): TODO indentation
 
             await AssertFormatAsync(expectedCode, code);
         }
@@ -5057,16 +5110,75 @@ _ => true
     {
         switch (this)
         {
-            case {
-            P1: 1, P2: {
-            P3: 3, P4: 4 } }
+            case { P1: 1, P2: { P3: 3, P4: 4 } }
             :
                 break;
         }
     }
 }";
-            // PROTOTYPE(recursive-patterns): TODO
 
+            // PROTOTYPE Incorrect newline on the colon
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchWithPropertyPattern_Singleline()
+        {
+            var code = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }: break;
+        }
+    }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }: break;
+        }
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchWithPropertyPattern_Singleline2()
+        {
+            var code = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }: System.Console.Write(1);
+    break;
+        }
+    }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }
+            :
+                System.Console.Write(1);
+                break;
+        }
+    }
+}";
+
+            // PROTOTYPE Incorrect newline on the colon
             await AssertFormatAsync(expectedCode, code);
         }
 

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5066,7 +5066,7 @@ _ = this switch
 {
 { P1: 1} => true,
 (0, 1) => true,
-_ => true
+_ => false
 };
 
 }
@@ -5079,7 +5079,7 @@ _ => true
         {
         { P1: 1 } => true,
         (0, 1) => true,
-        _ => true
+        _ => false
         };
 
     }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4821,7 +4821,7 @@ var(x,y)=(1,2);
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
-        public async Task FormatRecursivePattern_Recursive()
+        public async Task FormatRecursivePattern_Positional()
         {
             var code = @"class C
 {
@@ -4830,6 +4830,33 @@ var(x,y)=(1,2);
             var expectedCode = @"class C
 {
     void M() { _ = this is (1, 2); }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional_Multiline()
+        {
+            var code = @"class C
+{
+    void M() { 
+_ = this is  
+( 
+1 , 
+2 )  ; 
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        (
+        1,
+        2);
+    }
 }";
 
             await AssertFormatAsync(expectedCode, code);
@@ -4847,6 +4874,71 @@ var(x,y)=(1,2);
 {
     void M() { _ = this is { P1: 1 }; }
 }";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Properties_Multiline()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is
+{
+P1 :  1  ,
+P2 : 2
+} ;
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        {
+        P1: 1,
+        P2: 2
+        };
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchExpression()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this switch
+{
+{ P1: 1} => true,
+(0, 1) => true,
+_ => true
+};
+
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+        {
+        P1: 1 }
+        => true,
+        (0, 1) => true,
+        _ => true
+        };
+
+    }
+}";
+            // PROTOTYPE(recursive-patterns): TODO
 
             await AssertFormatAsync(expectedCode, code);
         }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5098,9 +5098,49 @@ _ => false
     {
         _ = this switch
         {
-            { P1: 1 } => true,
+        { P1: 1 } => true,
         (0, 1) => true,
         _ => false
+        };
+
+    }
+}";
+            // PROTOTYPE(patterns2): TODO indentation
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchExpression_ExpressionAnchoredToArm()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this switch
+{
+{ P1: 1} 
+=> true,
+(0, 1) 
+    => true,
+_ 
+        => false
+};
+
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+        { P1: 1 }
+        => true,
+        (0, 1)
+            => true,
+        _
+                => false
         };
 
     }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4875,7 +4875,7 @@ _ = this is  ( 1 ,
         3);
     }
 }";
-            // PROTOTYPE: missing indent on 2 and 3
+            // PROTOTYPE(patterns2): missing indent on 2 and 3
             await AssertFormatAsync(expectedCode, code);
         }
 
@@ -4899,7 +4899,7 @@ _ = this is  ( 1 ,
         3);
     }
 }";
-            // PROTOTYPE: missing indent on 2 and 3
+            // PROTOTYPE(patterns2): missing indent on 2 and 3
             await AssertFormatAsync(expectedCode, code);
         }
 
@@ -4925,7 +4925,7 @@ _ = this is
         3);
     }
 }";
-            // PROTOTYPE: missing indent on open paren, 2 and 3
+            // PROTOTYPE(patterns2): missing indent on open paren, 2 and 3
             await AssertFormatAsync(expectedCode, code);
         }
 
@@ -4949,7 +4949,7 @@ _ = this is
         2, 3);
     }
 }";
-            // PROTOTYPE: missing indent on open paren, 2 and 3
+            // PROTOTYPE(patterns2): missing indent on open paren, 2 and 3
             await AssertFormatAsync(expectedCode, code);
         }
 
@@ -4959,11 +4959,11 @@ _ = this is
         {
             var code = @"class C
 {
-    void M() { _ = this is  {  P1 :  1  } ; }
+    void M() { _ = this is  C{  P1 :  1  } ; }
 }";
             var expectedCode = @"class C
 {
-    void M() { _ = this is { P1: 1 }; }
+    void M() { _ = this is C { P1: 1 }; }
 }";
 
             await AssertFormatAsync(expectedCode, code);
@@ -5047,13 +5047,32 @@ P2 : 2, P3: 3
         _ = this is
         {
         P1: 1,
-        P2: 2,
-        P3: 3
+        P2: 2, P3: 3
         };
     }
 }";
 
-            // PROTOTYPE: Wrong indentation 
+            // PROTOTYPE(patterns2): Wrong indentation
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_PositionalAndProperties()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is  C( 1 , 2 ){}  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is C (1, 2) { };
+    }
+}";
+            // a space separates the type, the positional pattern and the properties pattern
             await AssertFormatAsync(expectedCode, code);
         }
 
@@ -5086,7 +5105,7 @@ _ => false
 
     }
 }";
-            // PROTOTYPE(recursive-patterns): TODO indentation
+            // PROTOTYPE(patterns2): TODO indentation
 
             await AssertFormatAsync(expectedCode, code);
         }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5110,14 +5110,11 @@ _ => true
     {
         switch (this)
         {
-            case { P1: 1, P2: { P3: 3, P4: 4 } }
-            :
+            case { P1: 1, P2: { P3: 3, P4: 4 } }:
                 break;
         }
     }
 }";
-
-            // PROTOTYPE Incorrect newline on the colon
             await AssertFormatAsync(expectedCode, code);
         }
 
@@ -5170,15 +5167,12 @@ _ => true
     {
         switch (this)
         {
-            case { P1: 1, P2: { P3: 3, P4: 4 } }
-            :
+            case { P1: 1, P2: { P3: 3, P4: 4 } }:
                 System.Console.Write(1);
                 break;
         }
     }
 }";
-
-            // PROTOTYPE Incorrect newline on the colon
             await AssertFormatAsync(expectedCode, code);
         }
 

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5152,6 +5152,38 @@ _
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchExpression_ArmCommaWantsNewline()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this switch
+{
+{ P1: 1} => true,
+(0, 1) => true, _ => false
+};
+
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+        { P1: 1 } => true,
+        (0, 1) => true,
+        _ => false
+        };
+
+    }
+}";
+            // PROTOTYPE(patterns2): TODO indentation
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task FormatSwitchWithPropertyPattern()
         {
             var code = @"class C

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/IndentBlockOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/IndentBlockOperation.cs
@@ -61,5 +61,12 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         public bool IsRelativeIndentation { get; }
         public int IndentationDeltaOrPosition { get; }
+
+#if DEBUG
+        public override string ToString()
+        {
+            return $"Indent {TextSpan} from '{StartToken}' to '{EndToken}', by {IndentationDeltaOrPosition} relative to '{BaseToken}'";
+        }
+#endif
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/SuppressOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/SuppressOperation.cs
@@ -28,5 +28,12 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         public SyntaxToken StartToken { get; }
         public SyntaxToken EndToken { get; }
+
+#if DEBUG
+        public override string ToString()
+        {
+            return $"Suppress {TextSpan} from '{StartToken}' to '{EndToken}' with '{Option}'";
+        }
+#endif
     }
 }


### PR DESCRIPTION
Addressed:
- When typing a property-based pattern, completion should be offered for the name of the property. (this is working for many cases, but not all. A more general solution will use the upcoming `GetTypeInfo` API from the compiler)
- `switch` keyword offered for switch expression.
- Manually verified that `UpgradeProject` is properly offered.
- spacing between type and positional pattern
- missing spacing before positional pattern
- typing `e is {` gets a newline before brace

Not yet addressed:
- typing `e switch {` then `return` produces badly indented closing brace. Formatting the document doesn't fix the issue. So that's likely a formatting problem.
- completion isn't triggered in some contexts (inside property pattern in switch expression).

```C#
        _ = this switch
        {
        }; // typing this introduces extra newline and a bad indent on closing brace

        _ = this switch { { P1: 1 } => 1, _ => 2 }; // missing completion on P1
```