### PR TITLE
This fixes a crash while typing a positional pattern.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -554,6 +554,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundExpression deconstruct = MakeDeconstructInvocationExpression(
                     node.SubPatterns.Count, inputPlaceholder, node, diagnostics, outPlaceholders: out ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders);
                 deconstructMethod = deconstruct.ExpressionSymbol as MethodSymbol;
+                if (deconstructMethod == null)
+                {
+                    hasErrors = true;
+                }
+
                 int skippedExtensionParameters = deconstructMethod?.IsExtensionMethod == true ? 1 : 0;
                 for (int i = 0; i < node.SubPatterns.Count; i++)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -554,7 +554,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundExpression deconstruct = MakeDeconstructInvocationExpression(
                     node.SubPatterns.Count, inputPlaceholder, node, diagnostics, outPlaceholders: out ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders);
                 deconstructMethod = deconstruct.ExpressionSymbol as MethodSymbol;
-                if (deconstructMethod == null)
+                if (deconstructMethod is null)
                 {
                     hasErrors = true;
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
@@ -1974,6 +1974,38 @@ class Blah
             Assert.Equal(SpecialType.System_Boolean, typeInfo.Type.SpecialType);
         }
 
+        [Fact]
+        public void CrashOnWrongArity()
+        {
+            var source =
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        Point p = new Point() { X = 3, Y = 4 };
+        if (p is Point())
+        {
+        }
+    }
+}
+
+class Point
+{
+    public int X, Y;
+    public void Deconstruct(out int X, out int Y) => (X, Y) = (this.X, this.Y);
+}
+";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics(
+                // (6,18): error CS7036: There is no argument given that corresponds to the required formal parameter 'X' of 'Point.Deconstruct(out int, out int)'
+                //         if (p is Point())
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Point()").WithArguments("X", "Point.Deconstruct(out int, out int)").WithLocation(6, 18),
+                // (6,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'Point', with 0 out parameters and a void return type.
+                //         if (p is Point())
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "Point()").WithArguments("Point", "0").WithLocation(6, 18)
+                );
+        }
+
         class RemoveAliasQual : CSharpSyntaxRewriter
         {
             public override SyntaxNode VisitAliasQualifiedName(AliasQualifiedNameSyntax node)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
@@ -1975,7 +1975,7 @@ class Blah
         }
 
         [Fact]
-        public void CrashOnWrongArity()
+        public void WrongArity()
         {
             var source =
 @"class Program


### PR DESCRIPTION
This fixes a crash found while typing in the IDE. It is a tiny bug fix.
Fixes #26467

@jcouv @agocke @cston @dotnet/roslyn-compiler May I please have a couple of reviews?
