### PR TITLE
[WIP] Added support for naming rules to refactorings.

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
@@ -129,14 +129,14 @@ End Class</File>.ConvertTestSourceTag()
 
             Dim expected = <File>
 Class C
-    Private _x As Integer
+    Private x1 As Integer
 
     Public Property X As Integer
         Get
-            Return _x
+            Return x1
         End Get
         Set(value As Integer)
-            _x = value
+            x1 = value
         End Set
     End Property
 
@@ -161,14 +161,14 @@ End Class</File>.ConvertTestSourceTag()
 
             Dim expected = <File>
 Class C
-    Private _x As Integer
+    Private x1 As Integer
 
     Public Property X As Integer
         Get
-            Return _x
+            Return x1
         End Get
         Set(value As Integer)
-            _x = value
+            x1 = value
         End Set
     End Property
 
@@ -238,24 +238,24 @@ End Class</File>.ConvertTestSourceTag()
 
             Dim expected = <File>
 Class C
-    Private _x As String
-    Private _y As Integer
+    Private x1 As String
+    Private y1 As Integer
 
     Public Property X As String
         Get
-            Return _x
+            Return x1
         End Get
         Set(value As String)
-            _x = value
+            x1 = value
         End Set
     End Property
 
     Public Property Y As Integer
         Get
-            Return _y
+            Return y1
         End Get
         Set(value As Integer)
-            _y = value
+            y1 = value
         End Set
     End Property
 
@@ -375,14 +375,14 @@ End Class
 
             Dim expected = <File>
 Class D
-    Private ___ As Integer
+    Private __1 As Integer
 
     Public Property __ As Integer
         Get
-            Return ___
+            Return __1
         End Get
         Set(value As Integer)
-            ___ = value
+            __1 = value
         End Set
     End Property
 End Class
@@ -402,14 +402,14 @@ End Class
 
             Dim expected = <File>
 Class AA
-    Private name As String : Private _dsds As Integer
+    Private name As String : Private dsds1 As Integer
 
     Public Property Dsds As Integer
         Get
-            Return _dsds
+            Return dsds1
         End Get
         Set(value As Integer)
-            _dsds = value
+            dsds1 = value
         End Set
     End Property
 End Class
@@ -482,14 +482,14 @@ End Class</File>.ConvertTestSourceTag()
 
             Dim expected = <File>
 Class C
-    Private _x As Integer
+    Private x1 As Integer
 
     Protected Property X As Integer
         Get
-            Return _x
+            Return x1
         End Get
         Set(value As Integer)
-            _x = value
+            x1 = value
         End Set
     End Property
 End Class</File>.ConvertTestSourceTag()
@@ -511,14 +511,14 @@ End Class
 
             Dim expected = <File>
 Public Class Class1
-    Private _name As String
+    Private name1 As String
 
     Public Property Name As String
         Get
-            Return _name
+            Return name1
         End Get
         Set(value As String)
-            _name = value
+            name1 = value
         End Set
     End Property
 

--- a/src/EditorFeatures/VisualBasicTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.vb
@@ -59,14 +59,14 @@ End Class</File>.ConvertTestSourceTag()
 
             Dim expected = <File>
 Class C
-    Private _goo As Integer
+    Private goo1 As Integer
 
     Protected Property Goo As Integer
         Get
-            Return _goo
+            Return goo1
         End Get
         Set(value As Integer)
-            _goo = value
+            goo1 = value
         End Set
     End Property
 

--- a/src/EditorFeatures/VisualBasicTest/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateConstructor/GenerateConstructorTests.vb
@@ -882,10 +882,10 @@ End Class",
     End Sub
 End Class
 Class A
-    Private P1 As Integer
+    Private p1 As Integer
 
     Public Sub New(P As Integer)
-        P1 = P
+        p1 = P
     End Sub
 
     Shared Property P As Integer
@@ -1315,12 +1315,12 @@ Public Class MyAttribute
 
     Private v1 As Boolean
     Private v2 As Integer
-    Private Topic As String
+    Private topic As String
 
     Public Sub New(v1 As Boolean, v2 As Integer, Topic As String)
         Me.v1 = v1
         Me.v2 = v2
-        Me.Topic = Topic
+        Me.topic = Topic
     End Sub
 End Class
 <MyAttribute(true, 1, Topic:=""hello"")>

--- a/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -112,7 +112,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAutoPropertyToFullProperty
                 }
             }
 
-            return NameGenerator.GenerateUniqueName(fieldName, n => !property.ContainingType.GetMembers(n).Any());
+            return NameGenerator.GenerateUniqueName(
+                fieldName, 
+                n => !property.ContainingType.GetMembers(n).Any(),
+                name => NameGenerator.GenerateName(name, rules, new SymbolKindOrTypeKind(SymbolKind.Field), property.IsStatic ? DeclarationModifiers.Static : DeclarationModifiers.None, Accessibility.Private));
         }
 
         internal override (SyntaxNode newGetAccessor, SyntaxNode newSetAccessor) GetNewAccessors(

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
                 var methodTypeParameter = GetMethodTypeParameter(type, cancellationToken);
                 return methodTypeParameter != null
                     ? methodTypeParameter
-                    : CodeGenerationSymbolFactory.CreateTypeParameterSymbol(NameGenerator.GenerateUniqueName("T", isUnique));
+                    : CodeGenerationSymbolFactory.CreateTypeParameterSymbol(NameGenerator.GenerateUniqueName("T", isUnique, generateNewName: null));
             }
 
             private ITypeParameterSymbol GetMethodTypeParameter(TypeSyntax type, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
         private async Task<Result> EncapsulateFieldAsync(IFieldSymbol field, Document document, bool updateReferences, CancellationToken cancellationToken)
         {
             var originalField = field;
-            var finalNames = GeneratePropertyAndFieldNames(field);
+            var finalNames = GeneratePropertyAndFieldNames(field, document, cancellationToken);
             var finalFieldName = finalNames.Item1;
             var generatedPropertyName = finalNames.Item2;
 
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
                 Formatter.Annotation.AddAnnotationToSymbol(propertySymbol));
         }
 
-        protected abstract Tuple<string, string> GeneratePropertyAndFieldNames(IFieldSymbol field);
+        protected abstract Tuple<string, string> GeneratePropertyAndFieldNames(IFieldSymbol field, Document document, CancellationToken cancellationToken);
 
         protected Accessibility ComputeAccessibility(Accessibility accessibility, ITypeSymbol type)
         {

--- a/src/Features/Core/Portable/ExtractMethod/UniqueNameGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/UniqueNameGenerator.cs
@@ -21,7 +21,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             Contract.ThrowIfNull(baseName);
 
             return NameGenerator.GenerateUniqueName(baseName, string.Empty,
-               n => _semanticModel.LookupSymbols(contextNode.SpanStart, /*container*/null, n).Length == 0);
+               n => _semanticModel.LookupSymbols(contextNode.SpanStart, /*container*/null, n).Length == 0,
+               generateNewName: null);
         }
     }
 }

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -6,10 +6,13 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.GenerateType
@@ -227,7 +230,8 @@ namespace Microsoft.CodeAnalysis.GenerateType
                     {
                         if (!TryFindMatchingField(parameterName, parameterType, parameterToExistingFieldMap, caseSensitive: false))
                         {
-                            parameterToNewFieldMap[parameterName.BestNameForParameter] = parameterName.NameBasedOnArgument;
+                            parameterToNewFieldMap[parameterName.BestNameForParameter] = 
+                                NameGenerator.GenerateName(parameterName.NameBasedOnArgument, _namingRulesLazy.Value, SymbolKind.Field, Accessibility.Private);
                         }
                     }
 

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -266,7 +266,8 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                         string.Format("{0}_{1}", member.ContainingType.Name, member.Name),
                         n => !memberNames.Contains(n) &&
                             !implementedVisibleMembers.Any(m => IdentifiersMatch(m.Name, n)) &&
-                            !IsReservedName(n));
+                            !IsReservedName(n),
+                        generateNewName: null);
                 }
 
                 return member.Name;

--- a/src/Features/VisualBasic/Portable/GenerateMember/GenerateParameterizedMember/VisualBasicGenerateParameterizedMemberService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateMember/GenerateParameterizedMember/VisualBasicGenerateParameterizedMemberService.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateMethod
                 Dim methodTypeParameter = GetMethodTypeParameter(type, cancellationToken)
                 Return If(methodTypeParameter IsNot Nothing,
                            methodTypeParameter,
-                           CodeGenerationSymbolFactory.CreateTypeParameterSymbol(NameGenerator.GenerateUniqueName("T", isUnique)))
+                           CodeGenerationSymbolFactory.CreateTypeParameterSymbol(NameGenerator.GenerateUniqueName("T", isUnique, generateNewName:=Nothing)))
             End Function
 
             Private Function GetMethodTypeParameter(type As TypeSyntax, cancellationToken As CancellationToken) As ITypeParameterSymbol

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/ProjectItemsExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/ProjectItemsExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.E
 
         public static string GetUniqueName(this ProjectItems items, string itemName, string extension)
         {
-            return NameGenerator.GenerateUniqueName(itemName, extension, n => items.FindItem(n, StringComparer.OrdinalIgnoreCase) == null);
+            return NameGenerator.GenerateUniqueName(itemName, extension, n => items.FindItem(n, StringComparer.OrdinalIgnoreCase) == null, null);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/NamingStyles/DefaultNamingRules.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/DefaultNamingRules.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.NamingStyles;
+
+namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
+{
+    internal static class DefaultNamingRules
+    {
+        public static ImmutableArray<NamingRule> FieledAndPropertyRules { get; } = ImmutableArray.Create(
+               new NamingRule(new SymbolSpecification(
+                   Guid.NewGuid(), "Property",
+                   ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(SymbolKind.Property))),
+                   new NamingStyle(Guid.NewGuid(), capitalizationScheme: Capitalization.PascalCase),
+                   enforcementLevel: DiagnosticSeverity.Hidden),
+               new NamingRule(new SymbolSpecification(
+                   Guid.NewGuid(), "Field",
+                   ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(SymbolKind.Field))),
+                   new NamingStyle(Guid.NewGuid(), capitalizationScheme: Capitalization.CamelCase),
+                   enforcementLevel: DiagnosticSeverity.Hidden),
+               new NamingRule(new SymbolSpecification(
+                   Guid.NewGuid(), "FieldWithUnderscore",
+                   ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(SymbolKind.Field)),
+                   ImmutableArray.Create(Accessibility.Private)),
+                   new NamingStyle(Guid.NewGuid(), prefix: "_", capitalizationScheme: Capitalization.CamelCase),
+                   enforcementLevel: DiagnosticSeverity.Hidden));
+
+        public static ImmutableArray<NamingRule> InterfaceNameRule { get; } = ImmutableArray.Create(
+            new NamingRule(new SymbolSpecification(
+                   Guid.NewGuid(), "Interface",
+                   ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(TypeKind.Interface))),
+                   new NamingStyle(Guid.NewGuid(), prefix: "I", capitalizationScheme: Capitalization.PascalCase),
+                   enforcementLevel: DiagnosticSeverity.Hidden));
+    }
+}

--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -15,6 +15,8 @@ using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.GeneratedCodeRecognition;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Simplification;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
@@ -198,6 +200,16 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             var generatedCodeRecognitionService = document.GetLanguageService<IGeneratedCodeRecognitionService>();
             return generatedCodeRecognitionService?.IsGeneratedCode(document, cancellationToken) == true;
+        }
+
+        public static async Task<ImmutableArray<NamingRule>> GetNamingRulesAsync(
+               this Document document, CancellationToken cancellationToken)
+        {
+            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var namingStyleOptions = options.GetOption(SimplificationOptions.NamingPreferences);
+
+            var rules = namingStyleOptions.CreateRules().NamingRules;
+            return rules;
         }
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
@@ -329,17 +329,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestGenerateUniqueName()
         {
-            var a = NameGenerator.GenerateUniqueName("ABC", "txt", _ => true);
+            var a = NameGenerator.GenerateUniqueName("ABC", "txt", _ => true, generateNewName: null);
             Assert.True(a.StartsWith("ABC", StringComparison.Ordinal));
             Assert.True(a.EndsWith(".txt", StringComparison.Ordinal));
             Assert.False(a.EndsWith("..txt", StringComparison.Ordinal));
 
-            var b = NameGenerator.GenerateUniqueName("ABC", ".txt", _ => true);
+            var b = NameGenerator.GenerateUniqueName("ABC", ".txt", _ => true, generateNewName: null);
             Assert.True(b.StartsWith("ABC", StringComparison.Ordinal));
             Assert.True(b.EndsWith(".txt", StringComparison.Ordinal));
             Assert.False(b.EndsWith("..txt", StringComparison.Ordinal));
 
-            var c = NameGenerator.GenerateUniqueName("ABC", "\u0640.txt", _ => true);
+            var c = NameGenerator.GenerateUniqueName("ABC", "\u0640.txt", _ => true, generateNewName: null);
             Assert.True(c.StartsWith("ABC", StringComparison.Ordinal));
             Assert.True(c.EndsWith(".\u0640.txt", StringComparison.Ordinal));
             Assert.False(c.EndsWith("..txt", StringComparison.Ordinal));


### PR DESCRIPTION
Fixes #26417

Some tests will be updated.
Need to add tests with different naming rules.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
