### PR TITLE
Migrate VSTS YAML to dev15.7.x

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,0 +1,149 @@
+resources:
+- repo: self
+  clean: true
+queue:
+  name: VSEng-MicroBuildVS2017
+  timeoutInMinutes: 360
+  demands: 
+  - msbuild
+  - visualstudio
+  - DotNetFramework
+
+variables:
+  BuildPlatform: 'Any CPU'
+steps:
+- task: NuGetCommand@2
+  inputs:
+    command: custom
+    arguments: 'locals all -clear'
+
+- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+  inputs:
+    signType: real
+  condition: and(succeeded(), in(variables['PB_SignType'], 'test', 'real'))
+
+- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
+  inputs:
+    feedSource: 'https://devdiv-test.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json'
+
+- task: NuGetRestore@1
+  inputs:
+    solution: 'build\ToolsetPackages\InternalToolset.csproj'
+    feed: '8f470c7e-ac49-4afe-a6ee-cf784e438b93'
+
+- task: CmdLine@1
+  inputs:
+    filename: mkdir
+    arguments: 'Binaries\$(BuildConfiguration)'
+
+- task: VSBuild@1
+  inputs:
+    solution: 'src/Tools/MicroBuild/Build.proj'
+    vsVersion: 15.0
+    msbuildArgs: >- 
+        /p:TreatWarningsAsErrors=true 
+        /p:DeployExtension=false 
+        /p:TrackFileAccess=false
+        /p:OfficialBuild=true 
+        /p:VisualStudioVersion=14.0 
+        /flp1:Summary;Verbosity=diagnostic;Encoding=UTF-8;LogFile=$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\Roslyn.log 
+        /flp2:WarningsOnly;Verbosity=diagnostic;Encoding=UTF-8;LogFile=$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\Roslyn.wrn 
+        /flp3:ErrorsOnly;Verbosity=diagnostic;Encoding=UTF-8;LogFile=$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\Roslyn.err 
+        /p:RoslynMyGetApiKey=$(Roslyn.MyGetApiKey) 
+        /p:RoslynNuGetApiKey=$(Roslyn.NuGetApiKey) 
+        /p:RoslynGitHubEmail=$(Roslyn.GitHubEmail) 
+        /p:RoslynGitHubToken=$(Roslyn.GitHubToken) 
+        /p:RoslynGitHubUserName=$(Roslyn.GitHubUserName) 
+        /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey) 
+        /p:PublishStableVersions=false 
+        /p:VersionStampToPublish=prerelease
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+    maximumCpuCount: true
+    logProjectEvents: false
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\Logs'
+    ArtifactName: 'Build Diagnostic Files'
+    publishLocation: Container
+  continueOnError: true
+  condition: succeededOrFailed()
+
+- task: PublishTestResults@1
+  inputs:
+    testRunner: XUnit
+    testResultsFiles: '**/xUnitResults/*.xml'
+    mergeTestResults: true
+    testRunTitle: 'Unit Tests'
+  condition: succeededOrFailed()
+
+- task: PublishSymbols@1
+  displayName: Create Symbol Index
+  inputs:
+    SymbolsPath: '$(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\Symbols'
+    SearchPattern: '**\*.dll;**\*.exe;**\*.pdb'
+    SymbolsFolder: '$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\SymStore'
+    SkipIndexing: true
+    TreatNotIndexedAsWarning: true
+    SymbolsProduct: Roslyn
+    SymbolsVersion: '$(Build.BuildNumber)'
+    SymbolsArtifactName: Symbols
+  condition: and(succeeded(), contains(variables['PB_PublishType'], 'vsts'))
+
+- task: CopyFiles@2
+  displayName: Copy Files to Local Temporary Path
+  inputs:
+    SourceFolder: '$(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\Symbols'
+    TargetFolder: '$(Build.StagingDirectory)\SymbolsForPublish'
+  condition: and(succeeded(), contains(variables['PB_PublishType'], 'vsts'))
+
+- task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
+  displayName: Publish Symbols to Artifact Services
+  inputs:
+    symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
+    requestName: '$(system.teamProject)/Roslyn-Signed/$(Build.BuildNumber)/$(Build.BuildId)'
+    sourcePath: '$(Build.StagingDirectory)\SymbolsForPublish'
+    usePat: false
+  continueOnError: true
+  condition: and(succeeded(), contains(variables['PB_PublishType'], 'vsts'))
+
+- task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
+  displayName: Upload VSTS Drop
+  inputs:
+    DropFolder: 'Binaries\$(BuildConfiguration)\Insertion'
+  condition: and(succeeded(), contains(variables['PB_PublishType'], 'vsts'))
+
+- task: NuGetCommand@2
+  displayName: NuGet CoreXT publish
+  inputs:
+    command: push
+    feedsToUse: config
+    packagesToPush: '$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\DevDivPackages\**\*.nupkg'
+    publishVstsFeed: '97a41293-2972-4f48-8c0e-05493ae82010'
+    allowPackageConflicts: true
+  condition: and(succeeded(), contains(variables['PB_PublishType'], 'vsts'))
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish Drop (parallel)
+  inputs:
+    PathtoPublish: 'Binaries\$(BuildConfiguration)'
+    ArtifactName: '$(Build.BuildNumber)'
+    publishLocation: FilePath
+    TargetPath: '$(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)'
+    Parallel: true
+    ParallelCount: 64
+
+- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+  displayName: Perform Cleanup Tasks
+  condition: succeededOrFailed()
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish MicroBuild Outputs
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\MicroBuild\Output'
+    ArtifactName: '$(Build.BuildNumber)'
+    publishLocation: FilePath
+    TargetPath: '$(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)'
+  condition: and(succeededOrFailed(), contains(variables['PB_PublishType'], 'vsts'))
+

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -152,7 +152,7 @@
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.4.0-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
     <RoslynToolsMSBuildVersion>0.4.0-alpha</RoslynToolsMSBuildVersion>
     <RoslynToolsReferenceAssembliesVersion>0.1.3</RoslynToolsReferenceAssembliesVersion>
-    <RoslynToolsSignToolVersion>1.0.0-beta2-dev2</RoslynToolsSignToolVersion>
+    <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
     <RoslynMicrosoftVisualStudioExtensionManagerVersion>0.0.4</RoslynMicrosoftVisualStudioExtensionManagerVersion>
     <StreamJsonRpcVersion>1.1.92</StreamJsonRpcVersion>
     <SystemAppContextVersion>4.3.0</SystemAppContextVersion>


### PR DESCRIPTION
This copies our VSTS YAML file into dev15.7.x. This changes nothing
about our official build in this branch. It just seeds it with the
correct value and lets the merge bots move it to the rest of the trees.

The official switch over for 15.7 will happen at a later time and will
be very deliberate.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
