### PR TITLE
Preserve Digit Separators During Reduce Tokens Stage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ $RECYCLE.BIN/
 
 # JetBrains Rider
 .idea/
+.cr/Settings.xml

--- a/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests_WithDigitSeparators.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests_WithDigitSeparators.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
 {
+    [UseExportProvider]
     public class ReduceTokenTests_WithDigitSeparators
     {
         [Fact]

--- a/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests_WithDigitSeparators.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/ReduceTokenTests_WithDigitSeparators.cs
@@ -1,9 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CodeCleanup.Providers;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -13,12 +18,12 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
 {
-    [UseExportProvider]
-    public class ReduceTokenTests
+    public class ReduceTokenTests_WithDigitSeparators
     {
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceSingleLiterals_LessThan8Digits()
         {
             var code = @"[|
@@ -28,20 +33,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 5 significant digits
-        Const f_5_1 As Single = .14995F        ' Dev11 & Roslyn: Pretty listed to 0.14995F
-        Const f_5_2 As Single = 0.14995f       ' Dev11 & Roslyn: Unchanged
-        Const f_5_3 As Single = 1.4995F        ' Dev11 & Roslyn: Unchanged
-        Const f_5_4 As Single = 149.95f        ' Dev11 & Roslyn: Unchanged
-        Const f_5_5 As Single = 1499.5F        ' Dev11 & Roslyn: Unchanged
-        Const f_5_6 As Single = 14995.0f       ' Dev11 & Roslyn: Unchanged
+        Const f_5_1 As Single = .149_95F         ' Dev11 & Roslyn: Pretty listed to 0.14995F
+        Const f_5_2 As Single = 0.149_95f        ' Dev11 & Roslyn: Unchanged
+        Const f_5_3 As Single = 1.499_5F         ' Dev11 & Roslyn: Unchanged
+        Const f_5_4 As Single = 149.95f          ' Dev11 & Roslyn: Unchanged
+        Const f_5_5 As Single = 1_499.5F         ' Dev11 & Roslyn: Unchanged
+        Const f_5_6 As Single = 14_995.0f        ' Dev11 & Roslyn: Unchanged
 
         ' 7 significant digits
-        Const f_7_1 As Single = .1499995F      ' Dev11 & Roslyn: Pretty listed to 0.1499995F
-        Const f_7_2 As Single = 0.1499995f     ' Dev11 & Roslyn: Unchanged
-        Const f_7_3 As Single = 1.499995F      ' Dev11 & Roslyn: Unchanged
-        Const f_7_4 As Single = 1499.995f      ' Dev11 & Roslyn: Unchanged
-        Const f_7_5 As Single = 149999.5F      ' Dev11 & Roslyn: Unchanged
-        Const f_7_6 As Single = 1499995.0f     ' Dev11 & Roslyn: Unchanged
+        Const f_7_1 As Single = .149_999_5F      ' Dev11 & Roslyn: Pretty listed to 0.1499995F
+        Const f_7_2 As Single = 0.149_999_5f     ' Dev11 & Roslyn: Unchanged
+        Const f_7_3 As Single = 1.499_995F       ' Dev11 & Roslyn: Unchanged
+        Const f_7_4 As Single = 1_499.995f       ' Dev11 & Roslyn: Unchanged
+        Const f_7_5 As Single = 149_999.5F       ' Dev11 & Roslyn: Unchanged
+        Const f_7_6 As Single = 1_499_995.0f     ' Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_5_1)
         Console.WriteLine(f_5_2)
@@ -67,20 +72,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 5 significant digits
-        Const f_5_1 As Single = 0.14995F        ' Dev11 & Roslyn: Pretty listed to 0.14995F
-        Const f_5_2 As Single = 0.14995F       ' Dev11 & Roslyn: Unchanged
-        Const f_5_3 As Single = 1.4995F        ' Dev11 & Roslyn: Unchanged
-        Const f_5_4 As Single = 149.95F        ' Dev11 & Roslyn: Unchanged
-        Const f_5_5 As Single = 1499.5F        ' Dev11 & Roslyn: Unchanged
-        Const f_5_6 As Single = 14995.0F       ' Dev11 & Roslyn: Unchanged
+        Const f_5_1 As Single = .149_95F         ' Dev11 & Roslyn: Pretty listed to 0.14995F
+        Const f_5_2 As Single = 0.149_95F        ' Dev11 & Roslyn: Unchanged
+        Const f_5_3 As Single = 1.499_5F         ' Dev11 & Roslyn: Unchanged
+        Const f_5_4 As Single = 149.95F          ' Dev11 & Roslyn: Unchanged
+        Const f_5_5 As Single = 1_499.5F         ' Dev11 & Roslyn: Unchanged
+        Const f_5_6 As Single = 14_995.0F        ' Dev11 & Roslyn: Unchanged
 
         ' 7 significant digits
-        Const f_7_1 As Single = 0.1499995F      ' Dev11 & Roslyn: Pretty listed to 0.1499995F
-        Const f_7_2 As Single = 0.1499995F     ' Dev11 & Roslyn: Unchanged
-        Const f_7_3 As Single = 1.499995F      ' Dev11 & Roslyn: Unchanged
-        Const f_7_4 As Single = 1499.995F      ' Dev11 & Roslyn: Unchanged
-        Const f_7_5 As Single = 149999.5F      ' Dev11 & Roslyn: Unchanged
-        Const f_7_6 As Single = 1499995.0F     ' Dev11 & Roslyn: Unchanged
+        Const f_7_1 As Single = .149_999_5F      ' Dev11 & Roslyn: Pretty listed to 0.1499995F
+        Const f_7_2 As Single = 0.149_999_5F     ' Dev11 & Roslyn: Unchanged
+        Const f_7_3 As Single = 1.499_995F       ' Dev11 & Roslyn: Unchanged
+        Const f_7_4 As Single = 1_499.995F       ' Dev11 & Roslyn: Unchanged
+        Const f_7_5 As Single = 149_999.5F       ' Dev11 & Roslyn: Unchanged
+        Const f_7_6 As Single = 1_499_995.0F     ' Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_5_1)
         Console.WriteLine(f_5_2)
@@ -104,6 +109,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceSingleLiterals_LessThan8Digits_WithTypeCharacterSingle()
         {
             var code = @"[|
@@ -113,20 +119,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 5 significant digits
-        Const f_5_1 As Single = .14995!        ' Dev11 & Roslyn: Pretty listed to 0.14995!
-        Const f_5_2 As Single = 0.14995!       ' Dev11 & Roslyn: Unchanged
-        Const f_5_3 As Single = 1.4995!        ' Dev11 & Roslyn: Unchanged
-        Const f_5_4 As Single = 149.95!        ' Dev11 & Roslyn: Unchanged
-        Const f_5_5 As Single = 1499.5!        ' Dev11 & Roslyn: Unchanged
-        Const f_5_6 As Single = 14995.0!       ' Dev11 & Roslyn: Unchanged
+        Const f_5_1 As Single = .149_95!         ' Dev11 & Roslyn: Pretty listed to 0.14995!
+        Const f_5_2 As Single = 0.149_95!        ' Dev11 & Roslyn: Unchanged
+        Const f_5_3 As Single = 1.499_5!         ' Dev11 & Roslyn: Unchanged
+        Const f_5_4 As Single = 149.95!          ' Dev11 & Roslyn: Unchanged
+        Const f_5_5 As Single = 1_499.5!         ' Dev11 & Roslyn: Unchanged
+        Const f_5_6 As Single = 14_995.0!        ' Dev11 & Roslyn: Unchanged
 
         ' 7 significant digits
-        Const f_7_1 As Single = .1499995!      ' Dev11 & Roslyn: Pretty listed to 0.1499995!
-        Const f_7_2 As Single = 0.1499995!     ' Dev11 & Roslyn: Unchanged
-        Const f_7_3 As Single = 1.499995!      ' Dev11 & Roslyn: Unchanged
-        Const f_7_4 As Single = 1499.995!      ' Dev11 & Roslyn: Unchanged
-        Const f_7_5 As Single = 149999.5!      ' Dev11 & Roslyn: Unchanged
-        Const f_7_6 As Single = 1499995.0!     ' Dev11 & Roslyn: Unchanged
+        Const f_7_1 As Single = .149_999_5!      ' Dev11 & Roslyn: Pretty listed to 0.1499995!
+        Const f_7_2 As Single = 0.149_999_5!     ' Dev11 & Roslyn: Unchanged
+        Const f_7_3 As Single = 1.499_995!       ' Dev11 & Roslyn: Unchanged
+        Const f_7_4 As Single = 1_499.995!       ' Dev11 & Roslyn: Unchanged
+        Const f_7_5 As Single = 149_999.5!       ' Dev11 & Roslyn: Unchanged
+        Const f_7_6 As Single = 1_499_995.0!     ' Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_5_1)
         Console.WriteLine(f_5_2)
@@ -152,20 +158,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 5 significant digits
-        Const f_5_1 As Single = 0.14995!        ' Dev11 & Roslyn: Pretty listed to 0.14995!
-        Const f_5_2 As Single = 0.14995!       ' Dev11 & Roslyn: Unchanged
-        Const f_5_3 As Single = 1.4995!        ' Dev11 & Roslyn: Unchanged
-        Const f_5_4 As Single = 149.95!        ' Dev11 & Roslyn: Unchanged
-        Const f_5_5 As Single = 1499.5!        ' Dev11 & Roslyn: Unchanged
-        Const f_5_6 As Single = 14995.0!       ' Dev11 & Roslyn: Unchanged
+        Const f_5_1 As Single = .149_95!         ' Dev11 & Roslyn: Pretty listed to 0.14995!
+        Const f_5_2 As Single = 0.149_95!        ' Dev11 & Roslyn: Unchanged
+        Const f_5_3 As Single = 1.499_5!         ' Dev11 & Roslyn: Unchanged
+        Const f_5_4 As Single = 149.95!          ' Dev11 & Roslyn: Unchanged
+        Const f_5_5 As Single = 1_499.5!         ' Dev11 & Roslyn: Unchanged
+        Const f_5_6 As Single = 14_995.0!        ' Dev11 & Roslyn: Unchanged
 
         ' 7 significant digits
-        Const f_7_1 As Single = 0.1499995!      ' Dev11 & Roslyn: Pretty listed to 0.1499995!
-        Const f_7_2 As Single = 0.1499995!     ' Dev11 & Roslyn: Unchanged
-        Const f_7_3 As Single = 1.499995!      ' Dev11 & Roslyn: Unchanged
-        Const f_7_4 As Single = 1499.995!      ' Dev11 & Roslyn: Unchanged
-        Const f_7_5 As Single = 149999.5!      ' Dev11 & Roslyn: Unchanged
-        Const f_7_6 As Single = 1499995.0!     ' Dev11 & Roslyn: Unchanged
+        Const f_7_1 As Single = .149_999_5!      ' Dev11 & Roslyn: Pretty listed to 0.1499995!
+        Const f_7_2 As Single = 0.149_999_5!     ' Dev11 & Roslyn: Unchanged
+        Const f_7_3 As Single = 1.499_995!       ' Dev11 & Roslyn: Unchanged
+        Const f_7_4 As Single = 1_499.995!       ' Dev11 & Roslyn: Unchanged
+        Const f_7_5 As Single = 149_999.5!       ' Dev11 & Roslyn: Unchanged
+        Const f_7_6 As Single = 1_499_995.0!     ' Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_5_1)
         Console.WriteLine(f_5_2)
@@ -189,6 +195,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceSingleLiterals_8Digits()
         {
             var code = @"[|
@@ -197,19 +204,19 @@ Module Program
         ' CATEGORY 2: 8 significant digits
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 9 significant digits
 
-        Const f_8_1 As Single = .14999795F      ' Dev11 & Roslyn: 0.14999795F
-        Const f_8_2 As Single = .14999797f      ' Dev11 & Roslyn: 0.149997965F
+        Const f_8_1 As Single = .149_997_95F      ' (01) Dev11 & Roslyn: 0.14999795F
+        Const f_8_2 As Single = .149_997_97f      ' (02) Dev11 & Roslyn: 0.149997965F
 
-        Const f_8_3 As Single = 0.1499797F      ' Dev11 & Roslyn: Unchanged
+        Const f_8_3 As Single = 0.149_979_7F      ' (03) Dev11 & Roslyn: Unchanged
 
-        Const f_8_4 As Single = 1.4999794f      ' Dev11 & Roslyn: 1.49997938F
-        Const f_8_5 As Single = 1.4999797F      ' Dev11 & Roslyn: 1.49997973F
+        Const f_8_4 As Single = 1.499_979_4f      ' (04) Dev11 & Roslyn: 1.49997938F
+        Const f_8_5 As Single = 1.499_979_7F      ' (05) Dev11 & Roslyn: 1.49997973F
 
-        Const f_8_6 As Single = 1499.9794f      ' Dev11 & Roslyn: 1499.97937F
+        Const f_8_6 As Single = 1_499.979_4f      ' (06) Dev11 & Roslyn: 1499.97937F
 
-        Const f_8_7 As Single = 1499979.7F      ' Dev11 & Roslyn: 1499979.75F
+        Const f_8_7 As Single = 1_499_979.7F      ' (07) Dev11 & Roslyn: 1499979.75F
 
-        Const f_8_8 As Single = 14999797.0F     ' Dev11 & Roslyn: unchanged
+        Const f_8_8 As Single = 14_999_797.0F     ' (08) Dev11 & Roslyn: unchanged
 
         Console.WriteLine(f_8_1)
         Console.WriteLine(f_8_2)
@@ -229,19 +236,19 @@ Module Program
         ' CATEGORY 2: 8 significant digits
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 9 significant digits
 
-        Const f_8_1 As Single = 0.14999795F      ' Dev11 & Roslyn: 0.14999795F
-        Const f_8_2 As Single = 0.149997965F      ' Dev11 & Roslyn: 0.149997965F
+        Const f_8_1 As Single = .149_997_95F      ' (01) Dev11 & Roslyn: 0.14999795F
+        Const f_8_2 As Single = .149_997_97F      ' (02) Dev11 & Roslyn: 0.149997965F
 
-        Const f_8_3 As Single = 0.1499797F      ' Dev11 & Roslyn: Unchanged
+        Const f_8_3 As Single = 0.149_979_7F      ' (03) Dev11 & Roslyn: Unchanged
 
-        Const f_8_4 As Single = 1.49997938F      ' Dev11 & Roslyn: 1.49997938F
-        Const f_8_5 As Single = 1.49997973F      ' Dev11 & Roslyn: 1.49997973F
+        Const f_8_4 As Single = 1.499_979_4F      ' (04) Dev11 & Roslyn: 1.49997938F
+        Const f_8_5 As Single = 1.499_979_7F      ' (05) Dev11 & Roslyn: 1.49997973F
 
-        Const f_8_6 As Single = 1499.97937F      ' Dev11 & Roslyn: 1499.97937F
+        Const f_8_6 As Single = 1_499.979_4F      ' (06) Dev11 & Roslyn: 1499.97937F
 
-        Const f_8_7 As Single = 1499979.75F      ' Dev11 & Roslyn: 1499979.75F
+        Const f_8_7 As Single = 1_499_979.7F      ' (07) Dev11 & Roslyn: 1499979.75F
 
-        Const f_8_8 As Single = 14999797.0F     ' Dev11 & Roslyn: unchanged
+        Const f_8_8 As Single = 14_999_797.0F     ' (08) Dev11 & Roslyn: unchanged
 
         Console.WriteLine(f_8_1)
         Console.WriteLine(f_8_2)
@@ -259,6 +266,7 @@ End Module
 
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
         public async Task ReduceSingleLiterals_8Digits_WithTypeCharacterSingle()
         {
@@ -268,19 +276,19 @@ Module Program
         ' CATEGORY 2: 8 significant digits
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 9 significant digits
 
-        Const f_8_1 As Single = .14999795!      ' Dev11 & Roslyn: 0.14999795F
-        Const f_8_2 As Single = .14999797!      ' Dev11 & Roslyn: 0.149997965F
+        Const f_8_1 As Single = .149_997_95!      ' (01) Dev11 & Roslyn: 0.14999795F
+        Const f_8_2 As Single = .149_997_97!      ' (02) Dev11 & Roslyn: 0.149997965F
 
-        Const f_8_3 As Single = 0.1499797!      ' Dev11 & Roslyn: Unchanged
+        Const f_8_3 As Single = 0.149_979_7!      ' (03) Dev11 & Roslyn: Unchanged
 
-        Const f_8_4 As Single = 1.4999794!      ' Dev11 & Roslyn: 1.49997938F
-        Const f_8_5 As Single = 1.4999797!      ' Dev11 & Roslyn: 1.49997973F
+        Const f_8_4 As Single = 1.499_979_4!      ' (04) Dev11 & Roslyn: 1.49997938F
+        Const f_8_5 As Single = 1.499_979_7!      ' (05) Dev11 & Roslyn: 1.49997973F
 
-        Const f_8_6 As Single = 1499.9794!      ' Dev11 & Roslyn: 1499.97937F
+        Const f_8_6 As Single = 1_499.979_4!      ' (06) Dev11 & Roslyn: 1499.97937F
 
-        Const f_8_7 As Single = 1499979.7!      ' Dev11 & Roslyn: 1499979.75F
+        Const f_8_7 As Single = 1_499_979.7!      ' (07) Dev11 & Roslyn: 1499979.75F
 
-        Const f_8_8 As Single = 14999797.0!     ' Dev11 & Roslyn: unchanged
+        Const f_8_8 As Single = 14_999_797.0!     ' (08) Dev11 & Roslyn: unchanged
 
         Console.WriteLine(f_8_1)
         Console.WriteLine(f_8_2)
@@ -300,19 +308,19 @@ Module Program
         ' CATEGORY 2: 8 significant digits
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 9 significant digits
 
-        Const f_8_1 As Single = 0.14999795!      ' Dev11 & Roslyn: 0.14999795F
-        Const f_8_2 As Single = 0.149997965!      ' Dev11 & Roslyn: 0.149997965F
+        Const f_8_1 As Single = .149_997_95!      ' (01) Dev11 & Roslyn: 0.14999795F
+        Const f_8_2 As Single = .149_997_97!      ' (02) Dev11 & Roslyn: 0.149997965F
 
-        Const f_8_3 As Single = 0.1499797!      ' Dev11 & Roslyn: Unchanged
+        Const f_8_3 As Single = 0.149_979_7!      ' (03) Dev11 & Roslyn: Unchanged
 
-        Const f_8_4 As Single = 1.49997938!      ' Dev11 & Roslyn: 1.49997938F
-        Const f_8_5 As Single = 1.49997973!      ' Dev11 & Roslyn: 1.49997973F
+        Const f_8_4 As Single = 1.499_979_4!      ' (04) Dev11 & Roslyn: 1.49997938F
+        Const f_8_5 As Single = 1.499_979_7!      ' (05) Dev11 & Roslyn: 1.49997973F
 
-        Const f_8_6 As Single = 1499.97937!      ' Dev11 & Roslyn: 1499.97937F
+        Const f_8_6 As Single = 1_499.979_4!      ' (06) Dev11 & Roslyn: 1499.97937F
 
-        Const f_8_7 As Single = 1499979.75!      ' Dev11 & Roslyn: 1499979.75F
+        Const f_8_7 As Single = 1_499_979.7!      ' (07) Dev11 & Roslyn: 1499979.75F
 
-        Const f_8_8 As Single = 14999797.0!     ' Dev11 & Roslyn: unchanged
+        Const f_8_8 As Single = 14_999_797.0!     ' (08) Dev11 & Roslyn: unchanged
 
         Console.WriteLine(f_8_1)
         Console.WriteLine(f_8_2)
@@ -340,26 +348,26 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 9 significant digits
         
         ' (a) > 8 significant digits overall, but < 8 digits before decimal point.
-        Const f_9_1 As Single = .149997938F     ' Dev11 & Roslyn: 0.149997935F
-        Const f_9_2 As Single = 0.149997931f    ' Dev11 & Roslyn: 0.149997935F
-        Const f_9_3 As Single = 1.49997965F     ' Dev11 & Roslyn: 1.49997962F
+        Const f_9_1 As Single = .149_997_938F      ' (01) Dev11 & Roslyn: 0.149997935F
+        Const f_9_2 As Single = 0.149_997_931f     ' (02) Dev11 & Roslyn: 0.149997935F
+        Const f_9_3 As Single = 1.499_979_65F      ' (03) Dev11 & Roslyn: 1.49997962F
 
-        Const f_10_1 As Single = 14999.79652f   ' Dev11 & Roslyn: 14999.7969F
+        Const f_10_1 As Single = 14_999.796_52f    ' (04) Dev11 & Roslyn: 14999.7969F
 
         ' (b) > 8 significant digits before decimal point.
-        Const f_10_2 As Single = 149997965.2F   ' Dev11 & Roslyn: 149997968.0F
-        Const f_10_3 As Single = 1499979652.0f  ' Dev11 & Roslyn: 1.49997965E+9F
+        Const f_10_2 As Single = 149_997_965.2F    ' (05) Dev11 & Roslyn: 149997968.0F
+        Const f_10_3 As Single = 1_499_979_652.0f  ' (06) Dev11 & Roslyn: 1.49997965E+9F
 
-        Const f_24_1 As Single = 111111149999124689999.499F      ' Dev11 & Roslyn: 1.11111148E+20F
+        Const f_24_1 As Single = 111_111_149_999_124_689_999.499F      ' (07) Dev11 & Roslyn: 1.11111148E+20F
 
         ' (c) Overflow/Underflow cases for Single: Ensure no pretty listing/round off
         '     Holds signed IEEE 32-bit (4-byte) single-precision floating-point numbers ranging in value from -3.4028235E+38 through -1.401298E-45 for negative values and
         '     from 1.401298E-45 through 3.4028235E+38 for positive values.
         
-        Const f_overflow_1 As Single = -3.4028235E+39F          ' Dev11 & Roslyn: Unchanged
-        Const f_overflow_2 As Single = 3.4028235E+39F           ' Dev11 & Roslyn: Unchanged
-        Const f_underflow_1 As Single = -1.401298E-47F          ' Dev11: -0.0F, Roslyn: Unchanged
-        Const f_underflow_2 As Single = 1.401298E-47F           ' Dev11: 0.0F, Roslyn: Unchanged
+        Const f_overflow_1 As Single = -3.402_823_5E+39F          ' (08) Dev11 & Roslyn: Unchanged
+        Const f_overflow_2 As Single = 3.402_823_5E+39F           ' (09) Dev11 & Roslyn: Unchanged
+        Const f_underflow_1 As Single = -1.401_298E-47F           ' (10) Dev11: -0.0F, Roslyn: Unchanged
+        Const f_underflow_2 As Single = 1.401_298E-47F            ' (11) Dev11: 0.0F, Roslyn: Unchanged
         
         Console.WriteLine(f_9_1)
         Console.WriteLine(f_9_2)
@@ -384,26 +392,26 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 9 significant digits
 
         ' (a) > 8 significant digits overall, but < 8 digits before decimal point.
-        Const f_9_1 As Single = 0.149997935F     ' Dev11 & Roslyn: 0.149997935F
-        Const f_9_2 As Single = 0.149997935F    ' Dev11 & Roslyn: 0.149997935F
-        Const f_9_3 As Single = 1.49997962F     ' Dev11 & Roslyn: 1.49997962F
+        Const f_9_1 As Single = .149_997_938F      ' (01) Dev11 & Roslyn: 0.149997935F
+        Const f_9_2 As Single = 0.149_997_931F     ' (02) Dev11 & Roslyn: 0.149997935F
+        Const f_9_3 As Single = 1.499_979_65F      ' (03) Dev11 & Roslyn: 1.49997962F
 
-        Const f_10_1 As Single = 14999.7969F   ' Dev11 & Roslyn: 14999.7969F
+        Const f_10_1 As Single = 14_999.796_52F    ' (04) Dev11 & Roslyn: 14999.7969F
 
         ' (b) > 8 significant digits before decimal point.
-        Const f_10_2 As Single = 149997968.0F   ' Dev11 & Roslyn: 149997968.0F
-        Const f_10_3 As Single = 1.49997965E+9F  ' Dev11 & Roslyn: 1.49997965E+9F
+        Const f_10_2 As Single = 149_997_965.2F    ' (05) Dev11 & Roslyn: 149997968.0F
+        Const f_10_3 As Single = 1_499_979_652.0F  ' (06) Dev11 & Roslyn: 1.49997965E+9F
 
-        Const f_24_1 As Single = 1.11111148E+20F      ' Dev11 & Roslyn: 1.11111148E+20F
+        Const f_24_1 As Single = 111_111_149_999_124_689_999.499F      ' (07) Dev11 & Roslyn: 1.11111148E+20F
 
         ' (c) Overflow/Underflow cases for Single: Ensure no pretty listing/round off
         '     Holds signed IEEE 32-bit (4-byte) single-precision floating-point numbers ranging in value from -3.4028235E+38 through -1.401298E-45 for negative values and
         '     from 1.401298E-45 through 3.4028235E+38 for positive values.
 
-        Const f_overflow_1 As Single = -3.4028235E+39F          ' Dev11 & Roslyn: Unchanged
-        Const f_overflow_2 As Single = 3.4028235E+39F           ' Dev11 & Roslyn: Unchanged
-        Const f_underflow_1 As Single = -1.401298E-47F          ' Dev11: -0.0F, Roslyn: Unchanged
-        Const f_underflow_2 As Single = 1.401298E-47F           ' Dev11: 0.0F, Roslyn: Unchanged
+        Const f_overflow_1 As Single = -3.402_823_5E+39F          ' (08) Dev11 & Roslyn: Unchanged
+        Const f_overflow_2 As Single = 3.402_823_5E+39F           ' (09) Dev11 & Roslyn: Unchanged
+        Const f_underflow_1 As Single = -1.401_298E-47F           ' (10) Dev11: -0.0F, Roslyn: Unchanged
+        Const f_underflow_2 As Single = 1.401_298E-47F            ' (11) Dev11: 0.0F, Roslyn: Unchanged
 
         Console.WriteLine(f_9_1)
         Console.WriteLine(f_9_2)
@@ -426,6 +434,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceSingleLiterals_GreaterThan8Digits_WithTypeCharacterSingle()
         {
             var code = @"[|
@@ -435,26 +444,26 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 9 significant digits
         
         ' (a) > 8 significant digits overall, but < 8 digits before decimal point.
-        Const f_9_1 As Single = .149997938!     ' Dev11 & Roslyn: 0.149997935F
-        Const f_9_2 As Single = 0.149997931!    ' Dev11 & Roslyn: 0.149997935F
-        Const f_9_3 As Single = 1.49997965!     ' Dev11 & Roslyn: 1.49997962F
+        Const f_9_1 As Single = .149_997_938!           ' (01) Dev11 & Roslyn: 0.149997935F
+        Const f_9_2 As Single = 0.149_997_931!          ' (02) Dev11 & Roslyn: 0.149997935F
+        Const f_9_3 As Single = 1.499_979_65!           ' (03) Dev11 & Roslyn: 1.49997962F
 
-        Const f_10_1 As Single = 14999.79652!   ' Dev11 & Roslyn: 14999.7969F
+        Const f_10_1 As Single = 14_999.796_52!         ' (04) Dev11 & Roslyn: 14999.7969F
 
         ' (b) > 8 significant digits before decimal point.
-        Const f_10_2 As Single = 149997965.2!   ' Dev11 & Roslyn: 149997968.0F
-        Const f_10_3 As Single = 1499979652.0!  ' Dev11 & Roslyn: 1.49997965E+9F
+        Const f_10_2 As Single = 149_997_965.2!         ' (05) Dev11 & Roslyn: 149997968.0F
+        Const f_10_3 As Single = 1_499_979_652.0!       ' (06) Dev11 & Roslyn: 1.49997965E+9F
 
-        Const f_24_1 As Single = 111111149999124689999.499!      ' Dev11 & Roslyn: 1.11111148E+20F
+        Const f_24_1 As Single = 111_111_149_999_124_689_999.499!      ' (07) Dev11 & Roslyn: 1.11111148E+20F
 
         ' (c) Overflow/Underflow cases for Single: Ensure no pretty listing/round off
         '     Holds signed IEEE 32-bit (4-byte) single-precision floating-point numbers ranging in value from -3.4028235E+38 through -1.401298E-45 for negative values and
         '     from 1.401298E-45 through 3.4028235E+38 for positive values.
         
-        Const f_overflow_1 As Single = -3.4028235E+39!          ' Dev11 & Roslyn: Unchanged
-        Const f_overflow_2 As Single = 3.4028235E+39!           ' Dev11 & Roslyn: Unchanged
-        Const f_underflow_1 As Single = -1.401298E-47!          ' Dev11: -0.0F, Roslyn: Unchanged
-        Const f_underflow_2 As Single = 1.401298E-47!           ' Dev11: 0.0F, Roslyn: Unchanged
+        Const f_overflow_1 As Single = -3.402_823_5E+39!          ' (08) Dev11 & Roslyn: Unchanged
+        Const f_overflow_2 As Single = 3.402_823_5E+39!           ' (09) Dev11 & Roslyn: Unchanged
+        Const f_underflow_1 As Single = -1.401_298E-47!           ' (10) Dev11: -0.0F, Roslyn: Unchanged
+        Const f_underflow_2 As Single = 1.401_298E-47!            ' (11) Dev11: 0.0F, Roslyn: Unchanged
 
         Console.WriteLine(f_9_1)
         Console.WriteLine(f_9_2)
@@ -479,26 +488,26 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 9 significant digits
 
         ' (a) > 8 significant digits overall, but < 8 digits before decimal point.
-        Const f_9_1 As Single = 0.149997935!     ' Dev11 & Roslyn: 0.149997935F
-        Const f_9_2 As Single = 0.149997935!    ' Dev11 & Roslyn: 0.149997935F
-        Const f_9_3 As Single = 1.49997962!     ' Dev11 & Roslyn: 1.49997962F
+        Const f_9_1 As Single = .149_997_938!           ' (01) Dev11 & Roslyn: 0.149997935F
+        Const f_9_2 As Single = 0.149_997_931!          ' (02) Dev11 & Roslyn: 0.149997935F
+        Const f_9_3 As Single = 1.499_979_65!           ' (03) Dev11 & Roslyn: 1.49997962F
 
-        Const f_10_1 As Single = 14999.7969!   ' Dev11 & Roslyn: 14999.7969F
+        Const f_10_1 As Single = 14_999.796_52!         ' (04) Dev11 & Roslyn: 14999.7969F
 
         ' (b) > 8 significant digits before decimal point.
-        Const f_10_2 As Single = 149997968.0!   ' Dev11 & Roslyn: 149997968.0F
-        Const f_10_3 As Single = 1.49997965E+9!  ' Dev11 & Roslyn: 1.49997965E+9F
+        Const f_10_2 As Single = 149_997_965.2!         ' (05) Dev11 & Roslyn: 149997968.0F
+        Const f_10_3 As Single = 1_499_979_652.0!       ' (06) Dev11 & Roslyn: 1.49997965E+9F
 
-        Const f_24_1 As Single = 1.11111148E+20!      ' Dev11 & Roslyn: 1.11111148E+20F
+        Const f_24_1 As Single = 111_111_149_999_124_689_999.499!      ' (07) Dev11 & Roslyn: 1.11111148E+20F
 
         ' (c) Overflow/Underflow cases for Single: Ensure no pretty listing/round off
         '     Holds signed IEEE 32-bit (4-byte) single-precision floating-point numbers ranging in value from -3.4028235E+38 through -1.401298E-45 for negative values and
         '     from 1.401298E-45 through 3.4028235E+38 for positive values.
 
-        Const f_overflow_1 As Single = -3.4028235E+39!          ' Dev11 & Roslyn: Unchanged
-        Const f_overflow_2 As Single = 3.4028235E+39!           ' Dev11 & Roslyn: Unchanged
-        Const f_underflow_1 As Single = -1.401298E-47!          ' Dev11: -0.0F, Roslyn: Unchanged
-        Const f_underflow_2 As Single = 1.401298E-47!           ' Dev11: 0.0F, Roslyn: Unchanged
+        Const f_overflow_1 As Single = -3.402_823_5E+39!          ' (08) Dev11 & Roslyn: Unchanged
+        Const f_overflow_2 As Single = 3.402_823_5E+39!           ' (09) Dev11 & Roslyn: Unchanged
+        Const f_underflow_1 As Single = -1.401_298E-47!           ' (10) Dev11: -0.0F, Roslyn: Unchanged
+        Const f_underflow_2 As Single = 1.401_298E-47!            ' (11) Dev11: 0.0F, Roslyn: Unchanged
 
         Console.WriteLine(f_9_1)
         Console.WriteLine(f_9_2)
@@ -521,6 +530,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDoubleLiterals_LessThan16Digits()
         {
             var code = @"[|
@@ -530,20 +540,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 13 significant digits
-        Const f_13_1 As Double = .1499599999999         ' Dev11 & Roslyn: Pretty listed to 0.1499599999999
-        Const f_13_2 As Double = 0.149959999999         ' Dev11 & Roslyn: Unchanged
-        Const f_13_3 As Double = 1.499599999999         ' Dev11 & Roslyn: Unchanged
-        Const f_13_4 As Double = 1499599.999999         ' Dev11 & Roslyn: Unchanged
-        Const f_13_5 As Double = 149959999999.9         ' Dev11 & Roslyn: Unchanged
-        Const f_13_6 As Double = 1499599999999.0        ' Dev11 & Roslyn: Unchanged
+        Const f_13_1 As Double = .149_959_999_999_9         ' Dev11 & Roslyn: Pretty listed to 0.1499599999999
+        Const f_13_2 As Double = 0.149_959_999_999          ' Dev11 & Roslyn: Unchanged
+        Const f_13_3 As Double = 1.499_599_999_999          ' Dev11 & Roslyn: Unchanged
+        Const f_13_4 As Double = 1_499_599.999_999          ' Dev11 & Roslyn: Unchanged
+        Const f_13_5 As Double = 149_959_999_999.9          ' Dev11 & Roslyn: Unchanged
+        Const f_13_6 As Double = 1_499_599_999_999.0        ' Dev11 & Roslyn: Unchanged
 
         ' 15 significant digits
-        Const f_15_1 As Double = .149999999999995       ' Dev11 & Roslyn: Pretty listed to 0.149999999999995
-        Const f_15_2 As Double = 0.14999999999995       ' Dev11 & Roslyn: Unchanged
-        Const f_15_3 As Double = 1.49999999999995       ' Dev11 & Roslyn: Unchanged
-        Const f_15_4 As Double = 14999999.9999995       ' Dev11 & Roslyn: Unchanged
-        Const f_15_5 As Double = 14999999999999.5       ' Dev11 & Roslyn: Unchanged
-        Const f_15_6 As Double = 149999999999995.0      ' Dev11 & Roslyn: Unchanged
+        Const f_15_1 As Double = .149_999_999_999_995       ' Dev11 & Roslyn: Pretty listed to 0.149999999999995
+        Const f_15_2 As Double = 0.149_999_999_999_95       ' Dev11 & Roslyn: Unchanged
+        Const f_15_3 As Double = 1.499_999_999_999_95       ' Dev11 & Roslyn: Unchanged
+        Const f_15_4 As Double = 14_999_999.999_999_5       ' Dev11 & Roslyn: Unchanged
+        Const f_15_5 As Double = 14_999_999_999_999.5       ' Dev11 & Roslyn: Unchanged
+        Const f_15_6 As Double = 149_999_999_999_995.0      ' Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_13_1)
         Console.WriteLine(f_13_2)
@@ -569,20 +579,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 13 significant digits
-        Const f_13_1 As Double = 0.1499599999999         ' Dev11 & Roslyn: Pretty listed to 0.1499599999999
-        Const f_13_2 As Double = 0.149959999999         ' Dev11 & Roslyn: Unchanged
-        Const f_13_3 As Double = 1.499599999999         ' Dev11 & Roslyn: Unchanged
-        Const f_13_4 As Double = 1499599.999999         ' Dev11 & Roslyn: Unchanged
-        Const f_13_5 As Double = 149959999999.9         ' Dev11 & Roslyn: Unchanged
-        Const f_13_6 As Double = 1499599999999.0        ' Dev11 & Roslyn: Unchanged
+        Const f_13_1 As Double = .149_959_999_999_9         ' Dev11 & Roslyn: Pretty listed to 0.1499599999999
+        Const f_13_2 As Double = 0.149_959_999_999          ' Dev11 & Roslyn: Unchanged
+        Const f_13_3 As Double = 1.499_599_999_999          ' Dev11 & Roslyn: Unchanged
+        Const f_13_4 As Double = 1_499_599.999_999          ' Dev11 & Roslyn: Unchanged
+        Const f_13_5 As Double = 149_959_999_999.9          ' Dev11 & Roslyn: Unchanged
+        Const f_13_6 As Double = 1_499_599_999_999.0        ' Dev11 & Roslyn: Unchanged
 
         ' 15 significant digits
-        Const f_15_1 As Double = 0.149999999999995       ' Dev11 & Roslyn: Pretty listed to 0.149999999999995
-        Const f_15_2 As Double = 0.14999999999995       ' Dev11 & Roslyn: Unchanged
-        Const f_15_3 As Double = 1.49999999999995       ' Dev11 & Roslyn: Unchanged
-        Const f_15_4 As Double = 14999999.9999995       ' Dev11 & Roslyn: Unchanged
-        Const f_15_5 As Double = 14999999999999.5       ' Dev11 & Roslyn: Unchanged
-        Const f_15_6 As Double = 149999999999995.0      ' Dev11 & Roslyn: Unchanged
+        Const f_15_1 As Double = .149_999_999_999_995       ' Dev11 & Roslyn: Pretty listed to 0.149999999999995
+        Const f_15_2 As Double = 0.149_999_999_999_95       ' Dev11 & Roslyn: Unchanged
+        Const f_15_3 As Double = 1.499_999_999_999_95       ' Dev11 & Roslyn: Unchanged
+        Const f_15_4 As Double = 14_999_999.999_999_5       ' Dev11 & Roslyn: Unchanged
+        Const f_15_5 As Double = 14_999_999_999_999.5       ' Dev11 & Roslyn: Unchanged
+        Const f_15_6 As Double = 149_999_999_999_995.0      ' Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_13_1)
         Console.WriteLine(f_13_2)
@@ -606,6 +616,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDoubleLiterals_LessThan16Digits_WithTypeCharacter()
         {
             var code = @"[|
@@ -615,20 +626,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 13 significant digits
-        Const f_13_1 As Double = .1499599999999R         ' Dev11 & Roslyn: Pretty listed to 0.1499599999999
-        Const f_13_2 As Double = 0.149959999999r         ' Dev11 & Roslyn: Unchanged
-        Const f_13_3 As Double = 1.499599999999#         ' Dev11 & Roslyn: Unchanged
-        Const f_13_4 As Double = 1499599.999999#         ' Dev11 & Roslyn: Unchanged
-        Const f_13_5 As Double = 149959999999.9r         ' Dev11 & Roslyn: Unchanged
-        Const f_13_6 As Double = 1499599999999.0R        ' Dev11 & Roslyn: Unchanged
+        Const f_13_1 As Double = .149_959_999_999_9R         ' (01) Dev11 & Roslyn: Pretty listed to 0.1499599999999
+        Const f_13_2 As Double = 0.149_959_999_999r          ' (01) Dev11 & Roslyn: Unchanged
+        Const f_13_3 As Double = 1.499_599_999_999#          ' (02) Dev11 & Roslyn: Unchanged
+        Const f_13_4 As Double = 1_499_599.999_999#          ' (03) Dev11 & Roslyn: Unchanged
+        Const f_13_5 As Double = 149_959_999_999.9r          ' (04) Dev11 & Roslyn: Unchanged
+        Const f_13_6 As Double = 1_499_599_999_999.0R        ' (05) Dev11 & Roslyn: Unchanged
 
         ' 15 significant digits
-        Const f_15_1 As Double = .149999999999995R       ' Dev11 & Roslyn: Pretty listed to 0.149999999999995
-        Const f_15_2 As Double = 0.14999999999995r       ' Dev11 & Roslyn: Unchanged
-        Const f_15_3 As Double = 1.49999999999995#       ' Dev11 & Roslyn: Unchanged
-        Const f_15_4 As Double = 14999999.9999995#       ' Dev11 & Roslyn: Unchanged
-        Const f_15_5 As Double = 14999999999999.5r       ' Dev11 & Roslyn: Unchanged
-        Const f_15_6 As Double = 149999999999995.0R      ' Dev11 & Roslyn: Unchanged
+        Const f_15_1 As Double = .149_999_999_999_995R       ' (06) Dev11 & Roslyn: Pretty listed to 0.149999999999995
+        Const f_15_2 As Double = 0.149_999_999_999_95r       ' (07) Dev11 & Roslyn: Unchanged
+        Const f_15_3 As Double = 1.499_999_999_9999_5#       ' (08) Dev11 & Roslyn: Unchanged
+        Const f_15_4 As Double = 14_999_999.999_9995#        ' (09) Dev11 & Roslyn: Unchanged
+        Const f_15_5 As Double = 14_999_999_999_999.5r       ' (10) Dev11 & Roslyn: Unchanged
+        Const f_15_6 As Double = 149_999_999_999_995.0R      ' (11) Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_13_1)
         Console.WriteLine(f_13_2)
@@ -654,20 +665,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 13 significant digits
-        Const f_13_1 As Double = 0.1499599999999R         ' Dev11 & Roslyn: Pretty listed to 0.1499599999999
-        Const f_13_2 As Double = 0.149959999999R         ' Dev11 & Roslyn: Unchanged
-        Const f_13_3 As Double = 1.499599999999#         ' Dev11 & Roslyn: Unchanged
-        Const f_13_4 As Double = 1499599.999999#         ' Dev11 & Roslyn: Unchanged
-        Const f_13_5 As Double = 149959999999.9R         ' Dev11 & Roslyn: Unchanged
-        Const f_13_6 As Double = 1499599999999.0R        ' Dev11 & Roslyn: Unchanged
+        Const f_13_1 As Double = .149_959_999_999_9R         ' (01) Dev11 & Roslyn: Pretty listed to 0.1499599999999
+        Const f_13_2 As Double = 0.149_959_999_999R          ' (01) Dev11 & Roslyn: Unchanged
+        Const f_13_3 As Double = 1.499_599_999_999#          ' (02) Dev11 & Roslyn: Unchanged
+        Const f_13_4 As Double = 1_499_599.999_999#          ' (03) Dev11 & Roslyn: Unchanged
+        Const f_13_5 As Double = 149_959_999_999.9R          ' (04) Dev11 & Roslyn: Unchanged
+        Const f_13_6 As Double = 1_499_599_999_999.0R        ' (05) Dev11 & Roslyn: Unchanged
 
         ' 15 significant digits
-        Const f_15_1 As Double = 0.149999999999995R       ' Dev11 & Roslyn: Pretty listed to 0.149999999999995
-        Const f_15_2 As Double = 0.14999999999995R       ' Dev11 & Roslyn: Unchanged
-        Const f_15_3 As Double = 1.49999999999995#       ' Dev11 & Roslyn: Unchanged
-        Const f_15_4 As Double = 14999999.9999995#       ' Dev11 & Roslyn: Unchanged
-        Const f_15_5 As Double = 14999999999999.5R       ' Dev11 & Roslyn: Unchanged
-        Const f_15_6 As Double = 149999999999995.0R      ' Dev11 & Roslyn: Unchanged
+        Const f_15_1 As Double = .149_999_999_999_995R       ' (06) Dev11 & Roslyn: Pretty listed to 0.149999999999995
+        Const f_15_2 As Double = 0.149_999_999_999_95R       ' (07) Dev11 & Roslyn: Unchanged
+        Const f_15_3 As Double = 1.499_999_999_9999_5#       ' (08) Dev11 & Roslyn: Unchanged
+        Const f_15_4 As Double = 14_999_999.999_9995#        ' (09) Dev11 & Roslyn: Unchanged
+        Const f_15_5 As Double = 14_999_999_999_999.5R       ' (10) Dev11 & Roslyn: Unchanged
+        Const f_15_6 As Double = 149_999_999_999_995.0R      ' (11) Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_13_1)
         Console.WriteLine(f_13_2)
@@ -691,6 +702,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDoubleLiterals_16Digits()
         {
             var code = @"[|
@@ -699,21 +711,21 @@ Module Program
         ' CATEGORY 2: 16 significant digits
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 17 significant digits
 
-        Const f_16_1 As Double = .1499999999799993      ' Dev11 & Roslyn: 0.1499999999799993
-        Const f_16_2 As Double = .1499999999799997      ' Dev11 & Roslyn: 0.14999999997999969
+        Const f_16_1 As Double = .149_999_999_979_999_3     ' Dev11 & Roslyn: 0.1499999999799993
+        Const f_16_2 As Double = .149_999_999_979_999_7     ' Dev11 & Roslyn: 0.14999999997999969
 
-        Const f_16_3 As Double = 0.149999999799995      ' Dev11 & Roslyn: Unchanged
+        Const f_16_3 As Double = 0.149_999_999_799_995      ' Dev11 & Roslyn: Unchanged
 
-        Const f_16_4 As Double = 1.499999999799994      ' Dev11 & Roslyn: Unchanged
-        Const f_16_5 As Double = 1.499999999799995      ' Dev11 & Roslyn: 1.4999999997999951
+        Const f_16_4 As Double = 1.499_999_999_799_994      ' Dev11 & Roslyn: Unchanged
+        Const f_16_5 As Double = 1.499_999_999_799_995      ' Dev11 & Roslyn: 1.4999999997999951
 
-        Const f_16_6 As Double = 14999999.99799994      ' Dev11 & Roslyn: Unchanged
-        Const f_16_7 As Double = 14999999.99799995      ' Dev11 & Roslyn: 14999999.997999949
+        Const f_16_6 As Double = 14_999_999.997_999_94      ' Dev11 & Roslyn: Unchanged
+        Const f_16_7 As Double = 14_999_999.997_999_95      ' Dev11 & Roslyn: 14999999.997999949
 
-        Const f_16_8 As Double = 149999999997999.2      ' Dev11 & Roslyn: 149999999997999.19
-        Const f_16_9 As Double = 149999999997999.8      ' Dev11 & Roslyn: 149999999997999.81
+        Const f_16_8 As Double = 149_999_999_997_999.2      ' Dev11 & Roslyn: 149999999997999.19
+        Const f_16_9 As Double = 149_999_999_997_999.8      ' Dev11 & Roslyn: 149999999997999.81
 
-        Const f_16_10 As Double = 1499999999979995.0    ' Dev11 & Roslyn: Unchanged
+        Const f_16_10 As Double = 1_499_999_999_979_995.0   ' Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_16_1)
         Console.WriteLine(f_16_2)
@@ -735,21 +747,21 @@ Module Program
         ' CATEGORY 2: 16 significant digits
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 17 significant digits
 
-        Const f_16_1 As Double = 0.1499999999799993      ' Dev11 & Roslyn: 0.1499999999799993
-        Const f_16_2 As Double = 0.14999999997999969      ' Dev11 & Roslyn: 0.14999999997999969
+        Const f_16_1 As Double = .149_999_999_979_999_3     ' Dev11 & Roslyn: 0.1499999999799993
+        Const f_16_2 As Double = .149_999_999_979_999_7     ' Dev11 & Roslyn: 0.14999999997999969
 
-        Const f_16_3 As Double = 0.149999999799995      ' Dev11 & Roslyn: Unchanged
+        Const f_16_3 As Double = 0.149_999_999_799_995      ' Dev11 & Roslyn: Unchanged
 
-        Const f_16_4 As Double = 1.499999999799994      ' Dev11 & Roslyn: Unchanged
-        Const f_16_5 As Double = 1.4999999997999951      ' Dev11 & Roslyn: 1.4999999997999951
+        Const f_16_4 As Double = 1.499_999_999_799_994      ' Dev11 & Roslyn: Unchanged
+        Const f_16_5 As Double = 1.499_999_999_799_995      ' Dev11 & Roslyn: 1.4999999997999951
 
-        Const f_16_6 As Double = 14999999.99799994      ' Dev11 & Roslyn: Unchanged
-        Const f_16_7 As Double = 14999999.997999949      ' Dev11 & Roslyn: 14999999.997999949
+        Const f_16_6 As Double = 14_999_999.997_999_94      ' Dev11 & Roslyn: Unchanged
+        Const f_16_7 As Double = 14_999_999.997_999_95      ' Dev11 & Roslyn: 14999999.997999949
 
-        Const f_16_8 As Double = 149999999997999.19      ' Dev11 & Roslyn: 149999999997999.19
-        Const f_16_9 As Double = 149999999997999.81      ' Dev11 & Roslyn: 149999999997999.81
+        Const f_16_8 As Double = 149_999_999_997_999.2      ' Dev11 & Roslyn: 149999999997999.19
+        Const f_16_9 As Double = 149_999_999_997_999.8      ' Dev11 & Roslyn: 149999999997999.81
 
-        Const f_16_10 As Double = 1499999999979995.0    ' Dev11 & Roslyn: Unchanged
+        Const f_16_10 As Double = 1_499_999_999_979_995.0   ' Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_16_1)
         Console.WriteLine(f_16_2)
@@ -770,6 +782,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDoubleLiterals_16Digits_WithTypeCharacter()
         {
             var code = @"[|
@@ -778,21 +791,21 @@ Module Program
         ' CATEGORY 2: 16 significant digits
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 17 significant digits
 
-        Const f_16_1 As Double = .1499999999799993R      ' Dev11 & Roslyn: 0.1499999999799993
-        Const f_16_2 As Double = .1499999999799997r      ' Dev11 & Roslyn: 0.14999999997999969
+        Const f_16_1 As Double = .149_999_999_979_999_3R      ' (00) Dev11 & Roslyn: 0.149999999979999399799993
+        Const f_16_2 As Double = .149_999_999_979_999_7r      ' (01) Dev11 & Roslyn: 0.14999999997999969997999969
 
-        Const f_16_3 As Double = 0.149999999799995#      ' Dev11 & Roslyn: Unchanged
+        Const f_16_3 As Double = 0.149_999_999_799_995#       ' (03) Dev11 & Roslyn: Unchanged
 
-        Const f_16_4 As Double = 1.499999999799994R      ' Dev11 & Roslyn: Unchanged
-        Const f_16_5 As Double = 1.499999999799995r      ' Dev11 & Roslyn: 1.4999999997999951
+        Const f_16_4 As Double = 1.499_999_999_799_994R       ' (04) Dev11 & Roslyn: Unchanged
+        Const f_16_5 As Double = 1.499_999_999_799_995r       ' (05) Dev11 & Roslyn: 1.4999999997999951951
 
-        Const f_16_6 As Double = 14999999.99799994#      ' Dev11 & Roslyn: Unchanged
-        Const f_16_7 As Double = 14999999.99799995R      ' Dev11 & Roslyn: 14999999.997999949
+        Const f_16_6 As Double = 14_999_999.997_999_94#       ' (06) Dev11 & Roslyn: Unchanged
+        Const f_16_7 As Double = 14_999_999.997_999_95R       ' (07) Dev11 & Roslyn: 14999999.99799994997999949
 
-        Const f_16_8 As Double = 149999999997999.2r      ' Dev11 & Roslyn: 149999999997999.19
-        Const f_16_9 As Double = 149999999997999.8#      ' Dev11 & Roslyn: 149999999997999.81
+        Const f_16_8 As Double = 149_999_999_997_999.2r       ' (08) Dev11 & Roslyn: 149999999997999.1997999.19
+        Const f_16_9 As Double = 149_999_999_997_999.8#       ' (09) Dev11 & Roslyn: 149999999997999.8197999.81
 
-        Const f_16_10 As Double = 1499999999979995.0R    ' Dev11 & Roslyn: Unchanged
+        Const f_16_10 As Double = 1_499_999_999_979_995.0R    ' (10) Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_16_1)
         Console.WriteLine(f_16_2)
@@ -814,21 +827,21 @@ Module Program
         ' CATEGORY 2: 16 significant digits
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 17 significant digits
 
-        Const f_16_1 As Double = 0.1499999999799993R      ' Dev11 & Roslyn: 0.1499999999799993
-        Const f_16_2 As Double = 0.14999999997999969R      ' Dev11 & Roslyn: 0.14999999997999969
+        Const f_16_1 As Double = .149_999_999_979_999_3R      ' (00) Dev11 & Roslyn: 0.149999999979999399799993
+        Const f_16_2 As Double = .149_999_999_979_999_7R      ' (01) Dev11 & Roslyn: 0.14999999997999969997999969
 
-        Const f_16_3 As Double = 0.149999999799995#      ' Dev11 & Roslyn: Unchanged
+        Const f_16_3 As Double = 0.149_999_999_799_995#       ' (03) Dev11 & Roslyn: Unchanged
 
-        Const f_16_4 As Double = 1.499999999799994R      ' Dev11 & Roslyn: Unchanged
-        Const f_16_5 As Double = 1.4999999997999951R      ' Dev11 & Roslyn: 1.4999999997999951
+        Const f_16_4 As Double = 1.499_999_999_799_994R       ' (04) Dev11 & Roslyn: Unchanged
+        Const f_16_5 As Double = 1.499_999_999_799_995R       ' (05) Dev11 & Roslyn: 1.4999999997999951951
 
-        Const f_16_6 As Double = 14999999.99799994#      ' Dev11 & Roslyn: Unchanged
-        Const f_16_7 As Double = 14999999.997999949R      ' Dev11 & Roslyn: 14999999.997999949
+        Const f_16_6 As Double = 14_999_999.997_999_94#       ' (06) Dev11 & Roslyn: Unchanged
+        Const f_16_7 As Double = 14_999_999.997_999_95R       ' (07) Dev11 & Roslyn: 14999999.99799994997999949
 
-        Const f_16_8 As Double = 149999999997999.19R      ' Dev11 & Roslyn: 149999999997999.19
-        Const f_16_9 As Double = 149999999997999.81#      ' Dev11 & Roslyn: 149999999997999.81
+        Const f_16_8 As Double = 149_999_999_997_999.2R       ' (08) Dev11 & Roslyn: 149999999997999.1997999.19
+        Const f_16_9 As Double = 149_999_999_997_999.8#       ' (09) Dev11 & Roslyn: 149999999997999.8197999.81
 
-        Const f_16_10 As Double = 1499999999979995.0R    ' Dev11 & Roslyn: Unchanged
+        Const f_16_10 As Double = 1_499_999_999_979_995.0R    ' (10) Dev11 & Roslyn: Unchanged
 
         Console.WriteLine(f_16_1)
         Console.WriteLine(f_16_2)
@@ -849,6 +862,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDoubleLiterals_GreaterThan16Digits()
         {
             var code = @"[|
@@ -858,35 +872,35 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 17 significant digits
 
         ' (a) > 16 significant digits overall, but < 16 digits before decimal point.
-        Const f_17_1 As Double = .14999999997999938     ' Dev11 & Roslyn: 0.14999999997999938
-        Const f_17_2 As Double = .14999999997999939     ' Dev11 & Roslyn: 0.14999999997999938
-        Const f_17_3 As Double = .14999999997999937     ' Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_1 As Double = .149_999_999_979_999_38    ' (01) Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_2 As Double = .149_999_999_979_999_39    ' (02) Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_3 As Double = .149_999_999_979_999_37    ' (03) Dev11 & Roslyn: 0.14999999997999938
 
-        Const f_17_4 As Double = 0.1499999997999957     ' Dev11 & Roslyn: Unchanged
-        Const f_17_5 As Double = 0.1499999997999958     ' Dev11 & Roslyn: 0.14999999979999579
+        Const f_17_4 As Double = 0.149_999_999_799_995_7    ' (04) Dev11 & Roslyn: Unchanged
+        Const f_17_5 As Double = 0.149_999_999_799_995_8    ' (05) Dev11 & Roslyn: 0.14999999979999579
 
-        Const f_17_6 As Double = 1.4999999997999947     ' Dev11 & Roslyn: Unchanged
-        Const f_17_7 As Double = 1.4999999997999945     ' Dev11 & Roslyn: 1.4999999997999944
-        Const f_17_8 As Double = 1.4999999997999946     ' Dev11 & Roslyn: 1.4999999997999947
+        Const f_17_6 As Double = 1.499_999_999_799_994_7    ' (06) Dev11 & Roslyn: Unchanged
+        Const f_17_7 As Double = 1.499_999_999_799_994_5    ' (07) Dev11 & Roslyn: 1.4999999997999944
+        Const f_17_8 As Double = 1.499_999_999_799_994_6    ' (08) Dev11 & Roslyn: 1.4999999997999947
 
-        Const f_18_1 As Double = 14999999.9979999459    ' Dev11 & Roslyn: 14999999.997999946
-        Const f_18_2 As Double = 14999999.9979999451    ' Dev11 & Roslyn: 14999999.997999946
-        Const f_18_3 As Double = 14999999.9979999454    ' Dev11 & Roslyn: 14999999.997999946
+        Const f_18_1 As Double = 14_999_999.997_999_945_9   ' (09) Dev11 & Roslyn: 14999999.997999946
+        Const f_18_2 As Double = 14_999_999.997_999_945_1   ' (10) Dev11 & Roslyn: 14999999.997999946
+        Const f_18_3 As Double = 14_999_999.997_999_945_4   ' (11) Dev11 & Roslyn: 14999999.997999946
 
         ' (b) > 16 significant digits before decimal point.
-        Const f_18_4 As Double = 14999999999733999.2    ' Dev11 & Roslyn: 1.4999999999734E+16
-        Const f_18_5 As Double = 14999999999379995.0    ' Dev11 & Roslyn: 14999999999379996.0
+        Const f_18_4 As Double = 14_999_999_999_733_999.2   ' (12) Dev11 & Roslyn: 1.4999999999734E+16
+        Const f_18_5 As Double = 14_999_999_999_379_995.0   ' (13) Dev11 & Roslyn: 14999999999379996.0
 
-        Const f_24_1 As Double = 111111149999124689999.499      ' Dev11 & Roslyn: 1.1111114999912469E+20
+        Const f_24_1 As Double = 111_111_149_999_124_689_999.499     ' (14) Dev11 & Roslyn: 1.1111114999912469E+20
 
         ' (c) Overflow/Underflow cases for Double: Ensure no pretty listing/round off
         '     Holds signed IEEE 64-bit (8-byte) double-precision floating-point numbers ranging in value from -1.79769313486231570E+308 through -4.94065645841246544E-324 for negative values and
         '     from 4.94065645841246544E-324 through 1.79769313486231570E+308 for positive values.
 
-        Const f_overflow_1 As Double = -1.79769313486231570E+309        ' Dev11 & Roslyn: Unchanged
-        Const f_overflow_2 As Double = 1.79769313486231570E+309         ' Dev11 & Roslyn: Unchanged
-        Const f_underflow_1 As Double = -4.94065645841246544E-326       ' Dev11: -0.0F, Roslyn: unchanged
-        Const f_underflow_2 As Double = 4.94065645841246544E-326        ' Dev11: 0.0F, Roslyn: unchanged
+        Const f_overflow_1 As Double = -1.797_693_134_862_315_70E+309       ' (15) Dev11 & Roslyn: Unchanged
+        Const f_overflow_2 As Double = 1.797_693_134_862_315_70E+309        ' (16) Dev11 & Roslyn: Unchanged
+        Const f_underflow_1 As Double = -4.940_656_458_412_465_44E-326      ' (17) Dev11: -0.0F, Roslyn: unchanged
+        Const f_underflow_2 As Double = 4.940_656_458_412_465_44E-326       ' (18) Dev11: 0.0F, Roslyn: unchanged
 
         Console.WriteLine(f_17_1)
         Console.WriteLine(f_17_2)
@@ -920,35 +934,35 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 17 significant digits
 
         ' (a) > 16 significant digits overall, but < 16 digits before decimal point.
-        Const f_17_1 As Double = 0.14999999997999938     ' Dev11 & Roslyn: 0.14999999997999938
-        Const f_17_2 As Double = 0.14999999997999938     ' Dev11 & Roslyn: 0.14999999997999938
-        Const f_17_3 As Double = 0.14999999997999938     ' Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_1 As Double = .149_999_999_979_999_38    ' (01) Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_2 As Double = .149_999_999_979_999_39    ' (02) Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_3 As Double = .149_999_999_979_999_37    ' (03) Dev11 & Roslyn: 0.14999999997999938
 
-        Const f_17_4 As Double = 0.1499999997999957     ' Dev11 & Roslyn: Unchanged
-        Const f_17_5 As Double = 0.14999999979999579     ' Dev11 & Roslyn: 0.14999999979999579
+        Const f_17_4 As Double = 0.149_999_999_799_995_7    ' (04) Dev11 & Roslyn: Unchanged
+        Const f_17_5 As Double = 0.149_999_999_799_995_8    ' (05) Dev11 & Roslyn: 0.14999999979999579
 
-        Const f_17_6 As Double = 1.4999999997999947     ' Dev11 & Roslyn: Unchanged
-        Const f_17_7 As Double = 1.4999999997999944     ' Dev11 & Roslyn: 1.4999999997999944
-        Const f_17_8 As Double = 1.4999999997999947     ' Dev11 & Roslyn: 1.4999999997999947
+        Const f_17_6 As Double = 1.499_999_999_799_994_7    ' (06) Dev11 & Roslyn: Unchanged
+        Const f_17_7 As Double = 1.499_999_999_799_994_5    ' (07) Dev11 & Roslyn: 1.4999999997999944
+        Const f_17_8 As Double = 1.499_999_999_799_994_6    ' (08) Dev11 & Roslyn: 1.4999999997999947
 
-        Const f_18_1 As Double = 14999999.997999946    ' Dev11 & Roslyn: 14999999.997999946
-        Const f_18_2 As Double = 14999999.997999946    ' Dev11 & Roslyn: 14999999.997999946
-        Const f_18_3 As Double = 14999999.997999946    ' Dev11 & Roslyn: 14999999.997999946
+        Const f_18_1 As Double = 14_999_999.997_999_945_9   ' (09) Dev11 & Roslyn: 14999999.997999946
+        Const f_18_2 As Double = 14_999_999.997_999_945_1   ' (10) Dev11 & Roslyn: 14999999.997999946
+        Const f_18_3 As Double = 14_999_999.997_999_945_4   ' (11) Dev11 & Roslyn: 14999999.997999946
 
         ' (b) > 16 significant digits before decimal point.
-        Const f_18_4 As Double = 1.4999999999734E+16    ' Dev11 & Roslyn: 1.4999999999734E+16
-        Const f_18_5 As Double = 14999999999379996.0    ' Dev11 & Roslyn: 14999999999379996.0
+        Const f_18_4 As Double = 14_999_999_999_733_999.2   ' (12) Dev11 & Roslyn: 1.4999999999734E+16
+        Const f_18_5 As Double = 14_999_999_999_379_995.0   ' (13) Dev11 & Roslyn: 14999999999379996.0
 
-        Const f_24_1 As Double = 1.1111114999912469E+20      ' Dev11 & Roslyn: 1.1111114999912469E+20
+        Const f_24_1 As Double = 111_111_149_999_124_689_999.499     ' (14) Dev11 & Roslyn: 1.1111114999912469E+20
 
         ' (c) Overflow/Underflow cases for Double: Ensure no pretty listing/round off
         '     Holds signed IEEE 64-bit (8-byte) double-precision floating-point numbers ranging in value from -1.79769313486231570E+308 through -4.94065645841246544E-324 for negative values and
         '     from 4.94065645841246544E-324 through 1.79769313486231570E+308 for positive values.
 
-        Const f_overflow_1 As Double = -1.79769313486231570E+309        ' Dev11 & Roslyn: Unchanged
-        Const f_overflow_2 As Double = 1.79769313486231570E+309         ' Dev11 & Roslyn: Unchanged
-        Const f_underflow_1 As Double = -4.94065645841246544E-326       ' Dev11: -0.0F, Roslyn: unchanged
-        Const f_underflow_2 As Double = 4.94065645841246544E-326        ' Dev11: 0.0F, Roslyn: unchanged
+        Const f_overflow_1 As Double = -1.797_693_134_862_315_70E+309       ' (15) Dev11 & Roslyn: Unchanged
+        Const f_overflow_2 As Double = 1.797_693_134_862_315_70E+309        ' (16) Dev11 & Roslyn: Unchanged
+        Const f_underflow_1 As Double = -4.940_656_458_412_465_44E-326      ' (17) Dev11: -0.0F, Roslyn: unchanged
+        Const f_underflow_2 As Double = 4.940_656_458_412_465_44E-326       ' (18) Dev11: 0.0F, Roslyn: unchanged
 
         Console.WriteLine(f_17_1)
         Console.WriteLine(f_17_2)
@@ -980,6 +994,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDoubleLiterals_GreaterThan16Digits_WithTypeCharacter()
         {
             var code = @"[|
@@ -989,35 +1004,35 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 17 significant digits
 
         ' (a) > 16 significant digits overall, but < 16 digits before decimal point.
-        Const f_17_1 As Double = .14999999997999938R     ' Dev11 & Roslyn: 0.14999999997999938
-        Const f_17_2 As Double = .14999999997999939r     ' Dev11 & Roslyn: 0.14999999997999938
-        Const f_17_3 As Double = .14999999997999937#     ' Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_1 As Double = .149_999_999_979_999_38R     ' (01) Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_2 As Double = .149_999_999_979_999_39r     ' (02) Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_3 As Double = .149_999_999_979_999_37#     ' (03) Dev11 & Roslyn: 0.14999999997999938
 
-        Const f_17_4 As Double = 0.1499999997999957R     ' Dev11 & Roslyn: Unchanged
-        Const f_17_5 As Double = 0.1499999997999958r     ' Dev11 & Roslyn: 0.14999999979999579
+        Const f_17_4 As Double = 0.149_999_999_799_9957R      ' (04) Dev11 & Roslyn: Unchanged
+        Const f_17_5 As Double = 0.149_999_999_799_9958r      ' (05) Dev11 & Roslyn: 0.14999999979999579
 
-        Const f_17_6 As Double = 1.4999999997999947#     ' Dev11 & Roslyn: Unchanged
-        Const f_17_7 As Double = 1.4999999997999945R     ' Dev11 & Roslyn: 1.4999999997999944
-        Const f_17_8 As Double = 1.4999999997999946r     ' Dev11 & Roslyn: 1.4999999997999947
+        Const f_17_6 As Double = 1.499_999_999_799_9947#      ' (06) Dev11 & Roslyn: Unchanged
+        Const f_17_7 As Double = 1.499_999_999_799_9945R      ' (07) Dev11 & Roslyn: 1.4999999997999944
+        Const f_17_8 As Double = 1.499_999_999_799_9946r      ' (08) Dev11 & Roslyn: 1.4999999997999947
 
-        Const f_18_1 As Double = 14999999.9979999459#    ' Dev11 & Roslyn: 14999999.997999946
-        Const f_18_2 As Double = 14999999.9979999451R    ' Dev11 & Roslyn: 14999999.997999946
-        Const f_18_3 As Double = 14999999.9979999454r    ' Dev11 & Roslyn: 14999999.997999946
+        Const f_18_1 As Double = 14_999_999.997_999_945_9#    ' (09) Dev11 & Roslyn: 14999999.997999946
+        Const f_18_2 As Double = 14_999_999.997_999_945_1R    ' (10) Dev11 & Roslyn: 14999999.997999946
+        Const f_18_3 As Double = 14_999_999.997_999_945_4r    ' (11) Dev11 & Roslyn: 14999999.997999946
 
         ' (b) > 16 significant digits before decimal point.
-        Const f_18_4 As Double = 14999999999733999.2#    ' Dev11 & Roslyn: 1.4999999999734E+16
-        Const f_18_5 As Double = 14999999999379995.0R    ' Dev11 & Roslyn: 14999999999379996.0
+        Const f_18_4 As Double = 14_999_999_999_733_999.2#    ' (12) Dev11 & Roslyn: 1.4999999999734E+16
+        Const f_18_5 As Double = 14_999_999_999_379_995.0R    ' (13) Dev11 & Roslyn: 14999999999379996.0
 
-        Const f_24_1 As Double = 111111149999124689999.499r      ' Dev11 & Roslyn: 1.1111114999912469E+20
+        Const f_24_1 As Double = 1_111_111_499_991_246_899_99.499r      ' (14) Dev11 & Roslyn: 1.1111114999912469E+20
 
         ' (c) Overflow/Underflow cases for Double: Ensure no pretty listing/round off
         '     Holds signed IEEE 64-bit (8-byte) double-precision floating-point numbers ranging in value from -1.79769313486231570E+308 through -4.94065645841246544E-324 for negative values and
         '     from 4.94065645841246544E-324 through 1.79769313486231570E+308 for positive values.
 
-        Const f_overflow_1 As Double = -1.79769313486231570E+309#        ' Dev11 & Roslyn: Unchanged
-        Const f_overflow_2 As Double = 1.79769313486231570E+309R         ' Dev11 & Roslyn: Unchanged
-        Const f_underflow_1 As Double = -4.94065645841246544E-326r       ' Dev11: -0.0F, Roslyn: unchanged
-        Const f_underflow_2 As Double = 4.94065645841246544E-326#        ' Dev11: 0.0F, Roslyn: unchanged
+        Const f_overflow_1 As Double = -1.797_693_134_862_315_70E+309#        ' (15) Dev11 & Roslyn: Unchanged
+        Const f_overflow_2 As Double = 1.797_693_134_862_315_70E+309R         ' (16) Dev11 & Roslyn: Unchanged
+        Const f_underflow_1 As Double = -4.940_656_458_412_465_44E-326r       ' (17) Dev11: -0.0F, Roslyn: unchanged
+        Const f_underflow_2 As Double = 4.940_656_458_412_465_44E-326#        ' (18) Dev11: 0.0F, Roslyn: unchanged
 
         Console.WriteLine(f_17_1)
         Console.WriteLine(f_17_2)
@@ -1051,35 +1066,35 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: Always rounded off and pretty listed to <= 17 significant digits
 
         ' (a) > 16 significant digits overall, but < 16 digits before decimal point.
-        Const f_17_1 As Double = 0.14999999997999938R     ' Dev11 & Roslyn: 0.14999999997999938
-        Const f_17_2 As Double = 0.14999999997999938R     ' Dev11 & Roslyn: 0.14999999997999938
-        Const f_17_3 As Double = 0.14999999997999938#     ' Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_1 As Double = .149_999_999_979_999_38R     ' (01) Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_2 As Double = .149_999_999_979_999_39R     ' (02) Dev11 & Roslyn: 0.14999999997999938
+        Const f_17_3 As Double = .149_999_999_979_999_37#     ' (03) Dev11 & Roslyn: 0.14999999997999938
 
-        Const f_17_4 As Double = 0.1499999997999957R     ' Dev11 & Roslyn: Unchanged
-        Const f_17_5 As Double = 0.14999999979999579R     ' Dev11 & Roslyn: 0.14999999979999579
+        Const f_17_4 As Double = 0.149_999_999_799_9957R      ' (04) Dev11 & Roslyn: Unchanged
+        Const f_17_5 As Double = 0.149_999_999_799_9958R      ' (05) Dev11 & Roslyn: 0.14999999979999579
 
-        Const f_17_6 As Double = 1.4999999997999947#     ' Dev11 & Roslyn: Unchanged
-        Const f_17_7 As Double = 1.4999999997999944R     ' Dev11 & Roslyn: 1.4999999997999944
-        Const f_17_8 As Double = 1.4999999997999947R     ' Dev11 & Roslyn: 1.4999999997999947
+        Const f_17_6 As Double = 1.499_999_999_799_9947#      ' (06) Dev11 & Roslyn: Unchanged
+        Const f_17_7 As Double = 1.499_999_999_799_9945R      ' (07) Dev11 & Roslyn: 1.4999999997999944
+        Const f_17_8 As Double = 1.499_999_999_799_9946R      ' (08) Dev11 & Roslyn: 1.4999999997999947
 
-        Const f_18_1 As Double = 14999999.997999946#    ' Dev11 & Roslyn: 14999999.997999946
-        Const f_18_2 As Double = 14999999.997999946R    ' Dev11 & Roslyn: 14999999.997999946
-        Const f_18_3 As Double = 14999999.997999946R    ' Dev11 & Roslyn: 14999999.997999946
+        Const f_18_1 As Double = 14_999_999.997_999_945_9#    ' (09) Dev11 & Roslyn: 14999999.997999946
+        Const f_18_2 As Double = 14_999_999.997_999_945_1R    ' (10) Dev11 & Roslyn: 14999999.997999946
+        Const f_18_3 As Double = 14_999_999.997_999_945_4R    ' (11) Dev11 & Roslyn: 14999999.997999946
 
         ' (b) > 16 significant digits before decimal point.
-        Const f_18_4 As Double = 1.4999999999734E+16#    ' Dev11 & Roslyn: 1.4999999999734E+16
-        Const f_18_5 As Double = 14999999999379996.0R    ' Dev11 & Roslyn: 14999999999379996.0
+        Const f_18_4 As Double = 14_999_999_999_733_999.2#    ' (12) Dev11 & Roslyn: 1.4999999999734E+16
+        Const f_18_5 As Double = 14_999_999_999_379_995.0R    ' (13) Dev11 & Roslyn: 14999999999379996.0
 
-        Const f_24_1 As Double = 1.1111114999912469E+20R      ' Dev11 & Roslyn: 1.1111114999912469E+20
+        Const f_24_1 As Double = 1_111_111_499_991_246_899_99.499R      ' (14) Dev11 & Roslyn: 1.1111114999912469E+20
 
         ' (c) Overflow/Underflow cases for Double: Ensure no pretty listing/round off
         '     Holds signed IEEE 64-bit (8-byte) double-precision floating-point numbers ranging in value from -1.79769313486231570E+308 through -4.94065645841246544E-324 for negative values and
         '     from 4.94065645841246544E-324 through 1.79769313486231570E+308 for positive values.
 
-        Const f_overflow_1 As Double = -1.79769313486231570E+309#        ' Dev11 & Roslyn: Unchanged
-        Const f_overflow_2 As Double = 1.79769313486231570E+309R         ' Dev11 & Roslyn: Unchanged
-        Const f_underflow_1 As Double = -4.94065645841246544E-326R       ' Dev11: -0.0F, Roslyn: unchanged
-        Const f_underflow_2 As Double = 4.94065645841246544E-326#        ' Dev11: 0.0F, Roslyn: unchanged
+        Const f_overflow_1 As Double = -1.797_693_134_862_315_70E+309#        ' (15) Dev11 & Roslyn: Unchanged
+        Const f_overflow_2 As Double = 1.797_693_134_862_315_70E+309R         ' (16) Dev11 & Roslyn: Unchanged
+        Const f_underflow_1 As Double = -4.940_656_458_412_465_44E-326R       ' (17) Dev11: -0.0F, Roslyn: unchanged
+        Const f_underflow_2 As Double = 4.940_656_458_412_465_44E-326#        ' (18) Dev11: 0.0F, Roslyn: unchanged
 
         Console.WriteLine(f_17_1)
         Console.WriteLine(f_17_2)
@@ -1111,6 +1126,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDecimalLiterals_LessThan30Digits()
         {
             var code = @"[|
@@ -1120,20 +1136,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 27 significant digits
-        Const d_27_1 As Decimal = .123456789012345678901234567D        ' Dev11 & Roslyn: Pretty listed to 0.123456789012345678901234567D
-        Const d_27_2 As Decimal = 0.123456789012345678901234567d       ' Dev11 & Roslyn: Unchanged
-        Const d_27_3 As Decimal = 1.23456789012345678901234567D        ' Dev11 & Roslyn: Unchanged
-        Const d_27_4 As Decimal = 123456789012.345678901234567d        ' Dev11 & Roslyn: Unchanged
-        Const d_27_5 As Decimal = 12345678901234567890123456.7D        ' Dev11 & Roslyn: Unchanged
-        Const d_27_6 As Decimal = 123456789012345678901234567.0d       ' Dev11 & Roslyn: Pretty listed to 123456789012345678901234567D
+        Const d_27_1 As Decimal = .123_456_789_012_345_678_901_234_567D        ' (00) Dev11 & Roslyn: Pretty listed to 0.123456789012345678901234567D
+        Const d_27_2 As Decimal = 0.123_456_789_012_345_678_901_234_567d       ' (01) Dev11 & Roslyn: Unchanged
+        Const d_27_3 As Decimal = 1.234_567_890_123_456_789_012_345_67D        ' (02) Dev11 & Roslyn: Unchanged
+        Const d_27_4 As Decimal = 123456789012.345_678_901_234_567d            ' (03) Dev11 & Roslyn: Unchanged
+        Const d_27_5 As Decimal = 12_345_678_901_234_567_890_123_456.7D        ' (04) Dev11 & Roslyn: Unchanged
+        Const d_27_6 As Decimal = 123_456_789_012_345_678_901_234_567.0d       ' (05) Dev11 & Roslyn: Pretty listed to 123456789012345678901234567D
 
         ' 29 significant digits
-        Const d_29_1 As Decimal = .12345678901234567890123456789D      ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_29_2 As Decimal = 0.12345678901234567890123456789d     ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_29_3 As Decimal = 1.2345678901234567890123456789D      ' Dev11 & Roslyn: Unchanged
-        Const d_29_4 As Decimal = 123456789012.34567890123456789d      ' Dev11 & Roslyn: Unchanged
-        Const d_29_5 As Decimal = 1234567890123456789012345678.9D      ' Dev11 & Roslyn: Unchanged
-        Const d_29_6 As Decimal = 12345678901234567890123456789.0d     ' Dev11 & Roslyn: Pretty listed to 12345678901234567890123456789D
+        Const d_29_1 As Decimal = .123_456_789_012_345_678_901_234_567_89D     ' (06) Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_29_2 As Decimal = 0.123_456_789_012_345_678_901_234_567_89d    ' (07) Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_29_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_9D     ' (08) Dev11 & Roslyn: Unchanged
+        Const d_29_4 As Decimal = 123_456_789_012.345_678_901_234_567_8D       ' (09) Dev11 & Roslyn: Unchanged
+        Const d_29_5 As Decimal = 1_234_567_890_123_456_789_012_345_678.9D     ' (10) Dev11 & Roslyn: Unchanged
+        Const d_29_6 As Decimal = 12_345_678_901_234_567_890_123_456_789.0d    ' (11) Dev11 & Roslyn: Pretty listed to 12345678901234567890123456789D
 
         Console.WriteLine(d_27_1)
         Console.WriteLine(d_27_2)
@@ -1159,20 +1175,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 27 significant digits
-        Const d_27_1 As Decimal = 0.123456789012345678901234567D        ' Dev11 & Roslyn: Pretty listed to 0.123456789012345678901234567D
-        Const d_27_2 As Decimal = 0.123456789012345678901234567D       ' Dev11 & Roslyn: Unchanged
-        Const d_27_3 As Decimal = 1.23456789012345678901234567D        ' Dev11 & Roslyn: Unchanged
-        Const d_27_4 As Decimal = 123456789012.345678901234567D        ' Dev11 & Roslyn: Unchanged
-        Const d_27_5 As Decimal = 12345678901234567890123456.7D        ' Dev11 & Roslyn: Unchanged
-        Const d_27_6 As Decimal = 123456789012345678901234567D       ' Dev11 & Roslyn: Pretty listed to 123456789012345678901234567D
+        Const d_27_1 As Decimal = .123_456_789_012_345_678_901_234_567D        ' (00) Dev11 & Roslyn: Pretty listed to 0.123456789012345678901234567D
+        Const d_27_2 As Decimal = 0.123_456_789_012_345_678_901_234_567D       ' (01) Dev11 & Roslyn: Unchanged
+        Const d_27_3 As Decimal = 1.234_567_890_123_456_789_012_345_67D        ' (02) Dev11 & Roslyn: Unchanged
+        Const d_27_4 As Decimal = 123456789012.345_678_901_234_567D            ' (03) Dev11 & Roslyn: Unchanged
+        Const d_27_5 As Decimal = 12_345_678_901_234_567_890_123_456.7D        ' (04) Dev11 & Roslyn: Unchanged
+        Const d_27_6 As Decimal = 123_456_789_012_345_678_901_234_567.0D       ' (05) Dev11 & Roslyn: Pretty listed to 123456789012345678901234567D
 
         ' 29 significant digits
-        Const d_29_1 As Decimal = 0.1234567890123456789012345679D      ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_29_2 As Decimal = 0.1234567890123456789012345679D     ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_29_3 As Decimal = 1.2345678901234567890123456789D      ' Dev11 & Roslyn: Unchanged
-        Const d_29_4 As Decimal = 123456789012.34567890123456789D      ' Dev11 & Roslyn: Unchanged
-        Const d_29_5 As Decimal = 1234567890123456789012345678.9D      ' Dev11 & Roslyn: Unchanged
-        Const d_29_6 As Decimal = 12345678901234567890123456789D     ' Dev11 & Roslyn: Pretty listed to 12345678901234567890123456789D
+        Const d_29_1 As Decimal = .123_456_789_012_345_678_901_234_567_89D     ' (06) Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_29_2 As Decimal = 0.123_456_789_012_345_678_901_234_567_89D    ' (07) Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_29_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_9D     ' (08) Dev11 & Roslyn: Unchanged
+        Const d_29_4 As Decimal = 123_456_789_012.345_678_901_234_567_8D       ' (09) Dev11 & Roslyn: Unchanged
+        Const d_29_5 As Decimal = 1_234_567_890_123_456_789_012_345_678.9D     ' (10) Dev11 & Roslyn: Unchanged
+        Const d_29_6 As Decimal = 12_345_678_901_234_567_890_123_456_789.0D    ' (11) Dev11 & Roslyn: Pretty listed to 12345678901234567890123456789D
 
         Console.WriteLine(d_27_1)
         Console.WriteLine(d_27_2)
@@ -1196,6 +1212,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDecimalLiterals_LessThan30Digits_WithTypeCharacterDecimal()
         {
             var code = @"[|
@@ -1205,20 +1222,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 27 significant digits
-        Const d_27_1 As Decimal = .123456789012345678901234567@        ' Dev11 & Roslyn: Pretty listed to 0.123456789012345678901234567D
-        Const d_27_2 As Decimal = 0.123456789012345678901234567@       ' Dev11 & Roslyn: Unchanged
-        Const d_27_3 As Decimal = 1.23456789012345678901234567@        ' Dev11 & Roslyn: Unchanged
-        Const d_27_4 As Decimal = 123456789012.345678901234567@        ' Dev11 & Roslyn: Unchanged
-        Const d_27_5 As Decimal = 12345678901234567890123456.7@        ' Dev11 & Roslyn: Unchanged
-        Const d_27_6 As Decimal = 123456789012345678901234567.0@       ' Dev11 & Roslyn: Pretty listed to 123456789012345678901234567D
+        Const d_27_1 As Decimal = .123_456_789_012_345_678_901_234_567@        ' (00) Dev11 & Roslyn: Pretty listed to 0.123456789012345678901234567D
+        Const d_27_2 As Decimal = 0.123_456_789_012_345_678_901_234_567@       ' (01) Dev11 & Roslyn: Unchanged
+        Const d_27_3 As Decimal = 1.234_567_890_123_456_789_012_345_67@        ' (02) Dev11 & Roslyn: Unchanged
+        Const d_27_4 As Decimal = 123_456_789_012.345678901234567@             ' (03) Dev11 & Roslyn: Unchanged
+        Const d_27_5 As Decimal = 12_345_678_901_234_567_890_123_456.7@        ' (04) Dev11 & Roslyn: Unchanged
+        Const d_27_6 As Decimal = 123_456_789_012_345_678_901_234_567.0@       ' (05) Dev11 & Roslyn: Pretty listed to 123456789012345678901234567D
 
         ' 29 significant digits
-        Const d_29_1 As Decimal = .12345678901234567890123456789@      ' Dev11 & Roslyn: 0.1234567890123456789012345679@
-        Const d_29_2 As Decimal = 0.12345678901234567890123456789@     ' Dev11 & Roslyn: 0.1234567890123456789012345679@
-        Const d_29_3 As Decimal = 1.2345678901234567890123456789@      ' Dev11 & Roslyn: Unchanged
-        Const d_29_4 As Decimal = 123456789012.34567890123456789@      ' Dev11 & Roslyn: Unchanged
-        Const d_29_5 As Decimal = 1234567890123456789012345678.9@      ' Dev11 & Roslyn: Unchanged
-        Const d_29_6 As Decimal = 12345678901234567890123456789.0@     ' Dev11 & Roslyn: Pretty listed to 12345678901234567890123456789D
+        Const d_29_1 As Decimal = .123_456_789_012_345_678_901_234_567_89@     ' (06) Dev11 & Roslyn: 0.1234567890123456789012345679@
+        Const d_29_2 As Decimal = 0.123_456_789_012_345_678_901_234_567_89@    ' (07) Dev11 & Roslyn: 0.1234567890123456789012345679@
+        Const d_29_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_9@     ' (08) Dev11 & Roslyn: Unchanged
+        Const d_29_4 As Decimal = 123_456_789_012.345_678_901_234_567_89@      ' (09) Dev11 & Roslyn: Unchanged
+        Const d_29_5 As Decimal = 1_234_567_890_123_456_789_012_345_678.9@     ' (10) Dev11 & Roslyn: Unchanged
+        Const d_29_6 As Decimal = 12_345_678_901_234_567_890_123_456_789.0@    ' (11) Dev11 & Roslyn: Pretty listed to 12345678901234567890123456789D
 
         Console.WriteLine(d_27_1)
         Console.WriteLine(d_27_2)
@@ -1244,20 +1261,20 @@ Module Program
         ' Dev11 and Roslyn behavior are identical: UNCHANGED
 
         ' 27 significant digits
-        Const d_27_1 As Decimal = 0.123456789012345678901234567@        ' Dev11 & Roslyn: Pretty listed to 0.123456789012345678901234567D
-        Const d_27_2 As Decimal = 0.123456789012345678901234567@       ' Dev11 & Roslyn: Unchanged
-        Const d_27_3 As Decimal = 1.23456789012345678901234567@        ' Dev11 & Roslyn: Unchanged
-        Const d_27_4 As Decimal = 123456789012.345678901234567@        ' Dev11 & Roslyn: Unchanged
-        Const d_27_5 As Decimal = 12345678901234567890123456.7@        ' Dev11 & Roslyn: Unchanged
-        Const d_27_6 As Decimal = 123456789012345678901234567@       ' Dev11 & Roslyn: Pretty listed to 123456789012345678901234567D
+        Const d_27_1 As Decimal = .123_456_789_012_345_678_901_234_567@        ' (00) Dev11 & Roslyn: Pretty listed to 0.123456789012345678901234567D
+        Const d_27_2 As Decimal = 0.123_456_789_012_345_678_901_234_567@       ' (01) Dev11 & Roslyn: Unchanged
+        Const d_27_3 As Decimal = 1.234_567_890_123_456_789_012_345_67@        ' (02) Dev11 & Roslyn: Unchanged
+        Const d_27_4 As Decimal = 123_456_789_012.345678901234567@             ' (03) Dev11 & Roslyn: Unchanged
+        Const d_27_5 As Decimal = 12_345_678_901_234_567_890_123_456.7@        ' (04) Dev11 & Roslyn: Unchanged
+        Const d_27_6 As Decimal = 123_456_789_012_345_678_901_234_567.0@       ' (05) Dev11 & Roslyn: Pretty listed to 123456789012345678901234567D
 
         ' 29 significant digits
-        Const d_29_1 As Decimal = 0.1234567890123456789012345679@      ' Dev11 & Roslyn: 0.1234567890123456789012345679@
-        Const d_29_2 As Decimal = 0.1234567890123456789012345679@     ' Dev11 & Roslyn: 0.1234567890123456789012345679@
-        Const d_29_3 As Decimal = 1.2345678901234567890123456789@      ' Dev11 & Roslyn: Unchanged
-        Const d_29_4 As Decimal = 123456789012.34567890123456789@      ' Dev11 & Roslyn: Unchanged
-        Const d_29_5 As Decimal = 1234567890123456789012345678.9@      ' Dev11 & Roslyn: Unchanged
-        Const d_29_6 As Decimal = 12345678901234567890123456789@     ' Dev11 & Roslyn: Pretty listed to 12345678901234567890123456789D
+        Const d_29_1 As Decimal = .123_456_789_012_345_678_901_234_567_89@     ' (06) Dev11 & Roslyn: 0.1234567890123456789012345679@
+        Const d_29_2 As Decimal = 0.123_456_789_012_345_678_901_234_567_89@    ' (07) Dev11 & Roslyn: 0.1234567890123456789012345679@
+        Const d_29_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_9@     ' (08) Dev11 & Roslyn: Unchanged
+        Const d_29_4 As Decimal = 123_456_789_012.345_678_901_234_567_89@      ' (09) Dev11 & Roslyn: Unchanged
+        Const d_29_5 As Decimal = 1_234_567_890_123_456_789_012_345_678.9@     ' (10) Dev11 & Roslyn: Unchanged
+        Const d_29_6 As Decimal = 12_345_678_901_234_567_890_123_456_789.0@    ' (11) Dev11 & Roslyn: Pretty listed to 12345678901234567890123456789D
 
         Console.WriteLine(d_27_1)
         Console.WriteLine(d_27_2)
@@ -1281,6 +1298,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDecimalLiterals_30Digits()
         {
             var code = @"[|
@@ -1289,14 +1307,14 @@ Module Program
         ' CATEGORY 2: 30 significant digits
         ' Dev11 & Roslyn have identical behavior: pretty listed and round off to <= 29 significant digits
         
-        Const d_30_1 As Decimal = .123456789012345678901234567891D          ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_30_2 As Decimal = 0.1234567890123456789012345687891D        ' Dev11 & Roslyn: 0.1234567890123456789012345688D
-        Const d_30_3 As Decimal = 1.23456789012345678901234567891D          ' Dev11 & Roslyn: 1.2345678901234567890123456789D
-        Const d_30_4 As Decimal = 123456789012345.678901234567891D          ' Dev11 & Roslyn: 123456789012345.67890123456789D
-        Const d_30_5 As Decimal = 12345678901234567890123456789.1D          ' Dev11 & Roslyn: 12345678901234567890123456789D
+        Const d_30_1 As Decimal = .123_456_789_012_345_678_901_234_567_891D         ' Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_30_2 As Decimal = 0.123_456_789_012_345_678_901_234_568_789_1D      ' Dev11 & Roslyn: 0.1234567890123456789012345688D
+        Const d_30_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_91D         ' Dev11 & Roslyn: 1.2345678901234567890123456789D
+        Const d_30_4 As Decimal = 123_456_789_012_345.678_901_234_567_891D          ' Dev11 & Roslyn: 123456789012345.67890123456789D
+        Const d_30_5 As Decimal = 12_345_678_901_234_567_890_123_456_789.1D         ' Dev11 & Roslyn: 12345678901234567890123456789D
 
         ' Overflow case 30 significant digits before decimal place: Ensure no pretty listing.
-        Const d_30_6 As Decimal = 123456789012345678901234567891.0D          ' Dev11 & Roslyn: 123456789012345678901234567891.0D
+        Const d_30_6 As Decimal = 123_456_789_012_345_678_901_234_567_891.0D        ' Dev11 & Roslyn: 123456789012345678901234567891.0D
 
         Console.WriteLine(d_30_1)
         Console.WriteLine(d_30_2)
@@ -1314,14 +1332,14 @@ Module Program
         ' CATEGORY 2: 30 significant digits
         ' Dev11 & Roslyn have identical behavior: pretty listed and round off to <= 29 significant digits
 
-        Const d_30_1 As Decimal = 0.1234567890123456789012345679D          ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_30_2 As Decimal = 0.1234567890123456789012345688D        ' Dev11 & Roslyn: 0.1234567890123456789012345688D
-        Const d_30_3 As Decimal = 1.2345678901234567890123456789D          ' Dev11 & Roslyn: 1.2345678901234567890123456789D
-        Const d_30_4 As Decimal = 123456789012345.67890123456789D          ' Dev11 & Roslyn: 123456789012345.67890123456789D
-        Const d_30_5 As Decimal = 12345678901234567890123456789D          ' Dev11 & Roslyn: 12345678901234567890123456789D
+        Const d_30_1 As Decimal = .123_456_789_012_345_678_901_234_567_891D         ' Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_30_2 As Decimal = 0.123_456_789_012_345_678_901_234_568_789_1D      ' Dev11 & Roslyn: 0.1234567890123456789012345688D
+        Const d_30_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_91D         ' Dev11 & Roslyn: 1.2345678901234567890123456789D
+        Const d_30_4 As Decimal = 123_456_789_012_345.678_901_234_567_891D          ' Dev11 & Roslyn: 123456789012345.67890123456789D
+        Const d_30_5 As Decimal = 12_345_678_901_234_567_890_123_456_789.1D         ' Dev11 & Roslyn: 12345678901234567890123456789D
 
         ' Overflow case 30 significant digits before decimal place: Ensure no pretty listing.
-        Const d_30_6 As Decimal = 123456789012345678901234567891.0D          ' Dev11 & Roslyn: 123456789012345678901234567891.0D
+        Const d_30_6 As Decimal = 123_456_789_012_345_678_901_234_567_891.0D        ' Dev11 & Roslyn: 123456789012345678901234567891.0D
 
         Console.WriteLine(d_30_1)
         Console.WriteLine(d_30_2)
@@ -1338,6 +1356,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDecimalLiterals_30Digits_WithTypeCharacterDecimal()
         {
             var code = @"[|
@@ -1346,14 +1365,14 @@ Module Program
         ' CATEGORY 2: 30 significant digits
         ' Dev11 & Roslyn have identical behavior: pretty listed and round off to <= 29 significant digits
         
-        Const d_30_1 As Decimal = .123456789012345678901234567891@          ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_30_2 As Decimal = 0.1234567890123456789012345687891@        ' Dev11 & Roslyn: 0.1234567890123456789012345688D
-        Const d_30_3 As Decimal = 1.23456789012345678901234567891@          ' Dev11 & Roslyn: 1.2345678901234567890123456789D
-        Const d_30_4 As Decimal = 123456789012345.678901234567891@          ' Dev11 & Roslyn: 123456789012345.67890123456789D
-        Const d_30_5 As Decimal = 12345678901234567890123456789.1@          ' Dev11 & Roslyn: 12345678901234567890123456789D
+        Const d_30_1 As Decimal = .123_456_789_012_345_678_901_234_567_891@         ' Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_30_2 As Decimal = 0.123_456_789_012_345_678_901_234_568_789_1@      ' Dev11 & Roslyn: 0.1234567890123456789012345688D
+        Const d_30_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_91@         ' Dev11 & Roslyn: 1.2345678901234567890123456789D
+        Const d_30_4 As Decimal = 123_456_789_012_345.678_901_234_567_891@          ' Dev11 & Roslyn: 123456789012345.67890123456789D
+        Const d_30_5 As Decimal = 12_345_678_901_234_567_890_123_456_789.1@         ' Dev11 & Roslyn: 12345678901234567890123456789D
 
         ' Overflow case 30 significant digits before decimal place: Ensure no pretty listing.
-        Const d_30_6 As Decimal = 123456789012345678901234567891.0@          ' Dev11 & Roslyn: 123456789012345678901234567891.0D
+        Const d_30_6 As Decimal = 123_456_789_012_345_678_901_234_567_891.0@        ' Dev11 & Roslyn: 123456789012345678901234567891.0D
 
         Console.WriteLine(d_30_1)
         Console.WriteLine(d_30_2)
@@ -1371,14 +1390,14 @@ Module Program
         ' CATEGORY 2: 30 significant digits
         ' Dev11 & Roslyn have identical behavior: pretty listed and round off to <= 29 significant digits
 
-        Const d_30_1 As Decimal = 0.1234567890123456789012345679@          ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_30_2 As Decimal = 0.1234567890123456789012345688@        ' Dev11 & Roslyn: 0.1234567890123456789012345688D
-        Const d_30_3 As Decimal = 1.2345678901234567890123456789@          ' Dev11 & Roslyn: 1.2345678901234567890123456789D
-        Const d_30_4 As Decimal = 123456789012345.67890123456789@          ' Dev11 & Roslyn: 123456789012345.67890123456789D
-        Const d_30_5 As Decimal = 12345678901234567890123456789@          ' Dev11 & Roslyn: 12345678901234567890123456789D
+        Const d_30_1 As Decimal = .123_456_789_012_345_678_901_234_567_891@         ' Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_30_2 As Decimal = 0.123_456_789_012_345_678_901_234_568_789_1@      ' Dev11 & Roslyn: 0.1234567890123456789012345688D
+        Const d_30_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_91@         ' Dev11 & Roslyn: 1.2345678901234567890123456789D
+        Const d_30_4 As Decimal = 123_456_789_012_345.678_901_234_567_891@          ' Dev11 & Roslyn: 123456789012345.67890123456789D
+        Const d_30_5 As Decimal = 12_345_678_901_234_567_890_123_456_789.1@         ' Dev11 & Roslyn: 12345678901234567890123456789D
 
         ' Overflow case 30 significant digits before decimal place: Ensure no pretty listing.
-        Const d_30_6 As Decimal = 123456789012345678901234567891.0@          ' Dev11 & Roslyn: 123456789012345678901234567891.0D
+        Const d_30_6 As Decimal = 123_456_789_012_345_678_901_234_567_891.0@        ' Dev11 & Roslyn: 123456789012345678901234567891.0D
 
         Console.WriteLine(d_30_1)
         Console.WriteLine(d_30_2)
@@ -1395,6 +1414,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDecimalLiterals_GreaterThan30Digits()
         {
             var code = @"[|
@@ -1405,13 +1425,13 @@ Module Program
         ' Roslyn behavior: Always rounded off + pretty listed to <= 29 significant digits
         
         ' (a) > 30 significant digits overall, but < 30 digits before decimal point.
-        Const d_32_1 As Decimal = .12345678901234567890123456789012D          ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_32_2 As Decimal = 0.123456789012345678901234568789012@        ' Dev11 & Roslyn: 0.1234567890123456789012345688@
-        Const d_32_3 As Decimal = 1.2345678901234567890123456789012d          ' Dev11 & Roslyn: 1.2345678901234567890123456789D
-        Const d_32_4 As Decimal = 123456789012345.67890123456789012@          ' Dev11 & Roslyn: 123456789012345.67890123456789@
+        Const d_32_1 As Decimal = .123_456_789_012_345_678_901_234_567_890_12D          ' Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_32_2 As Decimal = 0.123_456_789_012_345_678_901_234_568_789_012@        ' Dev11 & Roslyn: 0.1234567890123456789012345688@
+        Const d_32_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_901_2d          ' Dev11 & Roslyn: 1.2345678901234567890123456789D
+        Const d_32_4 As Decimal = 123_456_789_012_345.678_901_234_567_890_12@           ' Dev11 & Roslyn: 123456789012345.67890123456789@
         
         ' (b) > 30 significant digits before decimal point (Overflow case): Ensure no pretty listing.
-        Const d_35_1 As Decimal = 123456789012345678901234567890123.45D          ' Dev11 & Roslyn: 123456789012345678901234567890123.45D
+        Const d_35_1 As Decimal = 123_456_789_012_345_678_901_234_567_890_123.45D       ' Dev11 & Roslyn: 123456789012345678901234567890123.45D
 
         Console.WriteLine(d_32_1)
         Console.WriteLine(d_32_2)
@@ -1430,13 +1450,13 @@ Module Program
         ' Roslyn behavior: Always rounded off + pretty listed to <= 29 significant digits
 
         ' (a) > 30 significant digits overall, but < 30 digits before decimal point.
-        Const d_32_1 As Decimal = 0.1234567890123456789012345679D          ' Dev11 & Roslyn: 0.1234567890123456789012345679D
-        Const d_32_2 As Decimal = 0.1234567890123456789012345688@        ' Dev11 & Roslyn: 0.1234567890123456789012345688@
-        Const d_32_3 As Decimal = 1.2345678901234567890123456789D          ' Dev11 & Roslyn: 1.2345678901234567890123456789D
-        Const d_32_4 As Decimal = 123456789012345.67890123456789@          ' Dev11 & Roslyn: 123456789012345.67890123456789@
+        Const d_32_1 As Decimal = .123_456_789_012_345_678_901_234_567_890_12D          ' Dev11 & Roslyn: 0.1234567890123456789012345679D
+        Const d_32_2 As Decimal = 0.123_456_789_012_345_678_901_234_568_789_012@        ' Dev11 & Roslyn: 0.1234567890123456789012345688@
+        Const d_32_3 As Decimal = 1.234_567_890_123_456_789_012_345_678_901_2D          ' Dev11 & Roslyn: 1.2345678901234567890123456789D
+        Const d_32_4 As Decimal = 123_456_789_012_345.678_901_234_567_890_12@           ' Dev11 & Roslyn: 123456789012345.67890123456789@
 
         ' (b) > 30 significant digits before decimal point (Overflow case): Ensure no pretty listing.
-        Const d_35_1 As Decimal = 123456789012345678901234567890123.45D          ' Dev11 & Roslyn: 123456789012345678901234567890123.45D
+        Const d_35_1 As Decimal = 123_456_789_012_345_678_901_234_567_890_123.45D       ' Dev11 & Roslyn: 123456789012345678901234567890123.45D
 
         Console.WriteLine(d_32_1)
         Console.WriteLine(d_32_2)
@@ -1452,6 +1472,7 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceFloatLiteralsWithNegativeExponents()
         {
             var code = @"[|
@@ -1476,26 +1497,26 @@ Module Program
         '           0.000000000012345678F   =>  1.23456783E-11F              (exponent = -11: exponent notation)
         '           0.0000000000012345678F  =>  1.23456779E-12F              (exponent = -12: exponent notation)
 
-        Const f_1 As Single = 0.000001234567F
-        Const f_2 As Single = 0.0000001234567F
-        Const f_3 As Single = 0.00000001234567F
-        Const f_4 As Single = 0.000000001234567F ' Change at -9
-        Const f_5 As Single = 0.0000000001234567F
+        Const f_1 As Single = 0.000_001_234_567F
+        Const f_2 As Single = 0.000_000_123_456_7F
+        Const f_3 As Single = 0.000_000_012_345_67F
+        Const f_4 As Single = 0.000_000_001_234_567F ' Change at -9
+        Const f_5 As Single = 0.000_000_000_123_456_7F
 
-        Const f_6 As Single = 0.00000000123456778F
-        Const f_7 As Single = 0.000000000123456786F
-        Const f_8 As Single = 0.000000000012345678F ' Change at -11
-        Const f_9 As Single = 0.0000000000012345678F
+        Const f_6 As Single = 0.000_000_001_234_567_78F
+        Const f_7 As Single = 0.000_000_000_123_456_786F
+        Const f_8 As Single = 0.000_000_000_012_345_678F ' Change at -11
+        Const f_9 As Single = 0.000_000_000_001_234_567_8F
 
-        Const d_1 As Single = 0.00000000000000123456789012345
-        Const d_2 As Single = 0.000000000000000123456789012345
-        Const d_3 As Single = 0.0000000000000000123456789012345 ' Change at -17
-        Const d_4 As Single = 0.00000000000000000123456789012345
+        Const d_1 As Single = 0.000_000_000_000_012_345_678_901_234_5
+        Const d_2 As Single = 0.000_000_000_000_000_123_456_789_012_345
+        Const d_3 As Single = 0.000_000_000_000_000_012_345_678_901_234_5 ' Change at -17
+        Const d_4 As Single = 0.000_000_000_000_000_001_234_567_890_123_45
 
-        Const d_5 As Double = 0.00000000000000001234567890123456
-        Const d_6 As Double = 0.000000000000000001234567890123456
-        Const d_7 As Double = 0.0000000000000000001234567890123456   ' Change at -19
-        Const d_8 As Double = 0.00000000000000000001234567890123456
+        Const d_5 As Double = 0.000_000_000_000_000_012_345_678_901_234_56
+        Const d_6 As Double = 0.000_000_000_000_000_001_234_567_890_123_456
+        Const d_7 As Double = 0.000_000_000_000_000_000_123_456_789_012_345_6   ' Change at -19
+        Const d_8 As Double = 0.000_000_000_000_000_000_012_345_678_901_234_56
     End Sub
 End Module
 |]";
@@ -1522,26 +1543,26 @@ Module Program
         '           0.000000000012345678F   =>  1.23456783E-11F              (exponent = -11: exponent notation)
         '           0.0000000000012345678F  =>  1.23456779E-12F              (exponent = -12: exponent notation)
 
-        Const f_1 As Single = 0.000001234567F
-        Const f_2 As Single = 0.0000001234567F
-        Const f_3 As Single = 0.00000001234567F
-        Const f_4 As Single = 1.234567E-9F ' Change at -9
-        Const f_5 As Single = 1.234567E-10F
+        Const f_1 As Single = 0.000_001_234_567F
+        Const f_2 As Single = 0.000_000_123_456_7F
+        Const f_3 As Single = 0.000_000_012_345_67F
+        Const f_4 As Single = 0.000_000_001_234_567F ' Change at -9
+        Const f_5 As Single = 0.000_000_000_123_456_7F
 
-        Const f_6 As Single = 0.00000000123456778F
-        Const f_7 As Single = 0.000000000123456786F
-        Const f_8 As Single = 1.23456783E-11F ' Change at -11
-        Const f_9 As Single = 1.23456779E-12F
+        Const f_6 As Single = 0.000_000_001_234_567_78F
+        Const f_7 As Single = 0.000_000_000_123_456_786F
+        Const f_8 As Single = 0.000_000_000_012_345_678F ' Change at -11
+        Const f_9 As Single = 0.000_000_000_001_234_567_8F
 
-        Const d_1 As Single = 0.00000000000000123456789012345
-        Const d_2 As Single = 0.000000000000000123456789012345
-        Const d_3 As Single = 1.23456789012345E-17 ' Change at -17
-        Const d_4 As Single = 1.23456789012345E-18
+        Const d_1 As Single = 0.000_000_000_000_012_345_678_901_234_5
+        Const d_2 As Single = 0.000_000_000_000_000_123_456_789_012_345
+        Const d_3 As Single = 0.000_000_000_000_000_012_345_678_901_234_5 ' Change at -17
+        Const d_4 As Single = 0.000_000_000_000_000_001_234_567_890_123_45
 
-        Const d_5 As Double = 0.000000000000000012345678901234561
-        Const d_6 As Double = 0.000000000000000001234567890123456
-        Const d_7 As Double = 1.2345678901234561E-19   ' Change at -19
-        Const d_8 As Double = 1.234567890123456E-20
+        Const d_5 As Double = 0.000_000_000_000_000_012_345_678_901_234_56
+        Const d_6 As Double = 0.000_000_000_000_000_001_234_567_890_123_456
+        Const d_7 As Double = 0.000_000_000_000_000_000_123_456_789_012_345_6   ' Change at -19
+        Const d_8 As Double = 0.000_000_000_000_000_000_012_345_678_901_234_56
     End Sub
 End Module
 ";
@@ -1551,22 +1572,23 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceSingleLiteralsWithTrailingZeros()
         {
             var code = @"[|
 Module Program
     Sub Main(args As String())
-        Const f1 As Single = 3.011000F                      ' Dev11 & Roslyn: 3.011F
-        Const f2 As Single = 3.000000!                      ' Dev11 & Roslyn: 3.0!
-        Const f3 As Single = 3.0F                           ' Dev11 & Roslyn: Unchanged
-        Const f4 As Single = 3000f                          ' Dev11 & Roslyn: 3000.0F
-        Const f5 As Single = 3000E+10!                      ' Dev11 & Roslyn: 3.0E+13!
-        Const f6 As Single = 3000.0E+10F                    ' Dev11 & Roslyn: 3.0E+13F
-        Const f7 As Single = 3000.010E+1F                   ' Dev11 & Roslyn: 30000.1F
-        Const f8 As Single = 3000.123456789010E+10!         ' Dev11 & Roslyn: 3.00012337E+13!
-        Const f9 As Single = 3000.123456789000E+10F         ' Dev11 & Roslyn: 3.00012337E+13F
-        Const f10 As Single = 30001234567890.10E-10f        ' Dev11 & Roslyn: 3000.12354F
-        Const f11 As Single = 3000E-10!                     ' Dev11 & Roslyn: 0.0000003!
+        Const f1 As Single = 3.011_000F                      ' Dev11 & Roslyn: 3.011F
+        Const f2 As Single = 3.000_000!                      ' Dev11 & Roslyn: 3.0!
+        Const f3 As Single = 3.0F                            ' Dev11 & Roslyn: Unchanged
+        Const f4 As Single = 3_000f                          ' Dev11 & Roslyn: 3000.0F
+        Const f5 As Single = 3_000E+10!                      ' Dev11 & Roslyn: 3.0E+13!
+        Const f6 As Single = 3_000.0E+10F                    ' Dev11 & Roslyn: 3.0E+13F
+        Const f7 As Single = 3_000.010E+1F                   ' Dev11 & Roslyn: 30000.1F
+        Const f8 As Single = 3_000.123_456_789_010E+10!      ' Dev11 & Roslyn: 3.00012337E+13!
+        Const f9 As Single = 3_000.123_456_789_000E+10F      ' Dev11 & Roslyn: 3.00012337E+13F
+        Const f10 As Single = 30_001_234_567_890.10E-10f     ' Dev11 & Roslyn: 3000.12354F
+        Const f11 As Single = 3_000E-10!                     ' Dev11 & Roslyn: 0.0000003!
 
         Console.WriteLine(f1)
         Console.WriteLine(f2)
@@ -1586,17 +1608,17 @@ End Module
             var expected = @"
 Module Program
     Sub Main(args As String())
-        Const f1 As Single = 3.011F                      ' Dev11 & Roslyn: 3.011F
-        Const f2 As Single = 3.0!                      ' Dev11 & Roslyn: 3.0!
-        Const f3 As Single = 3.0F                           ' Dev11 & Roslyn: Unchanged
-        Const f4 As Single = 3000.0F                          ' Dev11 & Roslyn: 3000.0F
-        Const f5 As Single = 3.0E+13!                      ' Dev11 & Roslyn: 3.0E+13!
-        Const f6 As Single = 3.0E+13F                    ' Dev11 & Roslyn: 3.0E+13F
-        Const f7 As Single = 30000.1F                   ' Dev11 & Roslyn: 30000.1F
-        Const f8 As Single = 3.00012337E+13!         ' Dev11 & Roslyn: 3.00012337E+13!
-        Const f9 As Single = 3.00012337E+13F         ' Dev11 & Roslyn: 3.00012337E+13F
-        Const f10 As Single = 3000.12354F        ' Dev11 & Roslyn: 3000.12354F
-        Const f11 As Single = 0.0000003!                     ' Dev11 & Roslyn: 0.0000003!
+        Const f1 As Single = 3.011_000F                      ' Dev11 & Roslyn: 3.011F
+        Const f2 As Single = 3.000_000!                      ' Dev11 & Roslyn: 3.0!
+        Const f3 As Single = 3.0F                            ' Dev11 & Roslyn: Unchanged
+        Const f4 As Single = 3_000F                          ' Dev11 & Roslyn: 3000.0F
+        Const f5 As Single = 3_000E+10!                      ' Dev11 & Roslyn: 3.0E+13!
+        Const f6 As Single = 3_000.0E+10F                    ' Dev11 & Roslyn: 3.0E+13F
+        Const f7 As Single = 3_000.010E+1F                   ' Dev11 & Roslyn: 30000.1F
+        Const f8 As Single = 3_000.123_456_789_010E+10!      ' Dev11 & Roslyn: 3.00012337E+13!
+        Const f9 As Single = 3_000.123_456_789_000E+10F      ' Dev11 & Roslyn: 3.00012337E+13F
+        Const f10 As Single = 30_001_234_567_890.10E-10F     ' Dev11 & Roslyn: 3000.12354F
+        Const f11 As Single = 3_000E-10!                     ' Dev11 & Roslyn: 0.0000003!
 
         Console.WriteLine(f1)
         Console.WriteLine(f2)
@@ -1618,22 +1640,23 @@ End Module
         [Fact]
         [WorkItem(5529, "DevDiv_Projects/Roslyn")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceDoubleLiteralsWithTrailingZeros()
         {
             var code = @"[|
 Module Program
     Sub Main(args As String())
-        Const d1 As Double = 3.011000                       ' Dev11 & Roslyn: 3.011
-        Const d2 As Double = 3.000000                       ' Dev11 & Roslyn: 3.0
-        Const d3 As Double = 3.0                            ' Dev11 & Roslyn: Unchanged
-        Const d4 As Double = 3000R                          ' Dev11 & Roslyn: 3000.0R
-        Const d5 As Double = 3000E+10#                      ' Dev11 & Roslyn: 30000000000000.0#
-        Const d6 As Double = 3000.0E+10                     ' Dev11 & Roslyn: 30000000000000.0
-        Const d7 As Double = 3000.010E+1                    ' Dev11 & Roslyn: 30000.1
-        Const d8 As Double = 3000.123456789010E+10#         ' Dev11 & Roslyn: 30001234567890.1#
-        Const d9 As Double = 3000.123456789000E+10          ' Dev11 & Roslyn: 30001234567890.0
-        Const d10 As Double = 30001234567890.10E-10d        ' Dev11 & Roslyn: 3000.12345678901D
-        Const d11 As Double = 3000E-10                      ' Dev11 & Roslyn: 0.0000003
+        Const d1 As Double = 3.011_000                       ' Dev11 & Roslyn: 3.011
+        Const d2 As Double = 3.000_000                       ' Dev11 & Roslyn: 3.0
+        Const d3 As Double = 3.0                             ' Dev11 & Roslyn: Unchanged
+        Const d4 As Double = 3_000R                          ' Dev11 & Roslyn: 3000.0R
+        Const d5 As Double = 3_000E+10#                      ' Dev11 & Roslyn: 30000000000000.0#
+        Const d6 As Double = 3_000.0E+10                     ' Dev11 & Roslyn: 30000000000000.0
+        Const d7 As Double = 3_000.010E+1                    ' Dev11 & Roslyn: 30000.1
+        Const d8 As Double = 3_000.123_456_789_010E+10#      ' Dev11 & Roslyn: 30001234567890.1#
+        Const d9 As Double = 3_000.123_456_789_000E+10       ' Dev11 & Roslyn: 30001234567890.0
+        Const d10 As Double = 30_001_234_567_890.10E-10d     ' Dev11 & Roslyn: 3000.12345678901D
+        Const d11 As Double = 3_000E-10                      ' Dev11 & Roslyn: 0.0000003
 
         Console.WriteLine(d1)
         Console.WriteLine(d2)
@@ -1653,17 +1676,17 @@ End Module
             var expected = @"
 Module Program
     Sub Main(args As String())
-        Const d1 As Double = 3.011                       ' Dev11 & Roslyn: 3.011
-        Const d2 As Double = 3.0                       ' Dev11 & Roslyn: 3.0
-        Const d3 As Double = 3.0                            ' Dev11 & Roslyn: Unchanged
-        Const d4 As Double = 3000.0R                          ' Dev11 & Roslyn: 3000.0R
-        Const d5 As Double = 30000000000000.0#                      ' Dev11 & Roslyn: 30000000000000.0#
-        Const d6 As Double = 30000000000000.0                     ' Dev11 & Roslyn: 30000000000000.0
-        Const d7 As Double = 30000.1                    ' Dev11 & Roslyn: 30000.1
-        Const d8 As Double = 30001234567890.1#         ' Dev11 & Roslyn: 30001234567890.1#
-        Const d9 As Double = 30001234567890.0          ' Dev11 & Roslyn: 30001234567890.0
-        Const d10 As Double = 3000.12345678901D        ' Dev11 & Roslyn: 3000.12345678901D
-        Const d11 As Double = 0.0000003                      ' Dev11 & Roslyn: 0.0000003
+        Const d1 As Double = 3.011_000                       ' Dev11 & Roslyn: 3.011
+        Const d2 As Double = 3.000_000                       ' Dev11 & Roslyn: 3.0
+        Const d3 As Double = 3.0                             ' Dev11 & Roslyn: Unchanged
+        Const d4 As Double = 3_000R                          ' Dev11 & Roslyn: 3000.0R
+        Const d5 As Double = 3_000E+10#                      ' Dev11 & Roslyn: 30000000000000.0#
+        Const d6 As Double = 3_000.0E+10                     ' Dev11 & Roslyn: 30000000000000.0
+        Const d7 As Double = 3_000.010E+1                    ' Dev11 & Roslyn: 30000.1
+        Const d8 As Double = 3_000.123_456_789_010E+10#      ' Dev11 & Roslyn: 30001234567890.1#
+        Const d9 As Double = 3_000.123_456_789_000E+10       ' Dev11 & Roslyn: 30001234567890.0
+        Const d10 As Double = 30_001_234_567_890.10E-10D     ' Dev11 & Roslyn: 3000.12345678901D
+        Const d11 As Double = 3_000E-10                      ' Dev11 & Roslyn: 0.0000003
 
         Console.WriteLine(d1)
         Console.WriteLine(d2)
@@ -1682,76 +1705,82 @@ End Module
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [WorkItem(5529, "DevDiv_Projects/Roslyn")]
-        [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
-        public async Task ReduceDecimalLiteralsWithTrailingZeros()
+        #region "Reduce Decimal Literal"
+
+        #region "With Trailing Zeros"
+        private async Task ReduceDecimalLiteralsWithTrailingZeros(string literal,string expected)
         {
-            var code = @"[|
+            var code = $@"[|
 Module Program
     Sub Main(args As String())
-        Const d1 As Decimal = 3.011000D                     ' Dev11 & Roslyn: 3.011D
-        Const d2 As Decimal = 3.000000D                     ' Dev11 & Roslyn: 3D
-        Const d3 As Decimal = 3.0D                          ' Dev11 & Roslyn: 3D
-        Const d4 As Decimal = 3000D                         ' Dev11 & Roslyn: 3000D
-        Const d5 As Decimal = 3000E+10D                     ' Dev11 & Roslyn: 30000000000000D
-        Const d6 As Decimal = 3000.0E+10D                   ' Dev11 & Roslyn: 30000000000000D
-        Const d7 As Decimal = 3000.010E+1D                  ' Dev11 & Roslyn: 30000.1D
-        Const d8 As Decimal = 3000.123456789010E+10D        ' Dev11 & Roslyn: 30001234567890.1D
-        Const d9 As Decimal = 3000.123456789000E+10D        ' Dev11 & Roslyn: 30001234567890D
-        Const d10 As Decimal = 30001234567890.10E-10D        ' Dev11 & Roslyn: 3000.12345678901D
-        Const d11 As Decimal = 3000E-10D                    ' Dev11 & Roslyn: 0.0000003D
-
+        Const d1 As Decimal = {literal}
         Console.WriteLine(d1)
-        Console.WriteLine(d2)
-        Console.WriteLine(d3)
-        Console.WriteLine(d4)
-        Console.WriteLine(d5)
-        Console.WriteLine(d6)
-        Console.WriteLine(d7)
-        Console.WriteLine(d8)
-        Console.WriteLine(d9)
-        Console.WriteLine(d10)
-        Console.WriteLine(d11)
     End Sub
 End Module
 |]";
-
-            var expected = @"
+            var code_expected = $@"
 Module Program
     Sub Main(args As String())
-        Const d1 As Decimal = 3.011D                     ' Dev11 & Roslyn: 3.011D
-        Const d2 As Decimal = 3D                     ' Dev11 & Roslyn: 3D
-        Const d3 As Decimal = 3D                          ' Dev11 & Roslyn: 3D
-        Const d4 As Decimal = 3000D                         ' Dev11 & Roslyn: 3000D
-        Const d5 As Decimal = 30000000000000D                     ' Dev11 & Roslyn: 30000000000000D
-        Const d6 As Decimal = 30000000000000D                   ' Dev11 & Roslyn: 30000000000000D
-        Const d7 As Decimal = 30000.1D                  ' Dev11 & Roslyn: 30000.1D
-        Const d8 As Decimal = 30001234567890.1D        ' Dev11 & Roslyn: 30001234567890.1D
-        Const d9 As Decimal = 30001234567890D        ' Dev11 & Roslyn: 30001234567890D
-        Const d10 As Decimal = 3000.12345678901D        ' Dev11 & Roslyn: 3000.12345678901D
-        Const d11 As Decimal = 0.0000003D                    ' Dev11 & Roslyn: 0.0000003D
-
+        Const d1 As Decimal = {expected}
         Console.WriteLine(d1)
-        Console.WriteLine(d2)
-        Console.WriteLine(d3)
-        Console.WriteLine(d4)
-        Console.WriteLine(d5)
-        Console.WriteLine(d6)
-        Console.WriteLine(d7)
-        Console.WriteLine(d8)
-        Console.WriteLine(d9)
-        Console.WriteLine(d10)
-        Console.WriteLine(d11)
     End Sub
 End Module
 ";
-            await VerifyAsync(code, expected);
+            await VerifyAsync(code, code_expected);
         }
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_00()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3.011_000D",@"3.011_000D"); /* Dev11 & Roslyn: 3.011D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_01()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3.000_000D", @"3.000_000D"); /* Dev11 & Roslyn: 3D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_02()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3.0D", @"3D"); /* Dev11 & Roslyn: 3D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_03()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3_000D", @"3_000D"); /* Dev11 & Roslyn: 3000D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_04()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3_000E+10D", @"3_000E+10D"); /* Dev11 & Roslyn: 30000000000000D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_05()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3_000.0E+10D", @"3_000.0E+10D"); /* Dev11 & Roslyn: 30000000000000D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_06()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3_000.010E+1D", @"3_000.010E+1D"); /* Dev11 & Roslyn: 30000.1D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_07()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3_000.123_456_789_010E+10D", @"3_000.123_456_789_010E+10D"); /* Dev11 & Roslyn: 30001234567890.1D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_08()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3_000.123_456_789_000E+10D", @"3_000.123_456_789_000E+10D"); /* Dev11 & Roslyn: 30001234567890D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_09()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"30_001_234_567_890.10E-10D", @"30_001_234_567_890.10E-10D"); /* Dev11 & Roslyn: 3000.12345678901D */
+
+        [Fact, WorkItem(5529, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.ReduceTokens), Trait(Traits.Feature, "WithDigitSeparators")]
+        public async Task ReduceDecimalLiteralsWithTrailingZeros_10()
+            => await ReduceDecimalLiteralsWithTrailingZeros(@"3_000E-10D", @"3_000E-10D"); /* Dev11 & Roslyn: 0.0000003D */
+
+        #endregion
+
+        #endregion
 
         [Fact]
         [WorkItem(623319, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/623319")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceFloatingAndDecimalLiteralsWithDifferentCulture()
         {
             var savedCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
@@ -1823,6 +1852,7 @@ End Module";
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceIntegerLiteralWithLeadingZeros()
         {
             var code = @"[|
@@ -1877,6 +1907,7 @@ End Module
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceIntegerLiteralWithNegativeHexOrOctalValue()
         {
             var code = @"[|
@@ -1921,6 +1952,7 @@ End Module
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceIntegerLiteralWithOverflow()
         {
             var code = @"[|
@@ -1957,6 +1989,7 @@ End Module
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceBinaryIntegerLiteral()
         {
             var code = @"[|
@@ -2064,23 +2097,8 @@ End Module
         [Fact]
         [WorkItem(14034, "https://github.com/dotnet/roslyn/issues/14034")]
         [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
+        [Trait(Traits.Feature, "WithDigitSeparators")]
         public async Task ReduceIntegersWithDigitSeparators()
-        {
-            var source = @"
-Module Module1
-    Sub Main()
-        Dim x = 100_000
-    End Sub
-End Module
-";
-            var expected = source;
-            await VerifyAsync($"[|{source}|]", expected);
-        }
-
-        [Fact]
-        [WorkItem(14034, "https://github.com/dotnet/roslyn/issues/14034")]
-        [Trait(Traits.Feature, Traits.Features.ReduceTokens)]
-        public async Task ReduceFloatWithDigitSeparators()
         {
             var source = @"
 Module Module1

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/ReduceTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/ReduceTokensCodeCleanupProvider.vb
@@ -91,7 +91,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                         End If
 
                         Dim base = literal.GetBase()
-                        If Not base.HasValue OrElse idText.Contains(digitSeperator) Then
+                        If Not base.HasValue Then
                             Return newNode
                         End If
 
@@ -101,7 +101,6 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                         If Not CaseInsensitiveComparison.Equals(valueText, idText) Then
                             Return newNode.ReplaceToken(literal, CreateLiteralToken(literal, valueText, value))
                         End If
-
                 End Select
 
                 Return newNode


### PR DESCRIPTION
Fix for Issue #22627 , by adding additional checks for digit separators… in floating point literals and decimals.

**Customer scenario**

```vb.net
Module Module1

    Sub Main()
        Dim z As Integer = 1_000_000
        Dim y As Single = 1_000.0_11
        Dim x As Double = 1_000.0_1_2
        Dim w As Decimal = 1_23_456.78_9D
    End Sub

End Module
```
The digit separators within the literal for variables `y`,`x`,`w` will be removed when moving the caret to another line. 

**Workarounds, if any**
Currently no know work around, to keep the digit separators present.

**Risk**
`Tiny`  

**Performance impact**
`Tiny` a couple of addition conditions within a workspace provider `ReduceTokensCodeCleanupProvider` 
This "Fix" disables formatting of the digits contains a separator.  Could be updated in the future to better handle them.

The current implementation removes digits separators, this pull-request attempts to preserves them, which it does but at a cost of ;-
  * no rounding
  * no removal of trail zeroes
  * no removal of leading zeroes

Fixes for those issues are discussed in (#22781).

**Is this a regression from a previous update?**
Unknown.

**Root cause analysis:**
 Initial thoughts were this was caused by the formatter, but I could not see where would be possible via visual inspection. So expanded the causal search to other sources. 
