### PR TITLE
Raise events when connecting or disconnecting from a workspace for semantic changed

### DIFF
--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SemanticChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SemanticChangedEventSource.cs
@@ -37,11 +37,13 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             protected override void ConnectToWorkspace(Workspace workspace)
             {
                 _notificationService.OpenedDocumentSemanticChanged += OnOpenedDocumentSemanticChanged;
+                this.RaiseChanged();
             }
 
             protected override void DisconnectFromWorkspace(Workspace workspace)
             {
                 _notificationService.OpenedDocumentSemanticChanged -= OnOpenedDocumentSemanticChanged;
+                this.RaiseChanged();
             }
 
             private void OnSubjectBufferChanged(object sender, TextContentChangedEventArgs e)


### PR DESCRIPTION
Connecting/disconnecting from a workspace was not kicking off semantic changed event. Talking with @jasonmalinowski and @Pilchie on Friday, it seems like it was an oversight and should be fixed.
