### PR TITLE
Fix the analyzer driver to make IOperation callbacks for code in cons…

### DIFF
--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -341,8 +341,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     arrowExpr = ((IndexerDeclarationSyntax)node).ExpressionBody;
                     break;
                 case SyntaxKind.ConstructorDeclaration:
+                    arrowExpr = ((ConstructorDeclarationSyntax)node).ExpressionBody;
+                    break;
                 case SyntaxKind.DestructorDeclaration:
-                    return null;
+                    arrowExpr = ((DestructorDeclarationSyntax)node).ExpressionBody;
+                    break;
                 default:
                     // Don't throw, just use for the assert in case this is used in the semantic model
                     ExceptionUtilities.UnexpectedValue(node.Kind());


### PR DESCRIPTION
…tructor/destructor expression body

Fixes #26520 

Reported via https://github.com/dotnet/roslyn-analyzers/issues/1606,  https://github.com/dotnet/roslyn-analyzers/issues/1607 and https://github.com/dotnet/roslyn-analyzers/issues/1563.

<details><summary>Ask Mode template</summary>

### Customer scenario

Customer uses analyzer package that has an IOperation analyzer and gets false positives and/or false negatives for C# code which has constructor/destructor declarations with an expression body.

### Bugs this fixes

#26520 

### Workarounds, if any

Disable IOperation analyzers or don't use expression body for constructors/destructors.

### Risk

Low, seems like an oversight of the fields of `ConstructorDeclarationSyntax` and `DestructorDeclarationSyntax` nodes.

### Performance impact

Low

### Is this a regression from a previous update?

No, seems this has never worked.

### Root cause analysis

We didn't have test covering this area, now we have a regression test. Verified that added unit test fails prior to this fix.

### How was the bug found?

Yes, reported by customers using FxCop analyzer packages (see https://github.com/dotnet/roslyn-analyzers/issues/1606, https://github.com/dotnet/roslyn-analyzers/issues/1607 and https://github.com/dotnet/roslyn-analyzers/issues/1563)

### Test documentation updated?

N/A

</details>
