### PR TITLE
Fewer TypeSymbolWithAnnotations implementations

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -193,14 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // member signatures visible outside the assembly. Consider overriding, implementing, NoPIA embedding, etc.
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol)
         {
-            if (typeSymbol is null)
-            {
-                return null;
-            }
-
-            // PROTOTYPE(NullableReferenceTypes): Consider if it makes
-            // sense to cache and reuse instances, at least for definitions.
-            return new WithoutCustomModifiers(typeSymbol);
+            return Create(typeSymbol, ImmutableArray<CustomModifier>.Empty);
         }
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
@@ -214,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // PROTOTYPE(NullableReferenceTypes): Consider if it makes
             // sense to cache and reuse instances, at least for definitions.
-            return new NullableReferenceTypeWithoutCustomModifiers(typeSymbol);
+            return new NonLazyType(typeSymbol, isNullable: true, ImmutableArray<CustomModifier>.Empty);
         }
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
@@ -226,12 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
-            if (customModifiers.IsDefaultOrEmpty)
-            {
-                return new WithoutCustomModifiers(typeSymbol);
-            }
-
-            return new WithCustomModifiers(typeSymbol, customModifiers);
+            return new NonLazyType(typeSymbol, isNullable: typeSymbol.IsNullableType(), customModifiers);
         }
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
@@ -245,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (isNullableIfReferenceType == null && typeSymbol.TypeKind == TypeKind.TypeParameter)
             {
-                return new ReferenceTypeUnknownNullabilityWithoutCustomModifiers(typeSymbol);
+                return new NonLazyType(typeSymbol, isNullable: null, ImmutableArray<CustomModifier>.Empty);
             }
 
             if (isNullableIfReferenceType == false || !typeSymbol.IsReferenceType || typeSymbol.IsNullableType())
@@ -253,12 +241,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Create(typeSymbol);
             }
 
-            if (isNullableIfReferenceType == true)
-            {
-                return new NullableReferenceTypeWithoutCustomModifiers(typeSymbol);
-            }
-
-            return new ReferenceTypeUnknownNullabilityWithoutCustomModifiers(typeSymbol); 
+            bool? isNullable = typeSymbol.IsNullableType() ? true : isNullableIfReferenceType;
+            return new NonLazyType(typeSymbol, isNullable, ImmutableArray<CustomModifier>.Empty);
         }
 
         public TypeSymbolWithAnnotations AsNullableReferenceOrValueType(CSharpCompilation compilation, SyntaxReference nullableTypeSyntax)
@@ -273,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (typeSymbol.IsReferenceType && ((CSharpParseOptions)nullableTypeSyntax.SyntaxTree.Options).IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking))
                 {
-                    return new NullableReferenceTypeWithoutCustomModifiers(typeSymbol);
+                    return new NonLazyType(typeSymbol, isNullable: true, this.CustomModifiers);
                 }
                 else
                 {
@@ -487,12 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (newIsNullable == true)
                 {
-                    if (newCustomModifiers.IsEmpty)
-                    {
-                        return new NullableReferenceTypeWithoutCustomModifiers(newTypeWithModifiers.TypeSymbol);
-                    }
-
-                    return new NullableReferenceTypeWithCustomModifiers(newTypeWithModifiers.TypeSymbol, newCustomModifiers);
+                    return new NonLazyType(newTypeWithModifiers.TypeSymbol, isNullable: true, newCustomModifiers);
                 }
 
                 Debug.Assert(newIsNullable == null);
@@ -631,186 +610,80 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private static TypeSymbolWithAnnotations CreateWithUnknownNullability(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
         {
-            if (customModifiers.IsDefaultOrEmpty)
-            {
-                return new ReferenceTypeUnknownNullabilityWithoutCustomModifiers(typeSymbol);
-            }
-
-            return new ReferenceTypeUnknownNullabilityWithCustomModifiers(typeSymbol, customModifiers);
+            return new NonLazyType(typeSymbol, isNullable: null, customModifiers);
         }
 
-        private class WithoutCustomModifiers : TypeSymbolWithAnnotations
+        private sealed class NonLazyType : TypeSymbolWithAnnotations
         {
-            protected readonly TypeSymbol _typeSymbol;
+            private readonly TypeSymbol _typeSymbol;
+            private readonly bool? _isNullable;
+            private readonly ImmutableArray<CustomModifier> _customModifiers;
 
-            public WithoutCustomModifiers(TypeSymbol typeSymbol)
+            public NonLazyType(TypeSymbol typeSymbol, bool? isNullable, ImmutableArray<CustomModifier> customModifiers)
             {
                 Debug.Assert((object)typeSymbol != null);
+                Debug.Assert(!customModifiers.IsDefault);
                 _typeSymbol = typeSymbol;
+                _isNullable = isNullable;
+                _customModifiers = customModifiers;
             }
 
             public sealed override TypeSymbol TypeSymbol => _typeSymbol;
-            public sealed override bool? IsNullable => _typeSymbol.IsNullableType();
-            public override ImmutableArray<CustomModifier> CustomModifiers => ImmutableArray<CustomModifier>.Empty;
+            public sealed override bool? IsNullable => _isNullable;
+            public override ImmutableArray<CustomModifier> CustomModifiers => _customModifiers;
 
             public override TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers)
             {
-                if (customModifiers.IsDefaultOrEmpty)
-                {
-                    return this;
-                }
-
-                return new WithCustomModifiers(_typeSymbol, customModifiers);
+                return new NonLazyType(_typeSymbol, _isNullable, customModifiers);
             }
 
             public override TypeSymbol AsTypeSymbolOnly() => _typeSymbol;
 
             // PROTOTYPE(NullableReferenceTypes): Use WithCustomModifiers.Is() => false
             // and set IsNullable=null always for GetTypeParametersAsTypeArguments.
-            public override bool Is(TypeSymbol other) => _typeSymbol.Equals(other, TypeCompareKind.CompareNullableModifiersForReferenceTypes);
+            public override bool Is(TypeSymbol other) => _typeSymbol.Equals(other, TypeCompareKind.CompareNullableModifiersForReferenceTypes) && _customModifiers.IsEmpty;
 
             protected sealed override TypeSymbolWithAnnotations DoUpdate(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
             {
-                return TypeSymbolWithAnnotations.Create(typeSymbol, customModifiers);
+                return new NonLazyType(typeSymbol, _isNullable, customModifiers);
             }
 
             public override TypeSymbolWithAnnotations AsNullableReferenceType()
             {
-                if (_typeSymbol.IsNullableType())
-                {
-                    return this;
-                }
-
-                return new NullableReferenceTypeWithoutCustomModifiers(_typeSymbol);
+                return _isNullable == true ?
+                    this :
+                    new NonLazyType(_typeSymbol, isNullable: true, _customModifiers);
             }
 
             public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
             {
-                return this;
+                return _isNullable == false ?
+                    this :
+                    new NonLazyType(_typeSymbol, isNullable: false, _customModifiers);
             }
 
             public override string ToDisplayString(SymbolDisplayFormat format)
             {
                 var str = _typeSymbol.ToDisplayString(format);
-                if (IsNullable == false &&
-                    format != null &&
-                    (format.CompilerInternalOptions & SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier) != 0)
+                if (format != null && !_typeSymbol.IsValueType)
                 {
-                    return str + "!";
+                    switch (_isNullable)
+                    {
+                        case true:
+                            if ((format.CompilerInternalOptions & SymbolDisplayCompilerInternalOptions.IncludeNullableReferenceTypeModifier) != 0)
+                            {
+                                return str + "?";
+                            }
+                            break;
+                        case false:
+                            if ((format.CompilerInternalOptions & SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier) != 0)
+                            {
+                                return str + "!";
+                            }
+                            break;
+                    }
                 }
                 return str;
-            }
-        }
-
-        private class NullableReferenceTypeWithoutCustomModifiers : TypeSymbolWithAnnotations
-        {
-            protected readonly TypeSymbol _typeSymbol;
-
-            public NullableReferenceTypeWithoutCustomModifiers(TypeSymbol typeSymbol)
-            {
-                Debug.Assert((object)typeSymbol != null);
-                Debug.Assert(!typeSymbol.IsNullableType());
-                _typeSymbol = typeSymbol;
-            }
-
-            public sealed override TypeSymbol TypeSymbol => _typeSymbol;
-            public sealed override bool? IsNullable => true;
-            public override ImmutableArray<CustomModifier> CustomModifiers => ImmutableArray<CustomModifier>.Empty;
-
-            public override TypeSymbol AsTypeSymbolOnly()
-            {
-                return _typeSymbol;
-            }
-
-            public sealed override bool Is(TypeSymbol other) => false; // It has nullable annotation.
-
-            public override TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers)
-            {
-                if (customModifiers.IsDefaultOrEmpty)
-                {
-                    return this;
-                }
-
-                return new NullableReferenceTypeWithCustomModifiers(_typeSymbol, customModifiers);
-            }
-
-            protected sealed override TypeSymbolWithAnnotations DoUpdate(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
-            {
-                if (customModifiers.IsDefaultOrEmpty)
-                {
-                    return new NullableReferenceTypeWithoutCustomModifiers(typeSymbol);
-                }
-
-                return new NullableReferenceTypeWithCustomModifiers(typeSymbol, customModifiers);
-            }
-
-            public sealed override TypeSymbolWithAnnotations AsNullableReferenceType()
-            {
-                return this;
-            }
-
-            public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
-            {
-                return new WithoutCustomModifiers(_typeSymbol);
-            }
-
-            public override string ToDisplayString(SymbolDisplayFormat format)
-            {
-                return _typeSymbol.ToDisplayString(format) + "?";
-            }
-        }
-
-        // Rename since it's not necessarily a reference type.
-        private class ReferenceTypeUnknownNullabilityWithoutCustomModifiers : TypeSymbolWithAnnotations
-        {
-            protected readonly TypeSymbol _typeSymbol;
-
-            public ReferenceTypeUnknownNullabilityWithoutCustomModifiers(TypeSymbol typeSymbol)
-            {
-                Debug.Assert((object)typeSymbol != null);
-                Debug.Assert(!typeSymbol.IsNullableType());
-                _typeSymbol = typeSymbol;
-            }
-
-            public sealed override TypeSymbol TypeSymbol => _typeSymbol;
-            public sealed override bool? IsNullable => null;
-            public override ImmutableArray<CustomModifier> CustomModifiers => ImmutableArray<CustomModifier>.Empty;
-
-            public override TypeSymbol AsTypeSymbolOnly()
-            {
-                return _typeSymbol;
-            }
-
-            public sealed override bool Is(TypeSymbol other) => _typeSymbol.Equals(other, TypeCompareKind.CompareNullableModifiersForReferenceTypes);
-
-            public override TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers)
-            {
-                if (customModifiers.IsDefaultOrEmpty)
-                {
-                    return this;
-                }
-
-                return new ReferenceTypeUnknownNullabilityWithCustomModifiers(_typeSymbol, customModifiers);
-            }
-
-            protected sealed override TypeSymbolWithAnnotations DoUpdate(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
-            {
-                return CreateWithUnknownNullability(typeSymbol, customModifiers);
-            }
-
-            public override TypeSymbolWithAnnotations AsNullableReferenceType()
-            {
-                return new NullableReferenceTypeWithoutCustomModifiers(_typeSymbol);
-            }
-
-            public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
-            {
-                return new WithoutCustomModifiers(_typeSymbol);
-            }
-
-            public override string ToDisplayString(SymbolDisplayFormat format)
-            {
-                return _typeSymbol.ToDisplayString(format);
             }
         }
 
@@ -904,7 +777,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return TypeSymbolWithAnnotations.Create(typeSymbol, customModifiers);
                 }
 
-                return new NullableReferenceTypeWithCustomModifiers(typeSymbol, customModifiers);
+                return new NonLazyType(typeSymbol, isNullable: true, customModifiers);
             }
 
             protected override TypeSymbolWithAnnotations DoUpdate(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
@@ -914,12 +787,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return TypeSymbolWithAnnotations.Create(typeSymbol, customModifiers);
                 }
 
-                if (customModifiers.IsDefaultOrEmpty)
-                {
-                    return new NullableReferenceTypeWithoutCustomModifiers(typeSymbol);
-                }
-
-                return new NullableReferenceTypeWithCustomModifiers(typeSymbol, customModifiers);
+                return new NonLazyType(typeSymbol, isNullable: true, customModifiers);
             }
 
             public override TypeSymbolWithAnnotations AsNullableReferenceType() => this;
@@ -1015,131 +883,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var underlyingType = _underlying.TypeSymbol;
                 var str = underlyingType.ToDisplayString(format);
                 return underlyingType.IsNullableType() ? str : str + "?";
-            }
-        }
-
-        private class WithCustomModifiers : WithoutCustomModifiers
-        {
-            private readonly ImmutableArray<CustomModifier> _customModifiers;
-
-            public WithCustomModifiers(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
-                : base(typeSymbol)
-            {
-                Debug.Assert(!customModifiers.IsDefaultOrEmpty);
-                _customModifiers = customModifiers;
-            }
-
-            public override TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers)
-            {
-                if (customModifiers.IsDefaultOrEmpty)
-                {
-                    return this;
-                }
-
-                return new WithCustomModifiers(_typeSymbol, _customModifiers.Concat(customModifiers));
-            }
-
-            public override ImmutableArray<CustomModifier> CustomModifiers => _customModifiers;
-
-            public override TypeSymbol AsTypeSymbolOnly()
-            {
-                Debug.Assert(this.CustomModifiers.IsEmpty);
-                return base.AsTypeSymbolOnly();
-            }
-
-            public override bool Is(TypeSymbol other)
-            {
-                return false; // have custom modifiers
-            }
-
-            public override TypeSymbolWithAnnotations AsNullableReferenceType()
-            {
-                if (_typeSymbol.IsNullableType())
-                {
-                    return this;
-                }
-
-                return new NullableReferenceTypeWithCustomModifiers(_typeSymbol, _customModifiers);
-            }
-
-            public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
-            {
-                return this;
-            }
-        }
-
-        private class NullableReferenceTypeWithCustomModifiers : NullableReferenceTypeWithoutCustomModifiers
-        {
-            private readonly ImmutableArray<CustomModifier> _customModifiers;
-
-            public NullableReferenceTypeWithCustomModifiers(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
-                : base(typeSymbol)
-            {
-                Debug.Assert(!customModifiers.IsDefaultOrEmpty);
-                _customModifiers = customModifiers;
-            }
-
-            public override TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers)
-            {
-                if (customModifiers.IsDefaultOrEmpty)
-                {
-                    return this;
-                }
-
-                return new NullableReferenceTypeWithCustomModifiers(_typeSymbol, _customModifiers.Concat(customModifiers));
-            }
-
-            public override ImmutableArray<CustomModifier> CustomModifiers => _customModifiers;
-
-            public override TypeSymbol AsTypeSymbolOnly()
-            {
-                Debug.Assert(this.CustomModifiers.IsEmpty);
-                return base.AsTypeSymbolOnly();
-            }
-
-            public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
-            {
-                return new WithCustomModifiers(_typeSymbol, _customModifiers);
-            }
-        }
-
-        private class ReferenceTypeUnknownNullabilityWithCustomModifiers : ReferenceTypeUnknownNullabilityWithoutCustomModifiers
-        {
-            private readonly ImmutableArray<CustomModifier> _customModifiers;
-
-            public ReferenceTypeUnknownNullabilityWithCustomModifiers(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
-                : base(typeSymbol)
-            {
-                Debug.Assert(!customModifiers.IsDefaultOrEmpty);
-                _customModifiers = customModifiers;
-            }
-
-            public override TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers)
-            {
-                if (customModifiers.IsDefaultOrEmpty)
-                {
-                    return this;
-                }
-
-                return new ReferenceTypeUnknownNullabilityWithCustomModifiers(_typeSymbol, _customModifiers.Concat(customModifiers));
-            }
-
-            public override ImmutableArray<CustomModifier> CustomModifiers => _customModifiers;
-
-            public override TypeSymbol AsTypeSymbolOnly()
-            {
-                Debug.Assert(this.CustomModifiers.IsEmpty);
-                return base.AsTypeSymbolOnly();
-            }
-
-            public override TypeSymbolWithAnnotations AsNullableReferenceType()
-            {
-                return new NullableReferenceTypeWithCustomModifiers(_typeSymbol, _customModifiers);
-            }
-
-            public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
-            {
-                return new WithCustomModifiers(_typeSymbol, _customModifiers);
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -1955,19 +1955,19 @@ class C
 {
     static void F1(A<object>? x1, B<object?> y1)
     {
-        (x1 ?? y1)/*T:B<object?>!*/.F.ToString();
+        (x1 ?? y1)/*T:B<object?>*/.F.ToString();
     }
     static void F2(A<object?>? x2, B<object> y2)
     {
-        (x2 ?? y2)/*T:B<object!>!*/.F.ToString();
+        (x2 ?? y2)/*T:B<object!>*/.F.ToString();
     }
     static void F3(A<object> x3, B<object?>? y3)
     {
-        (y3 ?? x3)/*T:B<object?>!*/.F.ToString();
+        (y3 ?? x3)/*T:B<object?>*/.F.ToString();
     }
     static void F4(A<object?> x4, B<object>? y4)
     {
-        (y4 ?? x4)/*T:B<object!>!*/.F.ToString();
+        (y4 ?? x4)/*T:B<object!>*/.F.ToString();
     }
     static void F5(A<object>? x5, B<object?>? y5)
     {
@@ -1983,40 +1983,40 @@ class C
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (14,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object?>'.
-                //         (x1 ?? y1)/*T:B<object?>!*/.F.ToString();
+                // (14,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object>'.
+                //         (x1 ?? y1)/*T:B<object?>*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x1").WithArguments("A<object>", "B<object?>").WithLocation(14, 10),
                 // (14,9): warning CS8602: Possible dereference of a null reference.
-                //         (x1 ?? y1)/*T:B<object?>!*/.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(x1 ?? y1)/*T:B<object?>!*/.F").WithLocation(14, 9),
-                // (18,10): warning CS8619: Nullability of reference types in value of type 'A<object?>' doesn't match target type 'B<object>'.
-                //         (x2 ?? y2)/*T:B<object!>!*/.F.ToString();
+                //         (x1 ?? y1)/*T:B<object?>*/.F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(x1 ?? y1)/*T:B<object?>*/.F").WithLocation(14, 9),
+                // (18,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object>'.
+                //         (x2 ?? y2)/*T:B<object!>*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x2").WithArguments("A<object?>", "B<object>").WithLocation(18, 10),
-                // (22,16): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'B<object?>'.
-                //         (y3 ?? x3)/*T:B<object?>!*/.F.ToString();
+                // (22,16): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'B<object>'.
+                //         (y3 ?? x3)/*T:B<object?>*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x3").WithArguments("B<object>", "B<object?>").WithLocation(22, 16),
                 // (22,9): warning CS8602: Possible dereference of a null reference.
-                //         (y3 ?? x3)/*T:B<object?>!*/.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(y3 ?? x3)/*T:B<object?>!*/.F").WithLocation(22, 9),
-                // (26,16): warning CS8619: Nullability of reference types in value of type 'B<object?>' doesn't match target type 'B<object>'.
-                //         (y4 ?? x4)/*T:B<object!>!*/.F.ToString();
+                //         (y3 ?? x3)/*T:B<object?>*/.F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(y3 ?? x3)/*T:B<object?>*/.F").WithLocation(22, 9),
+                // (26,16): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'B<object>'.
+                //         (y4 ?? x4)/*T:B<object!>*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x4").WithArguments("B<object?>", "B<object>").WithLocation(26, 16),
-                // (30,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object?>?'.
+                // (30,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object>?'.
                 //         (x5 ?? y5)/*T:B<object?>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x5").WithArguments("A<object>", "B<object?>?").WithLocation(30, 10),
                 // (30,9): warning CS8602: Possible dereference of a null reference.
                 //         (x5 ?? y5)/*T:B<object?>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(x5 ?? y5)/*T:B<object?>?*/.Value.F").WithLocation(30, 9),
-                // (31,16): warning CS8619: Nullability of reference types in value of type 'B<object>?' doesn't match target type 'B<object?>?'.
+                // (31,16): warning CS8619: Nullability of reference types in value of type 'B<object>?' doesn't match target type 'B<object>?'.
                 //         (y5 ?? x5)/*T:B<object?>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x5").WithArguments("B<object>?", "B<object?>?").WithLocation(31, 16),
                 // (31,9): warning CS8602: Possible dereference of a null reference.
                 //         (y5 ?? x5)/*T:B<object?>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(y5 ?? x5)/*T:B<object?>?*/.Value.F").WithLocation(31, 9),
-                // (35,10): warning CS8619: Nullability of reference types in value of type 'A<object?>' doesn't match target type 'B<object>?'.
+                // (35,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object>?'.
                 //         (x6 ?? y6)/*T:B<object!>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x6").WithArguments("A<object?>", "B<object>?").WithLocation(35, 10),
-                // (36,16): warning CS8619: Nullability of reference types in value of type 'B<object?>?' doesn't match target type 'B<object>?'.
+                // (36,16): warning CS8619: Nullability of reference types in value of type 'B<object>?' doesn't match target type 'B<object>?'.
                 //         (y6 ?? x6)/*T:B<object!>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x6").WithArguments("B<object?>?", "B<object>?").WithLocation(36, 16));
         }


### PR DESCRIPTION
Reduce the implementations of `TypeSymbolWithAnnotations` to two: one lazy and one non-lazy.