### PR TITLE
Bump version to 2.8.1

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -14,7 +14,7 @@
     <!-- This is the assembly version of Roslyn from the .NET assembly perspective. It should only be revved during significant point releases. -->
     <RoslynAssemblyVersionBase Condition="'$(RoslynAssemblyVersion)' == ''">2.8.0</RoslynAssemblyVersionBase>
     <!-- This is the file version of Roslyn, as placed in the PE header. It should be revved during point releases, and is also what provides the basis for our NuGet package versioning. -->
-    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.8.0</RoslynFileVersionBase>
+    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.8.1</RoslynFileVersionBase>
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>


### PR DESCRIPTION
FYI @dotnet/roslyn-infrastructure. @jaredpar We are publish 15.7 p6 bits to nuget.org as 2.8.0. So after the publication, we will need to bump the version to 2.8.1 if we are gonna  make more changes and do another insertion to d15.7. 