### PR TITLE
 Completion for property-based pattern and 'switch' keyword in switch expression

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -549,6 +549,27 @@ public class Program
         }
 
         [Fact]
+        public async Task PropertiesInRecursivePattern_InPositional_Incomplete_WithoutClosingBrace()
+        {
+            var markup =
+@"
+public class Program
+{
+    public int P1 { get; set; }
+
+    void M()
+    {
+        _ = this is ({ $$  // no deconstruction into 1 element
+    }
+
+    public void Deconstruct(out Program x, out Program y) => throw null;
+}
+";
+            // PROTOTYPE(patterns2): Like for typing arguments in methods, we should fall back to best overload resolution candidate
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
         public async Task PropertiesInRecursivePattern_InPositional_Incomplete_WithTwoTypes()
         {
             var markup =
@@ -648,7 +669,8 @@ class Program
     }
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1"); // PROTOTYPE(patterns2): Need to review and confirm
+            // Ignore browsability limiting attributes if the symbol is declared in source.
+            await VerifyItemExistsAsync(markup, "P1");
             await VerifyItemExistsAsync(markup, "P2");
         }
     }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -10,15 +10,15 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders
 {
     [Trait(Traits.Feature, Traits.Features.Completion)]
-    public class PropertySubPatternCompletionProviderTests : AbstractCSharpCompletionProviderTests
+    public class PropertySubpatternCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
-        public PropertySubPatternCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
+        public PropertySubpatternCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
         {
         }
 
         internal override CompletionProvider CreateCompletionProvider()
         {
-            return new PropertySubPatternCompletionProvider();
+            return new PropertySubpatternCompletionProvider();
         }
 
         [Fact]
@@ -298,27 +298,6 @@ class Program
         }
 
         [Fact]
-        public async Task PropertiesInRecursivePattern_WithPositionalPattern()
-        {
-            var markup =
-@"
-class Program
-{
-    public int P1 { get; set; }
-    public int P2 { get; set; }
-
-    void M()
-    {
-        _ = this is (1, 2) { $$ }
-    }
-    void Deconstruct(out int x, out int y) => throw null;
-}
-";
-            await VerifyItemExistsAsync(markup, "P1");
-            await VerifyItemExistsAsync(markup, "P2");
-        }
-
-        [Fact]
         public async Task PropertiesInRecursivePattern_NestedInProperty()
         {
             var markup =
@@ -563,6 +542,29 @@ public class Program
     }
 
     public void Deconstruct(out Program x, out Program y) => throw null;
+}
+";
+            // PROTOTYPE(patterns2): Like for typing arguments in methods, we should fall back to best overload resolution candidate
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_InPositional_Incomplete_WithTwoTypes()
+        {
+            var markup =
+@"
+public class Program
+{
+    void M()
+    {
+        _ = this is ({ $$ }) // no deconstruction into 1 element
+    }
+
+    public void Deconstruct(out D x, out Program y) => throw null;
+}
+public class D
+{
+    public int P2 { get; set; }
 }
 ";
             // PROTOTYPE(patterns2): Like for typing arguments in methods, we should fall back to best overload resolution candidate

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -43,6 +43,48 @@ class Program
         }
 
         [Fact]
+        public async Task PropertiesInRecursivePattern_WithPositional()
+        {
+            var markup =
+@"
+public class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is Program (1, 2) { $$ }
+    }
+    public void Deconstruct(out int x, out int y) => throw null;
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_WithPositional_UsingStaticType()
+        {
+            var markup =
+@"
+public class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is (1, 2) { $$ }
+    }
+    public void Deconstruct(out int x, out int y) => throw null;
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact]
         public async Task PropertiesInRecursivePattern_WithEscapedKeyword()
         {
             var markup =
@@ -235,10 +277,9 @@ class Program
             await VerifyItemExistsAsync(markup, "P2");
         }
 
-        [Fact(Skip = "PROTOTYPE(patterns2)")]
+        [Fact]
         public async Task PropertiesInRecursivePattern_InSwitchExpression()
         {
-            // PROTOTYPE(patterns2): I think this will be fixed by using GetTypeInfo (once merged)
             var markup =
 @"
 class Program
@@ -256,10 +297,9 @@ class Program
             await VerifyItemExistsAsync(markup, "P2");
         }
 
-        [Fact(Skip = "PROTOTYPE(patterns2)")]
+        [Fact]
         public async Task PropertiesInRecursivePattern_WithPositionalPattern()
         {
-            // PROTOTYPE(patterns2): I think this will be fixed by using GetTypeInfo (once merged)
             var markup =
 @"
 class Program
@@ -506,6 +546,67 @@ class D
 }
 ";
             await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_InPositional_Incomplete()
+        {
+            var markup =
+@"
+public class Program
+{
+    public int P1 { get; set; }
+
+    void M()
+    {
+        _ = this is ({ $$ }) // no deconstruction into 1 element
+    }
+
+    public void Deconstruct(out Program x, out Program y) => throw null;
+}
+";
+            // PROTOTYPE(patterns2): Like for typing arguments in methods, we should fall back to best overload resolution candidate
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_InPositional_Complete_BeforeComma()
+        {
+            var markup =
+@"
+public class Program
+{
+    public int P1 { get; set; }
+
+    void M()
+    {
+        _ = this is ({ $$ }, )
+    }
+
+    public void Deconstruct(out Program x, out Program y) => throw null;
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_InPositional_Complete_AfterComma()
+        {
+            var markup =
+@"
+public class Program
+{
+    public int P1 { get; set; }
+
+    void M()
+    {
+        _ = this is ( , { $$ })
+    }
+
+    public void Deconstruct(out Program x, out Program y) => throw null;
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -1,0 +1,552 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders
+{
+    [Trait(Traits.Feature, Traits.Features.Completion)]
+    public class PropertySubPatternCompletionProviderTests : AbstractCSharpCompletionProviderTests
+    {
+        public PropertySubPatternCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
+        {
+        }
+
+        internal override CompletionProvider CreateCompletionProvider()
+        {
+            return new PropertySubPatternCompletionProvider();
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { $$ }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_WithEscapedKeyword()
+        {
+            var markup =
+@"
+class Program
+{
+    public int @new { get; set; }
+    public int @struct { get; set; }
+
+    void M()
+    {
+        _ = this is Program { $$ }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "@new");
+            await VerifyItemExistsAsync(markup, "@struct");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_WriteOnlyProperties()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { set => throw null; }
+
+    void M()
+    {
+        _ = this is Program { $$ }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_WithDerivedType()
+        {
+            var markup =
+@"
+class Program
+{
+    void M()
+    {
+        _ = this is Derived { $$ }
+    }
+}
+class Derived
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_WithOtherType()
+        {
+            var markup =
+@"
+class Program
+{
+    void M(Other other)
+    {
+        _ = other is Other { $$ }
+    }
+}
+class Other
+{
+    public int P1 { get; set; }
+    public int F2;
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "F2");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_WithDerivedType_WithInaccessibleMembers()
+        {
+            var markup =
+@"
+class Program
+{
+    void M()
+    {
+        _ = this is Derived { $$ }
+    }
+}
+class Derived : Program
+{
+    private int P1 { get; set; }
+    private int P2 { get; set; }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_WithDerivedType_WithPrivateMember()
+        {
+            var markup =
+@"
+class Program
+{
+    private int P1 { get; set; }
+    void M()
+    {
+        _ = this is Derived { $$ }
+    }
+}
+class Derived : Program
+{
+    private int P2 { get; set; }
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_UseStaticTypeFromIs()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is { $$ }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_InSwitchStatement()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        switch (this)
+        {
+            case Program { $$ }
+        }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_UseStaticTypeFromSwitchStatement()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        switch (this)
+        {
+            case { $$ }
+        }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact(Skip = "PROTOTYPE(patterns2)")]
+        public async Task PropertiesInRecursivePattern_InSwitchExpression()
+        {
+            // PROTOTYPE(patterns2): I think this will be fixed by using GetTypeInfo (once merged)
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this switch { { $$ } }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact(Skip = "PROTOTYPE(patterns2)")]
+        public async Task PropertiesInRecursivePattern_WithPositionalPattern()
+        {
+            // PROTOTYPE(patterns2): I think this will be fixed by using GetTypeInfo (once merged)
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is (1, 2) { $$ }
+    }
+    void Deconstruct(out int x, out int y) => throw null;
+}
+";
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_NestedInProperty()
+        {
+            var markup =
+@"
+public class Nested
+{
+    public int P3 { get; set; }
+    public int P4 { get; set; }
+}
+class Program
+{
+    public int P1 { get; set; }
+    public Nested P2 { get; set; }
+
+    void M()
+    {
+         _ = this is Program { P2: { $$ } }
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "P1");
+            await VerifyItemIsAbsentAsync(markup, "P2");
+            await VerifyItemExistsAsync(markup, "P3");
+            await VerifyItemExistsAsync(markup, "P4");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_NestedInField()
+        {
+            var markup =
+@"
+public class Nested
+{
+    public int P3 { get; set; }
+    public int P4 { get; set; }
+}
+class Program
+{
+    public int P1 { get; set; }
+    public Nested F2;
+
+    void M()
+    {
+         _ = this is Program { F2: { $$ } }
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "P1");
+            await VerifyItemIsAbsentAsync(markup, "F2");
+            await VerifyItemExistsAsync(markup, "P3");
+            await VerifyItemExistsAsync(markup, "P4");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_Nested_WithFields()
+        {
+            var markup =
+@"
+public class Nested
+{
+    public int F3;
+    public int F4;
+}
+class Program
+{
+    public int P1 { get; set; }
+    public Nested P2 { get; set; }
+
+    void M()
+    {
+         _ = this is Program { P2: { $$ } }
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "P1");
+            await VerifyItemIsAbsentAsync(markup, "P2");
+            await VerifyItemExistsAsync(markup, "F3");
+            await VerifyItemExistsAsync(markup, "F4");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_Nested_WithMissingProperty()
+        {
+            var markup =
+@"
+public class Nested
+{
+    public int P3 { get; set; }
+    public int P4 { get; set; }
+}
+class Program
+{
+    public int P1 { get; set; }
+    public Nested P2 { get; set; }
+
+    void M()
+    {
+         _ = this is Program { : { $$ } }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_NoType()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = missing is { $$ }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_MissingAfterColon()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is { P1: $$ }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_SecondProperty()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { P2: 1, $$ }
+    }
+}
+";
+            // VerifyItemExistsAsync also tests with the item typed.
+            await VerifyItemExistsAsync(markup, "P1");
+            await VerifyItemIsAbsentAsync(markup, "P2");
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_PositionalInFirstProperty()
+        {
+            var markup =
+@"
+class Program
+{
+    public D P1 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { P1: ($$ }
+    }
+}
+class D
+{
+    public int P2 { get; set; }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_PositionalInFirstProperty_AfterComma()
+        {
+            var markup =
+@"
+class Program
+{
+    public D P1 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { P1: (1, $$ }
+    }
+}
+class D
+{
+    public int P2 { get; set; }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_PositionalInFirstProperty_AfterCommaAndBeforeParen()
+        {
+            var markup =
+@"
+class Program
+{
+    public D P1 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { P1: (1, $$) }
+    }
+}
+class D
+{
+    public int P2 { get; set; }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_NoPropertyLeft()
+        {
+            var markup =
+@"
+class Program
+{
+    public int P1 { get; set; }
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { P2: 1, P1: 2, $$ }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact]
+        public async Task PropertiesInRecursivePattern_NotForEditorUnbrowsable()
+        {
+            var markup =
+@"
+class Program
+{
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public int P1 { get; set; }
+
+    public int P2 { get; set; }
+
+    void M()
+    {
+        _ = this is Program { $$ }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "P1"); // PROTOTYPE(patterns2): Need to review and confirm
+            await VerifyItemExistsAsync(markup, "P2");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest2/Recommendations/IsKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/IsKeywordRecommenderTests.cs
@@ -160,6 +160,16 @@ $$");
 @"var x = ""\{0}\{1}\{2}"" $$"));
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterExpression_InMethodWithArrowBody()
+        {
+            await VerifyKeywordAsync(@"
+class C
+{
+    bool M() => this $$
+}");
+        }
+
         [WorkItem(1736, "https://github.com/dotnet/roslyn/issues/1736")]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotWithinNumericLiteral()

--- a/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
@@ -101,6 +101,16 @@ $$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterExpression_InMethodWithArrowBody()
+        {
+            await VerifyKeywordAsync(@"
+class C
+{
+    bool M() => this $$
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterForeachVar()
         {
             await VerifyAbsenceAsync(AddInsideMethod(@"foreach (var $$)"));

--- a/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/SwitchKeywordRecommenderTests.cs
@@ -95,6 +95,24 @@ $$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterExpression()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"_ = expr $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterForeachVar()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(@"foreach (var $$)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterTuple()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"_ = (expr, expr) $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterSwitch2()
         {
             await VerifyAbsenceAsync(AddInsideMethod(

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -949,6 +949,72 @@ class Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestPropertyInPropertySubpattern() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    int Prop { get; set; }
+    int OtherProp { get; set; }
+    public void M()
+    {
+        _ = this is $$
+    }
+}]]></Document>)
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("C")
+                Await state.AssertSelectedCompletionItem(displayText:="Class", isHardSelected:=True)
+                state.SendTypeChars(" { P")
+                Await state.AssertSelectedCompletionItem(displayText:="Prop", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("{ Prop:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars(" 0, ")
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", isSoftSelected:=True)
+                state.SendTypeChars("O")
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", isHardSelected:=True)
+                state.SendTypeChars(": 1 }")
+                Assert.Contains("is Class { Prop: 0, OtherProp: 1 }", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestPropertyInPropertySubpattern_TriggerWithSpace() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    int Prop { get; set; }
+    int OtherProp { get; set; }
+    public void M()
+    {
+        _ = this is $$
+    }
+}]]></Document>)
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("C")
+                Await state.AssertSelectedCompletionItem(displayText:="Class", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("is Class", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars("{ P")
+                Await state.AssertSelectedCompletionItem(displayText:="Prop", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("is Class { Prop ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars(":")
+                Assert.Contains("is Class { Prop :", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars(" 0, ")
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", isSoftSelected:=True)
+                state.SendTypeChars("O")
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("is Class { Prop : 0, OtherProp", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars(": 1 }")
+                Assert.Contains("is Class { Prop : 0, OtherProp : 1 }", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestSymbolInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(

--- a/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
+++ b/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
                 new TupleNameCompletionProvider(),
                 new DeclarationNameCompletionProvider(),
                 new InternalsVisibleToCompletionProvider(),
-                new PropertySubPatternCompletionProvider()
+                new PropertySubpatternCompletionProvider()
             );
 
         private readonly Workspace _workspace;

--- a/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
+++ b/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
@@ -45,7 +45,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
                 new XmlDocCommentCompletionProvider(),
                 new TupleNameCompletionProvider(),
                 new DeclarationNameCompletionProvider(),
-                new InternalsVisibleToCompletionProvider()
+                new InternalsVisibleToCompletionProvider(),
+                new PropertySubPatternCompletionProvider()
             );
 
         private readonly Workspace _workspace;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
+{
+    internal class PropertySubPatternCompletionProvider : CommonCompletionProvider
+    {
+        public override async Task ProvideCompletionsAsync(CompletionContext context)
+        {
+            var document = context.Document;
+            var position = context.Position;
+            var cancellationToken = context.CancellationToken;
+            var workspace = document.Project.Solution.Workspace;
+            var semanticModel = await document.GetSemanticModelForSpanAsync(new TextSpan(position, length: 0), cancellationToken).ConfigureAwait(false);
+
+            var token = TryGetOpenBraceOrCommaInPropertyPattern(document, semanticModel, position, cancellationToken);
+            if (token == default)
+            {
+                return;
+            }
+
+            var type = TryGetPatternType(token, semanticModel, cancellationToken);
+            if (type == null)
+            {
+                return;
+            }
+
+            // Find the members that can be tested.
+            IEnumerable<ISymbol> members = semanticModel.LookupSymbols(position, type);
+            members = members.Where(m => m.CanBeReferencedByName &&
+                IsFieldOrReadableProperty(m) &&
+                !m.IsImplicitlyDeclared);
+
+            // Filter out those members that have already been typed
+            var alreadyTestedMembers = GetTestedMembers(semanticModel.SyntaxTree, position, cancellationToken);
+            var untestedMembers = members.Where(m => !alreadyTestedMembers.Contains(m.Name) &&
+                m.IsEditorBrowsable(document.ShouldHideAdvancedMembers(), semanticModel.Compilation));
+
+            foreach (var untestedMember in untestedMembers)
+            {
+                context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
+                    displayText: untestedMember.Name.EscapeIdentifier(),
+                    insertionText: null,
+                    symbols: ImmutableArray.Create(untestedMember),
+                    contextPosition: token.GetLocation().SourceSpan.Start,
+                    rules: s_rules));
+            }
+        }
+
+        private static bool IsFieldOrReadableProperty(ISymbol symbol)
+        {
+            if (symbol.IsKind(SymbolKind.Field))
+            {
+                return true;
+            }
+
+            if (symbol.IsKind(SymbolKind.Property) && !((IPropertySymbol)symbol).IsWriteOnly)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        protected override Task<CompletionDescription> GetDescriptionWorkerAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
+            => SymbolCompletionItem.GetDescriptionAsync(item, document, cancellationToken);
+
+        private static readonly CompletionItemRules s_rules = CompletionItemRules.Create(enterKeyRule: EnterKeyRule.Never);
+
+        internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options) || text[characterPosition] == ' ';
+
+        private static SyntaxToken TryGetOpenBraceOrCommaInPropertyPattern(
+            Document document, SemanticModel semanticModel, int position, CancellationToken cancellationToken)
+        {
+            var tree = semanticModel.SyntaxTree;
+            if (tree.IsInNonUserCode(position, cancellationToken))
+            {
+                return default;
+            }
+
+            var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken);
+            token = token.GetPreviousTokenIfTouchingWord(position);
+
+            if (!token.IsKind(SyntaxKind.CommaToken, SyntaxKind.OpenBraceToken))
+            {
+                return default;
+            }
+
+            if (token.Parent.IsKind(SyntaxKind.PropertySubpattern) == false ||
+                token.Parent.Parent.IsKind(SyntaxKind.PropertyPattern) == false)
+            {
+                return default;
+            }
+
+            return token;
+        }
+
+        private static ITypeSymbol TryGetPatternType(
+            SyntaxToken token, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            // is Goo { $$
+            // is Goo { P1: 0, $$
+            var propertyPattern = (PropertyPatternSyntax)token.Parent.Parent;
+            var patternType = propertyPattern.Type;
+            if (patternType != null)
+            {
+                var typeSymbol = (ITypeSymbol)semanticModel.GetSymbolInfo(patternType, cancellationToken).Symbol;
+                return typeSymbol;
+            }
+
+            // e is { $$
+            // e is { P1: 0, $$
+            if (propertyPattern.IsParentKind(SyntaxKind.IsPatternExpression))
+            {
+                var isPattern = (IsPatternExpressionSyntax)propertyPattern.Parent;
+                var typeSymbol = semanticModel.GetTypeInfo(isPattern.Expression, cancellationToken).Type;
+                if (typeSymbol != null)
+                {
+                    return typeSymbol;
+                }
+            }
+
+            // switch (e) { case { $$
+            // switch (e) { case { P1: 0, $$
+            if (propertyPattern.IsParentKind(SyntaxKind.CasePatternSwitchLabel))
+            {
+                var casePattern = (CasePatternSwitchLabelSyntax)propertyPattern.Parent;
+                var switchStatment = casePattern.Parent?.Parent as SwitchStatementSyntax;
+                if (switchStatment != null && switchStatment.Expression != null)
+                {
+                    var typeSymbol = semanticModel.GetTypeInfo(switchStatment.Expression).Type;
+                    if (typeSymbol != null)
+                    {
+                        return typeSymbol;
+                    }
+                }
+            }
+
+            // e is { P1: { $$
+            // e is { P1: { P2: 2, $$
+            if (propertyPattern.IsParentKind(SyntaxKind.SubpatternElement))
+            {
+                var containingProperty = ((SubpatternElementSyntax)propertyPattern.Parent).NameColon?.Name;
+                if (containingProperty != null)
+                {
+                    var symbol = semanticModel.GetSymbolInfo(containingProperty).Symbol;
+
+                    switch (symbol)
+                    {
+                        case null:
+                            break;
+                        case IPropertySymbol propertySymbol:
+                            return propertySymbol.Type;
+                        case IFieldSymbol fieldSymbol:
+                            return fieldSymbol.Type;
+                    }
+                }
+            }
+
+            // PROTOTYPE(patterns2):
+            // All the cases above should be replaced by using the semantic model's GetTypeInfo (ConvertedType) once that is integrated
+
+            return default;
+        }
+
+        // List the members that are already tested in this property sub-pattern
+        private static HashSet<string> GetTestedMembers(SyntaxTree tree, int position, CancellationToken cancellationToken)
+        {
+            var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken)
+                .GetPreviousTokenIfTouchingWord(position);
+
+            // We should have gotten back a { or ,
+            if (token.IsKind(SyntaxKind.CommaToken, SyntaxKind.OpenBraceToken))
+            {
+                if (token.Parent is PropertySubpatternSyntax subpattern)
+                {
+                    return new HashSet<string>(subpattern.SubPatterns.Select(
+                        p => p.NameColon?.Name?.Identifier.ValueText).Where(s => !string.IsNullOrEmpty(s)));
+                }
+            }
+
+            return new HashSet<string>();
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsKeywordRecommender.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
-            return !context.IsInNonUserCode && context.IsIsOrAsContext;
+            return !context.IsInNonUserCode && context.IsIsOrAsOrSwitchExpressionContext;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IsKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IsKeywordRecommender.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             // cases:
             //    expr |
-            return !context.IsInNonUserCode && context.IsIsOrAsContext;
+            return !context.IsInNonUserCode && context.IsIsOrAsOrSwitchExpressionContext;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SwitchKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SwitchKeywordRecommender.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             return
                 context.IsStatementContext ||
-                context.IsGlobalStatementContext;
+                context.IsGlobalStatementContext ||
+                context.IsIsOrAsOrSwitchExpressionContext;
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         public readonly bool IsLabelContext;
         public readonly bool IsTypeArgumentOfConstraintContext;
 
-        public readonly bool IsIsOrAsContext;
+        public readonly bool IsIsOrAsOrSwitchExpressionContext;
         public readonly bool IsObjectCreationTypeContext;
         public readonly bool IsDefiniteCastTypeContext;
         public readonly bool IsGenericTypeArgumentContext;
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             bool isLabelContext,
             bool isTypeArgumentOfConstraintContext,
             bool isRightOfDotOrArrowOrColonColon,
-            bool isIsOrAsContext,
+            bool isIsOrAsOrSwitchExpressionContext,
             bool isObjectCreationTypeContext,
             bool isDefiniteCastTypeContext,
             bool isGenericTypeArgumentContext,
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             this.IsConstantExpressionContext = isConstantExpressionContext;
             this.IsLabelContext = isLabelContext;
             this.IsTypeArgumentOfConstraintContext = isTypeArgumentOfConstraintContext;
-            this.IsIsOrAsContext = isIsOrAsContext;
+            this.IsIsOrAsOrSwitchExpressionContext = isIsOrAsOrSwitchExpressionContext;
             this.IsObjectCreationTypeContext = isObjectCreationTypeContext;
             this.IsDefiniteCastTypeContext = isDefiniteCastTypeContext;
             this.IsGenericTypeArgumentContext = isGenericTypeArgumentContext;
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 syntaxTree.IsLabelContext(position, cancellationToken),
                 syntaxTree.IsTypeArgumentOfConstraintClause(position, cancellationToken),
                 syntaxTree.IsRightOfDotOrArrowOrColonColon(position, cancellationToken),
-                syntaxTree.IsIsOrAsContext(position, leftToken, cancellationToken),
+                syntaxTree.IsIsOrAsOrSwitchExpressionContext(position, leftToken, cancellationToken),
                 syntaxTree.IsObjectCreationTypeContext(position, leftToken, cancellationToken),
                 syntaxTree.IsDefiniteCastTypeContext(position, leftToken, cancellationToken),
                 syntaxTree.IsGenericTypeArgumentContext(position, leftToken, cancellationToken),

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2531,7 +2531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return false;
         }
 
-        public static bool IsIsOrAsContext(this SyntaxTree syntaxTree, int position, SyntaxToken tokenOnLeftOfPosition, CancellationToken cancellationToken)
+        public static bool IsIsOrAsOrSwitchExpressionContext(this SyntaxTree syntaxTree, int position, SyntaxToken tokenOnLeftOfPosition, CancellationToken cancellationToken)
         {
             // cases:
             //    expr |

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2545,7 +2545,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 return false;
             }
 
-            if (token.GetAncestor<BlockSyntax>() == null)
+            if (token.GetAncestor<BlockSyntax>() == null &&
+                token.GetAncestor<ArrowExpressionClauseSyntax>() == null)
             {
                 return false;
             }


### PR DESCRIPTION
The first commit in this PR is the subset of changes from last PR (https://github.com/dotnet/roslyn/pull/26474) which relate to completion. The second commit adds some tests and adopts the `GetTypeInfo` API.
I'll start a separate PR for the subset of changes related to formatting.

@Neme12 @CyrusNajmabadi Sorry for the PR churn. I believe this will be easier to review this way. Also, this allowed me to rebase to use new `GetTypeInfo` API which addressed many of the comments.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
