### PR TITLE
Formatting for recursive patterns

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -674,7 +674,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             // PROTOTYPE(patterns2): Error recovery here leaves much to be desired.
             var arms = _pool.AllocateSeparated<SwitchExpressionArmSyntax>();
-            do
+
+            while (this.CurrentToken.Kind != SyntaxKind.CloseBraceToken)
             {
                 // Use a precedence that excludes lambdas, assignments, and a ternary which could have a
                 // lambda on the right, because we need the parser to leave the EqualsGreaterThanToken
@@ -701,7 +702,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     break;
                 }
             }
-            while (this.CurrentToken.Kind != SyntaxKind.CloseBraceToken);
 
             SeparatedSyntaxList<SwitchExpressionArmSyntax> result = arms;
             _pool.Free(arms);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
@@ -519,6 +519,27 @@ public class Point
         }
 
         [Fact]
+        public void EmptySwitchExpression()
+        {
+            var source =
+@"class Program
+{
+    public static void Main()
+    {
+        var r = 1 switch { };
+    }
+}";
+            CreatePatternCompilation(source).VerifyDiagnostics(
+                // (5,17): error CS8406: No best type was found for the switch expression.
+                //         var r = 1 switch { };
+                Diagnostic(ErrorCode.ERR_SwitchExpressionNoBestType, "1 switch { }").WithLocation(5, 17),
+                // (5,19): warning CS8409: The switch expression does not handle all possible inputs (it is not exhaustive).
+                //         var r = 1 switch { };
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithLocation(5, 19)
+                );
+        }
+
+        [Fact]
         public void SwitchExpression_06()
         {
             // test common type vs delegate in match expression

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -2277,6 +2277,27 @@ case KeyValuePair<String, DateTime>[] pairs2:
         }
 
         [Fact]
+        public void EmptySwitchExpression()
+        {
+            UsingExpression("1 switch {}", TestOptions.RegularWithoutRecursivePatterns,
+                // (1,1): error CS8370: Feature 'recursive patterns' is not available in C# 7.3. Please use language version 8.0 or greater.
+                // 1 switch {}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "1 switch {}").WithArguments("recursive patterns", "8.0").WithLocation(1, 1)
+                );
+            N(SyntaxKind.SwitchExpression);
+            {
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
+        [Fact]
         public void SwitchExpression01()
         {
             UsingExpression("1 switch {a => b, c => d}", TestOptions.RegularWithoutRecursivePatterns,

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -372,6 +372,180 @@ $$
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void RecursivePattern()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = this is $$
+    }
+}";
+
+            var expectedBeforeReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this is { }
+    }
+}";
+
+            var expectedAfterReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this is
+        {
+
+        }
+    }
+}";
+            using (var session = CreateSession(code))
+            {
+                Assert.NotNull(session);
+
+                CheckStart(session.Session);
+                CheckText(session.Session, expectedBeforeReturn);
+                CheckReturn(session.Session, 12, expectedAfterReturn);
+            }
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void RecursivePattern_FollowedByInvocation()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = this is $$
+        M();
+    }
+}";
+
+            var expectedBeforeReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this is { }
+        M();
+    }
+}";
+
+            var expectedAfterReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this is
+        {
+
+        }
+        M();
+    }
+}";
+            using (var session = CreateSession(code))
+            {
+                Assert.NotNull(session);
+
+                CheckStart(session.Session);
+                CheckText(session.Session, expectedBeforeReturn);
+                CheckReturn(session.Session, 12, expectedAfterReturn);
+            }
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void RecursivePattern_WithInvocation_FollowedByInvocation()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = this is (1, 2) $$
+        M();
+    }
+}";
+
+            var expectedBeforeReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this is (1, 2) { }
+        M();
+    }
+}";
+
+            var expectedAfterReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this is (1, 2)
+        {
+
+        }
+        M();
+    }
+}";
+            using (var session = CreateSession(code))
+            {
+                Assert.NotNull(session);
+
+                CheckStart(session.Session);
+                CheckText(session.Session, expectedBeforeReturn);
+                CheckReturn(session.Session, 12, expectedAfterReturn);
+            }
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void SwitchExpression()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = this switch $$
+    }
+}";
+
+            var expectedBeforeReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this switch { }
+    }
+}";
+
+            var expectedAfterReturn = @"
+class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+
+        }
+    }
+}";
+            using (var session = CreateSession(code))
+            {
+                Assert.NotNull(session);
+
+                CheckStart(session.Session);
+                CheckText(session.Session, expectedBeforeReturn);
+                CheckReturn(session.Session, 12, expectedAfterReturn);
+            }
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void Class_ObjectInitializer_OpenBrace_Enter()
         {
             var code = @"using System.Collections.Generic;

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -465,6 +465,27 @@ namespace NS
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public async Task SwitchExpression()
+        {
+            var code = @"
+class Class
+{
+    void Method()
+    {
+        _ = switch
+        {
+true
+";
+            // PROTOTYPE(patterns2): Indenter should place cursor appropriately for switch expression arms and property patterns
+            await AssertIndentUsingSmartTokenFormatterAsync(
+                code,
+                'e',
+                indentationLine: 7,
+                expectedIndentation: 12);
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Block()
         {
             var code = @"using System;

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -465,27 +465,6 @@ namespace NS
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
-        public async Task SwitchExpression()
-        {
-            var code = @"
-class Class
-{
-    void Method()
-    {
-        _ = switch
-        {
-true
-";
-            // PROTOTYPE(patterns2): Indenter should place cursor appropriately for switch expression arms and property patterns
-            await AssertIndentUsingSmartTokenFormatterAsync(
-                code,
-                'e',
-                indentationLine: 7,
-                expectedIndentation: 12);
-        }
-
-        [WpfFact]
-        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Block()
         {
             var code = @"using System;

--- a/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
@@ -80,12 +80,17 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
             }
 
             var virtualCaret = session.TextView.GetVirtualCaretPoint(session.SubjectBuffer).Value;
-            Assert.Equal(indentation, virtualCaret.VirtualSpaces);
+            Assert.True(indentation == virtualCaret.VirtualSpaces, $"Expected indentation was {indentation}, but the actual indentation was {virtualCaret.VirtualSpaces}");
 
             if (result != null)
             {
                 Assert.Equal(result, session.SubjectBuffer.CurrentSnapshot.GetText());
             }
+        }
+
+        internal void CheckText(IBraceCompletionSession session, string result)
+        {
+            Assert.Equal(result, session.SubjectBuffer.CurrentSnapshot.GetText());
         }
 
         internal void CheckReturnOnNonEmptyLine(IBraceCompletionSession session, int expectedVirtualSpace)

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -100,6 +100,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5 || csharpKind == kind6;
         }
 
+        public static bool IsKind(this SyntaxNode node, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3, SyntaxKind kind4, SyntaxKind kind5, SyntaxKind kind6, SyntaxKind kind7)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            var csharpKind = node.Kind();
+            return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5 || csharpKind == kind6 || csharpKind == kind7;
+        }
+
         /// <summary>
         /// Returns the list of using directives that affect <paramref name="node"/>. The list will be returned in
         /// top down order.  
@@ -668,6 +679,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return (anonymousObjectCreationExpression.OpenBraceToken, anonymousObjectCreationExpression.CloseBraceToken);
                 case InitializerExpressionSyntax initializeExpressionNode:
                     return (initializeExpressionNode.OpenBraceToken, initializeExpressionNode.CloseBraceToken);
+                case PropertySubpatternSyntax propertySubpattern:
+                    return (propertySubpattern.OpenBraceToken, propertySubpattern.CloseBraceToken);
+                case SwitchExpressionSyntax switchExpression:
+                    return (switchExpression.OpenBraceToken, switchExpression.CloseBraceToken);
             }
 
             return default;

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -332,6 +332,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                      (token.Parent is AnonymousObjectCreationExpressionSyntax));
         }
 
+        public static bool IsColonInCasePatternSwitchLabel(this SyntaxToken token)
+            => token.Kind() == SyntaxKind.ColonToken && token.Parent is CasePatternSwitchLabelSyntax;
+
+        public static bool IsColonInSwitchExpressionArm(this SyntaxToken token)
+            => token.Kind() == SyntaxKind.ColonToken && token.Parent is SwitchExpressionArmSyntax;
+
+        public static bool IsCommaInSwitchExpression(this SyntaxToken token)
+            => token.Kind() == SyntaxKind.CommaToken && token.Parent is SwitchExpressionSyntax;
+
+        public static bool IsCommaInPropertySubpattern(this SyntaxToken token)
+            => token.Kind() == SyntaxKind.CommaToken && token.Parent is PropertySubpatternSyntax;
+
         public static bool IsIdentifierInLabeledStatement(this SyntaxToken token)
         {
             var labeledStatement = token.Parent as LabeledStatementSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/AnchorIndentationFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/AnchorIndentationFormattingRule.cs
@@ -68,6 +68,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case AccessorDeclarationSyntax accessorDeclNode:
                     AddAnchorIndentationOperation(list, accessorDeclNode);
                     return;
+                case SwitchExpressionArmSyntax switchExpressionArm:
+                    // The expression in a switch expression arm should be anchored to the beginning of the arm
+                    // ```
+                    // e switch
+                    // {
+                    // pattern:
+                    //         expression,
+                    // ```
+                    // We will keep the relative position of `expression` relative to `pattern:`. It will format to:
+                    // ```
+                    // e switch
+                    // {
+                    //     pattern:
+                    //             expression,
+                    // ```
+                    AddAnchorIndentationOperation(list, switchExpressionArm);
+                    return;
             }
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // for lambda, set alignment around braces so that users can put brace wherever they want
-            if (node.IsLambdaBodyBlock() || node.IsAnonymousMethodBlock())
+            if (node.IsLambdaBodyBlock() || node.IsAnonymousMethodBlock() || node.IsKind(SyntaxKind.PropertySubpattern) || node.IsKind(SyntaxKind.SwitchExpression))
             {
                 AddAlignmentBlockOperationRelativeToFirstTokenOnBaseTokenLine(list, bracePair);
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -325,6 +325,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
             }
 
+            // Put a space between the type and a positional pattern
+            // ex: `e is Type ( /*positional*/ )`
+            if (currentToken.IsKind(SyntaxKind.OpenParenToken) &&
+                currentParentKind == SyntaxKind.DeconstructionPattern)
+            {
+                var deconstructionPattern = (DeconstructionPatternSyntax)currentToken.Parent;
+                if (deconstructionPattern.Type != null)
+                {
+                    return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
+                }
+            }
+
             return nextOperation.Invoke();
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // ```
             // e switch
             // {
-            //     pattern1: expression1, // request newline
+            //     pattern1: expression1, // newline with minimum of 1 line (each arm must be on its own line)
             //     pattern2: expression2 ...
             // ```
             if (previousToken.IsCommaInSwitchExpression())
@@ -111,8 +111,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // ```
             // e is
             // {
-            //     property1: pattern1, // next line should be indented same as this one
-            //     property2: pattern2 ...
+            //     property1: pattern1, // newline so the next line should be indented same as this one
+            //     property2: pattern2, property3: pattern3, ... // but with minimum 0 lines so each property isn't forced to its own line
             // ```
             if (previousToken.IsCommaInPropertySubpattern())
             {

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4821,6 +4821,637 @@ var(x,y)=(1,2);
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional()
+        {
+            var code = @"class C
+{
+    void M() { _ = this is  ( 1 , 2 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M() { _ = this is (1, 2); }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional_Singleline()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is  ( 1 , 2 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is (1, 2);
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional_Multiline()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is  ( 1 ,
+2 ,
+3 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is (1,
+        2,
+        3);
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional_Multiline2()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is  ( 1 ,
+2 ,
+3 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is (1,
+        2,
+        3);
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional_Multiline3()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is
+( 1 ,
+2 ,
+3 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        (1,
+        2,
+        3);
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Positional_Multiline4()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is
+( 1 ,
+2 , 3 )  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        (1,
+        2, 3);
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Properties_Singleline()
+        {
+            var code = @"class C
+{
+    void M() { _ = this is  C{  P1 :  1  } ; }
+}";
+            var expectedCode = @"class C
+{
+    void M() { _ = this is C { P1: 1 }; }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Properties_Multiline()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is
+{
+P1 :  1  ,
+P2 : 2
+} ;
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        {
+            P1: 1,
+            P2: 2
+        };
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Properties_Multiline2()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is {
+P1 :  1  ,
+P2 : 2
+} ;
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        {
+            P1: 1,
+            P2: 2
+        };
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_Properties_Multiline3()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is {
+P1 :  1  ,
+P2 : 2, P3: 3
+} ;
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        {
+            P1: 1,
+            P2: 2, P3: 3
+        };
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatRecursivePattern_SpaceBetweenTypeAndPositionalSubpattern()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is  C( 1 , 2 ){}  ; }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is C (1, 2) { };
+    }
+}";
+            // a space separates the type, the positional pattern and the properties pattern
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatPropertyPattern_MultilineAndEmpty()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is
+            {
+                };
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is
+        {
+        };
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchExpression_IndentArms()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this switch
+{
+{ P1: 1} => true,
+(0, 1) => true,
+_ => false
+};
+
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+            { P1: 1 } => true,
+            (0, 1) => true,
+            _ => false
+        };
+
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatPropertyPattern_FollowedByInvocation()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is { }
+M();
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is { }
+        M();
+    }
+}";
+            // although 'M' will be parsed into the pattern on line above, we should not wrap the pattern
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatPositionalPattern_FollowedByInvocation()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is (1, 2) { }
+M();
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is (1, 2) { }
+        M();
+    }
+}";
+            // although 'M' will be parsed into the pattern on line above, we should not wrap the pattern
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatPositionalPattern_FollowedByScope()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this is (1, 2)
+{
+    M();
+}
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this is (1, 2)
+        {
+        M ();
+    }
+}
+}";
+            // You should not invoke Format on incomplete code and expect nice results
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchExpression_MultilineAndNoArms()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this switch
+{
+    };
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+        };
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchExpression_ExpressionAnchoredToArm()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this switch
+{
+{ P1: 1} 
+=> true,
+(0, 1)
+    => true,
+_
+        => false
+};
+
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+            { P1: 1 }
+            => true,
+            (0, 1)
+                => true,
+            _
+                    => false
+        };
+
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchExpression_NoSpaceBeforeColonInArm()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this switch
+{
+{ P1: 1}
+=> true,
+(0, 1)
+    => true,
+_
+        => false
+};
+
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+            { P1: 1 }
+            => true,
+            (0, 1)
+                => true,
+            _
+                    => false
+        };
+
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchExpression_ArmCommaWantsNewline()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this switch
+{
+{ P1: 1} => true,
+(0, 1) => true, _ => false
+};
+
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+            { P1: 1 } => true,
+            (0, 1) => true,
+            _ => false
+        };
+
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchExpression_ArmCommaPreservesLines()
+        {
+            var code = @"class C
+{
+    void M() {
+_ = this switch
+{
+{ P1: 1} => true,
+
+(0, 1) => true, _ => false
+};
+
+}
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        _ = this switch
+        {
+            { P1: 1 } => true,
+
+            (0, 1) => true,
+            _ => false
+        };
+
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchWithPropertyPattern()
+        {
+            var code = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }:
+                break;
+        }
+    }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }:
+                break;
+        }
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchWithPropertyPattern_Singleline()
+        {
+            var code = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }: break;
+        }
+    }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }: break;
+        }
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatSwitchWithPropertyPattern_Singleline2()
+        {
+            var code = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }: System.Console.Write(1);
+    break;
+        }
+    }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        switch (this)
+        {
+            case { P1: 1, P2: { P3: 3, P4: 4 } }:
+                System.Console.Write(1);
+                break;
+        }
+    }
+}";
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task SpacingInTupleExtension()
         {
             var code = @"static class Class5

--- a/src/Workspaces/Core/Portable/Formatting/Context/SuppressWrappingData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/SuppressWrappingData.cs
@@ -17,5 +17,10 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         public TextSpan TextSpan { get; }
         public bool NoWrapping { get; }
+
+#if DEBUG
+        public override string ToString()
+            => $"Suppress wrapping on '{TextSpan}' with NoWrapping={NoWrapping}";
+#endif
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/ContextIntervalTree.cs
+++ b/src/Workspaces/Core/Portable/Formatting/ContextIntervalTree.cs
@@ -172,5 +172,10 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return result;
             }
         }
+
+#if DEBUG
+        public override string ToString()
+            => $"Interval tree with '{System.Linq.Enumerable.Count(this)}' entries. Use '.ToList()' to visualize contents.";
+#endif
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/IndentBlockOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/IndentBlockOperation.cs
@@ -61,5 +61,12 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         public bool IsRelativeIndentation { get; }
         public int IndentationDeltaOrPosition { get; }
+
+#if DEBUG
+        public override string ToString()
+        {
+            return $"Indent {TextSpan} from '{StartToken}' to '{EndToken}', by {IndentationDeltaOrPosition}, with base token '{BaseToken}'";
+        }
+#endif
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/IndentBlockOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/IndentBlockOperation.cs
@@ -64,9 +64,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
 #if DEBUG
         public override string ToString()
-        {
-            return $"Indent {TextSpan} from '{StartToken}' to '{EndToken}', by {IndentationDeltaOrPosition}, with base token '{BaseToken}'";
-        }
+            => $"Indent {TextSpan} from '{StartToken}' to '{EndToken}', by {IndentationDeltaOrPosition}, with base token '{BaseToken}'";
 #endif
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/SuppressOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/SuppressOperation.cs
@@ -28,5 +28,12 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         public SyntaxToken StartToken { get; }
         public SyntaxToken EndToken { get; }
+
+#if DEBUG
+        public override string ToString()
+        {
+            return $"Suppress {TextSpan} from '{StartToken}' to '{EndToken}' with '{Option}'";
+        }
+#endif
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/Operations/SuppressOperation.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/Operations/SuppressOperation.cs
@@ -31,9 +31,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
 #if DEBUG
         public override string ToString()
-        {
-            return $"Suppress {TextSpan} from '{StartToken}' to '{EndToken}' with '{Option}'";
-        }
+            => $"Suppress {TextSpan} from '{StartToken}' to '{EndToken}' with '{Option}'";
 #endif
     }
 }


### PR DESCRIPTION
These are all the formatting changes from my previous PR (https://github.com/dotnet/roslyn/pull/26474) without any of the completion changes.
This PR is still work-in-progress. All the scenario that I know to be broken are captured with tests with PROTOTYPE marker (I intend to fix all those in this PR, unless we end up agreeing to punt to follow-up).

@CyrusNajmabadi @Neme12 @heejaechang Sorry for the PR churn.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
