### PR TITLE
Add features to offer using conditional expressions `?:` over explicit if-statement flows.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.cs
@@ -1,0 +1,961 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.UseConditionalExpression;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseConditionalExpression
+{
+    public partial class UseConditionalExpressionForAssignmentTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (new CSharpUseConditionalExpressionForAssignmentDiagnosticAnalyzer(),
+                new CSharpUseConditionalExpressionForAssignmentCodeRefactoringProvider());
+
+        private static readonly Dictionary<OptionKey, object> s_preferImplicitTypeAlways = new Dictionary<OptionKey, object>
+        {
+            { CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, CodeStyleOptions.TrueWithNoneEnforcement },
+            { CSharpCodeStyleOptions.UseImplicitTypeWherePossible, CodeStyleOptions.TrueWithNoneEnforcement },
+            { CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, CodeStyleOptions.TrueWithNoneEnforcement },
+        };
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnSimpleAssignment()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnSimpleAssignmentNoBlocks()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        [||]if (true)
+            i = 0;
+        else
+            i = 1;
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnSimpleAssignmentNoBlocks_NotInBlock()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        if (true)
+            [||]if (true)
+                i = 0;
+            else
+                i = 1;
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        if (true)
+            i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestNotOnSimpleAssignmentToDifferentTargets()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    void M(int i, int j)
+    {
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            j = 1;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnAssignmentToUndefinedField()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        [||]if (true)
+        {
+            this.i = 0;
+        }
+        else
+        {
+            this.i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        this.i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnNonUniformTargetSyntax()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        [||]if (true)
+        {
+            this.i = 0;
+        }
+        else
+        {
+            this . i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        this.i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnAssignmentToDefinedField()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int i;
+
+    void M()
+    {
+        [||]if (true)
+        {
+            this.i = 0;
+        }
+        else
+        {
+            this.i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    int i;
+
+    void M()
+    {
+        this.i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnAssignmentToAboveLocalNoInitializer()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i;
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnAssignmentToAboveLocalLiteralInitializer()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = 0;
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnAssignmentToAboveLocalDefaultLiteralInitializer()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = default;
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = true ? 0 : 1;
+    }
+}", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnAssignmentToAboveLocalDefaultExpressionInitializer()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = default(int);
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestDoNotMergeAssignmentToAboveLocalWithComplexInitializer()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = Foo();
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = Foo();
+        i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestDoNotMergeAssignmentToAboveLocalIfIntermediaryStatement()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = 0;
+        Console.WriteLine();
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = 0;
+        Console.WriteLine();
+        i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestDoNotMergeAssignmentToAboveIfLocalUsedInIfCondition()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = 0;
+        [||]if (Bar(i))
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = 0;
+        i = Bar(i) ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestDoNotMergeAssignmentToAboveIfMultiDecl()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = 0, j = 0;
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = 0, j = 0;
+        i = true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestUseImplicitTypeForIntrinsicTypes()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = 0;
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        var i = true ? 0 : 1;
+    }
+}", options: new Dictionary<OptionKey, object> {
+    {  CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, CodeStyleOptions.TrueWithNoneEnforcement }
+});
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestUseImplicitTypeWhereApparent()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = 0;
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = true ? 0 : 1;
+    }
+}", options: new Dictionary<OptionKey, object> {
+    {  CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, CodeStyleOptions.TrueWithNoneEnforcement }
+});
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestUseImplicitTypeWherePossible()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        int i = 0;
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int i = true ? 0 : 1;
+    }
+}", options: new Dictionary<OptionKey, object> {
+    {  CSharpCodeStyleOptions.UseImplicitTypeWherePossible, CodeStyleOptions.TrueWithNoneEnforcement }
+});
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMissingWithoutElse()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        [||]if (true)
+        {
+            i = 0;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMissingWithoutElseWithStatementAfterwards()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        [||]if (true)
+        {
+            i = 0;
+        }
+
+        i = 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestConversionWithUseVarForAll_CastInsertedToKeepTypeSame()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        // cast will be necessary, otherwise 'var' would get the type 'string'.
+        object o;
+        [||]if (true)
+        {
+            o = ""a"";
+        }
+        else
+        {
+            o = ""b"";
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        // cast will be necessary, otherwise 'var' would get the type 'string'.
+        var o = true ? ""a"" : (object)""b"";
+    }
+}", options: s_preferImplicitTypeAlways);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestConversionWithUseVarForAll_CanUseVarBecauseConditionalTypeMatches()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        string s;
+        [||]if (true)
+        {
+            s = ""a"";
+        }
+        else
+        {
+            s = null;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        var s = true ? ""a"" : null;
+    }
+}", options: s_preferImplicitTypeAlways);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestConversionWithUseVarForAll_CanUseVarButRequiresCastOfConditionalBranch()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        string s;
+        [||]if (true)
+        {
+            s = null;
+        }
+        else
+        {
+            s = null;
+        }
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        var s = true ? null : (string)null;
+    }
+}", options: s_preferImplicitTypeAlways);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestKeepTriviaAroundIf()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        // leading
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        } // trailing
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        // leading
+        i = true ? 0 : 1; // trailing
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestFixAll1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        {|FixAllInDocument:if|} (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = 1;
+        }
+
+        string s;
+        if (true)
+        {
+            s = ""a"";
+        }
+        else
+        {
+            s = ""b"";
+        }
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        i = true ? 0 : 1;
+
+        string s = true ? ""a"" : ""b"";
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMultiLine1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        [||]if (true)
+        {
+            i = Foo(
+                1, 2, 3);
+        }
+        else
+        {
+            i = 1;
+        }
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        i = true
+            ? Foo(
+                1, 2, 3)
+            : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMultiLine2()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        [||]if (true)
+        {
+            i = 0;
+        }
+        else
+        {
+            i = Foo(
+                1, 2, 3);
+        }
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        i = true
+            ? 0
+            : Foo(
+                1, 2, 3);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMultiLine3()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        [||]if (true)
+        {
+            i = Foo(
+                1, 2, 3);
+        }
+        else
+        {
+            i = Foo(
+                4, 5, 6);
+        }
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        i = true
+            ? Foo(
+                1, 2, 3)
+            : Foo(
+                4, 5, 6);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestElseIfWithBlock()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        if (true)
+        {
+        }
+        else [||]if (false)
+        {
+            i = 1;
+        }
+        else
+        {
+            i = 0;
+        }
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        if (true)
+        {
+        }
+        else
+        {
+            i = false ? 1 : 0;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestElseIfWithoutBlock()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(int i)
+    {
+        if (true) i = 2;
+        else [||]if (false) i = 1;
+        else i = 0;
+    }
+}",
+@"
+class C
+{
+    void M(int i)
+    {
+        if (true) i = 2;
+        else i = false ? 1 : 0;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestRefAssignment1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M(ref int i, ref int j)
+    {
+        ref int x = ref i;
+        [||]if (true)
+        {
+            x = ref i;
+        }
+        else
+        {
+            x = ref j
+        }
+    }
+}",
+@"
+class C
+{
+    void M(ref int i, ref int j)
+    {
+        ref int x = ref i;
+        x = ref true ? ref i : ref j;
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
@@ -1,0 +1,556 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.UseConditionalExpression;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseConditionalExpression
+{
+    public partial class UseConditionalExpressionForReturnTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (new CSharpUseConditionalExpressionForReturnDiagnosticAnalyzer(),
+                new CSharpUseConditionalExpressionForReturnCodeRefactoringProvider());
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnSimpleReturn()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        [||]if (true)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1;
+        }
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        return true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnSimpleReturnNoBlocks()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        [||]if (true)
+            return 0;
+        else
+            return 1;
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        return true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestOnSimpleReturnNoBlocks_NotInBlock()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        if (true)
+            [||]if (true)
+                return 0;
+            else
+                return 1;
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        if (true)
+            return true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMissingReturnValue1()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        [||]if (true)
+        {
+            return 0;
+        }
+        else
+        {
+            return;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMissingReturnValue2()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        [||]if (true)
+        {
+            return;
+        }
+        else
+        {
+            return 1;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMissingReturnValue3()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        [||]if (true)
+        {
+            return;
+        }
+        else
+        {
+            return;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestWithNoElseBlockButFollowingReturn()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M()
+    {
+        [||]if (true)
+        {
+            return 0;
+        }
+
+        return 1;
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        return true ? 0 : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMissingWithoutElse()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        [||]if (true)
+        {
+            return 0;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestConversion1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    object M()
+    {
+        [||]if (true)
+        {
+            return ""a"";
+        }
+        else
+        {
+            return ""b"";
+        }
+    }
+}",
+@"
+class C
+{
+    object M()
+    {
+        return true ? ""a"" : ""b"";
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestConversion2()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    string M()
+    {
+        [||]if (true)
+        {
+            return ""a"";
+        }
+        else
+        {
+            return null;
+        }
+    }
+}",
+@"
+class C
+{
+    string M()
+    {
+        return true ? ""a"" : null;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestConversion3()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    string M()
+    {
+        [||]if (true)
+        {
+            return null;
+        }
+        else
+        {
+            return null;
+        }
+    }
+}",
+@"
+class C
+{
+    string M()
+    {
+        return true ? null : (string)null;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestKeepTriviaAroundIf()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        // leading
+        [||]if (true)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1;
+        } // trailing
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        // leading
+        return true ? 0 : 1; // trailing
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestFixAll1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        {|FixAllInDocument:if|} (true)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1;
+        }
+
+        if (true)
+        {
+            return 2;
+        }
+
+        return 3;
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        return true ? 0 : 1;
+
+        return true ? 2 : 3;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMultiLine1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        [||]if (true)
+        {
+            return Foo(
+                1, 2, 3);
+        }
+        else
+        {
+            return 1;
+        }
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        return true
+            ? Foo(
+                1, 2, 3)
+            : 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMultiLine2()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        [||]if (true)
+        {
+            return 0;
+        }
+        else
+        {
+            return Foo(
+                1, 2, 3);
+        }
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        return true
+            ? 0
+            : Foo(
+                1, 2, 3);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestMultiLine3()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        [||]if (true)
+        {
+            return Foo(
+                1, 2, 3);
+        }
+        else
+        {
+            return Foo(
+                4, 5, 6);
+        }
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        return true
+            ? Foo(
+                1, 2, 3)
+            : Foo(
+                4, 5, 6);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestElseIfWithBlock()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        if (true)
+        {
+        }
+        else [||]if (false)
+        {
+            return 1;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        if (true)
+        {
+        }
+        else
+        {
+            return false ? 1 : 0;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestElseIfWithoutBlock()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int M()
+    {
+        if (true) return 2;
+        else [||]if (false) return 1;
+        else return 0;
+    }
+}",
+@"
+class C
+{
+    int M()
+    {
+        if (true) return 2;
+        else return false ? 1 : 0;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)]
+        public async Task TestRefReturns1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    ref int M(ref int i, ref int j)
+    {
+        [||]if (true)
+        {
+            return ref i;
+        }
+        else
+        {
+            return ref j;
+        }
+    }
+}",
+@"
+class C
+{
+    ref int M(ref int i, ref int j)
+    {
+        return ref true ? ref i : ref j;
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.vb
@@ -1,0 +1,553 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.UseConditionalExpression
+    Partial Public Class UseConditionalExpressionForAssignmentTests
+        Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
+
+        Friend Overrides Function CreateDiagnosticProviderAndFixer(Workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
+            Return (New VisualBasicUseConditionalExpressionForAssignmentDiagnosticAnalyzer(),
+                New VisualBasicUseConditionalExpressionForAssignmentCodeRefactoringProvider())
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnSimpleAssignment() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        [||]if true
+            i = 0
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M(i as integer)
+        i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnSimpleAssignmentNoBlocks() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        [||]if true
+            i = 0
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M(i as integer)
+        i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnSimpleAssignmentNoBlocks_NotInBlock() As Task
+
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        if true
+            [||]if true
+                i = 0
+            else
+                i = 1
+            end if
+        end if
+    end sub
+end class",
+"
+class C
+    sub M(i as integer)
+        if true
+            i = If(true, 0, 1)
+        end if
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestNotOnSimpleAssignmentToDifferentTargets() As Task
+            Await TestMissingAsync(
+"
+class C
+    sub M(i as integer, j as integer)
+        [||]if true
+            i = 0
+        else
+            j = 1
+        end if
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnAssignmentToUndefinedField() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        [||]if true
+            me.i = 0
+        else
+            me.i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        me.i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnNonUniformTargetSyntax() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        [||]if true
+            me.i = 0
+        else
+            me . i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        me.i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnAssignmentToDefinedField() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    dim i as integer
+
+    sub M()
+        [||]if true
+            me.i = 0
+        else
+            me.i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    dim i as integer
+
+    sub M()
+        me.i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnAssignmentToAboveLocalNoInitializer() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        dim i as integer
+        [||]if true
+            i = 0
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        dim i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnAssignmentToAboveLocalLiteralInitializer() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        dim i = 0
+        [||]if true
+            i = 0
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        dim i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnAssignmentToAboveLocalDefaultExpressionInitializer() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        dim i as integer = nothing
+        [||]if true
+            i = 0
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        dim i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestDoNotMergeAssignmentToAboveLocalWithComplexInitializer() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        dim i = Foo()
+        [||]if true
+            i = 0
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        dim i = Foo()
+        i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestDoNotMergeAssignmentToAboveLocalIfIntermediaryStatement() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        dim i = 0
+        Console.WriteLine()
+        [||]if true
+            i = 0
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        dim i = 0
+        Console.WriteLine()
+        i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestDoNotMergeAssignmentToAboveIfLocalUsedInIfCondition() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        dim i = 0
+        [||]if Bar(i)
+            i = 0
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        dim i = 0
+        i = If(Bar(i), 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestDoNotMergeAssignmentToAboveIfMultiDecl() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        dim i = 0, j = 0
+        [||]if true
+            i = 0
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        dim i = 0, j = 0
+        i = If(true, 0, 1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMissingWithoutElse() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        [||]if true
+            i = 0
+        end if
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMissingWithoutElseWithStatementAfterwards() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        [||]if true
+            i = 0
+        end if
+
+        i = 1
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestConversionWithUseDimForAll_CannotUseDimBecauseTypeWouldChange() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        ' keep object even though both values are strings
+        dim o as object
+        [||]if true
+            o = ""a""
+        else
+            o = ""b""
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        ' keep object even though both values are strings
+        dim o as object = If(true, ""a"", ""b"")
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestConversionWithUseDimForAll_CanUseDimBecauseConditionalTypeMatches() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        dim s as string
+        [||]if true
+            s = ""a""
+        else
+            s = nothing
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        dim s = If(true, ""a"", nothing)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestConversionWithUseDimForAll_CanUseDimButRequiresCastOfConditionalBranch() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M()
+        dim s as string
+        [||]if true
+            s = nothing
+        else
+            s = nothing
+        end if
+    end sub
+end class",
+"
+class C
+    sub M()
+        dim s = If(true, nothing, DirectCast(nothing, String))
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestKeepTriviaAroundIf() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        ' leading
+        [||]if true
+            i = 0
+        else
+            i = 1
+        end if ' trailing
+    end sub
+end class",
+"
+class C
+    sub M(i as integer)
+        ' leading
+        i = If(true, 0, 1) ' trailing
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestFixAll1() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        {|FixAllInDocument:if|} true
+            i = 0
+        else
+            i = 1
+        end if
+
+        dim s as string
+        if true
+            s = ""a""
+        else
+            s = ""b""
+        end if
+    end sub
+end class",
+"
+class C
+    sub M(i as integer)
+        i = If(true, 0, 1)
+
+        dim s = If(true, ""a"", ""b"")
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMultiLine1() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        [||]if true
+            i = Foo(
+                1, 2, 3)
+        else
+            i = 1
+        end if
+    end sub
+end class",
+"
+class C
+    sub M(i as integer)
+        i = If(true,
+            Foo(
+                1, 2, 3),
+            1)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMultiLine2() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        [||]if true
+            i = 0
+        else
+            i = Foo(
+                1, 2, 3)
+        end if
+    end sub
+end class",
+"
+class C
+    sub M(i as integer)
+        i = If(true,
+            0,
+            Foo(
+                1, 2, 3))
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMultiLine3() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    sub M(i as integer)
+        [||]if true
+            i = Foo(
+                1, 2, 3)
+        else
+            i = Foo(
+                4, 5, 6)
+        end if
+    end sub
+end class",
+"
+class C
+    sub M(i as integer)
+        i = If(true,
+            Foo(
+                1, 2, 3),
+            Foo(
+                4, 5, 6))
+    end sub
+end class")
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForReturnTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForReturnTests.vb
@@ -1,0 +1,355 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.UseConditionalExpression
+    Partial Public Class UseConditionalExpressionForReturnTests
+        Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
+
+        Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
+            Return (New VisualBasicUseConditionalExpressionForReturnDiagnosticAnalyzer(),
+                New VisualBasicUseConditionalExpressionForReturnCodeRefactoringProvider())
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnSimpleReturn() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return 0
+        else
+            return 1
+        end if
+    end function
+end class",
+"
+class 
+    function M() as integer
+        Return If(true, 0, 1)
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnSimpleReturnNoBlocks() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return 0
+        else
+            return 1
+        end if
+    end function
+end class",
+"
+class 
+    function M() as integer
+        Return If(true, 0, 1)
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnSimpleReturnNoBlocks_NotInBlock() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        if true
+            [||]if true
+                return 0
+            else
+                return 1
+            end if
+        end if
+    end function
+end class",
+"
+class 
+    function M() as integer
+        if true
+            Return If(true, 0, 1)
+        end if
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMissingReturnValue1() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return 0
+        else
+            return
+        end if
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMissingReturnValue2() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return
+        else
+            return 1
+        end if
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMissingReturnValue3() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return
+        else
+            return
+        end if
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestWithNoElseBlockButFollowingReturn() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return 0
+        end if
+
+        return 1
+    end function
+end class",
+"
+class 
+    function M() as integer
+        Return If(true, 0, 1)
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMissingWithoutElse() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return 0
+        end if
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestConversion1() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as object
+        [||]if true
+            return ""a""
+        else
+            return ""b""
+        end if
+    end function
+end class",
+"
+class 
+    function M() as object
+        Return If(true, ""a"", ""b"")
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestConversion2() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as string
+        [||]if true
+            return ""a""
+        else
+            return nothing
+        end if
+    end function
+end class",
+"
+class 
+    function M() as string
+        Return If(true, ""a"", nothing)
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestConversion3() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as string
+        [||]if true
+            return nothing
+        else
+            return nothing
+        end if
+    end function
+end class",
+"
+class 
+    function M() as string
+        Return If(true, nothing, DirectCast(nothing, String))
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestKeepTriviaAroundIf() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        ' leading
+        [||]if true
+            return 0
+        else
+            return 1
+        end if ' trailing
+    end function
+end class",
+"
+class 
+    function M() as integer
+        ' leading
+        Return If(true, 0, 1) ' trailing
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestFixAll1() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        {|FixAllInDocument:if|} true
+            return 0
+        else
+            return 1
+        end if
+
+        if true
+            return 2
+        end if
+
+        return 3
+    end function
+end class",
+"
+class 
+    function M() as integer
+        Return If(true, 0, 1)
+
+        Return If(true, 2, 3)
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMultiLine1() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return Foo(
+                1, 2, 3)
+        else
+            return 1
+        end if
+    end function
+end class",
+"
+class 
+    function M() as integer
+        Return If(true,
+            Foo(
+                1, 2, 3),
+            1)
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMultiLine2() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return 0
+        else
+            return Foo(
+                1, 2, 3)
+        end if
+    end function
+end class",
+"
+class 
+    function M() as integer
+        Return If(true,
+            0,
+            Foo(
+                1, 2, 3))
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestMultiLine3() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class 
+    function M() as integer
+        [||]if true
+            return Foo(
+                1, 2, 3)
+        else
+            return Foo(
+                4, 5, 6)
+        end if
+    end function
+end class",
+"
+class 
+    function M() as integer
+        Return If(true,
+            Foo(
+                1, 2, 3),
+            Foo(
+                4, 5, 6))
+    end function
+end class")
+        End Function
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -486,6 +486,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;if&apos; statement can be simplified.
+        /// </summary>
+        internal static string if_statement_can_be_simplified {
+            get {
+                return ResourceManager.GetString("if_statement_can_be_simplified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to indexer.
         /// </summary>
         internal static string indexer {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -527,4 +527,7 @@
   <data name="Convert_to_for" xml:space="preserve">
     <value>Convert to 'for'</value>
   </data>
+  <data name="if_statement_can_be_simplified" xml:space="preserve">
+    <value>'if' statement can be simplified</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForAssignmentCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForAssignmentCodeRefactoringProvider.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.UseConditionalExpression;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    internal partial class CSharpUseConditionalExpressionForAssignmentCodeRefactoringProvider
+        : AbstractUseConditionalExpressionForAssignmentCodeFixProvider<
+            StatementSyntax, IfStatementSyntax, LocalDeclarationStatementSyntax, VariableDeclaratorSyntax, ExpressionSyntax, ConditionalExpressionSyntax>
+    {
+        protected override IFormattingRule GetMultiLineFormattingRule()
+            => MultiLineConditionalExpressionFormattingRule.Instance;
+
+        protected override VariableDeclaratorSyntax WithInitializer(VariableDeclaratorSyntax variable, ExpressionSyntax value)
+            => variable.WithInitializer(SyntaxFactory.EqualsValueClause(value));
+
+        protected override VariableDeclaratorSyntax GetDeclaratorSyntax(IVariableDeclaratorOperation declarator)
+            => (VariableDeclaratorSyntax)declarator.Syntax;
+
+        protected override LocalDeclarationStatementSyntax AddSimplificationToType(LocalDeclarationStatementSyntax statement)
+            => statement.WithDeclaration(statement.Declaration.WithType(
+                statement.Declaration.Type.WithAdditionalAnnotations(Simplifier.Annotation)));
+
+        protected override StatementSyntax WrapWithBlockIfAppropriate(
+            IfStatementSyntax ifStatement, StatementSyntax statement)
+        {
+            if (ifStatement.Parent is ElseClauseSyntax &&
+                ifStatement.Statement is BlockSyntax block)
+            {
+                return block.WithStatements(SyntaxFactory.SingletonList(statement))
+                            .WithAdditionalAnnotations(Formatter.Annotation);
+            }
+
+            return statement;
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForAssignmentDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForAssignmentDiagnosticAnalyzer.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.UseConditionalExpression;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class CSharpUseConditionalExpressionForAssignmentDiagnosticAnalyzer
+        : AbstractUseConditionalExpressionForAssignmentDiagnosticAnalyzer<IfStatementSyntax>
+    {
+        public CSharpUseConditionalExpressionForAssignmentDiagnosticAnalyzer()
+            : base(new LocalizableResourceString(nameof(CSharpFeaturesResources.if_statement_can_be_simplified), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources)))
+        {
+        }
+
+        protected override ISyntaxFactsService GetSyntaxFactsService()
+            => CSharpSyntaxFactsService.Instance;
+    }
+}

--- a/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForReturnCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForReturnCodeRefactoringProvider.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.UseConditionalExpression;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    internal partial class CSharpUseConditionalExpressionForReturnCodeRefactoringProvider
+        : AbstractUseConditionalExpressionForReturnCodeFixProvider<StatementSyntax, IfStatementSyntax, ExpressionSyntax, ConditionalExpressionSyntax>
+    {
+        protected override bool IsRef(IReturnOperation returnOperation)
+            => returnOperation.Syntax is ReturnStatementSyntax statement &&
+               statement.Expression is RefExpressionSyntax;
+
+        protected override IFormattingRule GetMultiLineFormattingRule()
+            => MultiLineConditionalExpressionFormattingRule.Instance;
+
+        protected override StatementSyntax WrapWithBlockIfAppropriate(
+            IfStatementSyntax ifStatement, StatementSyntax statement)
+        {
+            if (ifStatement.Parent is ElseClauseSyntax &&
+                ifStatement.Statement is BlockSyntax block)
+            {
+                return block.WithStatements(SyntaxFactory.SingletonList(statement))
+                            .WithAdditionalAnnotations(Formatter.Annotation);
+            }
+
+            return statement;
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseConditionalExpression/CSharpUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.UseConditionalExpression;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class CSharpUseConditionalExpressionForReturnDiagnosticAnalyzer
+        : AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer<IfStatementSyntax>
+    {
+        public CSharpUseConditionalExpressionForReturnDiagnosticAnalyzer()
+            : base(new LocalizableResourceString(nameof(CSharpFeaturesResources.if_statement_can_be_simplified), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources)))
+        {
+        }
+
+        protected override ISyntaxFactsService GetSyntaxFactsService()
+            => CSharpSyntaxFactsService.Instance;
+    }
+}

--- a/src/Features/CSharp/Portable/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.cs
+++ b/src/Features/CSharp/Portable/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.Options;
+using static Microsoft.CodeAnalysis.UseConditionalExpression.UseConditionalExpressionHelpers;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
+{
+    /// <summary>
+    /// Special formatting rule that will convert a conditional expression into the following
+    /// form if it has the <see cref="SpecializedFormattingAnnotation"/> on it:
+    /// 
+    /// <code>
+    ///     var v = expr
+    ///         ? whenTrue
+    ///         : whenFalse
+    /// </code>
+    /// 
+    /// i.e. both branches will be on a newline, indented once from the parent indentation.
+    /// </summary>
+    internal class MultiLineConditionalExpressionFormattingRule : AbstractFormattingRule
+    {
+        public static readonly IFormattingRule Instance = new MultiLineConditionalExpressionFormattingRule();
+
+        private MultiLineConditionalExpressionFormattingRule()
+        {
+        }
+
+        private bool IsQuestionOrColonOfNewConditional(SyntaxToken token)
+        {
+            if (token.Kind() == SyntaxKind.QuestionToken ||
+                token.Kind() == SyntaxKind.ColonToken)
+            {
+                return token.Parent.HasAnnotation(SpecializedFormattingAnnotation);
+            }
+
+            return false;
+        }
+
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(
+            SyntaxToken previousToken, SyntaxToken currentToken, OptionSet optionSet, NextOperation<AdjustNewLinesOperation> nextOperation)
+        {
+            if (IsQuestionOrColonOfNewConditional(currentToken))
+            {
+                // We want to force the ? and : to each be put onto the following line.
+                return FormattingOperations.CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLines);
+            }
+
+            return nextOperation.Invoke();
+        }
+
+        public override void AddIndentBlockOperations(
+            List<IndentBlockOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<IndentBlockOperation> nextOperation)
+        {
+            if (node.HasAnnotation(SpecializedFormattingAnnotation) &&
+                node is ConditionalExpressionSyntax conditional)
+            {
+                var statement = conditional.FirstAncestorOrSelf<StatementSyntax>();
+                if (statement != null)
+                {
+                    var baseToken = statement.GetFirstToken();
+
+                    // we want to indent the ? and : in one level from the containing statement.
+                    list.Add(FormattingOperations.CreateRelativeIndentBlockOperation(
+                        baseToken, conditional.QuestionToken, conditional.WhenTrue.GetLastToken(),
+                        indentationDelta: 1, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine));
+                    list.Add(FormattingOperations.CreateRelativeIndentBlockOperation(
+                        baseToken, conditional.ColonToken, conditional.WhenFalse.GetLastToken(),
+                        indentationDelta: 1, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine));
+                    return;
+                }
+            }
+
+            nextOperation.Invoke(list);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Odebrat nepotřebné direktivy using</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;výraz lambda&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Nicht benötigte Using-Direktiven entfernen</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;Lambdaausdruck&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Eliminar instrucciones Using innecesarias</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;expresión lambda&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Supprimer les Usings inutiles</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;expression lambda&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Rimuovi istruzioni using non necessarie</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;espressione lambda&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">不要な using の削除</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;ラムダ式&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">불필요한 Using 제거</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;람다 식&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Usuń niepotrzebne użycia</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;wyrażenie lambda&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Remover Usos Desnecessários</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;expressão lambda&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Удалить ненужные директивы using</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;лямбда-выражение&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Gereksiz Kullanımları Kaldır</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;lambda ifadesi&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">删除不必要的 Using</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;lambda 表达式&gt;</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">移除不必要的 Using</target>
         <note />
       </trans-unit>
+      <trans-unit id="if_statement_can_be_simplified">
+        <source>'if' statement can be simplified</source>
+        <target state="new">'if' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;Lambda 運算式&gt;</target>

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -66,6 +66,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public const string MakeFieldReadonlyDiagnosticId = "IDE0044";
 
+        public const string UseConditionalExpressionForAssignmentDiagnosticId = "IDE0045";
+        public const string UseConditionalExpressionForReturnDiagnosticId = "IDE0046";
+
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";
         public const string AnalyzerDependencyConflictId = "IDE1002";

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -853,6 +853,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert to conditional expression.
+        /// </summary>
+        internal static string Convert_to_conditional_expression {
+            get {
+                return ResourceManager.GetString("Convert_to_conditional_expression", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Convert to decimal.
         /// </summary>
         internal static string Convert_to_decimal {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1352,4 +1352,7 @@ This version used in: {2}</value>
   <data name="Make_field_readonly" xml:space="preserve">
     <value>Make field readonly</value>
   </data>
+  <data name="Convert_to_conditional_expression" xml:space="preserve">
+    <value>Convert to conditional expression</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Simplification;
+using static Microsoft.CodeAnalysis.UseConditionalExpression.UseConditionalExpressionHelpers;
+
+namespace Microsoft.CodeAnalysis.UseConditionalExpression
+{
+    internal abstract class AbstractUseConditionalExpressionCodeFixProvider<
+        TStatementSyntax,
+        TIfStatementSyntax,
+        TExpressionSyntax,
+        TConditionalExpressionSyntax> : SyntaxEditorBasedCodeFixProvider
+        where TStatementSyntax : SyntaxNode
+        where TIfStatementSyntax : TStatementSyntax
+        where TExpressionSyntax : SyntaxNode
+        where TConditionalExpressionSyntax : TExpressionSyntax
+    {
+        protected abstract IFormattingRule GetMultiLineFormattingRule();
+        protected abstract TStatementSyntax WrapWithBlockIfAppropriate(TIfStatementSyntax ifStatement, TStatementSyntax statement);
+
+        protected abstract Task FixOneAsync(
+            Document document, Diagnostic diagnostic,
+            SyntaxEditor editor, CancellationToken cancellationToken);
+
+        protected override async Task FixAllAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics, SyntaxEditor editor,
+            CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            // Defer to our callback to actually make the edits for each diagnostic. In turn, it
+            // will return 'true' if it made a multi-line conditional expression. In that case,
+            // we'll need to explicitly format this node so we can get our special multi-line
+            // formatting in VB and C#.
+            var nestedEditor = new SyntaxEditor(root, document.Project.Solution.Workspace);
+            foreach (var diagnostic in diagnostics)
+            {
+                await FixOneAsync(
+                    document, diagnostic, nestedEditor, cancellationToken).ConfigureAwait(false);
+            }
+
+            var changedRoot = nestedEditor.GetChangedRoot();
+            // Get the language specific rule for formatting this construct and call into the
+            // formatted to explicitly format things.  Note: all we will format is the new
+            // conditional expression as that's the only node that has the appropriate
+            // annotation on it.
+            var rules = new List<IFormattingRule> { GetMultiLineFormattingRule() };
+
+            var formattedRoot = await Formatter.FormatAsync(changedRoot,
+                SpecializedFormattingAnnotation,
+                document.Project.Solution.Workspace,
+                await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false),
+                rules, cancellationToken).ConfigureAwait(false);
+            changedRoot = formattedRoot;
+
+            editor.ReplaceNode(root, changedRoot);
+        }
+
+        /// <summary>
+        /// Helper to create a conditional expression out of two original IOperation values
+        /// corresponding to the whenTrue and whenFalse parts. The helper will add the appropriate
+        /// annotations and casts to ensure that the conditional expression preserves semantics, but
+        /// is also properly simplified and formatted.
+        /// </summary>
+        protected async Task<TExpressionSyntax> CreateConditionalExpressionAsync(
+            Document document, IConditionalOperation ifOperation,
+            IOperation trueStatement, IOperation falseStatement,
+            IOperation trueValue, IOperation falseValue,
+            bool isRef, CancellationToken cancellationToken)
+        {
+            var generator = SyntaxGenerator.GetGenerator(document);
+
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+
+            var condition = ifOperation.Condition.Syntax;
+            var conditionalExpression = (TConditionalExpressionSyntax)generator.ConditionalExpression(
+                condition.WithoutTrivia(),
+                MakeRef(generator, isRef, CastValueIfNecessary(generator, trueValue)),
+                MakeRef(generator, isRef, CastValueIfNecessary(generator, falseValue)));
+
+            conditionalExpression = conditionalExpression.WithAdditionalAnnotations(Simplifier.Annotation);
+            var makeMultiLine = await MakeMultiLineAsync(
+                document, condition,
+                trueValue.Syntax, falseValue.Syntax, cancellationToken).ConfigureAwait(false);
+            if (makeMultiLine)
+            {
+                conditionalExpression = conditionalExpression.WithAdditionalAnnotations(
+                    SpecializedFormattingAnnotation);
+            }
+
+            return MakeRef(generator, isRef, conditionalExpression);
+        }
+
+        private TExpressionSyntax MakeRef(SyntaxGenerator generator, bool isRef, TExpressionSyntax syntaxNode)
+            => isRef ? (TExpressionSyntax)generator.RefExpression(syntaxNode) : syntaxNode;
+
+        /// <summary>
+        /// Checks if we should wrap the conditional expression over multiple lines.
+        /// </summary>
+        private static async Task<bool> MakeMultiLineAsync(
+            Document document, SyntaxNode condition, SyntaxNode trueSyntax, SyntaxNode falseSyntax,
+            CancellationToken cancellationToken)
+        {
+            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            if (!sourceText.AreOnSameLine(condition.GetFirstToken(), condition.GetLastToken()) ||
+                !sourceText.AreOnSameLine(trueSyntax.GetFirstToken(), trueSyntax.GetLastToken()) ||
+                !sourceText.AreOnSameLine(falseSyntax.GetFirstToken(), falseSyntax.GetLastToken()))
+            {
+                return true;
+            }
+
+            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var wrappingLength = options.GetOption(UseConditionalExpressionOptions.ConditionalExpressionWrappingLength);
+            if (condition.Span.Length + trueSyntax.Span.Length + falseSyntax.Span.Length > wrappingLength)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static TExpressionSyntax CastValueIfNecessary(
+            SyntaxGenerator generator, IOperation value)
+        {
+            var sourceSyntax = value.Syntax.WithoutTrivia();
+
+            // If there was an implicit conversion generated by the compiler, then convert that to an
+            // explicit conversion inside the condition.  This is needed as there is no type
+            // inference in conditional expressions, so we need to ensure that the same conversions
+            // that were occurring previously still occur after conversion. Note: the simplifier
+            // will remove any of these casts that are unnecessary.
+            if (value is IConversionOperation conversion &&
+                conversion.IsImplicit &&
+                conversion.Type != null &&
+                conversion.Type.TypeKind != TypeKind.Error)
+            {
+                // Note we only add the cast if the source had no type (like the null literal), or a
+                // non-error type itself.  We don't want to insert lots of casts in error code.
+                if (conversion.Operand.Type == null || conversion.Operand.Type.TypeKind != TypeKind.Error)
+                {
+                    return (TExpressionSyntax)generator.CastExpression(conversion.Type, sourceSyntax);
+                }
+            }
+
+            return (TExpressionSyntax)sourceSyntax;
+        }
+    }
+}

--- a/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
@@ -1,0 +1,238 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.UseConditionalExpression.UseConditionalExpressionHelpers;
+
+namespace Microsoft.CodeAnalysis.UseConditionalExpression
+{
+    internal abstract class AbstractUseConditionalExpressionForAssignmentCodeFixProvider<
+        TStatementSyntax,
+        TIfStatementSyntax,
+        TLocalDeclarationStatementSyntax,
+        TVariableDeclaratorSyntax,
+        TExpressionSyntax,
+        TConditionalExpressionSyntax>
+        : AbstractUseConditionalExpressionCodeFixProvider<TStatementSyntax, TIfStatementSyntax, TExpressionSyntax, TConditionalExpressionSyntax>
+        where TStatementSyntax : SyntaxNode
+        where TIfStatementSyntax : TStatementSyntax
+        where TLocalDeclarationStatementSyntax : TStatementSyntax
+        where TVariableDeclaratorSyntax : SyntaxNode
+        where TExpressionSyntax : SyntaxNode
+        where TConditionalExpressionSyntax : TExpressionSyntax
+    {
+        protected abstract TVariableDeclaratorSyntax WithInitializer(TVariableDeclaratorSyntax variable, TExpressionSyntax value);
+        protected abstract TVariableDeclaratorSyntax GetDeclaratorSyntax(IVariableDeclaratorOperation declarator);
+        protected abstract TLocalDeclarationStatementSyntax AddSimplificationToType(TLocalDeclarationStatementSyntax updatedLocalDeclaration);
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(IDEDiagnosticIds.UseConditionalExpressionForAssignmentDiagnosticId);
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(
+                new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
+                context.Diagnostics);
+            return SpecializedTasks.EmptyTask;
+        }
+
+        /// <summary>
+        /// Returns 'true' if a multi-line conditional was created, and thus should be
+        /// formatted specially.
+        /// </summary>
+        protected override async Task FixOneAsync(
+            Document document, Diagnostic diagnostic,
+            SyntaxEditor editor, CancellationToken cancellationToken)
+        {
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var ifStatement = diagnostic.AdditionalLocations[0].FindNode(cancellationToken);
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var ifOperation = (IConditionalOperation)semanticModel.GetOperation(ifStatement);
+
+            if (!UseConditionalExpressionForAssignmentHelpers.TryMatchPattern(
+                    syntaxFacts, ifOperation,
+                    out var trueAssignment, out var falseAssignment))
+            {
+                return;
+            }
+
+            var conditionalExpression = await CreateConditionalExpressionAsync(
+                document, ifOperation, trueAssignment.Parent, falseAssignment.Parent,
+                trueAssignment.Value, falseAssignment.Value, 
+                trueAssignment.IsRef, cancellationToken).ConfigureAwait(false);
+
+            // See if we're assigning to a variable declared directly above the if statement. If so,
+            // try to inline the conditional directly into the initializer for that variable.
+            if (!TryConvertWhenAssignmentToLocalDeclaredImmediateAbove(
+                    syntaxFacts, editor, ifOperation, 
+                    trueAssignment, falseAssignment, conditionalExpression))
+            {
+                // If not, just replace the if-statement with a single assignment of the new
+                // conditional.
+                ConvertOnlyIfToConditionalExpression(
+                    editor, ifOperation, trueAssignment, falseAssignment, conditionalExpression);
+            }
+        }
+
+        private void ConvertOnlyIfToConditionalExpression(
+            SyntaxEditor editor, IConditionalOperation ifOperation,
+            ISimpleAssignmentOperation trueAssignment, ISimpleAssignmentOperation falseAssignment,
+            TExpressionSyntax conditionalExpression)
+        {
+            var generator = editor.Generator;
+            var ifStatement = (TIfStatementSyntax)ifOperation.Syntax;
+            var expressionStatement = (TStatementSyntax)generator.ExpressionStatement(
+                generator.AssignmentStatement(
+                    trueAssignment.Target.Syntax,
+                    conditionalExpression)).WithTriviaFrom(ifStatement);
+
+            editor.ReplaceNode(
+                ifOperation.Syntax,
+                this.WrapWithBlockIfAppropriate(ifStatement, expressionStatement));
+        }
+
+        private bool TryConvertWhenAssignmentToLocalDeclaredImmediateAbove(
+            ISyntaxFactsService syntaxFacts, SyntaxEditor editor, IConditionalOperation ifOperation,
+            ISimpleAssignmentOperation trueAssignment, ISimpleAssignmentOperation falseAssignment,
+            TExpressionSyntax conditionalExpression)
+        {
+            if (!TryFindMatchingLocalDeclarationImmediatelyAbove(
+                    ifOperation, trueAssignment, falseAssignment,
+                    out var localDeclarationOperation))
+            {
+                return false;
+            }
+
+            // We found a valid local declaration right above the if-statement.
+            var localDeclaration = localDeclarationOperation.Syntax;
+            var declarator = localDeclarationOperation.Declarations[0].Declarators[0];
+            var variable = GetDeclaratorSyntax(declarator);
+
+            // Initialize that variable with the conditional expression.
+            var updatedVariable = WithInitializer(variable, conditionalExpression);
+
+            // Because we merged the initialization and the variable, the variable may now be able
+            // to use 'var' (c#), or elide its type (vb).  Add the simplification annotation
+            // appropriately so that can happen later down the line.
+            var updatedLocalDeclaration = localDeclaration.ReplaceNode(variable, updatedVariable);
+            updatedLocalDeclaration = AddSimplificationToType(
+                (TLocalDeclarationStatementSyntax)updatedLocalDeclaration);
+
+            editor.ReplaceNode(localDeclaration, updatedLocalDeclaration);
+            editor.RemoveNode(ifOperation.Syntax, GetRemoveOptions(syntaxFacts, ifOperation.Syntax));
+            return true;
+        }
+
+        private bool TryFindMatchingLocalDeclarationImmediatelyAbove(
+            IConditionalOperation ifOperation, ISimpleAssignmentOperation trueAssignment, ISimpleAssignmentOperation falseAssignment,
+            out IVariableDeclarationGroupOperation localDeclaration)
+        {
+            localDeclaration = null;
+
+            // See if both assignments are to the same local.
+            if (!(trueAssignment.Target is ILocalReferenceOperation trueLocal) ||
+                !(falseAssignment.Target is ILocalReferenceOperation falseLocal) ||
+                !Equals(trueLocal.Local, falseLocal.Local))
+            {
+                return false;
+            }
+
+            // If so, see if that local was declared immediately above the if-statement.
+            var parentBlock = ifOperation.Parent as IBlockOperation;
+            if (parentBlock == null)
+            {
+                return false;
+            }
+
+            var ifIndex = parentBlock.Operations.IndexOf(ifOperation);
+            if (ifIndex <= 0)
+            {
+                return false;
+            }
+
+            localDeclaration = parentBlock.Operations[ifIndex - 1] as IVariableDeclarationGroupOperation;
+            if (localDeclaration == null)
+            {
+                return false;
+            }
+
+            if (localDeclaration.Declarations.Length != 1)
+            {
+                return false;
+            }
+
+            var declaration = localDeclaration.Declarations[0];
+            var declarators = declaration.Declarators;
+            if (declarators.Length != 1)
+            {
+                return false;
+            }
+
+            var declarator = declarators[0];
+            var variable = declarator.Symbol;
+            if (!Equals(variable, trueLocal.Local))
+            {
+                // wasn't a declaration of the local we're assigning to.
+                return false;
+            }
+
+            var variableName = variable.Name;
+
+            var variableInitializer = declarator.Initializer ?? declaration.Initializer;
+            if (variableInitializer?.Value != null)
+            {
+                var unwrapped = UnwrapImplicitConversion(variableInitializer.Value);
+                // the variable has to either not have an initializer, or it needs to be basic
+                // literal/default expression.
+                if (!(unwrapped is ILiteralOperation) &&
+                    !(unwrapped is IDefaultValueOperation))
+                {
+                    return false;
+                }
+            }
+
+            // If the variable is referenced in the condition of the 'if' block, we can't merge the
+            // declaration and assignments.
+            return !ReferencesLocalVariable(ifOperation.Condition, variable);
+        }
+
+        private bool ReferencesLocalVariable(IOperation operation, ILocalSymbol variable)
+        {
+            if (operation is ILocalReferenceOperation localReference &&
+                Equals(variable, localReference.Local))
+            {
+                return true;
+            }
+
+            foreach (var child in operation.Children)
+            {
+                if (ReferencesLocalVariable(child, variable))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Convert_to_conditional_expression, createChangedDocument, IDEDiagnosticIds.UseConditionalExpressionForAssignmentDiagnosticId)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentDiagnosticAnalyzer.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeAnalysis.UseConditionalExpression
+{
+    internal abstract class AbstractUseConditionalExpressionForAssignmentDiagnosticAnalyzer<
+        TIfStatementSyntax>
+        : AbstractCodeStyleDiagnosticAnalyzer
+        where TIfStatementSyntax : SyntaxNode
+    {
+        public override bool OpenFileOnly(Workspace workspace) => false;
+        public override DiagnosticAnalyzerCategory GetAnalyzerCategory() 
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+
+        protected AbstractUseConditionalExpressionForAssignmentDiagnosticAnalyzer(
+            LocalizableResourceString message)
+            : base(IDEDiagnosticIds.UseConditionalExpressionForAssignmentDiagnosticId,
+                   new LocalizableResourceString(nameof(FeaturesResources.Convert_to_conditional_expression), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                   message)
+        {
+        }
+
+        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+
+        protected override void InitializeWorker(AnalysisContext context)
+            => context.RegisterOperationAction(AnalyzeOperation, OperationKind.Conditional);
+
+        private void AnalyzeOperation(OperationAnalysisContext context)
+        {
+            var ifOperation = (IConditionalOperation)context.Operation;
+            var ifStatement = ifOperation.Syntax as TIfStatementSyntax;
+            if (ifStatement == null)
+            {
+                return;
+            }
+
+            var language = ifStatement.Language;
+            var syntaxTree = ifStatement.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
+            var option = optionSet.GetOption(CodeStyleOptions.PreferConditionalExpressionOverAssignment, language);
+            if (!option.Value)
+            {
+                return;
+            }
+
+            if (!UseConditionalExpressionForAssignmentHelpers.TryMatchPattern(
+                    GetSyntaxFactsService(), ifOperation, out _, out _))
+            {
+                return;
+            }
+
+            var additionalLocations = ImmutableArray.Create(ifStatement.GetLocation());
+            context.ReportDiagnostic(Diagnostic.Create(
+                this.CreateDescriptorWithSeverity(option.Notification.Value),
+                ifStatement.GetFirstToken().GetLocation(),
+                additionalLocations));
+        }
+    }
+}

--- a/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/UseConditionalExpressionForAssignmentHelpers.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/UseConditionalExpressionForAssignmentHelpers.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeAnalysis.UseConditionalExpression
+{
+    internal static class UseConditionalExpressionForAssignmentHelpers 
+    {
+        public static bool TryMatchPattern(
+            ISyntaxFactsService syntaxFacts,
+            IConditionalOperation ifOperation,
+            out ISimpleAssignmentOperation trueAssignment,
+            out ISimpleAssignmentOperation falseAssignment)
+        {
+            trueAssignment = null;
+            falseAssignment = null;
+
+            var trueStatement = ifOperation.WhenTrue;
+            var falseStatement = ifOperation.WhenFalse;
+
+            trueStatement = UseConditionalExpressionHelpers.UnwrapSingleStatementBlock(trueStatement);
+            falseStatement = UseConditionalExpressionHelpers.UnwrapSingleStatementBlock(falseStatement);
+
+            if (!TryGetAssignment(trueStatement, out trueAssignment) ||
+                !TryGetAssignment(falseStatement, out falseAssignment))
+            {
+                return false;
+            }
+
+            // The left side of both assignment statements has to be syntactically identical (modulo
+            // trivia differences).
+            if (!syntaxFacts.AreEquivalent(trueAssignment.Target.Syntax, falseAssignment.Target.Syntax))
+            {
+                return false;
+            }
+
+            return UseConditionalExpressionHelpers.CanConvert(
+                syntaxFacts, ifOperation, trueAssignment, falseAssignment);
+        }
+
+        private static bool TryGetAssignment(
+            IOperation statement, out ISimpleAssignmentOperation assignment)
+        {
+            // Both the WhenTrue and WhenFalse statements must be of the form:
+            //      target = value;
+            if (!(statement is IExpressionStatementOperation exprStatement) ||
+                !(exprStatement.Operation is ISimpleAssignmentOperation assignmentOp) ||
+                assignmentOp.Target == null)
+            {
+                assignment = default;
+                return false;
+            }
+
+            assignment = assignmentOp;
+            return true;
+        }
+    }
+}

--- a/src/Features/Core/Portable/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnCodeFixProvider.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.UseConditionalExpression.UseConditionalExpressionHelpers;
+
+namespace Microsoft.CodeAnalysis.UseConditionalExpression
+{
+    internal abstract class AbstractUseConditionalExpressionForReturnCodeFixProvider<
+        TStatementSyntax,
+        TIfStatementSyntax,
+        TExpressionSyntax,
+        TConditionalExpressionSyntax>
+        : AbstractUseConditionalExpressionCodeFixProvider<TStatementSyntax, TIfStatementSyntax, TExpressionSyntax, TConditionalExpressionSyntax>
+        where TStatementSyntax : SyntaxNode
+        where TIfStatementSyntax : TStatementSyntax
+        where TExpressionSyntax : SyntaxNode
+        where TConditionalExpressionSyntax : TExpressionSyntax
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(IDEDiagnosticIds.UseConditionalExpressionForReturnDiagnosticId);
+
+        protected abstract bool IsRef(IReturnOperation returnOperation);
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(
+                new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
+                context.Diagnostics);
+            return SpecializedTasks.EmptyTask;
+        }
+
+        protected override async Task FixOneAsync(
+            Document document, Diagnostic diagnostic, 
+            SyntaxEditor editor, CancellationToken cancellationToken)
+        {
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var ifStatement = (TIfStatementSyntax)diagnostic.AdditionalLocations[0].FindNode(cancellationToken);
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var ifOperation = (IConditionalOperation)semanticModel.GetOperation(ifStatement);
+
+            if (!UseConditionalExpressionForReturnHelpers.TryMatchPattern(
+                    syntaxFacts, ifOperation, 
+                    out var trueReturn, out var falseReturn))
+            {
+                return;
+            }
+
+            var conditionalExpression = await CreateConditionalExpressionAsync(
+                document, ifOperation, trueReturn, falseReturn,
+                trueReturn.ReturnedValue, falseReturn.ReturnedValue,
+                IsRef(trueReturn), cancellationToken).ConfigureAwait(false);
+            
+            var returnStatement = (TStatementSyntax)editor.Generator.ReturnStatement(conditionalExpression)
+                                                                    .WithTriviaFrom(ifStatement);
+            editor.ReplaceNode(
+                ifStatement,
+                this.WrapWithBlockIfAppropriate(ifStatement, returnStatement));
+
+            // if the if-statement had no 'else' clause, then we were using the following statement
+            // as the 'false' statement.  If so, remove it explicitly.
+            if (ifOperation.WhenFalse == null)
+            {
+                editor.RemoveNode(falseReturn.Syntax, GetRemoveOptions(syntaxFacts, falseReturn.Syntax));
+            }
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) 
+                : base(FeaturesResources.Convert_to_conditional_expression, createChangedDocument, IDEDiagnosticIds.UseConditionalExpressionForReturnDiagnosticId)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeAnalysis.UseConditionalExpression
+{
+    internal abstract class AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer<
+        TIfStatementSyntax>
+        : AbstractCodeStyleDiagnosticAnalyzer
+        where TIfStatementSyntax : SyntaxNode
+    {
+        public override bool OpenFileOnly(Workspace workspace) => false;
+        public override DiagnosticAnalyzerCategory GetAnalyzerCategory() 
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+
+        protected AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer(
+            LocalizableResourceString message)
+            : base(IDEDiagnosticIds.UseConditionalExpressionForReturnDiagnosticId,
+                   new LocalizableResourceString(nameof(FeaturesResources.Convert_to_conditional_expression), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                   message)
+        {
+        }
+         
+        protected abstract ISyntaxFactsService GetSyntaxFactsService();
+
+        protected override void InitializeWorker(AnalysisContext context)
+            => context.RegisterOperationAction(AnalyzeOperation, OperationKind.Conditional);
+
+        private void AnalyzeOperation(OperationAnalysisContext context)
+        {
+            var ifOperation = (IConditionalOperation)context.Operation;
+            var ifStatement = ifOperation.Syntax as TIfStatementSyntax;
+            if (ifStatement == null)
+            {
+                return;
+            }
+
+            var language = ifStatement.Language;
+            var syntaxTree = ifStatement.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
+            var option = optionSet.GetOption(CodeStyleOptions.PreferConditionalExpressionOverReturn, language);
+            if (!option.Value)
+            {
+                return;
+            }
+
+            if (!UseConditionalExpressionForReturnHelpers.TryMatchPattern(
+                    GetSyntaxFactsService(), ifOperation, out _, out _))
+            {
+                return;
+            }
+
+            var additionalLocations = ImmutableArray.Create(ifStatement.GetLocation());
+            context.ReportDiagnostic(Diagnostic.Create(
+                this.CreateDescriptorWithSeverity(option.Notification.Value),
+                ifStatement.GetFirstToken().GetLocation(),
+                additionalLocations));
+        }
+    }
+}

--- a/src/Features/Core/Portable/UseConditionalExpression/ForReturn/UseConditionalExpressionForReturnHelpers.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForReturn/UseConditionalExpressionForReturnHelpers.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeAnalysis.UseConditionalExpression
+{
+    internal static class UseConditionalExpressionForReturnHelpers 
+    {
+        public static bool TryMatchPattern(
+            ISyntaxFactsService syntaxFacts,
+            IConditionalOperation ifOperation,
+            out IReturnOperation trueReturn,
+            out IReturnOperation falseReturn)
+        {
+            trueReturn = null;
+            falseReturn = null;
+
+            var trueStatement = ifOperation.WhenTrue;
+            var falseStatement = ifOperation.WhenFalse;
+
+            // we support:
+            //
+            //      if (expr)
+            //          return a;
+            //      else
+            //          return b;
+            //
+            // and
+            //
+            //      if (expr)
+            //          return a;
+            //      
+            //      return b;
+
+            if (falseStatement == null)
+            {
+                var parentBlock = ifOperation.Parent as IBlockOperation;
+                if (parentBlock == null)
+                {
+                    return false;
+                }
+
+                var ifIndex = parentBlock.Operations.IndexOf(ifOperation);
+                if (ifIndex < 0)
+                {
+                    return false;
+                }
+
+                if (ifIndex + 1 < parentBlock.Operations.Length)
+                {
+                    falseStatement = parentBlock.Operations[ifIndex + 1];
+                    if (falseStatement.IsImplicit)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            trueStatement = UseConditionalExpressionHelpers.UnwrapSingleStatementBlock(trueStatement);
+            falseStatement = UseConditionalExpressionHelpers.UnwrapSingleStatementBlock(falseStatement);
+
+            // Both return-statements must be of the form "return value"
+            if (!(trueStatement is IReturnOperation trueReturnOp) ||
+                !(falseStatement is IReturnOperation falseReturnOp) ||
+                trueReturnOp.ReturnedValue == null ||
+                falseReturnOp.ReturnedValue == null)
+            {
+                return false;
+            }
+
+            trueReturn = trueReturnOp;
+            falseReturn = falseReturnOp;
+
+            return UseConditionalExpressionHelpers.CanConvert(
+                syntaxFacts, ifOperation, trueReturn, falseReturn);
+        }
+    }
+}

--- a/src/Features/Core/Portable/UseConditionalExpression/UseConditionalExpressionHelpers.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/UseConditionalExpressionHelpers.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.UseConditionalExpression
+{
+    internal static class UseConditionalExpressionHelpers
+    {
+        public static readonly SyntaxAnnotation SpecializedFormattingAnnotation = new SyntaxAnnotation();
+
+        public static bool CanConvert(
+            ISyntaxFactsService syntaxFacts, IConditionalOperation ifOperation, 
+            IOperation whenTrue, IOperation whenFalse)
+        {
+            // Will likely screw things up if the if directive spans any preprocessor directives.
+            // So do not offer for now.
+            if (syntaxFacts.SpansPreprocessorDirective(ifOperation.Syntax))
+            {
+                return false;
+            }
+
+            // User may have comments on the when-true/when-false statements.  These statements can
+            // be very important. Often they indicate why the true/false branches are important in
+            // the first place.  We don't have any place to put these, so we don't offer here.
+            if (HasRegularComments(syntaxFacts, whenTrue.Syntax) ||
+                HasRegularComments(syntaxFacts, whenFalse.Syntax))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Will unwrap a block with a single statement in it to just that block.  Used so we can
+        /// support both ```if (expr) { statement }``` and ```if (expr) statement```
+        /// </summary>
+        public static IOperation UnwrapSingleStatementBlock(IOperation statement)
+            => statement is IBlockOperation block && block.Operations.Length == 1
+                ? block.Operations[0]
+                : statement;
+
+        public static IOperation UnwrapImplicitConversion(IOperation value)
+            => value is IConversionOperation conversion && conversion.IsImplicit
+                ? conversion.Operand
+                : value;
+
+        public static SyntaxRemoveOptions GetRemoveOptions(
+            ISyntaxFactsService syntaxFacts, SyntaxNode syntax)
+        {
+            var removeOptions = SyntaxGenerator.DefaultRemoveOptions;
+            if (HasRegularCommentTrivia(syntaxFacts, syntax.GetLeadingTrivia()))
+            {
+                removeOptions |= SyntaxRemoveOptions.KeepLeadingTrivia;
+            }
+
+            if (HasRegularCommentTrivia(syntaxFacts, syntax.GetTrailingTrivia()))
+            {
+                removeOptions |= SyntaxRemoveOptions.KeepTrailingTrivia;
+            }
+
+            return removeOptions;
+        }
+
+        private static bool HasRegularComments(ISyntaxFactsService syntaxFacts, SyntaxNode syntax)
+            => HasRegularCommentTrivia(syntaxFacts, syntax.GetLeadingTrivia()) ||
+               HasRegularCommentTrivia(syntaxFacts, syntax.GetTrailingTrivia());
+
+        private static bool HasRegularCommentTrivia(ISyntaxFactsService syntaxFacts, SyntaxTriviaList triviaList)
+        {
+            foreach (var trivia in triviaList)
+            {
+                if (syntaxFacts.IsRegularComment(trivia))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Features/Core/Portable/UseConditionalExpression/UseConditionalExpressionOptions.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/UseConditionalExpressionOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.UseConditionalExpression
+{
+    internal static class UseConditionalExpressionOptions
+    {
+        public static readonly PerLanguageOption<int> ConditionalExpressionWrappingLength = new PerLanguageOption<int>(
+            nameof(UseConditionalExpressionOptions),
+            nameof(ConditionalExpressionWrappingLength), defaultValue: 120,
+            storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ConditionalExpressionWrappingLength)}"));
+    }
+}

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -2015,6 +2015,11 @@ Tato verze se používá zde: {2}.</target>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -2015,6 +2015,11 @@ Diese Version wird verwendet in: {2}</target>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -2015,6 +2015,11 @@ Esta versión se utiliza en: {2}</target>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -2015,6 +2015,11 @@ Version utilisée dans : {2}</target>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -2015,6 +2015,11 @@ Questa versione è usata {2}</target>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -2015,6 +2015,11 @@ This version used in: {2}</source>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -2015,6 +2015,11 @@ This version used in: {2}</source>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -2015,6 +2015,11 @@ Ta wersja jest używana wersja: {2}</target>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -2015,6 +2015,11 @@ Essa versão é usada no: {2}</target>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -2015,6 +2015,11 @@ This version used in: {2}</source>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -2015,6 +2015,11 @@ Bu sürüm şurada kullanılır: {2}</target>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -2015,6 +2015,11 @@ This version used in: {2}</source>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -2015,6 +2015,11 @@ This version used in: {2}</source>
         <target state="new">Make field readonly</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_conditional_expression">
+        <source>Convert to conditional expression</source>
+        <target state="new">Convert to conditional expression</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/VisualBasic/Portable/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.vb
+++ b/src/Features/VisualBasic/Portable/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.vb
@@ -1,0 +1,77 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.CodeAnalysis.UseConditionalExpression
+Imports Microsoft.CodeAnalysis.Formatting.Rules
+Imports Microsoft.CodeAnalysis.Options
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
+    ''' <summary>
+    ''' Special formatting rule that will convert a conditional expression into the following form
+    ''' if it has the <see cref="UseConditionalExpressionHelpers.SpecializedFormattingAnnotation"/>
+    ''' on it:
+    '''
+    ''' <code>
+    '''     Dim v = If(expr,
+    '''         whenTrue,
+    '''         whenFalse)
+    ''' </code>
+    '''
+    ''' i.e. both branches will be on a newline, indented once from the parent indentation.
+    ''' </summary>
+    Friend Class MultiLineConditionalExpressionFormattingRule
+        Inherits AbstractFormattingRule
+
+        Public Shared ReadOnly Instance As New MultiLineConditionalExpressionFormattingRule()
+
+        Private Sub New()
+        End Sub
+
+        Private Function IsCommaOfNewConditional(token As SyntaxToken) As Boolean
+            If token.Kind() = SyntaxKind.CommaToken Then
+                Return token.Parent.HasAnnotation(
+                        UseConditionalExpressionHelpers.SpecializedFormattingAnnotation)
+            End If
+
+            Return False
+        End Function
+
+        Public Overrides Function GetAdjustNewLinesOperation(
+                previousToken As SyntaxToken, currentToken As SyntaxToken, optionSet As OptionSet, nextOperation As NextOperation(Of AdjustNewLinesOperation)) As AdjustNewLinesOperation
+            If IsCommaOfNewConditional(previousToken) Then
+                ' We want to force the expressions after the commas to be put on the 
+                ' next line.
+                Return FormattingOperations.CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLines)
+            End If
+
+            Return nextOperation.Invoke()
+        End Function
+
+        Public Overrides Sub AddIndentBlockOperations(
+                list As List(Of IndentBlockOperation), node As SyntaxNode, optionSet As OptionSet, nextOperation As NextAction(Of IndentBlockOperation))
+
+            If node.HasAnnotation(UseConditionalExpressionHelpers.SpecializedFormattingAnnotation) AndAlso
+               TypeOf node Is TernaryConditionalExpressionSyntax Then
+
+                Dim conditional = TryCast(node, TernaryConditionalExpressionSyntax)
+                Dim statement = conditional.FirstAncestorOrSelf(Of StatementSyntax)()
+                If statement IsNot Nothing Then
+                    Dim baseToken = statement.GetFirstToken()
+
+                    ' we want to indent the true and false conditions in one level from the
+                    ' containing statement.
+                    list.Add(FormattingOperations.CreateRelativeIndentBlockOperation(
+                            baseToken, conditional.WhenTrue.GetFirstToken(), conditional.WhenTrue.GetLastToken(),
+                            indentationDelta:=1, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine))
+                    list.Add(FormattingOperations.CreateRelativeIndentBlockOperation(
+                            baseToken, conditional.WhenFalse.GetFirstToken(), conditional.WhenFalse.GetLastToken(),
+                            indentationDelta:=1, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine))
+                    Return
+                End If
+            End If
+
+            nextOperation.Invoke(list)
+        End Sub
+    End Class
+
+End Namespace

--- a/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForAssignmentCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForAssignmentCodeRefactoringProvider.vb
@@ -1,0 +1,40 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Formatting.Rules
+Imports Microsoft.CodeAnalysis.Operations
+Imports Microsoft.CodeAnalysis.Simplification
+Imports Microsoft.CodeAnalysis.UseConditionalExpression
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
+
+    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicUseConditionalExpressionForAssignmentCodeRefactoringProvider
+        Inherits AbstractUseConditionalExpressionForAssignmentCodeFixProvider(Of
+            StatementSyntax, MultiLineIfBlockSyntax, LocalDeclarationStatementSyntax, VariableDeclaratorSyntax, ExpressionSyntax, TernaryConditionalExpressionSyntax)
+
+        Protected Overrides Function GetMultiLineFormattingRule() As IFormattingRule
+            Return MultiLineConditionalExpressionFormattingRule.Instance
+        End Function
+
+        Protected Overrides Function WithInitializer(variable As VariableDeclaratorSyntax, value As ExpressionSyntax) As VariableDeclaratorSyntax
+            Return variable.WithoutTrivia().WithInitializer(SyntaxFactory.EqualsValue(value)).
+                                            WithTriviaFrom(variable)
+        End Function
+
+        Protected Overrides Function GetDeclaratorSyntax(declarator As IVariableDeclaratorOperation) As VariableDeclaratorSyntax
+            Return DirectCast(declarator.Syntax.Parent, VariableDeclaratorSyntax)
+        End Function
+
+        Protected Overrides Function AddSimplificationToType(statement As LocalDeclarationStatementSyntax) As LocalDeclarationStatementSyntax
+            Dim declarator = statement.Declarators(0)
+            Return statement.ReplaceNode(declarator, declarator.WithAdditionalAnnotations(Simplifier.Annotation))
+        End Function
+
+        Protected Overrides Function WrapWithBlockIfAppropriate(ifStatement As MultiLineIfBlockSyntax, statement As StatementSyntax) As StatementSyntax
+            Return statement
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForAssignmentDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForAssignmentDiagnosticAnalyzer.vb
@@ -1,0 +1,21 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.UseConditionalExpression
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+    Friend Class VisualBasicUseConditionalExpressionForAssignmentDiagnosticAnalyzer
+        Inherits AbstractUseConditionalExpressionForAssignmentDiagnosticAnalyzer(Of MultiLineIfBlockSyntax)
+
+        Public Sub New()
+            MyBase.New(New LocalizableResourceString(NameOf(VBFeaturesResources.If_statement_can_be_simplified), VBFeaturesResources.ResourceManager, GetType(VBFeaturesResources.VBFeaturesResources)))
+        End Sub
+
+        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
+            Return VisualBasicSyntaxFactsService.Instance
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForReturnCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForReturnCodeRefactoringProvider.vb
@@ -1,0 +1,29 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Formatting.Rules
+Imports Microsoft.CodeAnalysis.Operations
+Imports Microsoft.CodeAnalysis.UseConditionalExpression
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
+    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicUseConditionalExpressionForReturnCodeRefactoringProvider
+        Inherits AbstractUseConditionalExpressionForReturnCodeFixProvider(Of
+            StatementSyntax, MultiLineIfBlockSyntax, ExpressionSyntax, TernaryConditionalExpressionSyntax)
+
+        Protected Overrides Function IsRef(returnOperation As IReturnOperation) As Boolean
+            ' VB does not have ref returns.
+            Return False
+        End Function
+
+        Protected Overrides Function GetMultiLineFormattingRule() As IFormattingRule
+            Return MultiLineConditionalExpressionFormattingRule.Instance
+        End Function
+
+        Protected Overrides Function WrapWithBlockIfAppropriate(ifStatement As MultiLineIfBlockSyntax, statement As StatementSyntax) As StatementSyntax
+            Return statement
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForReturnDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseConditionalExpression/VisualBasicUseConditionalExpressionForReturnDiagnosticAnalyzer.vb
@@ -1,0 +1,21 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.UseConditionalExpression
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+    Friend Class VisualBasicUseConditionalExpressionForReturnDiagnosticAnalyzer
+        Inherits AbstractUseConditionalExpressionForReturnDiagnosticAnalyzer(Of MultiLineIfBlockSyntax)
+
+        Public Sub New()
+            MyBase.New(New LocalizableResourceString(NameOf(VBFeaturesResources.If_statement_can_be_simplified), VBFeaturesResources.ResourceManager, GetType(VBFeaturesResources.VBFeaturesResources)))
+        End Sub
+
+        Protected Overrides Function GetSyntaxFactsService() As ISyntaxFactsService
+            Return VisualBasicSyntaxFactsService.Instance
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
@@ -1179,6 +1179,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to &apos;If&apos; statement can be simplified.
+        '''</summary>
+        Friend ReadOnly Property If_statement_can_be_simplified() As String
+            Get
+                Return ResourceManager.GetString("If_statement_can_be_simplified", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Implicit member access can&apos;t be included in the selection without containing statement.
         '''</summary>
         Friend ReadOnly Property Implicit_member_access_can_t_be_included_in_the_selection_without_containing_statement() As String

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
@@ -1253,4 +1253,7 @@ Sub(&lt;parameterList&gt;) &lt;statement&gt;</value>
   <data name="Convert_to_For" xml:space="preserve">
     <value>Convert  to 'For'</value>
   </data>
+  <data name="If_statement_can_be_simplified" xml:space="preserve">
+    <value>'If' statement can be simplified</value>
+  </data>
 </root>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.cs.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">Vložit {0}</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.de.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">"{0}" einfügen.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.es.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">Inserte '{0}'.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.fr.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">Insérer '{0}'.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.it.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">Inserisci '{0}'.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ja.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">{0} の挿入</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ko.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">{0}'을(를) 삽입합니다.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pl.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">Wstaw element {0}.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pt-BR.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">Inserir "{0}".</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ru.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">Вставка "{0}"</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.tr.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">{0}' öğesini ekleyin.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hans.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">插入“{0}”。</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hant.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="If_statement_can_be_simplified">
+        <source>'If' statement can be simplified</source>
+        <target state="new">'If' statement can be simplified</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Insert_0">
         <source>Insert '{0}'.</source>
         <target state="translated">插入 '{0}'。</target>

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -112,6 +112,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsUseAutoProperty = "CodeActions.UseAutoProperty";
             public const string CodeActionsUseCoalesceExpression = "CodeActions.UseCoalesceExpression";
             public const string CodeActionsUseCollectionInitializer = "CodeActions.UseCollectionInitializer";
+            public const string CodeActionsUseConditionalExpression = "CodeActions.UseConditionalExpression";
             public const string CodeActionsUseDeconstruction = "CodeActions.UseDeconstruction";
             public const string CodeActionsUseDefaultLiteral = "CodeActions.UseDefaultLiteral";
             public const string CodeActionsUseInferredMemberName = "CodeActions.UseInferredMemberName";

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
@@ -354,6 +354,53 @@ class C
 }}
 ";
 
+        private static readonly string s_preferConditionalExpressionOverIfWithAssignments = $@"
+class C
+{{
+    void M()
+    {{
+//[
+        // {ServicesVSResources.Prefer_colon}
+        string s = expr ? ""hello"" : ""world"";
+
+        // {ServicesVSResources.Over_colon}
+        string s;
+        if (expr)
+        {{
+            s = ""hello"";
+        }}
+        else
+        {{
+            s = ""world"";
+        }}
+//]
+    }}
+}}
+";
+
+        private static readonly string s_preferConditionalExpressionOverIfWithReturns = $@"
+class C
+{{
+    void M()
+    {{
+//[
+        // {ServicesVSResources.Prefer_colon}
+        return expr ? ""hello"" : ""world"";
+
+        // {ServicesVSResources.Over_colon}
+        if (expr)
+        {{
+            return ""hello"";
+        }}
+        else
+        {{
+            return ""world"";
+        }}
+//]
+    }}
+}}
+";
+
         private static readonly string s_preferPatternMatchingOverIsWithCastCheck = $@"
 class C
 {{
@@ -930,6 +977,8 @@ class Customer2
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferCollectionInitializer, ServicesVSResources.Prefer_collection_initializer, s_preferCollectionInitializer, s_preferCollectionInitializer, this, optionSet, expressionPreferencesGroupTitle));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck, CSharpVSResources.Prefer_pattern_matching_over_is_with_cast_check, s_preferPatternMatchingOverIsWithCastCheck, s_preferPatternMatchingOverIsWithCastCheck, this, optionSet, expressionPreferencesGroupTitle));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck, CSharpVSResources.Prefer_pattern_matching_over_as_with_null_check, s_preferPatternMatchingOverAsWithNullCheck, s_preferPatternMatchingOverAsWithNullCheck, this, optionSet, expressionPreferencesGroupTitle));
+            CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferConditionalExpressionOverAssignment, ServicesVSResources.Prefer_conditional_expression_over_if_with_assignments, s_preferConditionalExpressionOverIfWithAssignments, s_preferConditionalExpressionOverIfWithAssignments, this, optionSet, expressionPreferencesGroupTitle));
+            CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferConditionalExpressionOverReturn, ServicesVSResources.Prefer_conditional_expression_over_if_with_returns, s_preferConditionalExpressionOverIfWithReturns, s_preferConditionalExpressionOverIfWithReturns, this, optionSet, expressionPreferencesGroupTitle));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferExplicitTupleNames, ServicesVSResources.Prefer_explicit_tuple_name, s_preferExplicitTupleName, s_preferExplicitTupleName, this, optionSet, expressionPreferencesGroupTitle));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferSimpleDefaultExpression, ServicesVSResources.Prefer_simple_default_expression, s_preferSimpleDefaultExpression, s_preferSimpleDefaultExpression, this, optionSet, expressionPreferencesGroupTitle));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferInferredTupleNames, ServicesVSResources.Prefer_inferred_tuple_names, s_preferInferredTupleName, s_preferInferredTupleName, this, optionSet, expressionPreferencesGroupTitle));

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1723,6 +1723,24 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Prefer conditional expression over &apos;if&apos; with assignments.
+        /// </summary>
+        internal static string Prefer_conditional_expression_over_if_with_assignments {
+            get {
+                return ResourceManager.GetString("Prefer_conditional_expression_over_if_with_assignments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer conditional expression over &apos;if&apos; with returns.
+        /// </summary>
+        internal static string Prefer_conditional_expression_over_if_with_returns {
+            get {
+                return ResourceManager.GetString("Prefer_conditional_expression_over_if_with_returns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Prefer deconstructed variable declaration.
         /// </summary>
         internal static string Prefer_deconstructed_variable_declaration {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1034,4 +1034,10 @@ I agree to all of the foregoing:</value>
   <data name="Live_code_analysis" xml:space="preserve">
     <value>Live code analysis</value>
   </data>
+  <data name="Prefer_conditional_expression_over_if_with_assignments" xml:space="preserve">
+    <value>Prefer conditional expression over 'if' with assignments</value>
+  </data>
+  <data name="Prefer_conditional_expression_over_if_with_returns" xml:space="preserve">
+    <value>Prefer conditional expression over 'if' with returns</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1528,6 +1528,16 @@ Souhlasím se všemi výše uvedenými podmínkami:</target>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1528,6 +1528,16 @@ Ich stimme allen vorstehenden Bedingungen zu:</target>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1528,6 +1528,16 @@ Estoy de acuerdo con todo lo anterior:</target>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1528,6 +1528,16 @@ Je suis d'accord avec tout ce qui précède :</target>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1528,6 +1528,16 @@ L'utente accetta le condizioni sopra riportate:</target>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1528,6 +1528,16 @@ I agree to all of the foregoing:</source>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1528,6 +1528,16 @@ I agree to all of the foregoing:</source>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1528,6 +1528,16 @@ Wyrażam zgodę na wszystkie następujące postanowienia:</target>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1528,6 +1528,16 @@ Eu concordo com todo o conteúdo supracitado:</target>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1528,6 +1528,16 @@ I agree to all of the foregoing:</source>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1528,6 +1528,16 @@ Aşağıdakilerin tümünü onaylıyorum:</target>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1528,6 +1528,16 @@ I agree to all of the foregoing:</source>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1528,6 +1528,16 @@ I agree to all of the foregoing:</source>
         <target state="new">Live code analysis</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/VisualBasic/Impl/Options/StyleViewModel.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/StyleViewModel.vb
@@ -250,6 +250,43 @@ Class Customer
 end class
 "
 
+        Private Shared ReadOnly s_preferConditionalExpressionOverIfWithAssignments As String = $"
+Class Customer
+    Public Sub New(name as String, age As Integer)
+//[
+        ' {ServicesVSResources.Prefer_colon}
+        Dim s As String = If(expr, ""hello"", ""world"")
+
+        ' {ServicesVSResources.Over_colon}
+        Dim s As String
+        If expr Then
+            s = ""hello""
+        Else
+            s = ""world""
+        End If
+//]
+    End Sub
+end class
+"
+
+        Private Shared ReadOnly s_preferConditionalExpressionOverIfWithReturns As String = $"
+Class Customer
+    Public Sub New(name as String, age As Integer)
+//[
+        ' {ServicesVSResources.Prefer_colon}
+        Return If(expr, ""hello"", ""world"")
+
+        ' {ServicesVSResources.Over_colon}
+        If expr Then
+            Return ""hello""
+        Else
+            Return ""world""
+        End If
+//]
+    End Sub
+end class
+"
+
         Private Shared ReadOnly s_preferCoalesceExpression As String = $"
 Imports System
 
@@ -399,7 +436,8 @@ End Class"
             Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferExplicitTupleNames, ServicesVSResources.Prefer_explicit_tuple_name, s_preferExplicitTupleName, s_preferExplicitTupleName, Me, optionSet, expressionPreferencesGroupTitle))
             Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferInferredTupleNames, ServicesVSResources.Prefer_inferred_tuple_names, s_preferInferredTupleName, s_preferInferredTupleName, Me, optionSet, expressionPreferencesGroupTitle))
             Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferInferredAnonymousTypeMemberNames, ServicesVSResources.Prefer_inferred_anonymous_type_member_names, s_preferInferredAnonymousTypeMemberName, s_preferInferredAnonymousTypeMemberName, Me, optionSet, expressionPreferencesGroupTitle))
-
+            Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferConditionalExpressionOverAssignment, ServicesVSResources.Prefer_conditional_expression_over_if_with_assignments, s_preferConditionalExpressionOverIfWithAssignments, s_preferConditionalExpressionOverIfWithAssignments, Me, optionSet, expressionPreferencesGroupTitle))
+            Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferConditionalExpressionOverReturn, ServicesVSResources.Prefer_conditional_expression_over_if_with_returns, s_preferConditionalExpressionOverIfWithReturns, s_preferConditionalExpressionOverIfWithReturns, Me, optionSet, expressionPreferencesGroupTitle))
             ' nothing preferences
             Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferCoalesceExpression, ServicesVSResources.Prefer_coalesce_expression, s_preferCoalesceExpression, s_preferCoalesceExpression, Me, optionSet, nothingPreferencesGroupTitle))
             Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferNullPropagation, ServicesVSResources.Prefer_null_propagation, s_preferNullPropagation, s_preferNullPropagation, Me, optionSet, nothingPreferencesGroupTitle))

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -48,6 +48,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static ExpressionSyntax Parenthesize(
             this ExpressionSyntax expression, bool includeElasticTrivia = true, bool addSimplifierAnnotation = true)
         {
+            // a ref expression should never be parenthesized.  It fundamentally breaks the code.
+            // This is because, from the language's perspective there is no such thing as a ref
+            // expression.  instead, there are constructs like ```return ref expr``` or 
+            // ```x ? ref expr1 : ref expr2```, or ```ref int a = ref expr``` in these cases, the 
+            // ref's do not belong to the exprs, but instead belong to the parent construct. i.e.
+            // ```return ref``` or ``` ? ref  ... : ref ... ``` or ``` ... = ref ...```.  For 
+            // parsing convenience, and to prevent having to update all these constructs, we settled
+            // on a ref-expression node.  But this node isn't a true expression that be operated
+            // on like with everything else.
+            if (expression.IsKind(SyntaxKind.RefExpression))
+            {
+                return expression;
+            }
+
             var result = ParenthesizeWorker(expression, includeElasticTrivia);
             return addSimplifierAnnotation
                 ? result.WithAdditionalAnnotations(Simplifier.Annotation)

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
@@ -174,6 +174,22 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                 EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_prefer_is_null_check_over_reference_equality_method"),
                 new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(PreferIsNullCheckOverReferenceEqualityMethod)}") });
 
+        internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferConditionalExpressionOverAssignment = new PerLanguageOption<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions),
+            nameof(PreferConditionalExpressionOverAssignment),
+            defaultValue: TrueWithSuggestionEnforcement,
+            storageLocations: new OptionStorageLocation[]{
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_prefer_conditional_expression_over_assignment"),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferConditionalExpressionOverAssignment")});
+
+        internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferConditionalExpressionOverReturn = new PerLanguageOption<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions),
+            nameof(PreferConditionalExpressionOverReturn),
+            defaultValue: TrueWithSuggestionEnforcement,
+            storageLocations: new OptionStorageLocation[]{
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_prefer_conditional_expression_over_return"),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferConditionalExpressionOverReturn")});
+
         private static readonly CodeStyleOption<AccessibilityModifiersRequired> s_requireAccessibilityModifiersDefault =
             new CodeStyleOption<AccessibilityModifiersRequired>(AccessibilityModifiersRequired.ForNonInterfaceMembers, NotificationOption.None);
 


### PR DESCRIPTION
Note: this PR depends on https://github.com/dotnet/roslyn/pull/25865.  It should not be reviewed until that dependent PR is reviewed.

For example, with: 

![image](https://user-images.githubusercontent.com/4564579/38168541-146b3906-3504-11e8-9dbd-6ebacc4c6c95.png)

We offer:

![image](https://user-images.githubusercontent.com/4564579/38168544-1d5a1640-3504-11e8-8c42-9fe5ea0600b0.png)

Todo:

- [x]  VB
- [x]  Tests
- [x]  Better formatting for large or multi-line clauses in the ```?:``` expression.
- [x]  Support this for ```if```-statements with ```return``` statements in their bodies.

For the last one, this means recognizing:

```c#
if (expr) {
    return a;
} else {
    return b;
}

// as well as

if (expr) {
    return a;
}

return b;
```

and offering to convert to:

```c#
return expr ? a : b;
```

[jcouv edited] Fixes https://github.com/dotnet/roslyn/issues/26539