### PR TITLE
Add resources to our NuGet packages

### DIFF
--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -54,7 +54,7 @@
         "Dlls\\EditorFeatures\\Microsoft.CodeAnalysis.EditorFeatures.dll",
         "Dlls\\EditorFeatures\\*\\Microsoft.CodeAnalysis.EditorFeatures.resources.dll",
         "Dlls\\EditorFeatures.Wpf\\Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll",
-        "Dlls\\EditorFeatures.Wpf\\*\\Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll",
+        "Dlls\\EditorFeatures.Wpf\\*\\Microsoft.CodeAnalysis.EditorFeatures.Wpf.resources.dll",
         "Dlls\\Features\\Microsoft.CodeAnalysis.Features.dll",
         "Dlls\\Features\\*\\Microsoft.CodeAnalysis.Features.resources.dll",
         "Dlls\\InteractiveEditorFeatures\\Microsoft.CodeAnalysis.InteractiveEditorFeatures.dll",

--- a/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
@@ -55,5 +55,9 @@
     <file src="Dlls\MSBuildTask\net46\Microsoft.CSharp.Core.targets" target="contentFiles\any\any" />
     <file src="Dlls\MSBuildTask\net46\Microsoft.VisualBasic.Core.targets" target="contentFiles\any\any" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\MSBuildTask\netcoreapp2.0\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll" target="lib\netcoreapp2.0" />
+    <file src="Dlls\MSBuildTask\net46\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll" target="lib\net46" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.CodeStyle.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.CodeStyle.nuspec
@@ -33,6 +33,12 @@
     <file src="Dlls\CodeStyleFixes\Microsoft.CodeAnalysis.CodeStyle.Fixes.dll" target="analyzers\dotnet\cs" />
     <file src="$thirdPartyNoticesPath$" target="" />
 
+    <!-- Satellite assemblies -->
+    <file src="Dlls\CSharpCodeStyle\**\Microsoft.CodeAnalysis.CSharp.CodeStyle.resources.dll" target="analyzers\dotnet\cs" />
+    <file src="Dlls\CSharpCodeStyleFixes\**\Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.resources.dll" target="analyzers\dotnet\cs" />
+    <file src="Dlls\CodeStyle\**\Microsoft.CodeAnalysis.CodeStyle.resources.dll" target="analyzers\dotnet\cs" />
+    <file src="Dlls\CodeStyleFixes\**\Microsoft.CodeAnalysis.CodeStyle.Fixes.resources.dll" target="analyzers\dotnet\cs" />
+
     <!-- Scripts -->
     <file src="..\..\src\Setup\PowerShell\install.ps1" target="tools\" />
     <file src="..\..\src\Setup\PowerShell\uninstall.ps1" target="tools\" />

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Features.nuspec
@@ -32,5 +32,8 @@
     <file src="Dlls\CSharpFeatures\Microsoft.CodeAnalysis.CSharp.Features.xml" target="lib\netstandard1.3" />
     <file src="Dlls\CSharpFeatures\Microsoft.CodeAnalysis.CSharp.Features.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\CSharpFeatures\**\Microsoft.CodeAnalysis.CSharp.Features.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
@@ -32,5 +32,8 @@
     <file src="Dlls\CSharpScripting\Microsoft.CodeAnalysis.CSharp.Scripting.xml" target="lib\netstandard1.3" />
     <file src="Dlls\CSharpScripting\Microsoft.CodeAnalysis.CSharp.Scripting.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\CSharpScripting\**\Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Workspaces.nuspec
@@ -33,5 +33,8 @@
     <file src="Dlls\CSharpWorkspace\Microsoft.CodeAnalysis.CSharp.Workspaces.xml" target="lib\netstandard1.3" />
     <file src="Dlls\CSharpWorkspace\Microsoft.CodeAnalysis.CSharp.Workspaces.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\CSharpWorkspace\**\Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
@@ -32,5 +32,8 @@
     <file src="Dlls\CSharpCodeAnalysis\Microsoft.CodeAnalysis.CSharp.xml" target="lib\netstandard1.3" />
     <file src="Dlls\CSharpCodeAnalysis\Microsoft.CodeAnalysis.CSharp.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\CSharpCodeAnalysis\**\Microsoft.CodeAnalysis.CSharp.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
@@ -75,5 +75,8 @@
     <file src="Dlls\CodeAnalysis\Microsoft.CodeAnalysis.xml" target="lib\netstandard1.3" />
     <file src="Dlls\CodeAnalysis\Microsoft.CodeAnalysis.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\CodeAnalysis\**\Microsoft.CodeAnalysis.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
@@ -34,5 +34,8 @@
     <file src="Dlls\TextEditorFeatures\Microsoft.CodeAnalysis.EditorFeatures.Text.xml" target="lib\net46" />
     <file src="Dlls\TextEditorFeatures\Microsoft.CodeAnalysis.EditorFeatures.Text.pdb*" target="lib\net46" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\TextEditorFeatures\**\Microsoft.CodeAnalysis.EditorFeatures.Text.resources.dll" target="lib\net46" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Wpf.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Wpf.nuspec
@@ -31,5 +31,8 @@
   <files>
     <file src="Dlls\EditorFeatures.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll" target="lib\net46" />
     <file src="Dlls\EditorFeatures.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.xml" target="lib\net46" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\EditorFeatures.Wpf\**\Microsoft.CodeAnalysis.EditorFeatures.Wpf.resources.dll" target="lib\net46" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
@@ -40,5 +40,10 @@
     <file src="Dlls\BasicEditorFeatures\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll" target="lib\net46" />
     <file src="Dlls\BasicEditorFeatures\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.xml" target="lib\net46" />
     <file src="Dlls\BasicEditorFeatures\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.pdb*" target="lib\net46" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\EditorFeatures\**\Microsoft.CodeAnalysis.EditorFeatures.resources.dll" target="lib\net46" />
+    <file src="Dlls\CSharpEditorFeatures\**\Microsoft.CodeAnalysis.CSharp.EditorFeatures.resources.dll" target="lib\net46" />
+    <file src="Dlls\BasicEditorFeatures\**\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.resources.dll" target="lib\net46" />**\
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Features.nuspec
@@ -31,5 +31,8 @@
     <file src="Dlls\Features\Microsoft.CodeAnalysis.Features.xml" target="lib\netstandard1.3" />
     <file src="Dlls\Features\Microsoft.CodeAnalysis.Features.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\Features\**\Microsoft.CodeAnalysis.Features.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
@@ -32,5 +32,8 @@
     <file src="Dlls\RazorServiceHub\Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.dll" target="lib\net46" />
     <file src="Dlls\RazorServiceHub\Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.xml" target="lib\net46" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\RazorServiceHub\**\Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.resources.dll" target="lib\net46" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
@@ -36,5 +36,8 @@
     <file src="Dlls\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.xml" target="lib\net46" />
     <file src="Dlls\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.pdb*" target="lib\net46" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\ServiceHub\**\Microsoft.CodeAnalysis.Remote.ServiceHub.resources.dll" target="lib\net46" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
@@ -38,5 +38,8 @@
     <file src="Dlls\RemoteWorkspaces\Microsoft.CodeAnalysis.Remote.Workspaces.xml" target="lib\net46" />
     <file src="Dlls\RemoteWorkspaces\Microsoft.CodeAnalysis.Remote.Workspaces.pdb*" target="lib\net46" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\RemoteWorkspaces\**\Microsoft.CodeAnalysis.Remote.Workspaces.resources.dll" target="lib\net46" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
@@ -52,5 +52,8 @@
     <file src="Dlls\Scripting\Microsoft.CodeAnalysis.Scripting.xml" target="lib\netstandard1.3" />
     <file src="Dlls\Scripting\Microsoft.CodeAnalysis.Scripting.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\Scripting\**\Microsoft.CodeAnalysis.Scripting.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.nuspec
@@ -33,6 +33,12 @@
     <file src="Dlls\CodeStyleFixes\Microsoft.CodeAnalysis.CodeStyle.Fixes.dll" target="analyzers\dotnet\vb" />
     <file src="$thirdPartyNoticesPath$" target="" />
 
+    <!-- Satellite assemblies -->
+    <file src="Dlls\BasicCodeStyle\**\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.resources.dll" target="analyzers\dotnet\vb" />
+    <file src="Dlls\BasicCodeStyleFixes\**\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.resources.dll" target="analyzers\dotnet\vb" />
+    <file src="Dlls\CodeStyle\**\Microsoft.CodeAnalysis.CodeStyle.resources.dll" target="analyzers\dotnet\vb" />
+    <file src="Dlls\CodeStyleFixes\**\Microsoft.CodeAnalysis.CodeStyle.Fixes.resources.dll" target="analyzers\dotnet\vb" />
+
     <!-- Scripts -->
     <file src="..\..\src\Setup\PowerShell\install.ps1" target="tools\" />
     <file src="..\..\src\Setup\PowerShell\uninstall.ps1" target="tools\" />

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Features.nuspec
@@ -32,5 +32,8 @@
     <file src="Dlls\BasicFeatures\Microsoft.CodeAnalysis.VisualBasic.Features.xml" target="lib\netstandard1.3" />
     <file src="Dlls\BasicFeatures\Microsoft.CodeAnalysis.VisualBasic.Features.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\BasicFeatures\**\Microsoft.CodeAnalysis.VisualBasic.Features.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Scripting.nuspec
@@ -34,5 +34,8 @@
     <file src="Dlls\BasicScripting\Microsoft.CodeAnalysis.VisualBasic.Scripting.xml" target="lib\dotnet" />
     <file src="Dlls\BasicScripting\Microsoft.CodeAnalysis.VisualBasic.Scripting.pdb*" target="lib\dotnet" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\BasicScripting\**\Microsoft.CodeAnalysis.VisualBasic.Scripting.resources.dll" target="lib\dotnet" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Workspaces.nuspec
@@ -33,5 +33,8 @@
     <file src="Dlls\BasicWorkspace\Microsoft.CodeAnalysis.VisualBasic.Workspaces.xml" target="lib\netstandard1.3" />
     <file src="Dlls\BasicWorkspace\Microsoft.CodeAnalysis.VisualBasic.Workspaces.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\BasicWorkspace\**\Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
@@ -32,5 +32,8 @@
     <file src="Dlls\BasicCodeAnalysis\Microsoft.CodeAnalysis.VisualBasic.xml" target="lib\netstandard1.3" />
     <file src="Dlls\BasicCodeAnalysis\Microsoft.CodeAnalysis.VisualBasic.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\BasicCodeAnalysis\**\Microsoft.CodeAnalysis.VisualBasic.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
@@ -51,5 +51,10 @@
     <file src="Dlls\Workspaces\Microsoft.CodeAnalysis.Workspaces.xml" target="lib\netstandard1.3" />
     <file src="Dlls\Workspaces\Microsoft.CodeAnalysis.Workspaces.pdb*" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\Workspaces.Desktop\**\Microsoft.CodeAnalysis.Workspaces.Desktop.resources.dll" target="lib\net46" />
+    <file src="Dlls\Workspaces\**\Microsoft.CodeAnalysis.Workspaces.resources.dll" target="lib\net46" />
+    <file src="Dlls\Workspaces\**\Microsoft.CodeAnalysis.Workspaces.resources.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.MSBuild.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.MSBuild.nuspec
@@ -39,5 +39,8 @@
     <file src="Dlls\Workspaces.MSBuild\Microsoft.CodeAnalysis.Workspaces.MSBuild.xml" target="lib\net46" />
     <file src="Dlls\Workspaces.MSBuild\Microsoft.CodeAnalysis.Workspaces.MSBuild.pdb*" target="lib\net46" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\Workspaces.MSBuild\**\Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll" target="lib\net46" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -54,6 +54,14 @@
     <file src="Dlls\MSbuildTask\net46\Microsoft.CSharp.Core.targets" target="tools" />
     <file src="Dlls\MSbuildTask\net46\Microsoft.VisualBasic.Core.targets" target="tools" />
 
+    <!-- Satellite assemblies -->
+    <file src="Dlls\CodeAnalysis\**\Microsoft.CodeAnalysis.resources.dll" target="tools" />
+    <file src="Dlls\CSharpCodeAnalysis\**\Microsoft.CodeAnalysis.CSharp.resources.dll" target="tools" />
+    <file src="Dlls\Scripting\**\Microsoft.CodeAnalysis.Scripting.resources.dll" target="tools" />
+    <file src="Dlls\CSharpScripting\**\Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll" target="tools" />
+    <file src="Dlls\BasicCodeAnalysis\**\Microsoft.CodeAnalysis.VisualBasic.resources.dll" target="tools" />
+    <file src="Dlls\MSBuildTask\net46\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll" target="tools" />
+
     <!-- The assemblies are not signed by us and any deployed copy can be used.
          The Exes\Toolset directory specifically has all of the assemblies we need.
 

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
@@ -32,5 +32,8 @@
     <file src="Dlls\RazorVisualStudio\Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.dll" target="lib\net46" />
     <file src="Dlls\RazorVisualStudio\Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.xml" target="lib\net46" />
     <file src="$thirdPartyNoticesPath$" target="" />
+
+    <!-- Satellite assemblies -->
+    <file src="Dlls\RazorVisualStudio\**\Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.resources.dll" target="lib\net46" />
   </files>
 </package>

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -1031,8 +1031,14 @@ Public Class BuildDevDivInsertionFiles
 
         ' First copy over all the files from the compilers toolset. 
         For Each fileRelativePath In GetCompilerToolsetNuspecFiles()
-            Dim filePath = Path.Combine(_binDirectory, fileRelativePath)
             Dim fileName = Path.GetFileName(fileRelativePath)
+
+            ' Skip satellite assemblies; we don't need these for the compiler insertion
+            If fileName.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase) Then
+                Continue For
+            End If
+
+            Dim filePath = Path.Combine(_binDirectory, fileRelativePath)
             Dim destFilepath = Path.Combine(outputDir, fileName)
             File.Copy(filePath, destFilepath)
             nuspecFiles.Add(fileName)
@@ -1149,6 +1155,10 @@ set DEVPATH=%RoslynToolsRoot%;%DEVPATH%"
     Private Function GetCompilerInsertFiles() As IEnumerable(Of String)
         Return GetCompilerToolsetNuspecFiles().
             Select(AddressOf Path.GetFileName).
+            Where(Function(f)
+                      ' Skip satellite assemblies; we don't need these for the compiler insertion
+                      Return Not f.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase)
+                  End Function).
             Where(Function(f)
                       Select Case f
                           ' These files are inserted by MSBuild setup 


### PR DESCRIPTION
Now that we're producing satellite assemblies with localized resources
directly out of the repo we can include them in our NuGet packages.

Not all of these packages currently have satellite assemblies, but if they are added later we will pick them up.