### PR TITLE
Make VisualStudioRuleSetManager thread safe

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
@@ -112,15 +112,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             ReportDiagnostic? ruleSetGeneralDiagnosticOption = null;
             if (this.RuleSetFile != null)
             {
-                ruleSetGeneralDiagnosticOption = this.RuleSetFile.GetGeneralDiagnosticOption();
-                ruleSetSpecificDiagnosticOptions = new Dictionary<string, ReportDiagnostic>(this.RuleSetFile.GetSpecificDiagnosticOptions());
+                ruleSetGeneralDiagnosticOption = this.RuleSetFile.Target.GetGeneralDiagnosticOption();
+                ruleSetSpecificDiagnosticOptions = new Dictionary<string, ReportDiagnostic>(this.RuleSetFile.Target.GetSpecificDiagnosticOptions());
             }
             else
             {
                 ruleSetSpecificDiagnosticOptions = new Dictionary<string, ReportDiagnostic>();
             }
 
-            UpdateRuleSetError(this.RuleSetFile);
+            UpdateRuleSetError(this.RuleSetFile?.Target);
 
             ReportDiagnostic generalDiagnosticOption;
             var warningsAreErrors = GetNullableBooleanOption(CompilerOptions.OPTID_WARNINGSAREERRORS);

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
@@ -75,7 +75,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 // Verify SetRuleSetFile updates the ruleset.
                 File.WriteAllText(ruleSetFile.Path, ruleSetSource);
                 project.SetRuleSetFile(ruleSetFile.Path);
-                Assert.Equal(ruleSetFile.Path, project.RuleSetFile.FilePath);
+                Assert.Equal(ruleSetFile.Path, project.RuleSetFile.Target.FilePath);
 
                 // We need to explicitly update the command line arguments so the new ruleset is used to update options.
                 project.SetOptions($"/ruleset:{ruleSetFile.Path}");

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
@@ -174,7 +174,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
 
                 var projectRuleSetFile = project.RuleSetFile;
 
-                Assert.Equal(expected: ruleSetFile.Path, actual: projectRuleSetFile.FilePath);
+                Assert.Equal(expected: ruleSetFile.Path, actual: projectRuleSetFile.Target.FilePath);
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -199,7 +199,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// </summary>
         internal string BinOutputPath { get; private set; }
 
-        public IRuleSetFile RuleSetFile { get; private set; }
+        public IReferenceCountedDisposable<IRuleSetFile> RuleSetFile { get; private set; }
 
         protected VisualStudioProjectTracker ProjectTracker { get; }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             if (this.RuleSetFile != null &&
-                this.RuleSetFile.FilePath.Equals(ruleSetFileFullPath, StringComparison.OrdinalIgnoreCase))
+                this.RuleSetFile.Target.FilePath.Equals(ruleSetFileFullPath, StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -171,8 +171,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             if (ruleSetFileFullPath.Length != 0)
             {
-                this.RuleSetFile = this.ProjectTracker.RuleSetFileProvider.GetOrCreateRuleSet(ruleSetFileFullPath);
-                this.RuleSetFile.UpdatedOnDisk += OnRuleSetFileUpdateOnDisk;
+                this.RuleSetFile = this.ProjectTracker.RuleSetFileManager.GetOrCreateRuleSet(ruleSetFileFullPath);
+                this.RuleSetFile.Target.UpdatedOnDisk += OnRuleSetFileUpdateOnDisk;
             }
         }
 
@@ -180,7 +180,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             if (this.RuleSetFile != null)
             {
-                this.RuleSetFile.UpdatedOnDisk -= OnRuleSetFileUpdateOnDisk;
+                this.RuleSetFile.Target.UpdatedOnDisk -= OnRuleSetFileUpdateOnDisk;
+                this.RuleSetFile.Dispose();
                 this.RuleSetFile = null;
             }
         }
@@ -190,7 +191,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             AssertIsForeground();
 
-            var filePath = this.RuleSetFile.FilePath;
+            var filePath = this.RuleSetFile.Target.FilePath;
 
             ResetAnalyzerRuleSet(filePath);
         }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Options.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Options.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             AssertIsForeground();
 
-            this.UpdateRuleSetError(this.RuleSetFile);
+            this.UpdateRuleSetError(this.RuleSetFile?.Target);
 
             // Set options.
             this.SetOptionsCore(newCompilationOptions, newParseOptions);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
@@ -1,21 +1,33 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Shell.Interop;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    internal sealed partial class VisualStudioRuleSetManager : IWorkspaceService, IDisposable
+    internal sealed partial class VisualStudioRuleSetManager : IWorkspaceService
     {
         private readonly IVsFileChangeEx _fileChangeService;
         private readonly IForegroundNotificationService _foregroundNotificationService;
         private readonly IAsynchronousOperationListener _listener;
 
-        private readonly Dictionary<string, RuleSetFile> _ruleSetFileMap = new Dictionary<string, RuleSetFile>(StringComparer.OrdinalIgnoreCase);
+        /// <summary>
+        /// Gate that guards access to <see cref="_ruleSetFileMap"/>.
+        /// </summary>
+        private readonly object _gate = new object();
+
+        /// <summary>
+        /// The map of cached <see cref="RuleSetFile"/>. We use a WeakReference here because we want to strike this entry from the cache when all users are
+        /// disposed, but that means we ourselves don't want to be contributing to that reference count. Since consumers of this are responsible for all
+        /// disposing, it's safe for us to also remove entries from this map if we need to refresh -- once everybody who consumed it disposes everything,
+        /// the underlying file watchers will be cleaned up.
+        /// </summary>
+        private readonly Dictionary<string, ReferenceCountedDisposable<RuleSetFile>.WeakReference> _ruleSetFileMap =
+            new Dictionary<string, ReferenceCountedDisposable<RuleSetFile>.WeakReference>();
 
         public VisualStudioRuleSetManager(
             IVsFileChangeEx fileChangeService, IForegroundNotificationService foregroundNotificationService, IAsynchronousOperationListener listener)
@@ -25,35 +37,55 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _listener = listener;
         }
 
-        public IRuleSetFile GetOrCreateRuleSet(string ruleSetFileFullPath)
+        public IReferenceCountedDisposable<IRuleSetFile> GetOrCreateRuleSet(string ruleSetFileFullPath)
         {
-            if (!_ruleSetFileMap.TryGetValue(ruleSetFileFullPath, out var ruleSetFile))
+            ReferenceCountedDisposable<RuleSetFile> disposable = null;
+
+            lock (_gate)
             {
-                ruleSetFile = new RuleSetFile(ruleSetFileFullPath, _fileChangeService, this);
-                _ruleSetFileMap.Add(ruleSetFileFullPath, ruleSetFile);
+                // If we already have one in the map to hand out, great
+                if (_ruleSetFileMap.TryGetValue(ruleSetFileFullPath, out var weakReference))
+                {
+                    disposable = weakReference.TryAddReference();
+                }
+
+                if (disposable == null)
+                {
+                    // We didn't easily get a disposable, so one of two things is the case:
+                    //
+                    // 1. We have no entry in _ruleSetFileMap at all for this.
+                    // 2. We had an entry, but it was disposed and is no longer valid.
+
+                    // In either case, we'll create a new rule set file and add it to the map.
+                    disposable = new ReferenceCountedDisposable<RuleSetFile>(new RuleSetFile(ruleSetFileFullPath, this));
+                    _ruleSetFileMap[ruleSetFileFullPath] = new ReferenceCountedDisposable<RuleSetFile>.WeakReference(disposable);
+                }
             }
 
-            return ruleSetFile;
+            // Call InitializeFileTracking outside the lock, so we don't have requests for other files blocking behind the initialization of this one.
+            // RuleSetFile itself will ensure InitializeFileTracking is locked as appropriate.
+            disposable.Target.InitializeFileTracking(_fileChangeService);
+
+            return disposable;
         }
 
         private void StopTrackingRuleSetFile(RuleSetFile ruleSetFile)
         {
-            _ruleSetFileMap.Remove(ruleSetFile.FilePath);
-        }
-
-        public void ClearCachedRuleSetFiles()
-        {
-            foreach (var pair in _ruleSetFileMap)
+            // We can arrive here in one of two situations:
+            // 
+            // 1. The underlying RuleSetFile was disposed by all consumers, and we can try cleaning up our weak reference. This is purely an optimization
+            //    to avoid the key/value pair being unnecessarily held.
+            // 2. The RuleSetFile was modified, and we want to get rid of our cache now. Anybody still holding onto the values will dispose at their leaisure,
+            //    but it won't really matter anyways since the Dispose() that cleans up file trackers is already done.
+            //
+            // In either case, we can just be lazy and remove the key/value pair. It's possible in the mean time that the rule set had already been removed
+            // (perhaps by a file change), and we're removing a live instance. This is fine, as this doesn't affect correctness: we consider this to be a cache
+            // and if two callers got different copies that's fine. We *could* fetch the item out of the dictionary, check if the item is strong and then compare,
+            // but that seems overkill.
+            lock (_gate)
             {
-                pair.Value.UnsubscribeFromFileTrackers();
+                _ruleSetFileMap.Remove(ruleSetFile.FilePath);
             }
-
-            _ruleSetFileMap.Clear();
-        }
-
-        void IDisposable.Dispose()
-        {
-            ClearCachedRuleSetFiles();
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -148,16 +148,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             Contract.ThrowIfFalse(DocumentProvider == null);
             Contract.ThrowIfFalse(MetadataReferenceProvider == null);
-            Contract.ThrowIfFalse(RuleSetFileProvider == null);
+            Contract.ThrowIfFalse(RuleSetFileManager == null);
 
             DocumentProvider = documentProvider;
             MetadataReferenceProvider = metadataReferenceProvider;
-            RuleSetFileProvider = ruleSetFileProvider;
+            RuleSetFileManager = ruleSetFileProvider;
         }
 
         public DocumentProvider DocumentProvider { get; private set; }
         public VisualStudioMetadataReferenceManager MetadataReferenceProvider { get; private set; }
-        public VisualStudioRuleSetManager RuleSetFileProvider { get; private set; }
+        public VisualStudioRuleSetManager RuleSetFileManager { get; private set; }
 
         internal AbstractProject GetProject(ProjectId id)
         {
@@ -587,8 +587,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 _projectPathToIdMap.Clear();
             }
-
-            RuleSetFileProvider.ClearCachedRuleSetFiles();
 
             _solutionAdded = false;
             _pushedProjects.Clear();

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -260,7 +260,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             foreach (var group in groups)
             {
                 var project = (AbstractProject)workspace.GetHostProject(group.Key);
-                IRuleSetFile ruleSet = project.RuleSetFile;
+                IRuleSetFile ruleSet = project.RuleSetFile?.Target;
 
                 if (ruleSet != null)
                 {
@@ -385,7 +385,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                     try
                     {
                         EnvDTE.DTE dte = (EnvDTE.DTE)_serviceProvider.GetService(typeof(EnvDTE.DTE));
-                        dte.ItemOperations.OpenFile(project.RuleSetFile.FilePath);
+                        dte.ItemOperations.OpenFile(project.RuleSetFile.Target.FilePath);
                     }
                     catch (Exception e)
                     {
@@ -423,7 +423,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                     continue;
                 }
 
-                var pathToRuleSet = project.RuleSetFile?.FilePath;
+                var pathToRuleSet = project.RuleSetFile?.Target.FilePath;
 
                 if (pathToRuleSet == null)
                 {

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         Private ReadOnly _tempPath As String
 
         Public Sub New()
-            _tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+            _tempPath = Path.Combine(TempRoot.Root, Path.GetRandomFileName())
             Directory.CreateDirectory(_tempPath)
         End Sub
 

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
@@ -11,6 +11,18 @@ Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     Public Class VisualStudioRuleSetTests
+        Implements IDisposable
+
+        Private ReadOnly _tempPath As String
+
+        Public Sub New()
+            _tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+            Directory.CreateDirectory(_tempPath)
+        End Sub
+
+        Private Sub Dispose() Implements IDisposable.Dispose
+            Directory.Delete(_tempPath, recursive:=True)
+        End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub SingleFile()
@@ -25,26 +37,21 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
   </Rules>
 </RuleSet>"
 
-            Dim tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
-            Directory.CreateDirectory(tempPath)
 
-            Dim ruleSetPath As String = Path.Combine(tempPath, "a.ruleset")
+            Dim ruleSetPath As String = Path.Combine(_tempPath, "a.ruleset")
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Using ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
-                Dim visualStudioRuleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
+            Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
+            Using visualStudioRuleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = visualStudioRuleSet.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = visualStudioRuleSet.Target.GetGeneralDiagnosticOption()
 
                 Assert.Equal(expected:=1, actual:=fileChangeService.WatchedFileCount)
             End Using
 
             Assert.Equal(expected:=0, actual:=fileChangeService.WatchedFileCount)
-            GC.Collect()
-            GC.WaitForPendingFinalizers()
-            Directory.Delete(tempPath, recursive:=True)
         End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
@@ -67,31 +74,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
   </Rules>
 </RuleSet>"
 
-            Dim tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
-            Directory.CreateDirectory(tempPath)
-
-            Dim ruleSetPath As String = Path.Combine(tempPath, "a.ruleset")
+            Dim ruleSetPath As String = Path.Combine(_tempPath, "a.ruleset")
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
-            Dim includePath As String = Path.Combine(tempPath, "file1.ruleset")
+            Dim includePath As String = Path.Combine(_tempPath, "file1.ruleset")
             File.WriteAllText(includePath, includeSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Using ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
-                Dim visualStudioRuleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
+            Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
+            Using visualStudioRuleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = visualStudioRuleSet.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = visualStudioRuleSet.Target.GetGeneralDiagnosticOption()
 
                 Assert.Equal(expected:=2, actual:=fileChangeService.WatchedFileCount)
             End Using
 
             Assert.Equal(expected:=0, actual:=fileChangeService.WatchedFileCount)
-
-            GC.Collect()
-            GC.WaitForPendingFinalizers()
-
-            Directory.Delete(tempPath, recursive:=True)
         End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
@@ -114,36 +113,24 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
   </Rules>
 </RuleSet>"
 
-            Dim tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
-            Directory.CreateDirectory(tempPath)
-
-            Dim ruleSetPath As String = Path.Combine(tempPath, "a.ruleset")
+            Dim ruleSetPath As String = Path.Combine(_tempPath, "a.ruleset")
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
-            Dim includePath As String = Path.Combine(tempPath, "file1.ruleset")
+            Dim includePath As String = Path.Combine(_tempPath, "file1.ruleset")
             File.WriteAllText(includePath, includeSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Using ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
-                Dim ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
+            Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
+            Using ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
                 Dim handlerCalled As Boolean = False
-                Dim handler = Sub(sender As Object, e As EventArgs)
-                                  handlerCalled = True
-                              End Sub
-                AddHandler ruleSet1.UpdatedOnDisk, handler
+                AddHandler ruleSet1.Target.UpdatedOnDisk, Sub() handlerCalled = True
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = ruleSet1.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = ruleSet1.Target.GetGeneralDiagnosticOption()
 
                 fileChangeService.FireUpdate(includePath)
                 Assert.True(handlerCalled)
-
-                RemoveHandler ruleSet1.UpdatedOnDisk, handler
             End Using
-            GC.Collect()
-            GC.WaitForPendingFinalizers()
-
-            Directory.Delete(tempPath, recursive:=True)
         End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
@@ -159,34 +146,28 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
   </Rules>
 </RuleSet>"
 
-            Dim tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
-            Directory.CreateDirectory(tempPath)
-
-            Dim ruleSetPath As String = Path.Combine(tempPath, "a.ruleset")
+            Dim ruleSetPath As String = Path.Combine(_tempPath, "a.ruleset")
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Using ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
-                Dim ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
+            Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
+            Using ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = ruleSet1.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = ruleSet1.Target.GetGeneralDiagnosticOption()
                 fileChangeService.FireUpdate(ruleSetPath)
 
-                Dim ruleSet2 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
+                Using ruleSet2 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
-                ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                generalDiagnosticOption = ruleSet2.GetGeneralDiagnosticOption()
+                    ' Signing up for file change notifications is lazy, so read the rule set to force it.
+                    generalDiagnosticOption = ruleSet2.Target.GetGeneralDiagnosticOption()
 
-                Assert.Equal(expected:=1, actual:=fileChangeService.WatchedFileCount)
-                Assert.False(Object.ReferenceEquals(ruleSet1, ruleSet2))
+                    Assert.Equal(expected:=1, actual:=fileChangeService.WatchedFileCount)
+                    Assert.NotSame(ruleSet1.Target, ruleSet2.Target)
+                End Using
             End Using
 
-            Assert.Equal(expected:=0, actual:=fileChangeService.WatchedFileCount)
-            GC.Collect()
-            GC.WaitForPendingFinalizers()
-
-            Directory.Delete(tempPath, recursive:=True)
+                Assert.Equal(expected:=0, actual:=fileChangeService.WatchedFileCount)
         End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
@@ -202,28 +183,24 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
   </Rules>
 </RuleSet>"
 
-            Dim tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
-            Directory.CreateDirectory(tempPath)
-
-            Dim ruleSetPath As String = Path.Combine(tempPath, "a.ruleset")
+            Dim ruleSetPath As String = Path.Combine(_tempPath, "a.ruleset")
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Using ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
-                Dim ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
+            Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
+            Using ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = ruleSet1.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = ruleSet1.Target.GetGeneralDiagnosticOption()
 
-                Dim ruleSet2 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
+                Using ruleSet2 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
-                Assert.Equal(expected:=1, actual:=fileChangeService.WatchedFileCount)
-                Assert.Same(ruleSet1, ruleSet2)
+                    Assert.Equal(expected:=1, actual:=fileChangeService.WatchedFileCount)
+                    Assert.Same(ruleSet1.Target, ruleSet2.Target)
+                End Using
             End Using
 
             Assert.Equal(expected:=0, actual:=fileChangeService.WatchedFileCount)
-
-            Directory.Delete(tempPath, recursive:=True)
         End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
@@ -239,25 +216,20 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
   </Rules>
 </RuleSet>"
 
-            Dim tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
-            Directory.CreateDirectory(tempPath)
-
-            Dim ruleSetPath As String = Path.Combine(tempPath, "a.ruleset")
+            Dim ruleSetPath As String = Path.Combine(_tempPath, "a.ruleset")
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Using ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
-                Dim ruleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
+            Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeService, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
+            Using ruleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
-                Dim generalDiagnosticOption = ruleSet.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = ruleSet.Target.GetGeneralDiagnosticOption()
 
                 Assert.Equal(expected:=ReportDiagnostic.Default, actual:=generalDiagnosticOption)
 
-                Dim exception = ruleSet.GetException()
+                Dim exception = ruleSet.Target.GetException()
                 Assert.NotNull(exception)
             End Using
-
-            Directory.Delete(tempPath, recursive:=True)
         End Sub
 
     End Class

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -406,7 +406,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
         Protected Overrides Function CreateCompilationOptions(commandLineArguments As CommandLineArguments, newParseOptions As ParseOptions) As CompilationOptions
             Dim baseCompilationOptions = DirectCast(MyBase.CreateCompilationOptions(commandLineArguments, newParseOptions), VisualBasicCompilationOptions)
             Dim vbParseOptions = DirectCast(newParseOptions, VisualBasicParseOptions)
-            Return VisualBasicProjectOptionsHelper.CreateCompilationOptions(baseCompilationOptions, vbParseOptions, _rawOptions, _compilerHost, _imports, ContainingDirectoryPathOpt, RuleSetFile)
+            Return VisualBasicProjectOptionsHelper.CreateCompilationOptions(baseCompilationOptions, vbParseOptions, _rawOptions, _compilerHost, _imports, ContainingDirectoryPathOpt, RuleSetFile?.Target)
         End Function
 
         Protected Overrides Function CreateParseOptions(commandLineArguments As CommandLineArguments) As ParseOptions

--- a/src/Workspaces/Core/Portable/Utilities/IReferenceCountedDisposable.cs
+++ b/src/Workspaces/Core/Portable/Utilities/IReferenceCountedDisposable.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// A covariant interface form of <see cref="ReferenceCountedDisposable{T}"/> that lets you re-cast an <see cref="ReferenceCountedDisposable{T}"/>
+    /// to a more base type. This can include types that do not implement <see cref="IDisposable"/> if you want to prevent a caller from accidentally
+    /// disposing <see cref="Target"/> directly.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal interface IReferenceCountedDisposable<out T> : IDisposable
+        where T : class
+    {
+        /// <summary>
+        /// Gets the target object.
+        /// </summary>
+        /// <remarks>
+        /// <para>This call is not valid after <see cref="IDisposable.Dispose"/> is called. If this property or the target
+        /// object is used concurrently with a call to <see cref="IDisposable.Dispose"/>, it is possible for the code to be
+        /// using a disposed object. After the current instance is disposed, this property throws
+        /// <see cref="ObjectDisposedException"/>. However, the exact time when this property starts throwing after
+        /// <see cref="IDisposable.Dispose"/> is called is unspecified; code is expected to not use this property or the object
+        /// it returns after any code invokes <see cref="IDisposable.Dispose"/>.</para>
+        /// </remarks>
+        /// <value>The target object.</value>
+        T Target { get; }
+
+        /// <summary>
+        /// Increments the reference count for the disposable object, and returns a new disposable reference to it.
+        /// </summary>
+        /// <remarks>
+        /// <para>The returned object is an independent reference to the same underlying object. Disposing of the
+        /// returned value multiple times will only cause the reference count to be decreased once.</para>
+        /// </remarks>
+        /// <returns>A new <see cref="ReferenceCountedDisposable{T}"/> pointing to the same underlying object, if it
+        /// has not yet been disposed; otherwise, <see langword="null"/> if this reference to the underlying object
+        /// has already been disposed.</returns>
+        IReferenceCountedDisposable<T> TryAddReference();
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/ReferenceCountedDisposable.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ReferenceCountedDisposable.cs
@@ -49,7 +49,7 @@ namespace Roslyn.Utilities
     /// even in concurrent execution.</para>
     /// </remarks>
     /// <typeparam name="T">The type of disposable object.</typeparam>
-    internal sealed class ReferenceCountedDisposable<T> : IDisposable
+    internal sealed class ReferenceCountedDisposable<T> : IReferenceCountedDisposable<T>, IDisposable
         where T : class, IDisposable
     {
         /// <summary>
@@ -126,6 +126,11 @@ namespace Roslyn.Utilities
         public ReferenceCountedDisposable<T> TryAddReference()
         {
             return TryAddReferenceImpl(_instance, _boxedReferenceCount);
+        }
+
+        IReferenceCountedDisposable<T> IReferenceCountedDisposable<T>.TryAddReference()
+        {
+            return TryAddReference();
         }
 
         /// <summary>


### PR DESCRIPTION
VisualStudioRuleSetManager acts a single global cache for the contents of rule set files, and also offers eventing if the effective contents change. This was previously only being called on the UI thread everywhere, but it won't be much sooner.

Now that we have ReferenceCountedDisposable, I also take advantage of that type to change how we do caching: previously, we would keep filling this cache until the solution close, and then we'd clear out everything at once. There are two things that aren't great about this pattern:

1. It's a small memory leak, at least up until solution close if you stopped using a rule set -- we'll keep holding onto it until we close everything.
2. It assumes that once solution close happens, all projects are indeed gone. This isn't a good assumption if we ever open up our project APIs and let anybody add things to VisualStudioWorkspace, since projects may then live past the solution close event.

<details><summary>Ask Mode template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

New feature work: this makes one part of our Visual Studio project system layer thread safe in advance of moving it to the background thread.

### Workarounds, if any

None, we need this. :smile:

### Risk

Moderate: any threading code is never low risk. But the API shape is otherwise more or less untouched, so existing consumers will see the same things they've always seen.

### Performance impact

None, at least when things are still on the UI thread.

</details>
