### PR TITLE
Use SyntaxEditorBasedCodeFixProvider for 'qualify member access'

### DIFF
--- a/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -2,18 +2,20 @@
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.QualifyMemberAccess;
 
 namespace Microsoft.CodeAnalysis.CSharp.QualifyMemberAccess
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal sealed class CSharpQualifyMemberAccessDiagnosticAnalyzer : AbstractQualifyMemberAccessDiagnosticAnalyzer<SyntaxKind>
+    internal sealed class CSharpQualifyMemberAccessDiagnosticAnalyzer 
+        : AbstractQualifyMemberAccessDiagnosticAnalyzer<SyntaxKind, ExpressionSyntax, SimpleNameSyntax>
     {
         protected override string GetLanguageName()
             => LanguageNames.CSharp;
 
-        protected override bool IsAlreadyQualifiedMemberAccess(SyntaxNode node)
+        protected override bool IsAlreadyQualifiedMemberAccess(ExpressionSyntax node)
             => node.IsKind(SyntaxKind.ThisExpression);
 
         // If the member is already qualified with `base.`,

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
                 return null;
             }
 
-            var applicableOption = AbstractQualifyMemberAccessDiagnosticAnalyzer<TLanguageKindEnum>.GetApplicableOptionFromSymbolKind(symbolInfo.Symbol.Kind);
+            var applicableOption = QualifyMembersHelpers.GetApplicableOptionFromSymbolKind(symbolInfo.Symbol.Kind);
             var optionValue = optionSet.GetOption(applicableOption, GetLanguageName());
             var severity = optionValue.Notification.Value;
 

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessCodeFixprovider.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessCodeFixprovider.cs
@@ -12,51 +12,46 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.QualifyMemberAccess
 {
-    internal abstract class AbstractQualifyMemberAccessCodeFixprovider<TSyntaxNode> : CodeFixProvider where TSyntaxNode : SyntaxNode
+    internal abstract class AbstractQualifyMemberAccessCodeFixprovider<TSimpleNameSyntax> 
+        : SyntaxEditorBasedCodeFixProvider 
+        where TSimpleNameSyntax : SyntaxNode
     {
+        protected abstract string GetTitle();
+
         public sealed override ImmutableArray<string> FixableDiagnosticIds
             => ImmutableArray.Create(IDEDiagnosticIds.AddQualificationDiagnosticId);
 
-        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            var document = context.Document;
-            var span = context.Span;
-            var cancellationToken = context.CancellationToken;
-
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-            var token = root.FindToken(span.Start);
-            if (!token.Span.IntersectsWith(span))
-            {
-                return;
-            }
-
-            var node = token.GetAncestor<TSyntaxNode>();
-            if (node == null)
-            {
-                return;
-            }
-
-            var generator = document.GetLanguageService<SyntaxGenerator>();
-            var title = this.GetTitle();
-            var codeAction = new MyCodeAction(
-                title, c => document.ReplaceNodeAsync(node, GetReplacementSyntax(node, generator), c));
-            context.RegisterCodeFix(codeAction, context.Diagnostics);
+            context.RegisterCodeFix(new MyCodeAction(
+                this.GetTitle(),
+                c => FixAsync(context.Document, context.Diagnostics[0], c)),
+                context.Diagnostics);
+            return Task.CompletedTask;
         }
 
-        protected abstract string GetTitle();
-
-        public override FixAllProvider GetFixAllProvider() => BatchFixAllProvider.Instance;
-
-        private static SyntaxNode GetReplacementSyntax(SyntaxNode node, SyntaxGenerator generator)
+        protected override async Task FixAllAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics, 
+            SyntaxEditor editor, CancellationToken cancellationToken)
         {
-            var qualifiedAccess =
-                generator.MemberAccessExpression(
-                    generator.ThisExpression(),
-                    node.WithLeadingTrivia())
-                .WithLeadingTrivia(node.GetLeadingTrivia());
-            return qualifiedAccess;
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var generator = document.GetLanguageService<SyntaxGenerator>();
+
+            foreach (var diagnostic in diagnostics)
+            {
+                var node = diagnostic.Location.FindNode(getInnermostNodeForTie: true, cancellationToken) as TSimpleNameSyntax;
+                if (node != null)
+                {
+                    var qualifiedAccess =
+                        generator.MemberAccessExpression(
+                            generator.ThisExpression(),
+                            node.WithLeadingTrivia())
+                        .WithLeadingTrivia(node.GetLeadingTrivia());
+
+                    editor.ReplaceNode(node, qualifiedAccess);
+                }
+            }
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
@@ -2,17 +2,18 @@
 
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.QualifyMemberAccess
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.QualifyMemberAccess
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Friend NotInheritable Class VisualBasicQualifyMemberAccessDiagnosticAnalyzer
-        Inherits AbstractQualifyMemberAccessDiagnosticAnalyzer(Of SyntaxKind)
+        Inherits AbstractQualifyMemberAccessDiagnosticAnalyzer(Of SyntaxKind, ExpressionSyntax, SimpleNameSyntax)
 
         Protected Overrides Function GetLanguageName() As String
             Return LanguageNames.VisualBasic
         End Function
 
-        Protected Overrides Function IsAlreadyQualifiedMemberAccess(node As SyntaxNode) As Boolean
+        Protected Overrides Function IsAlreadyQualifiedMemberAccess(node As ExpressionSyntax) As Boolean
             Return node.IsKind(SyntaxKind.MeExpression)
         End Function
 


### PR DESCRIPTION
As per https://github.com/dotnet/roslyn/pull/26558#discussion_r185895035 there are substantive benefits to using this over the default BatchFixAllProvider.