### PR TITLE
lower interpolated strings to string concatenation where possible

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using System.Diagnostics;
 
@@ -33,6 +32,42 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
+        private static bool CanLowerToStringConcatenation(BoundInterpolatedString node)
+        {
+            foreach (var part in node.Parts)
+            {
+                if (part is BoundStringInsert fillin)
+                {
+                    // this is one of the expression holes
+                    if (fillin.HasErrors ||
+                        fillin.Value.Type?.SpecialType != SpecialType.System_String ||
+                        fillin.Alignment != null ||
+                        fillin.Format != null)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static string Unescape(string s)
+        {
+            var builder = PooledStringBuilder.GetInstance();
+            int formatLength = s.Length;
+            for (int i = 0; i < formatLength; i++)
+            {
+                char c = s[i];
+                builder.Builder.Append(c);
+                if ((c == '{' || c == '}') && (i + 1) < formatLength && s[i + 1] == c)
+                {
+                    i++;
+                }
+            }
+            return builder.ToStringAndFree();
+        }
+
         private void MakeInterpolatedStringFormat(BoundInterpolatedString node, out BoundExpression format, out ArrayBuilder<BoundExpression> expressions)
         {
             _factory.Syntax = node.Syntax;
@@ -52,16 +87,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     // this is one of the expression holes
-                    formatString.Builder.Append("{").Append(nextFormatPosition++);
+                    formatString.Builder.Append('{').Append(nextFormatPosition++);
                     if (fillin.Alignment != null && !fillin.Alignment.HasErrors)
                     {
-                        formatString.Builder.Append(",").Append(fillin.Alignment.ConstantValue.Int64Value);
+                        formatString.Builder.Append(',').Append(fillin.Alignment.ConstantValue.Int64Value);
                     }
                     if (fillin.Format != null && !fillin.Format.HasErrors)
                     {
-                        formatString.Builder.Append(":").Append(fillin.Format.ConstantValue.StringValue);
+                        formatString.Builder.Append(':').Append(fillin.Format.ConstantValue.StringValue);
                     }
-                    formatString.Builder.Append("}");
+                    formatString.Builder.Append('}');
                     var value = fillin.Value;
                     if (value.Type?.TypeKind == TypeKind.Dynamic)
                     {
@@ -77,48 +112,110 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitInterpolatedString(BoundInterpolatedString node)
         {
-            //
-            // We lower an interpolated string into an invocation of String.Format.  For example, we translate the expression
-            //
-            //     $"Jenny don\'t change your number { 8675309 }"
-            //
-            // into
-            //
-            //     String.Format("Jenny don\'t change your number {0}", new object[] { 8675309 })
-            //
-
             Debug.Assert(node.Type.SpecialType == SpecialType.System_String); // if target-converted, we should not get here.
-            BoundExpression format;
-            ArrayBuilder<BoundExpression> expressions;
-            MakeInterpolatedStringFormat(node, out format, out expressions);
-            if (expressions.Count == 0)
+
+            BoundExpression result;
+
+            if (CanLowerToStringConcatenation(node))
             {
-                // There are no fill-ins. Handle the escaping of {{ and }} and return the value.
-                Debug.Assert(!format.HasErrors && format.ConstantValue != null && format.ConstantValue.IsString);
-                var builder = PooledStringBuilder.GetInstance();
-                var formatText = format.ConstantValue.StringValue;
-                int formatLength = formatText.Length;
-                for (int i = 0; i < formatLength; i++)
+                // All fill-ins, if any, are strings, and none of them have alignment or format specifiers.
+                // We can lower to a more efficient string concatenation
+                // The normal pattern for lowering is to lower subtrees before the enclosing tree. However in this case
+                // we want to lower the entire concatenation so we get the optimizations done by that lowering (e.g. constant folding).
+
+                int length = node.Parts.Length;
+                if (length == 0)
                 {
-                    char c = formatText[i];
-                    builder.Builder.Append(c);
-                    if ((c == '{' || c == '}') && (i + 1) < formatLength && formatText[i + 1] == c)
+                    // $"" -> ""
+                    return _factory.StringLiteral("");
+                }
+
+                if (length == 1)
+                {
+                    var part = node.Parts[0];
+
+                    if (part is BoundStringInsert fillin)
                     {
-                        i++;
+                        // $"{part}"
+                        // this is the filled-in expression
+                        part = fillin.Value;
+
+                        if (part.ConstantValue != null)
+                        {
+                            if (part.ConstantValue.StringValue == null)
+                            {
+                                return _factory.StringLiteral("");
+                            }
+                            else
+                            {
+                                result = part;
+                            }
+                        }
+                        else if (part is BoundBinaryOperator bbo && bbo.OperatorKind == BinaryOperatorKind.StringConcatenation)
+                        {
+                            // $"{a + b}" -> a + b
+                            result = part;
+                        }
+                        else
+                        {
+                            result = _factory.Coalesce(part, _factory.StringLiteral(""));
+                        }
+                    }
+                    else
+                    {
+                        // $"abc" -> "abc"
+                        // this is the literal part
+                        return _factory.StringLiteral(Unescape(part.ConstantValue.StringValue));
                     }
                 }
-                return _factory.StringLiteral(builder.ToStringAndFree());
+                else
+                {
+                    result = null;
+                    for (int i = 0; i < length; i++)
+                    {
+                        var part = node.Parts[i];
+                        if (part is BoundStringInsert fillin)
+                        {
+                            // this is one of the filled-in expressions
+                            part = fillin.Value;
+                        }
+                        else
+                        {
+                            // this is one of the literal parts
+                            part = _factory.StringLiteral(Unescape(part.ConstantValue.StringValue));
+                        }
+
+                        result = result == null ?
+                            part :
+                            _factory.Binary(BinaryOperatorKind.StringConcatenation, node.Type, result, part);
+                    }
+                }
+            }
+            else
+            {
+                //
+                // We lower an interpolated string into an invocation of String.Format.  For example, we translate the expression
+                //
+                //     $"Jenny don\'t change your number { 8675309 }"
+                //
+                // into
+                //
+                //     String.Format("Jenny don\'t change your number {0}", new object[] { 8675309 })
+                //
+
+                MakeInterpolatedStringFormat(node, out BoundExpression format, out ArrayBuilder<BoundExpression> expressions);
+
+                // The normal pattern for lowering is to lower subtrees before the enclosing tree. However we cannot lower
+                // the arguments first in this situation because we do not know what conversions will be
+                // produced for the arguments until after we've done overload resolution. So we produce the invocation
+                // and then lower it along with its arguments.
+                expressions.Insert(0, format);
+                var stringType = node.Type;
+                result = _factory.StaticCall(stringType, "Format", expressions.ToImmutableAndFree(),
+                    allowUnexpandedForm: false // if an interpolation expression is the null literal, it should not match a params parameter.
+                    );
             }
 
-            // The normal pattern for lowering is to lower subtrees before the enclosing tree. However we cannot lower
-            // the arguments first in this situation because we do not know what conversions will be
-            // produced for the arguments until after we've done overload resolution. So we produce the invocation
-            // and then lower it along with its arguments.
-            expressions.Insert(0, format);
-            var stringType = node.Type;
-            var result = _factory.StaticCall(stringType, "Format", expressions.ToImmutableAndFree(),
-                allowUnexpandedForm: false // if an interpolation expression is the null literal, it should not match a params parameter.
-                );
             if (!result.HasAnyErrors)
             {
                 result = VisitExpression(result); // lower the arguments AND handle expanded form, argument conversions, etc.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1093,22 +1093,16 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size       32 (0x20)
-  .maxstack  3
-  .locals init (string V_0, //x
-                string V_1) //y
-  IL_0000:  ldstr      ""goodbye""
-  IL_0005:  stloc.0
-  IL_0006:  ldnull
-  IL_0007:  stloc.0
-  IL_0008:  ldstr      ""hello""
-  IL_000d:  stloc.1
-  IL_000e:  ldstr      ""{0}{1}""
-  IL_0013:  ldloc.0
-  IL_0014:  ldloc.1
-  IL_0015:  call       ""string string.Format(string, object, object)""
-  IL_001a:  call       ""void System.Console.WriteLine(string)""
-  IL_001f:  ret
+  // Code size       19 (0x13)
+  .maxstack  2
+  .locals init (string V_0) //y
+  IL_0000:  ldnull
+  IL_0001:  ldstr      ""hello""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  call       ""string string.Concat(string, string)""
+  IL_000d:  call       ""void System.Console.WriteLine(string)""
+  IL_0012:  ret
 } ");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInterpolatedString.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInterpolatedString.cs
@@ -1,0 +1,214 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
+{
+    public class InterpolatedStringTests : CSharpTestBase
+    {
+        [Fact]
+        public void ConstInterpolations()
+        {
+            var source = @"
+using System;
+
+public class Test
+{
+    const string constantabc = ""abc"";
+    const string constantnull = null;
+
+    static void Main()
+    {
+        Console.WriteLine($"""");
+        Console.WriteLine($""ABC"");
+        Console.WriteLine($""{constantabc}"");
+        Console.WriteLine($""{constantnull}"");
+        Console.WriteLine($""{constantabc}{constantnull}"");
+        Console.WriteLine($""({constantabc})({constantnull})"");
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: @"
+ABC
+abc
+
+abc
+(abc)()
+");
+
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("Test.Main", @"
+{
+  // Code size       61 (0x3d)
+  .maxstack  1
+  IL_0000:  ldstr      """"
+  IL_0005:  call       ""void System.Console.WriteLine(string)""
+  IL_000a:  ldstr      ""ABC""
+  IL_000f:  call       ""void System.Console.WriteLine(string)""
+  IL_0014:  ldstr      ""abc""
+  IL_0019:  call       ""void System.Console.WriteLine(string)""
+  IL_001e:  ldstr      """"
+  IL_0023:  call       ""void System.Console.WriteLine(string)""
+  IL_0028:  ldstr      ""abc""
+  IL_002d:  call       ""void System.Console.WriteLine(string)""
+  IL_0032:  ldstr      ""(abc)()""
+  IL_0037:  call       ""void System.Console.WriteLine(string)""
+  IL_003c:  ret
+}
+");
+        }
+
+        [Fact]
+        public void InterpolatedStringIsNeverNull()
+        {
+            var source = @"
+using System;
+
+public class Test
+{
+    static void Main()
+    {
+        Console.WriteLine(M6(null) == """");
+        Console.WriteLine(M6(""abc""));
+    }
+
+    static string M6(string a) => $""{a}"";
+
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: @"True
+abc
+");
+
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("Test.M6", @"
+{
+  // Code size       11 (0xb)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  dup
+  IL_0002:  brtrue.s   IL_000a
+  IL_0004:  pop
+  IL_0005:  ldstr      """"
+  IL_000a:  ret
+}
+");
+        }
+
+        [Fact]
+        public void ConcatenatedStringInterpolations()
+        {
+            var source = @"
+using System;
+
+public class Test
+{
+    static void Main()
+    {
+        string a = ""a"";
+        string b = ""b"";
+
+        Console.WriteLine($""a: {a}"");
+        Console.WriteLine($""{a + b}"");
+        Console.WriteLine($""{a}{b}"");
+        Console.WriteLine($""a: {a}, b: {b}"");
+        Console.WriteLine($""{{{a}}}"");
+        Console.WriteLine(""a:"" + $"" {a}"");
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: @"a: a
+ab
+ab
+a: a, b: b
+{a}
+a: a
+");
+
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("Test.Main", @"
+{
+  // Code size      112 (0x70)
+  .maxstack  4
+  .locals init (string V_0, //a
+                string V_1) //b
+  IL_0000:  ldstr      ""a""
+  IL_0005:  stloc.0
+  IL_0006:  ldstr      ""b""
+  IL_000b:  stloc.1
+  IL_000c:  ldstr      ""a: ""
+  IL_0011:  ldloc.0
+  IL_0012:  call       ""string string.Concat(string, string)""
+  IL_0017:  call       ""void System.Console.WriteLine(string)""
+  IL_001c:  ldloc.0
+  IL_001d:  ldloc.1
+  IL_001e:  call       ""string string.Concat(string, string)""
+  IL_0023:  call       ""void System.Console.WriteLine(string)""
+  IL_0028:  ldloc.0
+  IL_0029:  ldloc.1
+  IL_002a:  call       ""string string.Concat(string, string)""
+  IL_002f:  call       ""void System.Console.WriteLine(string)""
+  IL_0034:  ldstr      ""a: ""
+  IL_0039:  ldloc.0
+  IL_003a:  ldstr      "", b: ""
+  IL_003f:  ldloc.1
+  IL_0040:  call       ""string string.Concat(string, string, string, string)""
+  IL_0045:  call       ""void System.Console.WriteLine(string)""
+  IL_004a:  ldstr      ""{""
+  IL_004f:  ldloc.0
+  IL_0050:  ldstr      ""}""
+  IL_0055:  call       ""string string.Concat(string, string, string)""
+  IL_005a:  call       ""void System.Console.WriteLine(string)""
+  IL_005f:  ldstr      ""a: ""
+  IL_0064:  ldloc.0
+  IL_0065:  call       ""string string.Concat(string, string)""
+  IL_006a:  call       ""void System.Console.WriteLine(string)""
+  IL_006f:  ret
+}
+");
+        }
+
+        [Fact]
+        public void NonConcatenatedInterpolations()
+        {
+            var source = @"
+using System;
+
+public class Test
+{
+    static void Main()
+    {
+        object a = ""a"";
+
+        Console.WriteLine($""{a}"");
+        Console.WriteLine($""a: {a}"");
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: @"a
+a: a
+");
+
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("Test.Main", @"
+{
+  // Code size       39 (0x27)
+  .maxstack  2
+  .locals init (object V_0) //a
+  IL_0000:  ldstr      ""a""
+  IL_0005:  stloc.0
+  IL_0006:  ldstr      ""{0}""
+  IL_000b:  ldloc.0
+  IL_000c:  call       ""string string.Format(string, object)""
+  IL_0011:  call       ""void System.Console.WriteLine(string)""
+  IL_0016:  ldstr      ""a: {0}""
+  IL_001b:  ldloc.0
+  IL_001c:  call       ""string string.Format(string, object)""
+  IL_0021:  call       ""void System.Console.WriteLine(string)""
+  IL_0026:  ret
+}
+");
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInterpolatedString.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInterpolatedString.cs
@@ -115,6 +115,7 @@ public class Test
         Console.WriteLine($""a: {a}, b: {b}"");
         Console.WriteLine($""{{{a}}}"");
         Console.WriteLine(""a:"" + $"" {a}"");
+        Console.WriteLine($""a: {$""{a}, b: {b}""}"");
     }
 }
 ";
@@ -124,12 +125,13 @@ ab
 a: a, b: b
 {a}
 a: a
+a: a, b: b
 ");
 
             comp.VerifyDiagnostics();
             comp.VerifyIL("Test.Main", @"
 {
-  // Code size      112 (0x70)
+  // Code size      134 (0x86)
   .maxstack  4
   .locals init (string V_0, //a
                 string V_1) //b
@@ -164,7 +166,13 @@ a: a
   IL_0064:  ldloc.0
   IL_0065:  call       ""string string.Concat(string, string)""
   IL_006a:  call       ""void System.Console.WriteLine(string)""
-  IL_006f:  ret
+  IL_006f:  ldstr      ""a: ""
+  IL_0074:  ldloc.0
+  IL_0075:  ldstr      "", b: ""
+  IL_007a:  ldloc.1
+  IL_007b:  call       ""string string.Concat(string, string, string, string)""
+  IL_0080:  call       ""void System.Console.WriteLine(string)""
+  IL_0085:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -3030,25 +3030,25 @@ class Student : Person { public double GPA; }
         <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" document=""1"" />
         <entry offset=""0x4"" hidden=""true"" document=""1"" />
-        <entry offset=""0x28"" hidden=""true"" document=""1"" />
-        <entry offset=""0x2a"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
-        <entry offset=""0x3d"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""57"" document=""1"" />
-        <entry offset=""0x5c"" hidden=""true"" document=""1"" />
-        <entry offset=""0x61"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""57"" document=""1"" />
-        <entry offset=""0x82"" hidden=""true"" document=""1"" />
-        <entry offset=""0x87"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""59"" document=""1"" />
-        <entry offset=""0xa3"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""43"" document=""1"" />
-        <entry offset=""0xb7"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2d"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x40"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""57"" document=""1"" />
+        <entry offset=""0x5f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x64"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""57"" document=""1"" />
+        <entry offset=""0x85"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8a"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""59"" document=""1"" />
+        <entry offset=""0xab"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""43"" document=""1"" />
+        <entry offset=""0xbf"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xba"">
-        <scope startOffset=""0x28"" endOffset=""0x5c"">
-          <local name=""s"" il_index=""3"" il_start=""0x28"" il_end=""0x5c"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0xc2"">
+        <scope startOffset=""0x2b"" endOffset=""0x5f"">
+          <local name=""s"" il_index=""3"" il_start=""0x2b"" il_end=""0x5f"" attributes=""0"" />
         </scope>
-        <scope startOffset=""0x5c"" endOffset=""0x82"">
-          <local name=""s"" il_index=""4"" il_start=""0x5c"" il_end=""0x82"" attributes=""0"" />
+        <scope startOffset=""0x5f"" endOffset=""0x85"">
+          <local name=""s"" il_index=""4"" il_start=""0x5f"" il_end=""0x85"" attributes=""0"" />
         </scope>
-        <scope startOffset=""0x82"" endOffset=""0xa3"">
-          <local name=""t"" il_index=""5"" il_start=""0x82"" il_end=""0xa3"" attributes=""0"" />
+        <scope startOffset=""0x85"" endOffset=""0xab"">
+          <local name=""t"" il_index=""5"" il_start=""0x85"" il_end=""0xab"" attributes=""0"" />
         </scope>
       </scope>
     </method>
@@ -3109,7 +3109,7 @@ class Student : Person { public double GPA; }
         <forward declaringType=""Program"" methodName=""Main"" parameterNames=""args"" />
         <encLocalSlotMap>
           <slot kind=""30"" offset=""0"" />
-          <slot kind=""30"" offset=""383"" />
+          <slot kind=""30"" offset=""202"" />
           <slot kind=""35"" offset=""11"" />
           <slot kind=""35"" offset=""11"" />
           <slot kind=""35"" offset=""11"" />
@@ -3119,7 +3119,7 @@ class Student : Person { public double GPA; }
         <encLambdaMap>
           <methodOrdinal>2</methodOrdinal>
           <closure offset=""0"" />
-          <closure offset=""383"" />
+          <closure offset=""202"" />
           <lambda offset=""109"" closure=""1"" />
           <lambda offset=""202"" closure=""1"" />
           <lambda offset=""295"" closure=""1"" />
@@ -3209,7 +3209,7 @@ class Student : Person { public double GPA; }
         <forward declaringType=""Program"" methodName=""Main"" parameterNames=""args"" />
         <encLocalSlotMap>
           <slot kind=""30"" offset=""0"" />
-          <slot kind=""30"" offset=""475"" />
+          <slot kind=""30"" offset=""234"" />
           <slot kind=""35"" offset=""11"" />
           <slot kind=""35"" offset=""11"" />
           <slot kind=""35"" offset=""11"" />
@@ -3219,7 +3219,7 @@ class Student : Person { public double GPA; }
         <encLambdaMap>
           <methodOrdinal>2</methodOrdinal>
           <closure offset=""0"" />
-          <closure offset=""475"" />
+          <closure offset=""234"" />
           <lambda offset=""111"" closure=""1"" />
           <lambda offset=""234"" closure=""1"" />
           <lambda offset=""357"" closure=""1"" />


### PR DESCRIPTION
This PR handles #22594 and is a follow up for #22595.

**Customer scenario**

The user uses string interpolation where concatenation could be used.

**Risk**

This PR modifies code generation of interpolated strings, but only in the case where all fill-ins are strings without alignment or format specifiers.

**Performance impact**

Code generation for interpolated strings will be somewhat slower. The generated code will be significantly faster in the case where all fill-ins in the interpolated string are strings, without alignment or format specifiers. In all other cases, the new implementation has one additional loop over the parts with no memory allocations in it, fairly simple logic and early exit as soon it is determined that the code gen optimization cannot be done.

Given the following declarations:

    const string constantabc = "abc";
    const string constantnull = null;

With `/o`, the following methods compile to the following IL:

    string M1() => $"";

	IL_0000: ldstr ""
	IL_0005: ret

    string M2() => $"abc";

	IL_0000: ldstr "abc"
	IL_0005: ret

    string M3() => $"{constantabc}";

	IL_0000: ldstr "abc"
	IL_0005: ret

    string M4() => $"{constantnull}";

	IL_0000: ldstr ""
	IL_0005: ret

    string M5() => $"{constantabc}{constantnull}";

	IL_0000: ldstr "abc"
	IL_0005: ret

    string M6(string a) => $"{a}";

	IL_0000: ldarg.1
	IL_0001: dup
	IL_0002: brtrue.s IL_000a
	IL_0004: pop
	IL_0005: ldstr ""
	IL_000a: ret

    string M7(string a) => $"a: {a}";

	IL_0000: ldstr "a: "
	IL_0005: ldarg.1
	IL_0006: call string [mscorlib]System.String::Concat(string, string)
	IL_000b: ret

    string M8(string a, string b) => $"{a + b}";

	IL_0000: ldarg.1
	IL_0001: ldarg.2
	IL_0002: call string [mscorlib]System.String::Concat(string, string)
	IL_0007: ret

    string M9(string a, string b) => $"{a}{b}";

	IL_0000: ldarg.1
	IL_0001: ldarg.2
	IL_0002: call string [mscorlib]System.String::Concat(string, string)
	IL_0007: ret

    string M10(string a, string b) => $"a: {a}, b: {b}";

	IL_0000: ldstr "a: "
	IL_0005: ldarg.1
	IL_0006: ldstr ", b: "
	IL_000b: ldarg.2
	IL_000c: call string [mscorlib]System.String::Concat(string, string, string, string)
	IL_0011: ret

    string M11(object a) => $"{a}";

	IL_0000: ldstr "{0}"
	IL_0005: ldarg.1
	IL_0006: call string [mscorlib]System.String::Format(string, object)
	IL_000b: ret

    string M12(object a) => $"a: {a}";

	IL_0000: ldstr "a: {0}"
	IL_0005: ldarg.1
	IL_0006: call string [mscorlib]System.String::Format(string, object)
	IL_000b: ret

    string M13(string a) => $"{{{a}}}";

	IL_0000: ldstr "{"
	IL_0005: ldarg.1
	IL_0006: ldstr "}"
	IL_000b: call string [mscorlib]System.String::Concat(string, string, string)
	IL_0010: ret

    string M14(string a) => "a:" + $" {a}";

	IL_0000: ldstr "a: "
	IL_0005: ldarg.1
	IL_0006: call string [mscorlib]System.String::Concat(string, string)
	IL_000b: ret