### PR TITLE
Add a DeclareAsNullable fixer

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -12,12 +12,46 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNullable
 {
     [Trait(Traits.Feature, Traits.Features.CodeActionsDeclareAsNullable)]
-    public partial class DeclareAsNullableCodeFixTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    public class CSharpDeclareAsNullableCodeFixTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-            => (null, new DeclareAsNullableCodeFixProvider());
+            => (null, new CSharpDeclareAsNullableCodeFixProvider());
 
-        static readonly TestParameters s_nullableFeature = new TestParameters(parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+        private static readonly TestParameters s_nullableFeature = new TestParameters(parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+
+        [Fact]
+        public async Task FixAll()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    static string M()
+    {
+        return {|FixAllInDocument:null|};
+    }
+    static string M2(bool b)
+    {
+        if (b)
+            return null;
+        else
+            return null;
+    }
+}",
+@"class Program
+{
+    static string? M()
+    {
+        return null;
+    }
+    static string? M2(bool b)
+    {
+        if (b)
+            return null;
+        else
+            return null;
+    }
+}", parameters: s_nullableFeature);
+        }
 
         [Fact]
         public async Task FixReturnType()
@@ -53,6 +87,33 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 }", parameters: s_nullableFeature);
         }
 
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26639")]
+        [WorkItem(26639, "https://github.com/dotnet/roslyn/issues/26639")]
+        public async Task FixLocalFunctionReturnType()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    void M()
+    {
+        string local()
+        {
+            return [|null|];
+        }
+    }
+}",
+@"class Program
+{
+    void M()
+    {
+        string? local()
+        {
+            return null;
+        }
+    }
+}", parameters: s_nullableFeature);
+        }
+
         [Fact]
         public async Task NoFixAlreadyNullableReturnType()
         {
@@ -63,6 +124,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
     {
         return [|null|];
     }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26628")]
+        [WorkItem(26628, "https://github.com/dotnet/roslyn/issues/26628")]
+        public async Task FixField()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    string x = [|null|];
+}",
+@"class Program
+{
+    string? x = null;
 }", parameters: s_nullableFeature);
         }
 
@@ -87,6 +163,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         }
 
         [Fact]
+        public async Task FixLocalDeclaration_WithVar()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Program
+{
+    static void M()
+    {
+        var x = [|null|];
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
         public async Task NoFixMultiDeclaration()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -99,14 +188,32 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 }", parameters: s_nullableFeature);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26628")]
         [WorkItem(26628, "https://github.com/dotnet/roslyn/issues/26628")]
         public async Task FixPropertyDeclaration()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestInRegularAndScript1Async(
 @"class Program
 {
     string x { get; set; } = [|null|];
+",
+@"class Program
+{
+    string? x { get; set; } = null;
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task FixPropertyDeclaration_WithReturnNull()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    string x { get { return [|null|]; } }
+}",
+@"class Program
+{
+    string? x { get { return null; } }
 }", parameters: s_nullableFeature);
         }
 
@@ -124,14 +231,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 }", parameters: s_nullableFeature);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26626")]
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
         public async Task FixOptionalParameter()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestInRegularAndScript1Async(
 @"class Program
 {
     static void M(string x = [|null|]) { }
+}",
+@"class Program
+{
+    static void M(string? x = null) { }
 }", parameters: s_nullableFeature);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -109,6 +109,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 
         [Fact]
         [WorkItem(26639, "https://github.com/dotnet/roslyn/issues/26639")]
+        public async Task FixReturnType_LocalFunction_ArrowBody()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Program
+{
+    static void M()
+    {
+        string local() => [|null|];
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        [WorkItem(26639, "https://github.com/dotnet/roslyn/issues/26639")]
         public async Task FixLocalFunctionReturnType()
         {
             await TestMissingInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -74,6 +74,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         }
 
         [Fact]
+        public async Task FixReturnType_WithTrivia()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    static /*before*/ string /*after*/ M()
+    {
+        return [|null|];
+    }
+}",
+@"class Program
+{
+    static /*before*/ string? /*after*/ M()
+    {
+        return null;
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
         public async Task FixReturnType_ArrowBody()
         {
             await TestInRegularAndScript1Async(
@@ -87,11 +107,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 }", parameters: s_nullableFeature);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26639")]
+        [Fact]
         [WorkItem(26639, "https://github.com/dotnet/roslyn/issues/26639")]
         public async Task FixLocalFunctionReturnType()
         {
-            await TestInRegularAndScript1Async(
+            await TestMissingInRegularAndScriptAsync(
 @"class Program
 {
     void M()
@@ -99,16 +119,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         string local()
         {
             return [|null|];
-        }
-    }
-}",
-@"class Program
-{
-    void M()
-    {
-        string? local()
-        {
-            return null;
         }
     }
 }", parameters: s_nullableFeature);
@@ -127,18 +137,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 }", parameters: s_nullableFeature);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26628")]
+        [Fact]
         [WorkItem(26628, "https://github.com/dotnet/roslyn/issues/26628")]
         public async Task FixField()
         {
-            await TestInRegularAndScript1Async(
+            await TestMissingInRegularAndScriptAsync(
 @"class Program
 {
     string x = [|null|];
-}",
-@"class Program
-{
-    string? x = null;
 }", parameters: s_nullableFeature);
         }
 
@@ -188,18 +194,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 }", parameters: s_nullableFeature);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26628")]
+        [Fact]
         [WorkItem(26628, "https://github.com/dotnet/roslyn/issues/26628")]
         public async Task FixPropertyDeclaration()
         {
-            await TestInRegularAndScript1Async(
+            await TestMissingInRegularAndScriptAsync(
 @"class Program
 {
     string x { get; set; } = [|null|];
-",
-@"class Program
-{
-    string? x { get; set; } = null;
 }", parameters: s_nullableFeature);
         }
 
@@ -231,18 +233,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 }", parameters: s_nullableFeature);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26626")]
+        [Fact]
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
         public async Task FixOptionalParameter()
         {
-            await TestInRegularAndScript1Async(
+            await TestMissingInRegularAndScriptAsync(
 @"class Program
 {
     static void M(string x = [|null|]) { }
-}",
-@"class Program
-{
-    static void M(string? x = null) { }
 }", parameters: s_nullableFeature);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/DeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/DeclareAsNullableCodeFixTests.cs
@@ -50,5 +50,38 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
     }
 }", parameters: s_nullableFeature);
         }
+
+        [Fact]
+        public async Task FixLocalDeclaration()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    static void M()
+    {
+        string x = [|null|];
+    }
+}",
+@"class Program
+{
+    static void M()
+    {
+        string? x = null;
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task NoFixMultiDeclaration()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Program
+{
+    static void M()
+    {
+        string x = [|null|], y = null;
+    }
+}", parameters: s_nullableFeature);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/DeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/DeclareAsNullableCodeFixTests.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNullable
@@ -81,6 +82,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
     {
         string x = [|null|], y = null;
     }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        [WorkItem(26628, "https://github.com/dotnet/roslyn/issues/26628")]
+        public async Task FixPropertyDeclaration()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Program
+{
+    string x { get; set; } = [|null|];
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
+        public async Task FixOptionalParameter()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Program
+{
+    static void M(string x = [|null|]) { }
 }", parameters: s_nullableFeature);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/DeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/DeclareAsNullableCodeFixTests.cs
@@ -40,6 +40,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         }
 
         [Fact]
+        public async Task FixReturnType_ArrowBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    static string M() => [|null|];
+}",
+@"class Program
+{
+    static string? M() => null;
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
         public async Task NoFixAlreadyNullableReturnType()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -93,6 +107,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 @"class Program
 {
     string x { get; set; } = [|null|];
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task FixPropertyDeclaration_ArrowBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    string x => [|null|];
+}",
+@"class Program
+{
+    string? x => null;
 }", parameters: s_nullableFeature);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/DeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/DeclareAsNullableCodeFixTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNullable
+{
+    [Trait(Traits.Feature, Traits.Features.CodeActionsDeclareAsNullable)]
+    public partial class DeclareAsNullableCodeFixTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (null, new DeclareAsNullableCodeFixProvider());
+
+        static readonly TestParameters s_nullableFeature = new TestParameters(parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+
+        [Fact]
+        public async Task FixReturnType()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    static string M()
+    {
+        return [|null|];
+    }
+}",
+@"class Program
+{
+    static string? M()
+    {
+        return null;
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task NoFixAlreadyNullableReturnType()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Program
+{
+    static string? M()
+    {
+        return [|null|];
+    }
+}", parameters: s_nullableFeature);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -315,11 +315,11 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Declare as Nullable.
+        ///   Looks up a localized string similar to Declare as nullable.
         /// </summary>
-        internal static string Declare_as_Nullable {
+        internal static string Declare_as_nullable {
             get {
-                return ResourceManager.GetString("Declare_as_Nullable", resourceCulture);
+                return ResourceManager.GetString("Declare_as_nullable", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -315,6 +315,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Declare as Nullable.
+        /// </summary>
+        internal static string Declare_as_Nullable {
+            get {
+                return ResourceManager.GetString("Declare_as_Nullable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to deconstruction.
         /// </summary>
         internal static string deconstruction {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -162,8 +162,8 @@
   <data name="Remove_Unnecessary_Cast" xml:space="preserve">
     <value>Remove Unnecessary Cast</value>
   </data>
-  <data name="Declare_as_Nullable" xml:space="preserve">
-    <value>Declare as Nullable</value>
+  <data name="Declare_as_nullable" xml:space="preserve">
+    <value>Declare as nullable</value>
   </data>
   <data name="Cast_is_redundant" xml:space="preserve">
     <value>Cast is redundant</value>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -162,6 +162,9 @@
   <data name="Remove_Unnecessary_Cast" xml:space="preserve">
     <value>Remove Unnecessary Cast</value>
   </data>
+  <data name="Declare_as_Nullable" xml:space="preserve">
+    <value>Declare as Nullable</value>
+  </data>
   <data name="Cast_is_redundant" xml:space="preserve">
     <value>Cast is redundant</value>
   </data>

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -80,7 +80,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
 
             if (node.IsParentKind(SyntaxKind.ReturnStatement))
             {
-                var containingMember = node.GetAncestors().FirstOrDefault(a => a.IsKind(SyntaxKind.MethodDeclaration, SyntaxKind.PropertyDeclaration));
+                var containingMember = node.GetAncestors().FirstOrDefault(a => a.IsKind(SyntaxKind.MethodDeclaration, SyntaxKind.PropertyDeclaration,
+                    SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression, SyntaxKind.LocalFunctionStatement));
+
                 if (containingMember == null)
                 {
                     return null;
@@ -95,6 +97,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
                     case SyntaxKind.PropertyDeclaration:
                         // string x { get { return null; } }
                         return ((PropertyDeclarationSyntax)containingMember).Type;
+
+                    case SyntaxKind.ParenthesizedLambdaExpression:
+                    case SyntaxKind.SimpleLambdaExpression:
+                    case SyntaxKind.LocalFunctionStatement:
+                        return null;
                 }
             }
 

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
             if (node.IsParentKind(SyntaxKind.ReturnStatement))
             {
                 var containingMember = node.GetAncestors().FirstOrDefault(a => a.IsKind(SyntaxKind.MethodDeclaration, SyntaxKind.PropertyDeclaration,
-                    SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression, SyntaxKind.LocalFunctionStatement));
+                    SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression, SyntaxKind.LocalFunctionStatement, SyntaxKind.AnonymousMethodExpression));
 
                 if (containingMember == null)
                 {
@@ -98,9 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
                         // string x { get { return null; } }
                         return ((PropertyDeclarationSyntax)containingMember).Type;
 
-                    case SyntaxKind.ParenthesizedLambdaExpression:
-                    case SyntaxKind.SimpleLambdaExpression:
-                    case SyntaxKind.LocalFunctionStatement:
+                    default:
                         return null;
                 }
             }

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -80,8 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
 
             if (node.IsParentKind(SyntaxKind.ReturnStatement))
             {
-                var containingMember = node.GetAncestors().FirstOrDefault(a => a.IsKind(SyntaxKind.MethodDeclaration, SyntaxKind.PropertyDeclaration,
-                    SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression, SyntaxKind.LocalFunctionStatement, SyntaxKind.AnonymousMethodExpression));
+                var containingMember = node.GetAncestors().FirstOrDefault(a => a.IsReturnableConstruct());
 
                 if (containingMember == null)
                 {

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -20,12 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.DeclareAsNullable), Shared]
     internal class CSharpDeclareAsNullableCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
-        public sealed override ImmutableArray<string> FixableDiagnosticIds
-        {
-            // warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-            // warning CS8600: Converting null literal or possible null value to non-nullable type.
-            get { return ImmutableArray.Create("CS8625", "CS8600"); }
-        }
+        // warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+        // warning CS8600: Converting null literal or possible null value to non-nullable type.
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("CS8625", "CS8600");
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -55,14 +52,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
 
             foreach (var diagnostic in diagnostics)
             {
-                var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+                var node = diagnostic.Location.FindNode(getInnermostNodeForTie: true, cancellationToken);
                 MakeDeclarationNullable(document, editor, node, alreadyHandled);
             }
 
             return Task.CompletedTask;
         }
 
-        private void MakeDeclarationNullable(Document document, SyntaxEditor editor, SyntaxNode node, HashSet<TypeSyntax> alreadyHandled)
+        private static void MakeDeclarationNullable(Document document, SyntaxEditor editor, SyntaxNode node, HashSet<TypeSyntax> alreadyHandled)
         {
             var declarationTypeToFix = TryGetDeclarationTypeToFix(node);
             if (declarationTypeToFix != null && !alreadyHandled.Contains(declarationTypeToFix))
@@ -99,7 +96,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
                         return ((PropertyDeclarationSyntax)containingMember).Type;
                 }
             }
-
 
             // string x = null;
             if (node.Parent?.Parent?.IsParentKind(SyntaxKind.VariableDeclaration) == true)

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -80,22 +80,25 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
 
             if (node.IsParentKind(SyntaxKind.ReturnStatement))
             {
-                var containingMember = node.GetAncestors().FirstOrDefault(a => a.IsReturnableConstruct());
+                var containingMember = node.GetAncestors().FirstOrDefault(a => a.IsKind(
+                    SyntaxKind.MethodDeclaration, SyntaxKind.PropertyDeclaration, SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression,
+                    SyntaxKind.LocalFunctionStatement, SyntaxKind.AnonymousMethodExpression, SyntaxKind.ConstructorDeclaration, SyntaxKind.DestructorDeclaration,
+                    SyntaxKind.OperatorDeclaration, SyntaxKind.IndexerDeclaration, SyntaxKind.EventDeclaration));
 
                 if (containingMember == null)
                 {
                     return null;
                 }
 
-                switch (containingMember.Kind())
+                switch (containingMember)
                 {
-                    case SyntaxKind.MethodDeclaration:
+                    case MethodDeclarationSyntax method:
                         // string M() { return null; }
-                        return ((MethodDeclarationSyntax)containingMember).ReturnType;
+                        return method.ReturnType;
 
-                    case SyntaxKind.PropertyDeclaration:
+                    case PropertyDeclarationSyntax property:
                         // string x { get { return null; } }
-                        return ((PropertyDeclarationSyntax)containingMember).Type;
+                        return property.Type;
 
                     default:
                         return null;

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/DeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/DeclareAsNullableCodeFixProvider.cs
@@ -10,12 +10,8 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Simplification;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
@@ -114,6 +110,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
             {
                 var parameter = (ParameterSyntax)node.Parent.Parent;
                 return parameter.Type;
+            }
+
+            // static string M() => null;
+            if (node.IsParentKind(SyntaxKind.ArrowExpressionClause) && node.Parent.IsParentKind(SyntaxKind.MethodDeclaration))
+            {
+                var arrowMethod = (MethodDeclarationSyntax)node.Parent.Parent;
+                return arrowMethod.ReturnType;
             }
 
             return null;

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/DeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/DeclareAsNullableCodeFixProvider.cs
@@ -79,6 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
                 return null;
             }
 
+            // return null;
             if (node.IsParentKind(SyntaxKind.ReturnStatement))
             {
                 var methodDeclaration = node.GetAncestors<MethodDeclarationSyntax>().FirstOrDefault();
@@ -88,15 +89,31 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
                 }
             }
 
+            // string x = null;
             if (node.Parent?.Parent?.IsParentKind(SyntaxKind.VariableDeclaration) == true)
             {
                 var variableDeclaration = (VariableDeclarationSyntax)node.Parent.Parent.Parent;
                 if (variableDeclaration.Variables.Count != 1)
                 {
+                    // string x = null, y = null;
                     return null;
                 }
 
                 return variableDeclaration.Type;
+            }
+
+            // string x { get; set; } = null;
+            if (node.Parent?.IsParentKind(SyntaxKind.PropertyDeclaration) == true)
+            {
+                var propertyDeclaration = (PropertyDeclarationSyntax)node.Parent.Parent;
+                return propertyDeclaration.Type;
+            }
+
+            // void M(string x = null) { }
+            if (node.Parent?.IsParentKind(SyntaxKind.Parameter) == true)
+            {
+                var parameter = (ParameterSyntax)node.Parent.Parent;
+                return parameter.Type;
             }
 
             return null;

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/DeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/DeclareAsNullableCodeFixProvider.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.DeclareAsNullable), Shared]
+    internal partial class DeclareAsNullableCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            // warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+            get { return ImmutableArray.Create("CS8625"); }
+        }
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(new MyCodeAction(
+                c => FixAsync(context.Document, context.Diagnostics.First(), c)),
+                context.Diagnostics);
+
+            return SpecializedTasks.EmptyTask;
+        }
+
+        protected override Task FixAllAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics,
+            SyntaxEditor editor, CancellationToken cancellationToken)
+        {
+            var root = editor.OriginalRoot;
+
+            foreach (var diagnostic in diagnostics)
+            {
+                var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+                MakeDeclarationNullable(document, editor, node);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        internal static void MakeDeclarationNullable(Document document, SyntaxEditor editor, SyntaxNode node)
+        {
+            var declarationTypeToFix = TryGetDeclarationTypeToFix(node);
+            var fixedDeclaration = SyntaxFactory.NullableType(declarationTypeToFix);
+            editor.ReplaceNode(declarationTypeToFix, fixedDeclaration);
+        }
+
+        private static TypeSyntax TryGetDeclarationTypeToFix(SyntaxNode node)
+        {
+            if (node.IsKind(SyntaxKind.NullLiteralExpression) &&
+               node.IsParentKind(SyntaxKind.ReturnStatement))
+            {
+                var methodDeclaration = node.GetAncestors<MethodDeclarationSyntax>().FirstOrDefault();
+                if (methodDeclaration != null)
+                {
+                    return methodDeclaration.ReturnType;
+                }
+            }
+
+            return null;
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
+                base(CSharpFeaturesResources.Declare_as_Nullable,
+                     createChangedDocument,
+                     CSharpFeaturesResources.Declare_as_Nullable)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -642,9 +642,9 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Declare_as_Nullable">
-        <source>Declare as Nullable</source>
-        <target state="new">Declare as Nullable</target>
+      <trans-unit id="Declare_as_nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare_as_Nullable">
+        <source>Declare as Nullable</source>
+        <target state="new">Declare as Nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -39,6 +39,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string PopulateSwitch = nameof(PopulateSwitch);
         public const string QualifyMemberAccess = nameof(QualifyMemberAccess);
         public const string RemoveUnnecessaryCast = nameof(RemoveUnnecessaryCast);
+        public const string DeclareAsNullable = nameof(DeclareAsNullable);
         public const string RemoveUnnecessaryImports = nameof(RemoveUnnecessaryImports);
         public const string RemoveUnreachableCode = nameof(RemoveUnreachableCode);
         public const string RemoveUnusedLocalFunction = nameof(RemoveUnusedLocalFunction);

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -100,6 +100,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsRemoveByVal = "CodeActions.RemoveByVal";
             public const string CodeActionsRemoveDocCommentNode = "CodeActions.RemoveDocCommentNode";
             public const string CodeActionsRemoveUnnecessaryCast = "CodeActions.RemoveUnnecessaryCast";
+            public const string CodeActionsDeclareAsNullable = "CodeActions.DeclareAsNullable";
             public const string CodeActionsRemoveUnusedLocalFunction = "CodeActions.RemoveUnusedLocalFunction";
             public const string CodeActionsRemoveUnusedVariable = "CodeActions.RemoveUnusedVariable";
             public const string CodeActionsRemoveUnnecessaryImports = "CodeActions.RemoveUnnecessaryImports";

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -100,6 +100,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5 || csharpKind == kind6;
         }
 
+        public static bool IsKind(this SyntaxNode node, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3, SyntaxKind kind4, SyntaxKind kind5, SyntaxKind kind6, SyntaxKind kind7, SyntaxKind kind8, SyntaxKind kind9, SyntaxKind kind10, SyntaxKind kind11)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            var csharpKind = node.Kind();
+            return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5 || csharpKind == kind6 || csharpKind == kind7 || csharpKind == kind8 || csharpKind == kind9 || csharpKind == kind10 || csharpKind == kind11;
+        }
+
         /// <summary>
         /// Returns the list of using directives that affect <paramref name="node"/>. The list will be returned in
         /// top down order.  


### PR DESCRIPTION
This fixer is designed to automatically fix only some trivial cases (so that FixAll is appropriate):
- local declaration: `string x = null;` (note: multi-declarations don't get fixed)
- return type: `string M() { return null }` and `string M() => null;`
- optional parameters: `void M(string x = null) ...` (depends on a compiler fix for https://github.com/dotnet/roslyn/issues/26626)
- properties: `string x { get; set; } = null;` (depends on a compiler fix for https://github.com/dotnet/roslyn/issues/26628), `string x => null;`

This is to support customers migrating their projects to use nullable annotations, including our own dogfooding.

![image](https://user-images.githubusercontent.com/12466233/39645274-9a32ccaa-4f8c-11e8-9a98-abd780588547.png)

![image](https://user-images.githubusercontent.com/12466233/39645281-a16e1cae-4f8c-11e8-9686-2653df85fbea.png)

@dotnet/roslyn-ide for review.
@dotnet/roslyn-compiler FYI.