### PR TITLE
Change code blocks to inline code to make the paragraph read nicer

### DIFF
--- a/src/Compilers/Core/Portable/Diagnostic/Location.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Location.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Gets the location in terms of path, line and column after applying source line mapping directives
-        /// (<code>#line</code> in C# or <code>#ExternalSource</code> in VB). 
+        /// (`#line` in C# or `#ExternalSource` in VB).
         /// </summary>
         /// <returns>
         /// <see cref="FileLinePositionSpan"/> that contains file, line and column information,

--- a/src/Compilers/Core/Portable/Diagnostic/Location.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Location.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Gets the location in terms of path, line and column after applying source line mapping directives
-        /// (`#line` in C# or `#ExternalSource` in VB).
+        /// (<c>#line</c> in C# or <c>#ExternalSource</c> in VB).
         /// </summary>
         /// <returns>
         /// <see cref="FileLinePositionSpan"/> that contains file, line and column information,


### PR DESCRIPTION
Relates to dotnet/roslyn-api-docs#43