### PR TITLE
Fix inline code documentation syntax

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1018,7 +1018,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// NOTE: the escape scope for ref and val escapes is the same for invocations except for trivial cases (ordinary type returned by val) 
         ///       where escape is known otherwise. Therefore we do not vave two ref/val variants of this.
         ///       
-        /// NOTE: we need scopeOfTheContainingExpression as some expressions such as optional `in` parameters or `ref dynamic` behave as 
+        /// NOTE: we need scopeOfTheContainingExpression as some expressions such as optional <c>in</c> parameters or <c>ref dynamic</c> behave as 
         ///       local variables declared at the scope of the invocation.
         /// </summary>
         internal static uint GetInvocationEscapeScope(
@@ -1123,11 +1123,11 @@ moreArguments:
         }
 
         /// <summary>
-        /// Validates whether given invocation can allow its results to escape from `escapeFrom` level to `escapeTo` level.
+        /// Validates whether given invocation can allow its results to escape from <paramref name="escapeFrom"/> level to <paramref name="escapeTo"/> level.
         /// The result indicates whether the escape is possible. 
         /// Additionally, the method emits diagnostics (possibly more than one, recursively) that would help identify the cause for the failure.
         /// 
-        /// NOTE: we need scopeOfTheContainingExpression as some expressions such as optional `in` parameters or `ref dynamic` behave as 
+        /// NOTE: we need scopeOfTheContainingExpression as some expressions such as optional <c>in</c> parameters or <c>ref dynamic</c> behave as 
         ///       local variables declared at the scope of the invocation.
         /// </summary>
         private static bool CheckInvocationEscape(
@@ -1240,7 +1240,7 @@ moreArguments:
 
         /// <summary>
         /// Validates whether the invocation is valid per no-mixing rules.
-        /// Returns `false` when it is not valid and produces diagnostics (possibly more than one recursively) that helps to figure the reason.
+        /// Returns <see langword="false"/> when it is not valid and produces diagnostics (possibly more than one recursively) that helps to figure the reason.
         /// </summary>
         private static bool CheckInvocationArgMixing(
             SyntaxNode syntax,
@@ -1663,7 +1663,7 @@ moreArguments:
         }
 
         /// <summary>
-        /// Checks whether given expression can escape from the current scope to the `escapeTo`
+        /// Checks whether given expression can escape from the current scope to the <paramref name="escapeTo"/>
         /// In a case if it cannot a bad expression is returned and diagnostics is produced.
         /// </summary>
         internal BoundExpression ValidateEscape(BoundExpression expr, uint escapeTo, bool isByRef, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Find the Deconstruct method for the expression on the right, that will fit the number of assignable variables on the left.
         /// Returns an invocation expression if the Deconstruct method is found.
         ///     If so, it outputs placeholders that were coerced to the output types of the resolved Deconstruct method.
-        /// The overload resolution is similar to writing `receiver.Deconstruct(out var x1, out var x2, ...)`.
+        /// The overload resolution is similar to writing <c>receiver.Deconstruct(out var x1, out var x2, ...)</c>.
         /// </summary>
         private BoundExpression MakeDeconstructInvocationExpression(
                                     int numCheckedVariables, BoundExpression receiver, SyntaxNode rightSyntax,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// If an element-wise binary operator returns a non-bool type, we will either:
         /// - prepare a conversion to bool if one exists
-        /// - prepare a truth operator: op_false in the case of an equality (`a == b` will be lowered to `!((a == b).op_false)) or op_true in the case of inequality,
+        /// - prepare a truth operator: op_false in the case of an equality (<c>a == b</c> will be lowered to <c>!((a == b).op_false)</c>) or op_true in the case of inequality,
         ///     with the conversion being used for its input.
         /// </summary>
         private void PrepareBoolConversionAndTruthOperator(TypeSymbol type, BinaryExpressionSyntax node, BinaryOperatorKind binaryOperator, DiagnosticBag diagnostics,

--- a/src/Compilers/CSharp/Portable/BoundTree/DecisionTree.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DecisionTree.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// A guarded decision tree, which simply binds a set of variables (this is used to assign to the
         /// pattern variables of the switch case), optionally evaluates a Guard expression (which corresponds
-        /// to the `when` expression of a switch case), and the branches to a given label if the guard
+        /// to the <c>when</c> expression of a switch case), and the branches to a given label if the guard
         /// is true (or there is no guard).
         /// </summary>
         public class Guarded : DecisionTree

--- a/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/TupleBinaryOperatorInfo.cs
@@ -18,9 +18,9 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// <summary>
     /// A tree of binary operators for tuple comparisons.
     ///
-    /// For `(a, (b, c)) == (d, (e, f))` we'll hold a Multiple with two elements.
-    /// The first element is a Single (describing the binary operator and conversions that are involved in `a == d`).
-    /// The second element is a Multiple containing two Singles (one for the `b == e` comparison and the other for `c == f`).
+    /// For <c>(a, (b, c)) == (d, (e, f))</c> we'll hold a Multiple with two elements.
+    /// The first element is a Single (describing the binary operator and conversions that are involved in <c>a == d</c>).
+    /// The second element is a Multiple containing two Singles (one for the <c>b == e</c> comparison and the other for <c>c == f</c>).
     /// </summary>
     internal abstract class TupleBinaryOperatorInfo
     {
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Holds the information for an element-wise comparison (like `a == b` as part of `(a, ...) == (b, ...)`)
+        /// Holds the information for an element-wise comparison (like <c>a == b</c> as part of <c>(a, ...) == (b, ...)</c>)
         /// </summary>
         internal class Single : TupleBinaryOperatorInfo
         {
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Holds the information for a tuple comparison, either at the top-level (like `(a, b) == ...`) or nested (like `(..., (a, b)) == (..., ...)`).
+        /// Holds the information for a tuple comparison, either at the top-level (like <c>(a, b) == ...</c>) or nested (like <c>(..., (a, b)) == (..., ...)</c>).
         /// </summary>
         internal class Multiple : TupleBinaryOperatorInfo
         {
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Represents an element-wise null/null comparison.
-        /// For instance, `(null, ...) == (null, ...)`.
+        /// For instance, <c>(null, ...) == (null, ...)</c>.
         /// </summary>
         internal class NullNull : TupleBinaryOperatorInfo
         {

--- a/src/Compilers/CSharp/Portable/Compilation/DeconstructionInfo.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/DeconstructionInfo.cs
@@ -13,9 +13,9 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// Methods only appear in non-terminal nodes. All terminal nodes have a Conversion.
     ///
     /// Here's an example:
-    /// A deconstruction like `(int x1, (long x2, long x3)) = deconstructable1` with
-    /// `Deconstructable1.Deconstruct(out int y1, out Deconstructable2 y2)` and
-    /// `Deconstructable2.Deconstruct(out int z1, out int z2)` is represented as 5 DeconstructionInfo nodes.
+    /// A deconstruction like <c>(int x1, (long x2, long x3)) = deconstructable1</c> with
+    /// <c>Deconstructable1.Deconstruct(out int y1, out Deconstructable2 y2)</c> and
+    /// <c>Deconstructable2.Deconstruct(out int z1, out int z2)</c> is represented as 5 DeconstructionInfo nodes.
     ///
     /// The top-level node has a <see cref="Method"/> (Deconstructable1.Deconstruct), no <see cref="Conversion"/>, but has two <see cref="Nested"/> nodes.
     /// Its first nested node has no <see cref="Method"/>, but has a <see cref="Conversion"/> (Identity).

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -672,7 +672,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// even though l is a local, we must access it via a temp since "goo(ref l)" may change it
         /// on between accesses.
         ///
-        /// Note: In `this.x++`, `this` cannot change between reads. But in `(this, ...) == (..., this.Mutate())` it can.
+        /// Note: In <c>this.x++</c>, <c>this</c> cannot change between reads. But in <c>(this, ...) == (..., this.Mutate())</c> it can.
         /// </summary>
         internal static bool CanChangeValueBetweenReads(
             BoundExpression expression,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -508,7 +508,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// (1) assigns it into a local, or
         /// (2) deconstructs it into multiple locals (if there is a deconstruct step).
         ///
-        /// Produces `V v = /* expression */` or `(D1 d1, ...) = /* expression */`.
+        /// Produces <c>V v = /* expression */</c> or <c>(D1 d1, ...) = /* expression */</c>.
         /// </summary>
         private BoundStatement LocalOrDeconstructionDeclaration(
                                     BoundForEachStatement forEachBound,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
@@ -11,14 +11,14 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed partial class LocalRewriter
     {
         /// <summary>
-        /// Rewrite `GetTuple() == (1, 2)` to `tuple.Item1 == 1 &amp;&amp; tuple.Item2 == 2`.
+        /// Rewrite <c>GetTuple() == (1, 2)</c> to <c>tuple.Item1 == 1 &amp;&amp; tuple.Item2 == 2</c>.
         /// Also supports the != operator, nullable and nested tuples.
         ///
         /// Note that all the side-effects for visible expressions are evaluated first and from left to right. The initialization phase
         /// contains side-effects for:
-        /// - single elements in tuple literals, like `a` in `(a, ...) == (...)` for example
-        /// - nested expressions that aren't tuple literals, like `GetTuple()` in `(..., GetTuple()) == (..., (..., ...))`
-        /// On the other hand, `Item1` and `Item2` of `GetTuple()` are not saved as part of the initialization phase of `GetTuple() == (..., ...)`
+        /// - single elements in tuple literals, like <c>a</c> in <c>(a, ...) == (...)</c> for example
+        /// - nested expressions that aren't tuple literals, like <c>GetTuple()</c> in <c>(..., GetTuple()) == (..., (..., ...))</c>
+        /// On the other hand, <c>Item1</c> and <c>Item2</c> of <c>GetTuple()</c> are not saved as part of the initialization phase of <c>GetTuple() == (..., ...)</c>
         ///
         /// Element-wise conversions occur late, together with the element-wise comparisons. They might not be evaluated.
         /// </summary>
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Produce a `.HasValue` and a `.GetValueOrDefault()` for nullable expressions that are neither always null or never null, and functionally equivalent parts for other cases.
+        /// Produce a <c>.HasValue</c> and a <c>.GetValueOrDefault()</c> for nullable expressions that are neither always null or never null, and functionally equivalent parts for other cases.
         /// </summary>
         private void MakeNullableParts(BoundExpression expr, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> innerEffects,
             ArrayBuilder<BoundExpression> outerEffects, bool saveHasValue, out BoundExpression hasValue, out BoundExpression value, out bool isNullable)
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// For tuple literals, we just return the element.
-        /// For expressions with tuple type, we access `Item{i}`.
+        /// For expressions with tuple type, we access <c>Item{i}</c>.
         /// </summary>
         private BoundExpression GetTuplePart(BoundExpression tuple, int i)
         {
@@ -327,9 +327,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Produce an element-wise comparison and logic to ensure the result is a bool type.
         ///
         /// If an element-wise comparison doesn't return bool, then:
-        /// - if it is dynamic, we'll do `!(comparisonResult.false)` or `comparisonResult.true`
+        /// - if it is dynamic, we'll do <c>!(comparisonResult.false)</c> or <c>comparisonResult.true</c>
         /// - if it implicitly converts to bool, we'll just do the conversion
-        /// - otherwise, we'll do `!(comparisonResult.false)` or `comparisonResult.true` (as we'd do for `if` or `while`)
+        /// - otherwise, we'll do <c>!(comparisonResult.false)</c> or <c>comparisonResult.true</c> (as we'd do for <c>if</c> or <c>while</c>)
         /// </summary>
         private BoundExpression RewriteTupleSingleOperator(TupleBinaryOperatorInfo.Single single,
             BoundExpression left, BoundExpression right, TypeSymbol boolType, BinaryOperatorKind operatorKind)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4884,7 +4884,7 @@ tryAgain:
 
         /// <summary>
         /// True if the given token is not really some contextual keyword.
-        /// This method is for use in executable code, as it treats `partial` as an identifier.
+        /// This method is for use in executable code, as it treats <c>partial</c> as an identifier.
         /// </summary>
         private bool IsTrueIdentifier(SyntaxToken token)
         {
@@ -8294,7 +8294,7 @@ tryAgain:
         }
 
         /// <summary>
-        /// Parse a single variable designation (e.g. `x`) or a wildcard designation (e.g. `_`)
+        /// Parse a single variable designation (e.g. <c>x</c>) or a wildcard designation (e.g. <c>_</c>)
         /// </summary>
         /// <returns></returns>
         private VariableDesignationSyntax ParseSimpleDesignation()

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         /// <summary>
-        /// Is the following set of tokens, interpreted as a type, the type `var`?
+        /// Is the following set of tokens, interpreted as a type, the type <c>var</c>?
         /// </summary>
         private bool IsVarType()
         {

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -1086,7 +1086,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         /// <summary>
-        /// Whenever parsing in a `while (true)` loop and a bug could prevent the loop from making progress,
+        /// Whenever parsing in a <c>while (true)</c> loop and a bug could prevent the loop from making progress,
         /// this method can prevent the parsing from hanging.
         /// Use as:
         ///     int tokenProgress = -1;

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -1029,7 +1029,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// If this symbol represents a metadata assembly returns the underlying <see cref="AssemblyMetadata"/>.
         /// 
-        /// Otherwise, this returns <code>null</code>.
+        /// Otherwise, this returns <see langword="null"/>.
         /// </summary>
         public abstract AssemblyMetadata GetMetadata();
 

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -728,11 +728,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// We'll look at the result of equality without tuple names (1) and with tuple names (2).
         /// The question is whether there is a change in tuple element names only (3).
         ///
-        /// member1                  vs. member2                   | (1) | (2) |    (3)    |
-        /// `(int a, int b) M()`     vs. `(int a, int b) M()`      | yes | yes |   match   |
-        /// `(int a, int b) M()`     vs. `(int x, int y) M()`      | yes | no  | different |
-        /// `void M((int a, int b))` vs. `void M((int x, int y))`  | yes | no  | different |
-        /// `int M()`                vs. `string M()`              | no  | no  |   match   |
+        /// member1                       vs. member2                        | (1) | (2) |    (3)    |
+        /// <c>(int a, int b) M()</c>     vs. <c>(int a, int b) M()</c>      | yes | yes |   match   |
+        /// <c>(int a, int b) M()</c>     vs. <c>(int x, int y) M()</c>      | yes | no  | different |
+        /// <c>void M((int a, int b))</c> vs. <c>void M((int x, int y))</c>  | yes | no  | different |
+        /// <c>int M()</c>                vs. <c>string M()</c>              | no  | no  |   match   |
         ///
         /// </summary>
         internal static bool ConsideringTupleNamesCreatesDifference(Symbol member1, Symbol member2)

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -399,7 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// If this symbol represents a metadata module returns the underlying <see cref="ModuleMetadata"/>.
         /// 
-        /// Otherwise, this returns <code>null</code>.
+        /// Otherwise, this returns <see langword="null"/>.
         /// </summary>
         public abstract ModuleMetadata GetMetadata();
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -919,7 +919,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// True if this is a reference to an <em>unbound</em> generic type.  These occur only
-        /// within a <code>typeof</code> expression.  A generic type is considered <em>unbound</em>
+        /// within a <c>typeof</c> expression.  A generic type is considered <em>unbound</em>
         /// if all of the type argument lists in its fully qualified name are empty.
         /// Note that the type arguments of an unbound generic type will be returned as error
         /// types because they do not really have type arguments.  An unbound generic type

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -630,7 +630,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// Symbol for a deconstruction local that might require type inference.
-        /// For instance, local `x` in `var (x, y) = ...` or `(var x, int y) = ...`.
+        /// For instance, local <c>x</c> in <c>var (x, y) = ...</c> or <c>(var x, int y) = ...</c>.
         /// </summary>
         private class DeconstructionLocalSymbol : SourceLocalSymbol
         {

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConversionExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConversionExpression.cs
@@ -579,7 +579,7 @@ IVariableDeclaratorOperation (Symbol: System.Int64 i1) (OperationKind.VariableDe
         }
 
         /// <summary>
-        /// This test documents the fact that `default(T)` is already T, and does not introduce a conversion
+        /// This test documents the fact that <c>default(T)</c> is already T, and does not introduce a conversion
         /// </summary>
         [CompilerTrait(CompilerFeature.IOperation)]
         [Fact]

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1026,7 +1026,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Returns a new anonymous type symbol with the given member types member names.
         /// Anonymous type members will be readonly by default.  Writable properties are
-        /// supported in VB and can be created by passing in <code>false</code> in the
+        /// supported in VB and can be created by passing in <see langword="false"/> in the
         /// appropriate locations in <paramref name="memberIsReadOnly"/>.
         ///
         /// Source locations can also be provided through <paramref name="memberLocations"/>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2577,9 +2577,9 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Returns a tuple of streams where
-        /// * `peStream` is a stream which will carry the output PE bits
-        /// * `signingStream` is the stream which will be signed by the legacy strong name signer, or null if we aren't using the legacy signer
-        /// * `selectedStream` is an alias of either peStream or signingStream, and is the stream that will be written to by the emitter.
+        /// * <c>peStream</c> is a stream which will carry the output PE bits
+        /// * <c>signingStream</c> is the stream which will be signed by the legacy strong name signer, or null if we aren't using the legacy signer
+        /// * <c>selectedStream</c> is an alias of either peStream or signingStream, and is the stream that will be written to by the emitter.
         /// </summary>
         private (Stream peStream, Stream signingStream, Stream selectedStream) GetPeStream(DiagnosticBag metadataDiagnostics, EmitStreamProvider peStreamProvider, bool metadataOnly)
         {

--- a/src/Compilers/Core/Portable/Diagnostic/FileLinePositionSpan.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/FileLinePositionSpan.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis
         /// True if the <see cref="Path"/> is a mapped path.
         /// </summary>
         /// <remarks>
-        /// A mapped path is a path specified in source via <code>#line</code> (C#) or <code>#ExternalSource</code> (VB) directives.
+        /// A mapped path is a path specified in source via <c>#line</c> (C#) or <c>#ExternalSource</c> (VB) directives.
         /// </remarks>
         public bool HasMappedPath { get { return _hasMappedPath; } }
 

--- a/src/Compilers/Core/Portable/Emit/EmitOptions.cs
+++ b/src/Compilers/Core/Portable/Emit/EmitOptions.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         /// <summary>
         /// A crypto hash algorithm used to calculate PDB Checksum stored in the PE/COFF File.
-        /// If not specified (the value is <code>default(HashAlgorithmName)</code>) the checksum is not calculated.
+        /// If not specified (the value is <c>default(HashAlgorithmName)</c>) the checksum is not calculated.
         /// </summary>
         public HashAlgorithmName PdbChecksumAlgorithm { get; private set; }
 

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -785,18 +785,18 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         public IMethodSymbol OperatorMethod { get; }
         /// <summary>
-        /// <code>true</code> if this is a 'lifted' binary operator.  When there is an
+        /// <see langword="true"/> if this is a 'lifted' binary operator.  When there is an
         /// operator that is defined to work on a value type, 'lifted' operators are
         /// created to work on the <see cref="System.Nullable{T}"/> versions of those
         /// value types.
         /// </summary>
         public bool IsLifted { get; }
         /// <summary>
-        /// <code>true</code> if overflow checking is performed for the arithmetic operation.
+        /// <see langword="true"/> if overflow checking is performed for the arithmetic operation.
         /// </summary>
         public bool IsChecked { get; }
         /// <summary>
-        /// <code>true</code> if the comparison is text based for string or object comparison in VB.
+        /// <see langword="true"/> if the comparison is text based for string or object comparison in VB.
         /// </summary>
         public bool IsCompareText { get; }
         public override IEnumerable<IOperation> Children
@@ -1200,11 +1200,11 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         public BinaryOperatorKind OperatorKind { get; }
         /// <summary>
-        /// <code>true</code> if this assignment contains a 'lifted' binary operation.
+        /// <see langword="true"/> if this assignment contains a 'lifted' binary operation.
         /// </summary>
         public bool IsLifted { get; }
         /// <summary>
-        /// <code>true</code> if overflow checking is performed for the arithmetic operation.
+        /// <see langword="true"/> if overflow checking is performed for the arithmetic operation.
         /// </summary>
         public bool IsChecked { get; }
         /// <summary>
@@ -2428,19 +2428,19 @@ namespace Microsoft.CodeAnalysis.Operations
             OperatorMethod = operatorMethod;
         }
         /// <summary>
-        /// <code>true</code> if this is a postfix expression.
-        /// <code>false</code> if this is a prefix expression.
+        /// <see langword="true"/> if this is a postfix expression.
+        /// <see langword="false"/> if this is a prefix expression.
         /// </summary>
         public bool IsPostfix { get; }
         /// <summary>
-        /// <code>true</code> if this is a 'lifted' increment operator.  When there is an
+        /// <see langword="true"/> if this is a 'lifted' increment operator.  When there is an
         /// operator that is defined to work on a value type, 'lifted' operators are
         /// created to work on the <see cref="System.Nullable{T}"/> versions of those
         /// value types.
         /// </summary>
         public bool IsLifted { get; }
         /// <summary>
-        /// <code>true</code> if overflow checking is performed for the arithmetic operation.
+        /// <see langword="true"/> if overflow checking is performed for the arithmetic operation.
         /// </summary>
         public bool IsChecked { get; }
         protected abstract IOperation TargetImpl { get; }
@@ -5359,14 +5359,14 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         public IMethodSymbol OperatorMethod { get; }
         /// <summary>
-        /// <code>true</code> if this is a 'lifted' binary operator.  When there is an
+        /// <see langword="true"/> if this is a 'lifted' binary operator.  When there is an
         /// operator that is defined to work on a value type, 'lifted' operators are
         /// created to work on the <see cref="System.Nullable{T}"/> versions of those
         /// value types.
         /// </summary>
         public bool IsLifted { get; }
         /// <summary>
-        /// <code>true</code> if overflow checking is performed for the arithmetic operation.
+        /// <see langword="true"/> if overflow checking is performed for the arithmetic operation.
         /// </summary>
         public bool IsChecked { get; }
         public override IEnumerable<IOperation> Children

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -385,8 +385,8 @@ namespace System.Linq
 {
     /// <summary>
     /// Declare the following extension methods in System.Linq namespace to avoid accidental boxing of ImmutableArray{T} that implements IEnumerable{T}.
-    /// The boxing would occur if the methods were defined in Roslyn.Utilities and the file calling these methods has <code>using Roslyn.Utilities</code>
-    /// but not <code>using System.Linq"</code>.
+    /// The boxing would occur if the methods were defined in Roslyn.Utilities and the file calling these methods has <c>using Roslyn.Utilities</c>
+    /// but not <c>using System.Linq</c>.
     /// </summary>
     internal static class EnumerableExtensions
     {

--- a/src/Compilers/Core/Portable/Operations/IBinaryOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IBinaryOperation.cs
@@ -33,18 +33,18 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IMethodSymbol OperatorMethod { get; }
         /// <summary>
-        /// <code>true</code> if this is a 'lifted' binary operator.  When there is an 
+        /// <see langword="true"/> if this is a 'lifted' binary operator.  When there is an 
         /// operator that is defined to work on a value type, 'lifted' operators are 
         /// created to work on the <see cref="System.Nullable{T}"/> versions of those
         /// value types.
         /// </summary>
         bool IsLifted { get; }
         /// <summary>
-        /// <code>true</code> if this is a 'checked' binary operator.
+        /// <see langword="true"/> if this is a 'checked' binary operator.
         /// </summary>
         bool IsChecked { get; }
         /// <summary>
-        /// <code>true</code> if the comparison is text based for string or object comparison in VB.
+        /// <see langword="true"/> if the comparison is text based for string or object comparison in VB.
         /// </summary>
         bool IsCompareText { get; }
     }

--- a/src/Compilers/Core/Portable/Operations/ICompoundAssignmentOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/ICompoundAssignmentOperation.cs
@@ -27,12 +27,12 @@ namespace Microsoft.CodeAnalysis.Operations
         IMethodSymbol OperatorMethod { get; }
 
         /// <summary>
-        /// <code>true</code> if this assignment contains a 'lifted' binary operation.
+        /// <see langword="true"/> if this assignment contains a 'lifted' binary operation.
         /// </summary>
         bool IsLifted { get; }
 
         /// <summary>
-        /// <code>true</code> if overflow checking is performed for the arithmetic operation.
+        /// <see langword="true"/> if overflow checking is performed for the arithmetic operation.
         /// </summary>
         bool IsChecked { get; }
 

--- a/src/Compilers/Core/Portable/Operations/IConditionalAccessInstanceOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IConditionalAccessInstanceOperation.cs
@@ -4,7 +4,7 @@ namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>
     /// Represents the value of a conditionally-accessed operation within <see cref="IConditionalAccessOperation.WhenNotNull"/>.
-    /// For a conditional access operation of the form <code>someExpr?.Member</code>, this operation is used as the InstanceReceiver for the right operation <code>Member</code>.
+    /// For a conditional access operation of the form <c>someExpr?.Member</c>, this operation is used as the InstanceReceiver for the right operation <c>Member</c>.
     /// See https://github.com/dotnet/roslyn/issues/21279#issuecomment-323153041 for more details.
     /// <para>
     /// Current usage:

--- a/src/Compilers/Core/Portable/Operations/IConversionOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IConversionOperation.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Operations
         CommonConversion Conversion { get; }
         /// <summary>
         /// False if the conversion will fail with a <see cref="InvalidCastException"/> at runtime if the cast fails. This is true for C#'s
-        /// <code>as</code> operator and for VB's <code>TryCast</code> operator.
+        /// <c>as</c> operator and for VB's <c>TryCast</c> operator.
         /// </summary>
         bool IsTryCast { get; }
         /// <summary>

--- a/src/Compilers/Core/Portable/Operations/IIncrementOrDecrementOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IIncrementOrDecrementOperation.cs
@@ -28,13 +28,13 @@ namespace Microsoft.CodeAnalysis.Operations
         IMethodSymbol OperatorMethod { get; }
 
         /// <summary>
-        /// <code>true</code> if this is a postfix expression.
-        /// <code>false</code> if this is a prefix expression.
+        /// <see langword="true"/> if this is a postfix expression.
+        /// <see langword="false"/> if this is a prefix expression.
         /// </summary>
         bool IsPostfix { get; }
 
         /// <summary>
-        /// <code>true</code> if this is a 'lifted' increment operator.  When there is an 
+        /// <see langword="true"/> if this is a 'lifted' increment operator.  When there is an 
         /// operator that is defined to work on a value type, 'lifted' operators are 
         /// created to work on the <see cref="System.Nullable{T}"/> versions of those
         /// value types.
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Operations
         bool IsLifted { get; }
 
         /// <summary>
-        /// <code>true</code> if overflow checking is performed for the arithmetic operation.
+        /// <see langword="true"/> if overflow checking is performed for the arithmetic operation.
         /// </summary>
         bool IsChecked { get; }
     }

--- a/src/Compilers/Core/Portable/Operations/IUnaryOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IUnaryOperation.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Operations
         IMethodSymbol OperatorMethod { get; }
 
         /// <summary>
-        /// <code>true</code> if this is a 'lifted' unary operator.  When there is an 
+        /// <see langword="true"/> if this is a 'lifted' unary operator.  When there is an 
         /// operator that is defined to work on a value type, 'lifted' operators are 
         /// created to work on the <see cref="System.Nullable{T}"/> versions of those
         /// value types.
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Operations
         bool IsLifted { get; }
 
         /// <summary>
-        /// <code>true</code> if overflow checking is performed for the arithmetic operation.
+        /// <see langword="true"/> if overflow checking is performed for the arithmetic operation.
         /// </summary>
         bool IsChecked { get; }
     }

--- a/src/Compilers/Core/Portable/Operations/IVariableDeclarationOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IVariableDeclarationOperation.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Individual variable declarations declared by this multiple declaration.
         /// </summary>
         /// <remarks>
-        /// All <see cref="IVariableDeclarationGroupOperation"/> will have at least 1 <code>IVariableDeclarationOpertion</code>,
+        /// All <see cref="IVariableDeclarationGroupOperation"/> will have at least 1 <see cref="IVariableDeclarationOperation"/>,
         /// even if the declaration group only declares 1 variable.
         /// </remarks>
         ImmutableArray<IVariableDeclaratorOperation> Declarators { get; }

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -80,7 +80,7 @@ namespace Roslyn.Utilities
 
         /// <summary>
         /// Attempts to create a <see cref="ObjectReader"/> from the provided <paramref name="stream"/>.
-        /// If the <paramref name="stream"/> does not start with a valid header, then <code>null</code> will
+        /// If the <paramref name="stream"/> does not start with a valid header, then <see langword="null"/> will
         /// be returned.
         /// </summary>
         public static ObjectReader TryGetReader(

--- a/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// If this symbol represents a metadata assembly returns the underlying <see cref="AssemblyMetadata"/>.
         /// 
-        /// Otherwise, this returns <code>null</code>.
+        /// Otherwise, this returns <see langword="null"/>.
         /// </summary>
         AssemblyMetadata GetMetadata();
     }

--- a/src/Compilers/Core/Portable/Symbols/IDiscardSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IDiscardSymbol.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis
 {
     /// <summary>
     /// A symbol representing a discarded value, e.g. a symbol in the result of
-    /// GetSymbolInfo for `_` in `M(out _)` or `(x, _) = e`.
+    /// GetSymbolInfo for <c>_</c> in <c>M(out _)</c> or <c>(x, _) = e</c>.
     /// </summary>
     public interface IDiscardSymbol : ISymbol
     {

--- a/src/Compilers/Core/Portable/Symbols/IModuleSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IModuleSymbol.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// If this symbol represents a metadata module returns the underlying <see cref="ModuleMetadata"/>.
         /// 
-        /// Otherwise, this returns <code>null</code>.
+        /// Otherwise, this returns <see langword="null"/>.
         /// </summary>
         ModuleMetadata GetMetadata();
     }

--- a/src/Compilers/Core/Portable/Syntax/ICompilationUnitSyntax.cs
+++ b/src/Compilers/Core/Portable/Syntax/ICompilationUnitSyntax.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Interface implemented by any node that is the root 'CompilationUnit' of a <see cref="SyntaxTree"/>.  i.e. 
     /// any node returned by <see cref="SyntaxTree.GetRoot"/> where <see cref="SyntaxTree.HasCompilationUnitRoot"/>
-    /// is <code>true</code> will implement this interface.
+    /// is <see langword="true"/> will implement this interface.
     ///
     /// This interface provides a common way to both easily find the root of a <see cref="SyntaxTree"/>
     /// given any <see cref="SyntaxNode"/>, as well as a common way for handling the special 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
@@ -188,24 +188,24 @@ namespace Microsoft.CodeAnalysis
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>
         /// A valid <see cref="FileLinePositionSpan"/> that contains path, line and column information.
-        /// The values are not affected by line mapping directives (<code>#line</code>).
+        /// The values are not affected by line mapping directives (<c>#line</c>).
         /// </returns>
         public abstract FileLinePositionSpan GetLineSpan(TextSpan span, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Gets the location in terms of path, line and column after applying source line mapping directives 
-        /// (<code>#line</code> in C# or <code>#ExternalSource</code> in VB). 
+        /// (<c>#line</c> in C# or <c>#ExternalSource</c> in VB). 
         /// </summary>
         /// <param name="span">Span within the tree.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>
         /// A valid <see cref="FileLinePositionSpan"/> that contains path, line and column information.
         /// 
-        /// If the location path is mapped the resulting path is the path specified in the corresponding <code>#line</code>,
+        /// If the location path is mapped the resulting path is the path specified in the corresponding <c>#line</c>,
         /// otherwise it's <see cref="SyntaxTree.FilePath"/>.
         /// 
-        /// A location path is considered mapped if the first <code>#line</code> directive that precedes it and that 
-        /// either specifies an explicit file path or is <code>#line default</code> exists and specifies an explicit path.
+        /// A location path is considered mapped if the first <c>#line</c> directive that precedes it and that 
+        /// either specifies an explicit file path or is <c>#line default</c> exists and specifies an explicit path.
         /// </returns>
         public abstract FileLinePositionSpan GetMappedLineSpan(TextSpan span, CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' If this symbol represents a metadata assembly returns the underlying <see cref="AssemblyMetadata"/>.
         ''' 
-        ''' Otherwise, this returns <code>nothing</code>.
+        ''' Otherwise, this returns <see langword="Nothing"/>.
         ''' </summary>
         Public MustOverride Function GetMetadata() As AssemblyMetadata Implements IAssemblySymbol.GetMetadata
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
@@ -126,7 +126,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' If this symbol represents a metadata module returns the underlying <see cref="ModuleMetadata"/>.
         ''' 
-        ''' Otherwise, this returns <code>nothing</code>.
+        ''' Otherwise, this returns <see langword="Nothing"/>.
         ''' </summary>
         Public MustOverride Function GetMetadata() As ModuleMetadata Implements IModuleSymbol.GetMetadata
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1033,7 +1033,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         ''' <summary>
         ''' True if this is a reference to an <em>unbound</em> generic type.  These occur only
-        ''' within a <code>GetType</code> expression.  A generic type is considered <em>unbound</em>
+        ''' within a <c>GetType</c> expression.  A generic type is considered <em>unbound</em>
         ''' if all of the type argument lists in its fully qualified name are empty.
         ''' Note that the type arguments of an unbound generic type will be returned as error
         ''' types because they do not really have type arguments.  An unbound generic type

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/CodeFixes/AddDocCommentNodesCodeFixProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/CodeFixes/AddDocCommentNodesCodeFixProviderTests.cs
@@ -150,8 +150,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.DocumentationComments.C
     /// <summary>
     /// 
     /// </summary>
-    /// <param name=""i"">Parameter `i` does something</param>
-    /// <param name=""k"">Parameter `k` does something else</param>
+    /// <param name=""i"">Parameter <paramref name=""i""/> does something</param>
+    /// <param name=""k"">Parameter <paramref name=""k""/> does something else</param>
     public void Fizz(int i, int [|j|], int k) {}
 }
 ";
@@ -162,9 +162,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.DocumentationComments.C
     /// <summary>
     /// 
     /// </summary>
-    /// <param name=""i"">Parameter `i` does something</param>
+    /// <param name=""i"">Parameter <paramref name=""i""/> does something</param>
     /// <param name=""j""></param>
-    /// <param name=""k"">Parameter `k` does something else</param>
+    /// <param name=""k"">Parameter <paramref name=""k""/> does something else</param>
     public void Fizz(int i, int j, int k) {}
 }
 ";

--- a/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
+++ b/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
         /// be searching.
         /// 
         /// Note that the <see cref="Solution"/> returned may absolutely *not* be
-        /// the same as <code>document.Project.Solution</code>.  This is because 
+        /// the same as <c>document.Project.Solution</c>.  This is because 
         /// there may be symbol mapping involved (for example in Metadata-As-Source
         /// scenarios).
         /// </summary>

--- a/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
@@ -194,13 +194,13 @@ namespace Microsoft.CodeAnalysis.Editor
 
         /// <summary>
         /// Called before the rename is applied to the specified documents in the workspace.  Return 
-        /// <code>true</code> if rename should proceed, or <code>false</code> if it should be canceled.
+        /// <see langword="true"/> if rename should proceed, or <see langword="false"/> if it should be canceled.
         /// </summary>
         bool TryOnBeforeGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText);
 
         /// <summary>
         /// Called after the rename is applied to the specified documents in the workspace.  Return 
-        /// <code>true</code> if this operation succeeded, or <code>false</code> if it failed.
+        /// <see langword="true"/> if this operation succeeded, or <see langword="false"/> if it failed.
         /// </summary>
         bool TryOnAfterGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText);
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_ComputeModel.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                 => p1.ToString() == p2.ToString();
 
             /// <summary>
-            /// Returns <code>null</code> if our work was preempted and we want to return the 
+            /// Returns <see langword="null"/> if our work was preempted and we want to return the 
             /// previous model we've computed.
             /// </summary>
             private async Task<(ISignatureHelpProvider provider, SignatureHelpItems items)?> ComputeItemsAsync(

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpPreferFrameworkTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpPreferFrameworkTypeDiagnosticAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.Analyzers
             ImmutableArray.Create(SyntaxKind.PredefinedType);
 
         ///<remarks>
-        /// every predefined type keyword except `void` can be replaced by its framework type in code.
+        /// every predefined type keyword except <c>void</c> can be replaced by its framework type in code.
         ///</remarks>
         protected override bool IsPredefinedTypeReplaceableWithFrameworkType(PredefinedTypeSyntax node) =>
             node.Keyword.Kind() != SyntaxKind.VoidKeyword;

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -402,10 +402,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             }
 
             /// <summary>
-            /// If the statement has an `out var` declaration expression for a variable which
-            /// needs to be removed, we need to turn it into a plain `out` parameter, so that
+            /// If the statement has an <c>out var</c> declaration expression for a variable which
+            /// needs to be removed, we need to turn it into a plain <c>out</c> parameter, so that
             /// it doesn't declare a duplicate variable.
-            /// If the statement has a pattern declaration (such as `3 is int i`) for a variable
+            /// If the statement has a pattern declaration (such as <c>3 is int i</c>) for a variable
             /// which needs to be removed, we will annotate it as a conflict, since we don't have
             /// a better refactoring.
             /// </summary>

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 {
     /// <summary>
     /// DiagnosticAnalyzer that looks for is-tests and cast-expressions, and offers to convert them
-    /// to use patterns.  i.e. if the user has <code>obj is TestFile &amp;&amp; ((TestFile)obj).Name == "Test"</code>
-    /// it will offer to convert that <code>obj is TestFile file &amp;&amp; file.Name == "Test"</code>.
+    /// to use patterns.  i.e. if the user has <c>obj is TestFile &amp;&amp; ((TestFile)obj).Name == "Test"</c>
+    /// it will offer to convert that <c>obj is TestFile file &amp;&amp; file.Name == "Test"</c>.
     /// 
     /// Complements <see cref="CSharpIsAndCastCheckDiagnosticAnalyzer"/> (which does the same,
     /// but only for code cases where the user has provided an appropriate variable name in

--- a/src/Features/Core/Portable/RQName/RQNameInternal.cs
+++ b/src/Features/Core/Portable/RQName/RQNameInternal.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Features.RQName
     internal static class RQNameInternal
     {
         /// <summary>
-        /// Returns an RQName for the given symbol, or <code>null</code>if the symbol cannot be represented by an RQName.
+        /// Returns an RQName for the given symbol, or <see langword="null"/> if the symbol cannot be represented by an RQName.
         /// </summary>
         /// <param name="symbol">The symbol to build an RQName for.</param>
         public static string From(ISymbol symbol)

--- a/src/Features/Core/Portable/SignatureHelp/SignatureHelpItems.cs
+++ b/src/Features/Core/Portable/SignatureHelp/SignatureHelpItems.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
         public string ArgumentName { get; }
 
         /// <summary>
-        /// The item to select by default.  If this is <code>null</code> then the controller will
+        /// The item to select by default.  If this is <see langword="null"/> then the controller will
         /// pick the first item that has enough arguments to be viable based on what argument 
         /// position the user is currently inside of.
         /// </summary>

--- a/src/Features/Core/Portable/UseConditionalExpression/UseConditionalExpressionHelpers.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/UseConditionalExpressionHelpers.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
 
         /// <summary>
         /// Will unwrap a block with a single statement in it to just that block.  Used so we can
-        /// support both ```if (expr) { statement }``` and ```if (expr) statement```
+        /// support both <c>if (expr) { statement }</c> and <c>if (expr) statement</c>
         /// </summary>
         public static IOperation UnwrapSingleStatementBlock(IOperation statement)
             => statement is IBlockOperation block && block.Operations.Length == 1

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
     ''' <summary>
-    ''' Offers to simplify tuple expressions and anonymous types with redundant names, such as `(a:=a, b:=b)` or `New With {.a = a, .b = b}`
+    ''' Offers to simplify tuple expressions and anonymous types with redundant names, such as <c>(a:=a, b:=b)</c> or <c>New With {.a = a, .b = b}</c>
     ''' </summary>
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Friend Class VisualBasicUseInferredMemberNameDiagnosticAnalyzer

--- a/src/Test/Utilities/Portable/InstrumentationChecker.cs
+++ b/src/Test/Utilities/Portable/InstrumentationChecker.cs
@@ -288,7 +288,7 @@ End Namespace
         /// <param name="snippet">
         /// A short snippet of code capturing the what you expect the span for this method to look like.
         /// It will be verified against the start of the actual method source span.
-        /// If no snippet is passed in, then snippet validation will be disabled for the whole method (subsequent calls to `True` or `False`).
+        /// If no snippet is passed in, then snippet validation will be disabled for the whole method (subsequent calls to <c>True</c> or <c>False</c>).
         /// </param>
         public MethodChecker Method(int method, int file, string snippet = null, bool expectBodySpan = true)
         {

--- a/src/Tools/Source/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/Source/RunTests/AssemblyScheduler.cs
@@ -275,7 +275,7 @@ namespace RunTests
         }
 
         /// <summary>
-        /// Determine if this type should be one of the `class` values passed to xunit.  This
+        /// Determine if this type should be one of the <c>class</c> values passed to xunit.  This
         /// code doesn't actually resolve base types or trace through inherrited Fact attributes
         /// hence we have to error on the side of including types with no tests vs. excluding them.
         /// </summary>

--- a/src/VisualStudio/Core/Def/Implementation/RQName/RQName.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/RQName.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServices
     public static class RQName
     {
         /// <summary>
-        /// Returns an RQName for the given symbol, or <code>null</code>if the symbol cannot be represented by an RQName.
+        /// Returns an RQName for the given symbol, or <see langword="null"/> if the symbol cannot be represented by an RQName.
         /// </summary>
         /// <param name="symbol">The symbol to build an RQName for.</param>
         /// <returns>A string suitable to pass as the pszRQName argument to methods in <see cref="IVsRefactorNotify"/>

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetInfoService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetInfoService.cs
@@ -158,14 +158,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         /// eventually calls into the native CExpansionEnumeratorShim::Next method, which has the
         /// same contract of expecting a non-null rgelt that it can drop expansion data into. When
         /// we call from the UI thread, this transition from managed code to the
-        /// CExpansionEnumeratorShim` goes smoothly and everything works.
+        /// CExpansionEnumeratorShim goes smoothly and everything works.
         ///
         /// When we call from a background thread, the COM marshaller has to move execution to the
         /// UI thread, and as part of this process it uses the interface as defined in the idl to
         /// set up the appropriate arguments to pass. The same parameter from the idl is defined as
         ///    [out, size_is(celt), length_is(*pceltFetched)] VsExpansion **rgelt
         ///
-        /// Because rgelt is specified as an `out` parameter, the marshaller is discarding the
+        /// Because rgelt is specified as an <c>out</c> parameter, the marshaller is discarding the
         /// pointer we passed and substituting the null reference. This then causes a null
         /// reference exception in the shim. Calling from the UI thread avoids this marshaller.
         /// </remarks>

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -542,7 +542,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         /// <summary>
-        /// Checks whether currentToken is the opening paren of a deconstruction-declaration in var form, such as `var (x, y) = ...`
+        /// Checks whether currentToken is the opening paren of a deconstruction-declaration in var form, such as <c>var (x, y) = ...</c>
         /// </summary>
         public static bool IsOpenParenInVarDeconstructionDeclaration(this SyntaxToken currentToken)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public bool AutoInsertionLocation { get; }
 
         /// <summary>
-        /// If <see cref="AutoInsertionLocation"/> is <code>false</code>, determines if members will be
+        /// If <see cref="AutoInsertionLocation"/> is <see langword="false"/>, determines if members will be
         /// sorted before being added to the end of the list of members.
         /// </summary>
         public bool SortMembers { get; }

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
     /// <summary>
     /// Represents a code style option and an associated notification option.  Supports
-    /// being instantiated with T as a <see cref="bool"/> or an <code>enum type</code>.
+    /// being instantiated with T as a <see cref="bool"/> or an <c>enum type</c>.
     /// 
     /// CodeStyleOption also has some basic support for migration a <see cref="bool"/> option
-    /// forward to an <code>enum type</code> option.  Specifically, if a previously serialized
+    /// forward to an <c>enum type</c> option.  Specifically, if a previously serialized
     /// bool-CodeStyleOption is then deserialized into an enum-CodeStyleOption then 'false' 
     /// values will be migrated to have the 0-value of the enum, and 'true' values will be
     /// migrated to have the 1-value of the enum.

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -131,8 +131,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         /// <summary>
         /// Returns the expression node the member is being accessed off of.  If <paramref name="allowImplicitTarget"/>
-        /// is <code>false</code>, this will be the node directly to the left of the dot-token.  If <paramref name="allowImplicitTarget"/>
-        /// is <code>true</code>, then this can return another node in the tree that the member will be accessed
+        /// is <see langword="false"/>, this will be the node directly to the left of the dot-token.  If <paramref name="allowImplicitTarget"/>
+        /// is <see langword="true"/>, then this can return another node in the tree that the member will be accessed
         /// off of.  For example, in VB, if you have a member-access-expression of the form ".Length" then this
         /// may return the expression in the surrounding With-statement.
         /// </summary>

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Tries to resolve the provided <paramref name="symbolKey"/> in the given 
         /// <paramref name="compilation"/> to a matching symbol.  <paramref name="resolveLocations"/>
-        /// should only be given <code>true</code> if the symbol was produced from a compilation
+        /// should only be given <see langword="true"/> if the symbol was produced from a compilation
         /// that has the exact same source as the compilation we're resolving against.  Otherwise
         /// the locations resolved may not actually be correct in the final compilation.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -63,10 +63,10 @@ namespace Microsoft.CodeAnalysis
         public string OutputRefFilePath => _projectState.OutputRefFilePath;
 
         /// <summary>
-        /// <code>true</code> if this <see cref="Project"/> supports providing data through the
+        /// <see langword="true"/> if this <see cref="Project"/> supports providing data through the
         /// <see cref="GetCompilationAsync(CancellationToken)"/> method.
         /// 
-        /// If <code>false</code> then this method will return <code>null</code> instead.
+        /// If <see langword="false"/> then this method will return <see langword="null"/> instead.
         /// </summary>
         public bool SupportsCompilation => this.LanguageServices.GetService<ICompilationFactoryService>() != null;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1683,7 +1683,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Returns the compilation for the specified <see cref="ProjectId"/>.  Can return <code>null</code> when the project
+        /// Returns the compilation for the specified <see cref="ProjectId"/>.  Can return <see langword="null"/> when the project
         /// does not support compilations.
         /// </summary>
         private Task<Compilation> GetCompilationAsync(ProjectId projectId, CancellationToken cancellationToken)
@@ -1692,7 +1692,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Returns the compilation for the specified <see cref="ProjectState"/>.  Can return <code>null</code> when the project
+        /// Returns the compilation for the specified <see cref="ProjectState"/>.  Can return <see langword="null"/> when the project
         /// does not support compilations.
         /// </summary>
         public Task<Compilation> GetCompilationAsync(ProjectState project, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1093,8 +1093,8 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Returns <code>true</code> if a reference to referencedProject can be added to
-        /// referencingProject.  <code>false</code> otherwise.
+        /// Returns <see langword="true"/> if a reference to referencedProject can be added to
+        /// referencingProject.  <see langword="false"/> otherwise.
         /// </summary>
         internal virtual bool CanAddProjectReference(ProjectId referencingProject, ProjectId referencedProject)
         {

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
@@ -1093,7 +1093,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         ''' <Remarks>
         ''' Note: This helper exists solely to work around Bug 1012713. Once it is fixed, this helper must be
         ''' deleted in favor of <see cref="InsideCrefReference(ExpressionSyntax)"/>.
-        ''' Context: Bug 1012713 makes it so that the compiler doesn't support `PredefinedType.Member` inside crefs 
+        ''' Context: Bug 1012713 makes it so that the compiler doesn't support <c>PredefinedType.Member</c> inside crefs 
         ''' (i.e. System.Int32.MaxValue is supported but Integer.MaxValue isn't). Until this bug is fixed, we don't 
         ''' support simplifying types names Like System.Int32.MaxValue to Integer.MaxValue.
         ''' </Remarks>


### PR DESCRIPTION
* Fix use of backticks for inline code in documentation comments
* Fix use of `<code>` for inline code in documentation comments

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
