### PR TITLE
Enable portable signing for Mono

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
@@ -287,7 +287,7 @@ namespace Microsoft.CodeAnalysis
             string tempDirectory)
         {
             bool fallback =
-                !(CoreClrShim.IsRunningOnCoreClr || Type.GetType("Mono.Runtime") != null) ||
+                !(CoreClrShim.IsRunningOnCoreClr || PlatformInformation.IsRunningOnMono) ||
                 ParseOptionsCore.Features.ContainsKey("UseLegacyStrongNameProvider") ||
                 CompilationOptionsCore.CryptoKeyContainer != null;
             return fallback ?

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
@@ -287,7 +287,7 @@ namespace Microsoft.CodeAnalysis
             string tempDirectory)
         {
             bool fallback =
-                !CoreClrShim.IsRunningOnCoreClr ||
+                !(CoreClrShim.IsRunningOnCoreClr || Type.GetType("Mono.Runtime") != null) ||
                 ParseOptionsCore.Features.ContainsKey("UseLegacyStrongNameProvider") ||
                 CompilationOptionsCore.CryptoKeyContainer != null;
             return fallback ?

--- a/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 
 namespace Roslyn.Utilities
@@ -13,5 +14,20 @@ namespace Roslyn.Utilities
     {
         public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
         public static bool IsUnix => Path.DirectorySeparatorChar == '/';
+        public static bool IsRunningOnMono
+        {
+            get
+            {
+                try
+                {
+                    return !(Type.GetType("Mono.Runtime") is null);
+                }
+                catch
+                {
+                    // Arbitrarily assume we're not running on Mono.
+                    return false;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Customer scenario

Signing was previously working on Mono for keyfiles, but does not work after 2.7.1.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/26678
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/615168

### Workarounds, if any

None, for Mono.

### Risk

This check is only used for switching the key providers, and has a focused change just to allow mono to go through the same path as CoreCLR.

### Performance impact

Low, one small reflection check per compile.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

We have no Mono tests. It's not clear that this was supposed to work for Mono, it may have simply been functioning by accident.

### How was the bug found?

Mono reported.
