### PR TITLE
When computing method references ignore nulls

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
@@ -178,6 +178,39 @@ public class A
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
+        public async Task TestMethodReferencesWithDocstrings()
+        {
+            const string input = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+public class A
+{
+    /// <summary>
+    ///     <see cref=""A.C""/>
+    /// </summary>
+    {|0: public void B()
+    {
+        C();
+    }|}
+
+    {|2: public void C()
+    {
+        D();
+    }|}
+
+    {|1: public void D()
+    {
+        C();
+    }|}
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>";
+            await RunMethodReferenceTest(input);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
         public async Task TestFullyQualifiedName()
         {
             const string input = @"<Workspace>

--- a/src/EditorFeatures/VisualBasicTest/CodeLens/VisualBasicCodeLensTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeLens/VisualBasicCodeLensTests.vb
@@ -109,5 +109,35 @@ End Class
 </Workspace>
             Await RunMethodReferenceTest(input)
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeLens)>
+        Public Async Function TestMethodReferencesWithDocstrings() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Proj1">
+        <Document FilePath="CurrentDocument.cs"><![CDATA[
+Class A
+{
+    ''' <summary>
+    '''     <see cref="A.C"/>
+    ''' </summary>
+    {|0: Sub B()|}
+        C();
+    End Sub
+
+    {|2: Sub C()|}
+        D();
+    End Sub
+
+    {|1: Sub D()|}
+        C();
+    End Sub
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await RunMethodReferenceTest(input)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
             return null;
         }
 
-        private static async Task<ReferenceMethodDescriptor> GetMethodDescriptorAsync(Location commonLocation, Solution solution, CancellationToken cancellationToken)
+        private static async Task<ReferenceMethodDescriptor> TryGetMethodDescriptorAsync(Location commonLocation, Solution solution, CancellationToken cancellationToken)
         {
             var doc = solution.GetDocument(commonLocation.SourceTree);
             if (doc == null)
@@ -246,12 +246,12 @@ namespace Microsoft.CodeAnalysis.CodeLens
                 {
                     var descriptorTasks =
                         progress.Locations
-                        .Select(location => GetMethodDescriptorAsync(location, solution, cancellationToken))
+                        .Select(location => TryGetMethodDescriptorAsync(location, solution, cancellationToken))
                         .ToArray();
 
                     var result = await Task.WhenAll(descriptorTasks).ConfigureAwait(false);
 
-                    return (IEnumerable<ReferenceMethodDescriptor>)result;
+                    return result.OfType<ReferenceMethodDescriptor>();
                 }, onCapped: null, searchCap: 0, cancellationToken: cancellationToken);
         }
 


### PR DESCRIPTION
The CodeLensReferencesService when computing the method references
should ignore any null method descriptors. These can occur if the
reference is not part of a method body (for example docstring
<see cref="method"/> tags).

### Customer scenario

Open Visual Studio, add the following code to an xunit test class:

```csharp
/// <summary> tests <see cref="HelperMethod"/></summary>
[Fact] public void SomeTest() { HelperMethod(); }

public void HelperMethod() { }
```

After running tests the `HelperMethod` should have a code lens that `1/1 tests passed` but it doesn't.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/570945

### Workarounds, if any

You cannot have any `<see cref=""/>` references in your code to tested methods.