### PR TITLE
Update LangVersion to 7.3

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -287,7 +287,7 @@
     <When Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#' OR '$(ProjectLanguage)' == 'CSharp'">
       <PropertyGroup>
         <ProjectLanguage>CSharp</ProjectLanguage>
-        <LangVersion>7.2</LangVersion>
+        <LangVersion>7.3</LangVersion>
         <WarningLevel>4</WarningLevel>
         <ErrorReport>prompt</ErrorReport>
 


### PR DESCRIPTION
Although not strictly necessary, I'd been holding off updating the language version used in Roslyn projects until VS 15.7 released. And today, it did.

Fixes https://github.com/dotnet/roslyn/issues/25816

@sharwell @jasonmalinowski @dotnet/roslyn-infrastructure for review. Thanks