### PR TITLE
fix extension deployment and add explainatory comment

### DIFF
--- a/src/Compilers/Extension/CompilerExtension.csproj
+++ b/src/Compilers/Extension/CompilerExtension.csproj
@@ -18,6 +18,7 @@
     <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <RoslynProjectType>Vsix</RoslynProjectType>
+    <IncludeCopyLocalReferencesInVSIXContainer>false</IncludeCopyLocalReferencesInVSIXContainer> 
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Compilers/Extension/SetGlobalGlobalPropertiesForCPS.cs
+++ b/src/Compilers/Extension/SetGlobalGlobalPropertiesForCPS.cs
@@ -22,6 +22,8 @@ namespace Roslyn.Compilers.Extension
 
         public override Task<IImmutableDictionary<string, string>> GetGlobalPropertiesAsync(CancellationToken cancellationToken)
         {
+            // Currently the SolutionExists context will always occur before CPS calls this class
+            // If this behavior ever changes we will need to modify this class.
             return CompilerPackage.RoslynHive != null
                 ? Task.FromResult<IImmutableDictionary<string, string>>(Empty.PropertiesMap.Add("RoslynHive", CompilerPackage.RoslynHive))
                 : Task.FromResult<IImmutableDictionary<string, string>>(Empty.PropertiesMap);


### PR DESCRIPTION
follow up to https://github.com/dotnet/roslyn/pull/26665

MSBuild nuget packages have a target that stops `Microsoft.Codeanalysis.dll` and `Microsoft.Codeanalysis.CSharp.dll` from being included in the VSIX container.

<img width="513" alt="futute_of_cpp" src="https://user-images.githubusercontent.com/9797472/39731181-e8e57a4c-521a-11e8-9912-659868f45bca.png">
