### PR TITLE
Fix the message for Make Field Readonly

### DIFF
--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -41,16 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         {
             using (var workspace = new AdhocWorkspace())
             {
-                DiagnosticAnalyzer diagnosticAnalyzer;
-                try
-                {
-                    diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
-                }
-                catch (NotSupportedException)
-                {
-                    return;
-                }
-
+                var diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
                 if (diagnosticAnalyzer == null)
                 {
                     return;
@@ -74,16 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         {
             using (var workspace = new AdhocWorkspace())
             {
-                DiagnosticAnalyzer diagnosticAnalyzer;
-                try
-                {
-                    diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
-                }
-                catch (NotSupportedException)
-                {
-                    return;
-                }
-
+                var diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
                 if (diagnosticAnalyzer == null)
                 {
                     return;
@@ -110,16 +92,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         {
             using (var workspace = new AdhocWorkspace())
             {
-                DiagnosticAnalyzer diagnosticAnalyzer;
-                try
-                {
-                    diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
-                }
-                catch (NotSupportedException)
-                {
-                    return;
-                }
-
+                var diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
                 if (diagnosticAnalyzer == null)
                 {
                     return;

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -36,6 +36,102 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 : CreateDiagnosticProviderAndFixer(workspace, parameters);
         }
 
+        [Fact]
+        public void TestSupportedDiagnosticsMessageTitle()
+        {
+            using (var workspace = new AdhocWorkspace())
+            {
+                DiagnosticAnalyzer diagnosticAnalyzer;
+                try
+                {
+                    diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
+                }
+                catch (NotSupportedException)
+                {
+                    return;
+                }
+
+                if (diagnosticAnalyzer == null)
+                {
+                    return;
+                }
+
+                foreach (var descriptor in diagnosticAnalyzer.SupportedDiagnostics)
+                {
+                    if (descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable))
+                    {
+                        // The title only displayed for rule configuration
+                        continue;
+                    }
+
+                    Assert.NotEqual("", descriptor.Title?.ToString() ?? "");
+                }
+            }
+        }
+
+        [Fact]
+        public void TestSupportedDiagnosticsMessageDescription()
+        {
+            using (var workspace = new AdhocWorkspace())
+            {
+                DiagnosticAnalyzer diagnosticAnalyzer;
+                try
+                {
+                    diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
+                }
+                catch (NotSupportedException)
+                {
+                    return;
+                }
+
+                if (diagnosticAnalyzer == null)
+                {
+                    return;
+                }
+
+                foreach (var descriptor in diagnosticAnalyzer.SupportedDiagnostics)
+                {
+                    if (descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable))
+                    {
+                        if (!descriptor.IsEnabledByDefault || descriptor.DefaultSeverity == DiagnosticSeverity.Hidden)
+                        {
+                            // The message only displayed if either enabled and not hidden, or configurable
+                            continue;
+                        }
+                    }
+
+                    Assert.NotEqual("", descriptor.MessageFormat?.ToString() ?? "");
+                }
+            }
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26717")]
+        public void TestSupportedDiagnosticsMessageHelpLinkUri()
+        {
+            using (var workspace = new AdhocWorkspace())
+            {
+                DiagnosticAnalyzer diagnosticAnalyzer;
+                try
+                {
+                    diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
+                }
+                catch (NotSupportedException)
+                {
+                    return;
+                }
+
+                if (diagnosticAnalyzer == null)
+                {
+                    return;
+                }
+
+                foreach (var descriptor in diagnosticAnalyzer.SupportedDiagnostics)
+                {
+                    Assert.NotEqual("", descriptor.HelpLinkUri ?? "");
+                }
+            }
+        }
+
         internal async override Task<IEnumerable<Diagnostic>> GetDiagnosticsAsync(
             TestWorkspace workspace, TestParameters parameters)
         {

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
         End Function
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
-            Throw New NotImplementedException()
+            Throw New NotSupportedException()
         End Function
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace, parameters As TestParameters) As (DiagnosticAnalyzer, CodeFixProvider)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -30,7 +30,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
         End Function
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
-            Throw New NotSupportedException()
+            ' This is used by inherited tests to ensure the properties of diagnostic analyzers are correct. It's not
+            ' needed by the tests in this class, but can't throw an exception.
+            Return (Nothing, Nothing)
         End Function
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace, parameters As TestParameters) As (DiagnosticAnalyzer, CodeFixProvider)

--- a/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyDiagnosticAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.MakeFieldReadonly
             : base(
                 IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId,
                 new LocalizableResourceString(nameof(FeaturesResources.Add_readonly_modifier), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-                new LocalizableResourceString(nameof(FeaturesResources.Make_field_readonly), WorkspacesResources.ResourceManager, typeof(WorkspacesResources)))
+                new LocalizableResourceString(nameof(FeaturesResources.Make_field_readonly), FeaturesResources.ResourceManager, typeof(FeaturesResources)))
         {
         }
 

--- a/src/Test/Utilities/Portable/Diagnostics/DescriptorFactory.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/DescriptorFactory.cs
@@ -14,7 +14,8 @@ namespace Roslyn.Test.Utilities
         /// </summary>
         /// <remarks>
         /// Returned <see cref="DiagnosticDescriptor"/> has
-        /// - empty <see cref="DiagnosticDescriptor.Title"/>, <see cref="DiagnosticDescriptor.MessageFormat"/> and <see cref="DiagnosticDescriptor.Category"/>
+        /// - empty <see cref="DiagnosticDescriptor.Title"/> and <see cref="DiagnosticDescriptor.Category"/>
+        /// - <see cref="DiagnosticDescriptor.MessageFormat"/> set to <paramref name="id"/>
         /// - <see cref="DiagnosticDescriptor.DefaultSeverity"/> set to <see cref="DiagnosticSeverity.Hidden"/>
         /// - <see cref="WellKnownDiagnosticTags.NotConfigurable"/> custom tag added in <see cref="DiagnosticDescriptor.CustomTags"/>.
         /// </remarks>
@@ -22,7 +23,7 @@ namespace Roslyn.Test.Utilities
         /// <returns>A <see cref="DiagnosticDescriptor"/> with specified <see cref="DiagnosticDescriptor.Id"/>.</returns>
         public static DiagnosticDescriptor CreateSimpleDescriptor(string id)
         {
-            return new DiagnosticDescriptor(id, title: "", messageFormat: "", category: "",
+            return new DiagnosticDescriptor(id, title: "", messageFormat: id, category: "",
                 defaultSeverity: DiagnosticSeverity.Hidden, isEnabledByDefault: true,
                 customTags: WellKnownDiagnosticTags.NotConfigurable);
         }


### PR DESCRIPTION
Fixes #26219

### Customer scenario

A customer upgrades to version 15.7. IDE0044 warnings start appearing, but no description is given for the warning so it's not clear to users what the problem is.

### Bugs this fixes

Fixes #26219

### Workarounds, if any

None, but also none needed. In order to understand a workaround, users would need to understand what IDE0044 is. Once a user understands what IDE0044 is without a description, no workaround is needed.

### Risk

Very low. The fix is production code is clear and concise.

### Performance impact

None.

### Is this a regression from a previous update?

IDE0044 is new for the 15.7 release, so "errors appear without a description" could be considered a regression. On the other hand, IDE0044 never shipped in a previous release with a description.

### Root cause analysis

Several items contributed to this issue:

* No generalized test was included for this behavior
* The IDE code is intentionally resilient to this type of failure, opting to omit missing text rather than fail (crash the IDE, etc.) because third-party extension developers can provide implementations of the same functionality

### How was the bug found?

Customer reported

### Test documentation updated?

No, but a regression test is added to ensure the situation does not reappear for existing or new diagnostics.