### PR TITLE
Implement IDiscardSymbol.Equals and GetHashCode

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
@@ -16,6 +16,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         ITypeSymbol IDiscardSymbol.Type => Type;
         public TypeSymbol Type { get; }
 
+        /// <summary>
+        /// Produce a fresh discard symbol for testing.
+        /// </summary>
+        internal static DiscardSymbol CreateForTest(ITypeSymbol type) => new DiscardSymbol((TypeSymbol)type);
+
         public override Symbol ContainingSymbol => null;
         public override Accessibility DeclaredAccessibility => Accessibility.NotApplicable;
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal class DiscardSymbol : Symbol, IDiscardSymbol
+    internal sealed class DiscardSymbol : Symbol, IDiscardSymbol
     {
         public DiscardSymbol(TypeSymbol type)
         {
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override void Accept(CSharpSymbolVisitor visitor) => visitor.VisitDiscard(this);
         public override TResult Accept<TResult>(CSharpSymbolVisitor<TResult> visitor) => visitor.VisitDiscard(this);
 
-        public override bool Equals(object obj) => obj is DiscardSymbol other && this.Type.Equals(other.Type);
+        public override bool Equals(object obj) => this == (object)obj || obj is DiscardSymbol other && this.Type.Equals(other.Type);
         public override int GetHashCode() => this.Type.GetHashCode();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override void Accept(CSharpSymbolVisitor visitor) => visitor.VisitDiscard(this);
         public override TResult Accept<TResult>(CSharpSymbolVisitor<TResult> visitor) => visitor.VisitDiscard(this);
 
-        public override bool Equals(object obj) => this == (object)obj || obj is DiscardSymbol other && this.Type.Equals(other.Type);
+        public override bool Equals(object obj) => obj is DiscardSymbol other && this.Type.Equals(other.Type);
         public override int GetHashCode() => this.Type.GetHashCode();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
@@ -7,16 +7,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal class DiscardSymbol : Symbol, IDiscardSymbol
     {
-        private readonly TypeSymbol _type;
-
         public DiscardSymbol(TypeSymbol type)
         {
             Debug.Assert((object)type != null);
-            _type = type;
+            Type = type;
         }
 
-        ITypeSymbol IDiscardSymbol.Type => _type;
-        public TypeSymbol Type => _type;
+        ITypeSymbol IDiscardSymbol.Type => Type;
+        public TypeSymbol Type { get; }
 
         public override Symbol ContainingSymbol => null;
         public override Accessibility DeclaredAccessibility => Accessibility.NotApplicable;
@@ -36,5 +34,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override TResult Accept<TResult>(SymbolVisitor<TResult> visitor) => visitor.VisitDiscard(this);
         public override void Accept(CSharpSymbolVisitor visitor) => visitor.VisitDiscard(this);
         public override TResult Accept<TResult>(CSharpSymbolVisitor<TResult> visitor) => visitor.VisitDiscard(this);
+
+        public override bool Equals(object obj) => obj is DiscardSymbol other && this.Type.Equals(other.Type);
+        public override int GetHashCode() => this.Type.GetHashCode();
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5754,6 +5754,16 @@ class C
                 Assert.Equal(symbol0, symbol);
                 Assert.Equal(symbol, symbol);
                 Assert.Equal(symbol.GetHashCode(), symbol0.GetHashCode());
+
+                // Test to show that reference-unequal discards are equal by type.
+                IDiscardSymbol symbolClone = DiscardSymbol.CreateForTest(symbol.Type);
+                Assert.True(symbol != (object)symbolClone);
+                Assert.Equal(SymbolKind.Discard, symbolClone.Kind);
+                Assert.Equal("int _", symbolClone.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                Assert.Equal(symbol.Type, symbolClone.Type);
+                Assert.Equal(symbol0, symbolClone);
+                Assert.Equal(symbol, symbolClone);
+                Assert.Equal(symbol.GetHashCode(), symbolClone.GetHashCode());
             }
 
             Assert.Equal(1, set.Count);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5743,6 +5743,7 @@ class C
             var discards = GetDiscardIdentifiers(tree).ToArray();
             Assert.Equal(4, discards.Length);
             var symbol0 = (IDiscardSymbol)model.GetSymbolInfo(discards[0]).Symbol;
+            Assert.Equal(symbol0, symbol0);
             var set = new HashSet<ISymbol>();
             foreach (var discard in discards)
             {
@@ -5751,6 +5752,8 @@ class C
                 Assert.Equal(SymbolKind.Discard, symbol.Kind);
                 Assert.Equal("int _", symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
                 Assert.Equal(symbol0, symbol);
+                Assert.Equal(symbol, symbol);
+                Assert.Equal(symbol.GetHashCode(), symbol0.GetHashCode());
             }
 
             Assert.Equal(1, set.Count);
@@ -5786,12 +5789,13 @@ class C
             foreach (var discard in discards)
             {
                 var symbol = (IDiscardSymbol)model.GetSymbolInfo(discard).Symbol;
-                set.Add(symbol);
                 Assert.Equal(SymbolKind.Discard, symbol.Kind);
+                set.Add(symbol);
                 if (discard == discards[0])
                 {
                     Assert.Equal("double _", symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
                     Assert.Equal(symbol0, symbol);
+                    Assert.Equal(symbol0.GetHashCode(), symbol.GetHashCode());
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #25829

@jcouv @AlekseyTs Please review this tiny bug fix.
/cc @dotnet/roslyn-compiler 
