### PR TITLE
Exclude Microsoft.Composition as something we build a dependency map for 

### DIFF
--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -531,7 +531,8 @@ Public Class BuildDevDivInsertionFiles
                 If packageName.StartsWith("Microsoft.VisualStudio.") OrElse
                    packageName = "EnvDTE" OrElse
                    packageName = "stdole" OrElse
-                   packageName.StartsWith("Microsoft.Build") Then
+                   packageName.StartsWith("Microsoft.Build") OrElse
+                   packageName = "Microsoft.Composition" Then
                     Continue For
                 End If
 

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -25,6 +25,7 @@ Public Class BuildDevDivInsertionFiles
     Private ReadOnly _nugetPackageRoot As String
     Private ReadOnly _nuspecDirectory As String
     Private ReadOnly _pathMap As Dictionary(Of String, String)
+    Private ReadOnly _verbose As Boolean
 
     Private Sub New(args As String())
         _binDirectory = Path.GetFullPath(args(0))
@@ -33,14 +34,15 @@ Public Class BuildDevDivInsertionFiles
         _setupDirectory = Path.Combine(repoDirectory, "src\Setup")
         _nuspecDirectory = Path.Combine(repoDirectory, "src\Nuget")
         _nugetPackageRoot = Path.GetFullPath(args(2))
+        _verbose = args.Last() = "/verbose"
         _outputDirectory = Path.Combine(_binDirectory, DevDivInsertionFilesDirName)
         _outputPackageDirectory = Path.Combine(_binDirectory, DevDivPackagesDirName)
         _pathMap = CreatePathMap()
     End Sub
 
     Public Shared Function Main(args As String()) As Integer
-        If args.Length <> 3 Then
-            Console.WriteLine("Expected arguments: <bin dir> <setup dir> <nuget root dir>")
+        If args.Length < 3 Then
+            Console.WriteLine("Expected arguments: <bin dir> <setup dir> <nuget root dir> [/verbose]")
             Console.WriteLine($"Actual argument count is {args.Length}")
             Return 1
         End If
@@ -909,6 +911,8 @@ Public Class BuildDevDivInsertionFiles
         ' We build our language service authoring by cracking our .vsixes and pulling out the bits that matter
         For Each vsixFileName In VsixesToInstall
             Dim vsixName As String = Path.GetFileNameWithoutExtension(vsixFileName)
+            WriteLineIfVerbose($"Processing {vsixName}")
+
             Using vsix = Package.Open(Path.Combine(_binDirectory, vsixFileName), FileMode.Open, FileAccess.Read, FileShare.Read)
                 For Each vsixPart In vsix.GetParts()
 
@@ -920,12 +924,16 @@ Public Class BuildDevDivInsertionFiles
                     Dim partRelativePath = GetPartRelativePath(vsixPart)
                     Dim partFileName = Path.GetFileName(partRelativePath)
 
+                    WriteLineIfVerbose($"     Processing {partFileName}")
+
                     ' If this is something that we don't need to ship, skip it
                     If VsixContentsToSkip.Contains(partFileName) Then
+                        WriteLineIfVerbose($"        Skipping because {partFileName} is in {NameOf(VsixContentsToSkip)}")
                         Continue For
                     End If
 
                     If IsLanguageServiceRegistrationFile(partFileName) Then
+                        WriteLineIfVerbose($"        Skipping because {partFileName} is a language service registration file that doesn't need to be processed")
                         Continue For
                     End If
 
@@ -935,6 +943,7 @@ Public Class BuildDevDivInsertionFiles
                     End If
 
                     If dependencies.ContainsKey(partFileName) Then
+                        WriteLineIfVerbose($"        Skipping because {partFileName} is a dependency that is coming from NuGet package {dependencies(partFileName).PackageName}")
                         Continue For
                     End If
 
@@ -1175,4 +1184,10 @@ set DEVPATH=%RoslynToolsRoot%;%DEVPATH%"
                       End Select
                   End Function)
     End Function
+
+    Private Sub WriteLineIfVerbose(s As String)
+        If _verbose Then
+            Console.WriteLine(s)
+        End If
+    End Sub
 End Class


### PR DESCRIPTION
This creates ironically the reverse effect you might imagine: CompilerExtension contains this package now, which would cause it to be added to the dependency map; this then causes the package to be excluded from the insertion package, where it is supposed to be. Since CompilerExtension and VS are (in some sense) separate targets, presence in the former shouldn't impact the other.