### PR TITLE
Align the implementations of IAssemblySymbol.GivesAccessTo

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -967,11 +967,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitAssembly(this);
         }
 
-        AssemblyMetadata IAssemblySymbol.GetMetadata()
-        {
-            throw new NotImplementedException();
-        }
-
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -886,127 +886,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return CorLibrary.GetDeclaredSpecialTypeMember(member);
         }
 
-        protected enum IVTConclusion
-        {
-            // This indicates that friend access should be granted.
-
-            Match,
-
-            // This indicates that friend access should be granted for the purposes of error recovery,
-            // but the program is wrong.
-            //
-            // That's because this indicates that a strong-named assembly has referred to a weak-named assembly 
-            // which has extended friend access to the strong-named assembly. This will ultimately 
-            // result in an error because strong-named assemblies may not refer to weak-named assemblies. 
-            // In Roslyn we give a new error, CS7029, before emit time. In the dev10 compiler we error at 
-            // emit time.
-
-            OneSignedOneNot,
-
-            // This indicates that friend access should not be granted because the other assembly grants
-            // friend access to a strong-named assembly, and either this assembly is weak-named, or
-            // it is strong-named and the names don't match.
-
-            PublicKeyDoesntMatch,
-
-            // This indicates that friend access should not be granted because the other assembly 
-            // does not name this assembly as a friend in any way whatsoever.
-
-            NoRelationshipClaimed
-        }
-
         internal abstract ImmutableArray<byte> PublicKey { get; }
-
-        protected IVTConclusion PerformIVTCheck(ImmutableArray<byte> key, AssemblyIdentity otherIdentity)
-        {
-            // This gets a bit complicated. Let's break it down.
-            //
-            // First off, let's assume that the "other" assembly is Smith.DLL, that the "this"
-            // assembly is "Jones.DLL", and that Smith has named Jones as a friend. Whether we 
-            // allow Jones to see internals of Smith depends on these four factors:
-            //
-            // q1) Is Smith strong-named?
-            // q2) Did Smith name Jones as a friend via a strong name?
-            // q3) Is Jones strong-named?
-            // q4) Does Smith give a strong-name for Jones that matches our strong name?
-            //
-            // Before we dive into the details, we should mention two additional facts:
-            //
-            // * If the answer to q1 is "yes", and Smith was compiled by the C# compiler, then q2 must be "yes" also.
-            //   Strong-named Smith must only be friends with strong-named Jones. See the blog article
-            //   http://blogs.msdn.com/b/ericlippert/archive/2009/06/04/alas-smith-and-jones.aspx
-            //   for an explanation of why this feature is desirable.
-            //
-            //   Now, just because the compiler enforces this rule does not mean that we will never run into
-            //   a scenario where Smith is strong-named and names Jones via a weak name. Not all assemblies
-            //   were compiled with the C# compiler. We still need to deal sensibly with this situation.
-            //   We do so by ignoring the problem; if strong-named Smith extends friendship to weak-named
-            //   Jones then we're done; any assembly named Jones is a friend of Smith.
-            //
-            //   Incidentally, the compiler produces error CS1726, ERR_FriendAssemblySNReq, when compiling 
-            //   a strong-named Smith that names a weak-named Jones as its friend.
-            //
-            // * If the answer to q1 is "no" and the answer to q3 is "yes" then we are in a situation where
-            //   strong-named Jones is referencing weak-named Smith, which is illegal. In the dev10 compiler
-            //   we do not give an error about this until emit time. In Roslyn we have a new error, CS7029,
-            //   which we give before emit time when we detect that weak-named Smith has given friend access
-            //   to strong-named Jones, which then references Smith. However, we still want to give friend
-            //   access to Jones for the purposes of semantic analysis.
-            //
-            // TODO: Roslyn does not yet give an error in other circumstances whereby a strong-named assembly
-            // TODO: references a weak-named assembly.
-            //
-            // Let's make a chart that illustrates all the possible answers to these four questions, and
-            // what the resulting accessibility should be:
-            //
-            // case q1  q2  q3  q4  Result                 Explanation
-            // 1    YES YES YES YES SUCCESS          Smith has named this strong-named Jones as a friend.
-            // 2    YES YES YES NO  NO MATCH         Smith has named a different strong-named Jones as a friend.
-            // 3    YES YES NO  NO  NO MATCH         Smith has named a strong-named Jones as a friend, but this Jones is weak-named.
-            // 4    YES NO  YES NO  SUCCESS          Smith has improperly (*) named any Jones as its friend. But we honor its offer of friendship.
-            // 5    YES NO  NO  NO  SUCCESS          Smith has improperly (*) named any Jones as its friend. But we honor its offer of friendship.
-            // 6    NO  YES YES YES SUCCESS, BAD REF Smith has named this strong-named Jones as a friend, but Jones should not be referring to a weak-named Smith.
-            // 7    NO  YES YES NO  NO MATCH         Smith has named a different strong-named Jones as a friend.
-            // 8    NO  YES NO  NO  NO MATCH         Smith has named a strong-named Jones as a friend, but this Jones is weak-named.
-            // 9    NO  NO  YES NO  SUCCESS, BAD REF Smith has named any Jones as a friend, but Jones should not be referring to a weak-named Smith.
-            // 10   NO  NO  NO  NO  SUCCESS          Smith has named any Jones as its friend.
-            //                                     
-            // (*) Smith was not built with C#, which would have prevented this.
-            //
-            // This method never returns NoRelationshipClaimed because if control got here, then we know that
-            // Smith named Jones as a friend somehow.
-            //
-            // All that said, we also have an easy out here. Suppose Smith names Jones as a friend, and Jones is 
-            // being compiled as a module, not as an assembly. You can only strong-name an assembly. So if this module
-            // is named Jones, and Smith is extending friend access to Jones, then we are going to optimistically 
-            // assume that Jones is going to be compiled into an assembly with a matching strong name, if necessary.
-
-            CSharpCompilation compilation = this.DeclaringCompilation;
-            if (compilation != null && compilation.Options.OutputKind.IsNetModule())
-            {
-                return IVTConclusion.Match;
-            }
-
-            bool q1 = otherIdentity.IsStrongName;
-            bool q2 = !key.IsDefaultOrEmpty;
-            bool q3 = !this.PublicKey.IsDefaultOrEmpty;
-            bool q4 = (q2 & q3) && ByteSequenceComparer.Equals(key, this.PublicKey);
-
-            // Cases 2, 3, 7 and 8:
-            if (q2 && !q4)
-            {
-                return IVTConclusion.PublicKeyDoesntMatch;
-            }
-
-            // Cases 6 and 9:
-            if (!q1 && q3)
-            {
-                return IVTConclusion.OneSignedOneNot;
-            }
-
-            // Cases 1, 4, 5 and 10:
-            return IVTConclusion.Match;
-        }
 
         #region IAssemblySymbol Members
 
@@ -1045,16 +925,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
-            var assembly = assemblyWantingAccess as AssemblySymbol;
-            if (assembly == null)
+            var myKeys = GetInternalsVisibleToPublicKeys(assemblyWantingAccess.Name);
+
+            // We have an easy out here. Suppose the assembly wanting access is 
+            // being compiled as a module. You can only strong-name an assembly. So we are going to optimistically 
+            // assume that it is going to be compiled into an assembly with a matching strong name, if necessary.
+            if (myKeys.Any() && assemblyWantingAccess.IsNetModule())
             {
-                return false;
+                return true;
             }
 
-            var myKeys = GetInternalsVisibleToPublicKeys(assembly.Identity.Name);
             foreach (var key in myKeys)
             {
-                IVTConclusion conclusion = assembly.PerformIVTCheck(key, this.Identity);
+                IVTConclusion conclusion = this.Identity.PerformIVTCheck(assemblyWantingAccess.Identity.PublicKey, key);
                 Debug.Assert(conclusion != IVTConclusion.NoRelationshipClaimed);
                 if (conclusion == IVTConclusion.Match || conclusion == IVTConclusion.OneSignedOneNot)
                 {
@@ -1082,6 +965,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
         {
             return visitor.VisitAssembly(this);
+        }
+
+        AssemblyMetadata IAssemblySymbol.GetMetadata()
+        {
+            throw new NotImplementedException();
         }
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2451,7 +2451,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // since there will be nothing left in the map/set the second time.
                 bool internalsAreVisible =
                     this.InternalsAreVisible ||
-                    this.DeclaringCompilation.Options.OutputKind.IsNetModule();
+                    this.IsNetModule();
 
                 HashSet<FieldSymbol> handledUnreadFields = null;
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -798,7 +798,7 @@ public class C {}",
         }
 
         [Fact]
-        public void IVTErrorNotBothSigned()
+        public void IVTNotBothSigned_CStoCS()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
             public class C { internal void Goo() {} }";
@@ -818,6 +818,45 @@ public class C {}",
     }
 }",
                 references: new[] { new CSharpCompilationReference(other) },
+                assemblyName: "John",
+                options: TestOptions.ReleaseDll.WithCryptoKeyFile(s_keyPairFile).WithStrongNameProvider(s_defaultDesktopProvider));
+
+            // We allow John to access Paul's internal Goo even though strong-named John should not be referencing weak-named Paul.
+            // Paul has, after all, specifically granted access to John.
+
+            // TODO: During emit time we should produce an error that says that a strong-named assembly cannot reference
+            // TODO: a weak-named assembly.
+            requestor.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void IVTNotBothSigned_VBtoCS()
+        {
+            string s = @"<assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>
+            Public Class C
+                Friend Sub Goo()
+                End Sub
+            End Class";
+
+            var other = VisualBasic.VisualBasicCompilation.Create(
+                syntaxTrees: new[] { VisualBasic.VisualBasicSyntaxTree.ParseText(s) },
+                references: new[] { MscorlibRef_v4_0_30316_17626 },
+                assemblyName: "Paul",
+                options: new VisualBasic.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithStrongNameProvider(s_defaultDesktopProvider));
+            other.VerifyDiagnostics();
+
+            var requestor = CreateCompilation(
+    @"public class A
+{
+    internal class B
+    {
+        protected B(C o)
+        {
+            o.Goo();
+        }
+    }
+}",
+                references: new[] { MetadataReference.CreateFromImage(other.EmitToArray()) },
                 assemblyName: "John",
                 options: TestOptions.ReleaseDll.WithCryptoKeyFile(s_keyPairFile).WithStrongNameProvider(s_defaultDesktopProvider));
 
@@ -2315,12 +2354,12 @@ public class C
             }
         }
 
-        [Fact, WorkItem(769840, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/769840")]
-        public void Bug769840()
+        [Fact, WorkItem(781312, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/781312")]
+        public void Bug781312()
         {
             var ca = CreateCompilation(
     @"
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Bug769840_B, PublicKey = 0024000004800000940000000602000000240000525341310004000001000100458a131798af87d9e33088a3ab1c6101cbd462760f023d4f41d97f691033649e60b42001e94f4d79386b5e087b0a044c54b7afce151b3ad19b33b332b83087e3b8b022f45b5e4ff9b9a1077b0572ff0679ce38f884c7bd3d9b4090e4a7ee086b7dd292dc20f81a3b1b8a0b67ee77023131e59831c709c81d11c6856669974cc4"")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Bug781312_B, PublicKey = 0024000004800000940000000602000000240000525341310004000001000100458a131798af87d9e33088a3ab1c6101cbd462760f023d4f41d97f691033649e60b42001e94f4d79386b5e087b0a044c54b7afce151b3ad19b33b332b83087e3b8b022f45b5e4ff9b9a1077b0572ff0679ce38f884c7bd3d9b4090e4a7ee086b7dd292dc20f81a3b1b8a0b67ee77023131e59831c709c81d11c6856669974cc4"")]
 
 internal class A
 {
@@ -2340,7 +2379,7 @@ internal class B
     }
 }",
                 options: TestOptions.ReleaseModule.WithStrongNameProvider(s_defaultDesktopProvider),
-                assemblyName: "Bug769840_B",
+                assemblyName: "Bug781312_B",
                 references: new[] { new CSharpCompilationReference(ca) });
 
             CompileAndVerify(cb, verify: Verification.Fails).Diagnostics.Verify();

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -824,8 +824,8 @@ public class C {}",
             // We allow John to access Paul's internal Goo even though strong-named John should not be referencing weak-named Paul.
             // Paul has, after all, specifically granted access to John.
 
-            // TODO: During emit time we should produce an error that says that a strong-named assembly cannot reference
-            // TODO: a weak-named assembly.
+            // During emit time we should produce an error that says that a strong-named assembly cannot reference
+            // a weak-named assembly. But the C# compiler doesn't currently do that. See https://github.com/dotnet/roslyn/issues/26722
             requestor.VerifyDiagnostics();
         }
 
@@ -863,8 +863,8 @@ public class C {}",
             // We allow John to access Paul's internal Goo even though strong-named John should not be referencing weak-named Paul.
             // Paul has, after all, specifically granted access to John.
 
-            // TODO: During emit time we should produce an error that says that a strong-named assembly cannot reference
-            // TODO: a weak-named assembly.
+            // During emit time we should produce an error that says that a strong-named assembly cannot reference
+            // a weak-named assembly. But the C# compiler doesn't currently do that. See https://github.com/dotnet/roslyn/issues/26722
             requestor.VerifyDiagnostics();
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/GivesAccessTo.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/GivesAccessTo.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class GivesAccessTo
+    {
+        [Fact, WorkItem(26459, "https://github.com/dotnet/roslyn/issues/26459")]
+        public void TestGivesAccessTo_CrossLanguageAndCompilation()
+        {
+            var csharpTree = CSharpSyntaxTree.ParseText(@"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""VB"")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""CS2"")]
+internal class CS
+{
+}
+");
+            var csharpTree2 = CSharpSyntaxTree.ParseText(@"
+internal class CS2
+{
+}
+");
+            var vbTree = VisualBasicSyntaxTree.ParseText(@"
+<assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""CS"")>
+<assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""VB2"")>
+Friend Class VB
+End Class
+");
+            var vbTree2 = VisualBasicSyntaxTree.ParseText(@"
+Friend Class VB2
+End Class
+");
+            var csc = CSharpCompilation.Create("CS", new[] { csharpTree }, new MetadataReference[] { TestBase.MscorlibRef });
+            var CS = csc.GlobalNamespace.GetMembers("CS")[0] as INamedTypeSymbol;
+
+            var csc2 = CSharpCompilation.Create("CS2", new[] { csharpTree2 }, new MetadataReference[] { TestBase.MscorlibRef });
+            var CS2 = csc2.GlobalNamespace.GetMembers("CS2")[0] as INamedTypeSymbol;
+
+            var vbc = VisualBasicCompilation.Create("VB", new[] { vbTree }, new MetadataReference[] { TestBase.MscorlibRef });
+            var VB = vbc.GlobalNamespace.GetMembers("VB")[0] as INamedTypeSymbol;
+
+            var vbc2 = VisualBasicCompilation.Create("VB2", new[] { vbTree2 }, new MetadataReference[] { TestBase.MscorlibRef });
+            var VB2 = vbc2.GlobalNamespace.GetMembers("VB2")[0] as INamedTypeSymbol;
+
+            Assert.True(CS.ContainingAssembly.GivesAccessTo(CS2.ContainingAssembly));
+            Assert.True(CS.ContainingAssembly.GivesAccessTo(VB.ContainingAssembly));
+            Assert.False(CS.ContainingAssembly.GivesAccessTo(VB2.ContainingAssembly));
+
+            Assert.True(VB.ContainingAssembly.GivesAccessTo(VB2.ContainingAssembly));
+            Assert.True(VB.ContainingAssembly.GivesAccessTo(CS.ContainingAssembly));
+            Assert.False(VB.ContainingAssembly.GivesAccessTo(CS2.ContainingAssembly));
+
+        }
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/GivesAccessTo.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/GivesAccessTo.cs
@@ -53,7 +53,6 @@ End Class
             Assert.True(VB.ContainingAssembly.GivesAccessTo(VB2.ContainingAssembly));
             Assert.True(VB.ContainingAssembly.GivesAccessTo(CS.ContainingAssembly));
             Assert.False(VB.ContainingAssembly.GivesAccessTo(CS2.ContainingAssembly));
-
         }
     }
 }

--- a/src/Compilers/Core/Portable/IVTConclusion.cs
+++ b/src/Compilers/Core/Portable/IVTConclusion.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// The result of <see cref="ISymbolExtensions.PerformIVTCheck(AssemblyIdentity, ImmutableArray{byte}, ImmutableArray{byte})"/>
+    /// </summary>
+    internal enum IVTConclusion
+    {
+        /// <summary>
+        /// This indicates that friend access should be granted.
+        /// </summary>
+        Match,
+
+        /// <summary>
+        /// This indicates that friend access should be granted for the purposes of error recovery,
+        /// but the program is wrong.
+        ///
+        /// That's because this indicates that a strong-named assembly has referred to a weak-named assembly 
+        /// which has extended friend access to the strong-named assembly. This will ultimately 
+        /// result in an error because strong-named assemblies may not refer to weak-named assemblies. 
+        /// In Roslyn we give a new error, CS7029, before emit time. In the dev10 compiler we error at 
+        /// emit time.
+        /// </summary>
+        OneSignedOneNot,
+
+        /// <summary>
+        /// This indicates that friend access should not be granted because the other assembly grants
+        /// friend access to a strong-named assembly, and either this assembly is weak-named, or
+        /// it is strong-named and the names don't match.
+        /// </summary>
+        PublicKeyDoesntMatch,
+
+        /// <summary>
+        /// This indicates that friend access should not be granted because the other assembly 
+        /// does not name this assembly as a friend in any way whatsoever.
+        /// </summary>
+        NoRelationshipClaimed
+    }
+}

--- a/src/Compilers/Core/Portable/Symbols/ISymbolExtensions.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbolExtensions.cs
@@ -1,15 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text;
-
 namespace Microsoft.CodeAnalysis
 {
-    public static class ISymbolExtensions
+    public static partial class ISymbolExtensions
     {
         /// <summary>
         /// Returns the constructed form of the ReducedFrom property,
@@ -100,5 +93,8 @@ namespace Microsoft.CodeAnalysis
 
             return null;
         }
+
+        internal static bool IsNetModule(this IAssemblySymbol assembly) =>
+            assembly is ISourceAssemblySymbol sourceAssembly && sourceAssembly.Compilation.Options.OutputKind == OutputKind.NetModule;
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/ISymbolExtensions.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbolExtensions.cs
@@ -95,6 +95,6 @@ namespace Microsoft.CodeAnalysis
         }
 
         internal static bool IsNetModule(this IAssemblySymbol assembly) =>
-            assembly is ISourceAssemblySymbol sourceAssembly && sourceAssembly.Compilation.Options.OutputKind == OutputKind.NetModule;
+            assembly is ISourceAssemblySymbol sourceAssembly && sourceAssembly.Compilation.Options.OutputKind.IsNetModule();
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/ISymbolExtensions_PerformIVTCheck.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbolExtensions_PerformIVTCheck.cs
@@ -19,61 +19,61 @@ namespace Microsoft.CodeAnalysis
         {
             // This gets a bit complicated. Let's break it down.
             //
-            // First off, let's assume that the "other" assembly is Smith.DLL, that the "this"
-            // assembly is "Jones.DLL", and that Smith has named Jones as a friend (that is a precondition
-            // to calling this method). Whether we allow Jones to see internals of Smith depends on these four factors:
+            // First off, let's assume that the "other" assembly is GrantingAssembly.DLL, that the "this"
+            // assembly is "WantingAssembly.DLL", and that GrantingAssembly has named WantingAssembly as a friend (that is a precondition
+            // to calling this method). Whether we allow WantingAssembly to see internals of GrantingAssembly depends on these four factors:
             //
-            // q1) Is Smith strong-named?
-            // q2) Did Smith name Jones as a friend via a strong name?
-            // q3) Is Jones strong-named?
-            // q4) Does Smith give a strong-name for Jones that matches our strong name?
+            // q1) Is GrantingAssembly strong-named?
+            // q2) Did GrantingAssembly name WantingAssembly as a friend via a strong name?
+            // q3) Is WantingAssembly strong-named?
+            // q4) Does GrantingAssembly give a strong-name for WantingAssembly that matches our strong name?
             //
             // Before we dive into the details, we should mention two additional facts:
             //
-            // * If the answer to q1 is "yes", and Smith was compiled by a Roslyn compiler, then q2 must be "yes" also.
-            //   Strong-named Smith must only be friends with strong-named Jones. See the blog article
+            // * If the answer to q1 is "yes", and GrantingAssembly was compiled by a Roslyn compiler, then q2 must be "yes" also.
+            //   Strong-named GrantingAssembly must only be friends with strong-named WantingAssembly. See the blog article
             //   http://blogs.msdn.com/b/ericlippert/archive/2009/06/04/alas-smith-and-jones.aspx
             //   for an explanation of why this feature is desirable.
             //
             //   Now, just because the compiler enforces this rule does not mean that we will never run into
-            //   a scenario where Smith is strong-named and names Jones via a weak name. Not all assemblies
+            //   a scenario where GrantingAssembly is strong-named and names WantingAssembly via a weak name. Not all assemblies
             //   were compiled with a Roslyn compiler. We still need to deal sensibly with this situation.
-            //   We do so by ignoring the problem; if strong-named Smith extends friendship to weak-named
-            //   Jones then we're done; any assembly named Jones is a friend of Smith.
+            //   We do so by ignoring the problem; if strong-named GrantingAssembly extends friendship to weak-named
+            //   WantingAssembly then we're done; any assembly named WantingAssembly is a friend of GrantingAssembly.
             //
             //   Incidentally, the C# compiler produces error CS1726, ERR_FriendAssemblySNReq, and VB produces
             //   the error VB31535, ERR_FriendAssemblyStrongNameRequired, when compiling 
-            //   a strong-named Smith that names a weak-named Jones as its friend.
+            //   a strong-named GrantingAssembly that names a weak-named WantingAssembly as its friend.
             //
             // * If the answer to q1 is "no" and the answer to q3 is "yes" then we are in a situation where
-            //   strong-named Jones is referencing weak-named Smith, which is illegal. In the dev10 compiler
+            //   strong-named WantingAssembly is referencing weak-named GrantingAssembly, which is illegal. In the dev10 compiler
             //   we do not give an error about this until emit time. In Roslyn we have a new error, CS7029,
-            //   which we give before emit time when we detect that weak-named Smith has given friend access
-            //   to strong-named Jones, which then references Smith. However, we still want to give friend
-            //   access to Jones for the purposes of semantic analysis.
+            //   which we give before emit time when we detect that weak-named GrantingAssembly has given friend access
+            //   to strong-named WantingAssembly, which then references GrantingAssembly. However, we still want to give friend
+            //   access to WantingAssembly for the purposes of semantic analysis.
             //
-            // TODO: Roslyn C# does not yet give an error in other circumstances whereby a strong-named assembly
-            // TODO: references a weak-named assembly.
+            // Roslyn C# does not yet give an error in other circumstances whereby a strong-named assembly
+            // references a weak-named assembly. See https://github.com/dotnet/roslyn/issues/26722
             //
             // Let's make a chart that illustrates all the possible answers to these four questions, and
             // what the resulting accessibility should be:
             //
             // case q1  q2  q3  q4  Result                 Explanation
-            // 1    YES YES YES YES SUCCESS          Smith has named this strong-named Jones as a friend.
-            // 2    YES YES YES NO  NO MATCH         Smith has named a different strong-named Jones as a friend.
-            // 3    YES YES NO  NO  NO MATCH         Smith has named a strong-named Jones as a friend, but this Jones is weak-named.
-            // 4    YES NO  YES NO  SUCCESS          Smith has improperly (*) named any Jones as its friend. But we honor its offer of friendship.
-            // 5    YES NO  NO  NO  SUCCESS          Smith has improperly (*) named any Jones as its friend. But we honor its offer of friendship.
-            // 6    NO  YES YES YES SUCCESS, BAD REF Smith has named this strong-named Jones as a friend, but Jones should not be referring to a weak-named Smith.
-            // 7    NO  YES YES NO  NO MATCH         Smith has named a different strong-named Jones as a friend.
-            // 8    NO  YES NO  NO  NO MATCH         Smith has named a strong-named Jones as a friend, but this Jones is weak-named.
-            // 9    NO  NO  YES NO  SUCCESS, BAD REF Smith has named any Jones as a friend, but Jones should not be referring to a weak-named Smith.
-            // 10   NO  NO  NO  NO  SUCCESS          Smith has named any Jones as its friend.
+            // 1    YES YES YES YES SUCCESS          GrantingAssembly has named this strong-named WantingAssembly as a friend.
+            // 2    YES YES YES NO  NO MATCH         GrantingAssembly has named a different strong-named WantingAssembly as a friend.
+            // 3    YES YES NO  NO  NO MATCH         GrantingAssembly has named a strong-named WantingAssembly as a friend, but this WantingAssembly is weak-named.
+            // 4    YES NO  YES NO  SUCCESS          GrantingAssembly has improperly (*) named any WantingAssembly as its friend. But we honor its offer of friendship.
+            // 5    YES NO  NO  NO  SUCCESS          GrantingAssembly has improperly (*) named any WantingAssembly as its friend. But we honor its offer of friendship.
+            // 6    NO  YES YES YES SUCCESS, BAD REF GrantingAssembly has named this strong-named WantingAssembly as a friend, but WantingAssembly should not be referring to a weak-named GrantingAssembly.
+            // 7    NO  YES YES NO  NO MATCH         GrantingAssembly has named a different strong-named WantingAssembly as a friend.
+            // 8    NO  YES NO  NO  NO MATCH         GrantingAssembly has named a strong-named WantingAssembly as a friend, but this WantingAssembly is weak-named.
+            // 9    NO  NO  YES NO  SUCCESS, BAD REF GrantingAssembly has named any WantingAssembly as a friend, but WantingAssembly should not be referring to a weak-named GrantingAssembly.
+            // 10   NO  NO  NO  NO  SUCCESS          GrantingAssembly has named any WantingAssembly as its friend.
             //                                     
-            // (*) Smith was not built with a Roslyn compiler, which would have prevented this.
+            // (*) GrantingAssembly was not built with a Roslyn compiler, which would have prevented this.
             //
             // This method never returns NoRelationshipClaimed because if control got here, then we assume
-            // (as a precondition) that Smith named Jones as a friend somehow.
+            // (as a precondition) that GrantingAssembly named WantingAssembly as a friend somehow.
 
             bool q1 = assemblyGrantingAccessIdentity.IsStrongName;
             bool q2 = !grantedToPublicKey.IsDefaultOrEmpty;

--- a/src/Compilers/Core/Portable/Symbols/ISymbolExtensions_PerformIVTCheck.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbolExtensions_PerformIVTCheck.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Collections;
+
+namespace Microsoft.CodeAnalysis
+{
+    public static partial class ISymbolExtensions
+    {
+        /// <summary>
+        /// Given that an assembly with identity assemblyGrantingAccessIdentity granted access to assemblyWantingAccess,
+        /// check the public keys to ensure the internals-visible-to check should succeed. This is used by both the
+        /// C# and VB implementations as a helper to implement `bool IAssemblySymbol.GivesAccessTo(IAssemblySymbol toAssembly)`.
+        /// </summary>
+        internal static IVTConclusion PerformIVTCheck(
+            this AssemblyIdentity assemblyGrantingAccessIdentity,
+            ImmutableArray<byte> assemblyWantingAccessKey,
+            ImmutableArray<byte> grantedToPublicKey)
+        {
+            // This gets a bit complicated. Let's break it down.
+            //
+            // First off, let's assume that the "other" assembly is Smith.DLL, that the "this"
+            // assembly is "Jones.DLL", and that Smith has named Jones as a friend (that is a precondition
+            // to calling this method). Whether we allow Jones to see internals of Smith depends on these four factors:
+            //
+            // q1) Is Smith strong-named?
+            // q2) Did Smith name Jones as a friend via a strong name?
+            // q3) Is Jones strong-named?
+            // q4) Does Smith give a strong-name for Jones that matches our strong name?
+            //
+            // Before we dive into the details, we should mention two additional facts:
+            //
+            // * If the answer to q1 is "yes", and Smith was compiled by a Roslyn compiler, then q2 must be "yes" also.
+            //   Strong-named Smith must only be friends with strong-named Jones. See the blog article
+            //   http://blogs.msdn.com/b/ericlippert/archive/2009/06/04/alas-smith-and-jones.aspx
+            //   for an explanation of why this feature is desirable.
+            //
+            //   Now, just because the compiler enforces this rule does not mean that we will never run into
+            //   a scenario where Smith is strong-named and names Jones via a weak name. Not all assemblies
+            //   were compiled with a Roslyn compiler. We still need to deal sensibly with this situation.
+            //   We do so by ignoring the problem; if strong-named Smith extends friendship to weak-named
+            //   Jones then we're done; any assembly named Jones is a friend of Smith.
+            //
+            //   Incidentally, the C# compiler produces error CS1726, ERR_FriendAssemblySNReq, and VB produces
+            //   the error VB31535, ERR_FriendAssemblyStrongNameRequired, when compiling 
+            //   a strong-named Smith that names a weak-named Jones as its friend.
+            //
+            // * If the answer to q1 is "no" and the answer to q3 is "yes" then we are in a situation where
+            //   strong-named Jones is referencing weak-named Smith, which is illegal. In the dev10 compiler
+            //   we do not give an error about this until emit time. In Roslyn we have a new error, CS7029,
+            //   which we give before emit time when we detect that weak-named Smith has given friend access
+            //   to strong-named Jones, which then references Smith. However, we still want to give friend
+            //   access to Jones for the purposes of semantic analysis.
+            //
+            // TODO: Roslyn C# does not yet give an error in other circumstances whereby a strong-named assembly
+            // TODO: references a weak-named assembly.
+            //
+            // Let's make a chart that illustrates all the possible answers to these four questions, and
+            // what the resulting accessibility should be:
+            //
+            // case q1  q2  q3  q4  Result                 Explanation
+            // 1    YES YES YES YES SUCCESS          Smith has named this strong-named Jones as a friend.
+            // 2    YES YES YES NO  NO MATCH         Smith has named a different strong-named Jones as a friend.
+            // 3    YES YES NO  NO  NO MATCH         Smith has named a strong-named Jones as a friend, but this Jones is weak-named.
+            // 4    YES NO  YES NO  SUCCESS          Smith has improperly (*) named any Jones as its friend. But we honor its offer of friendship.
+            // 5    YES NO  NO  NO  SUCCESS          Smith has improperly (*) named any Jones as its friend. But we honor its offer of friendship.
+            // 6    NO  YES YES YES SUCCESS, BAD REF Smith has named this strong-named Jones as a friend, but Jones should not be referring to a weak-named Smith.
+            // 7    NO  YES YES NO  NO MATCH         Smith has named a different strong-named Jones as a friend.
+            // 8    NO  YES NO  NO  NO MATCH         Smith has named a strong-named Jones as a friend, but this Jones is weak-named.
+            // 9    NO  NO  YES NO  SUCCESS, BAD REF Smith has named any Jones as a friend, but Jones should not be referring to a weak-named Smith.
+            // 10   NO  NO  NO  NO  SUCCESS          Smith has named any Jones as its friend.
+            //                                     
+            // (*) Smith was not built with a Roslyn compiler, which would have prevented this.
+            //
+            // This method never returns NoRelationshipClaimed because if control got here, then we assume
+            // (as a precondition) that Smith named Jones as a friend somehow.
+
+            bool q1 = assemblyGrantingAccessIdentity.IsStrongName;
+            bool q2 = !grantedToPublicKey.IsDefaultOrEmpty;
+            bool q3 = !assemblyWantingAccessKey.IsDefaultOrEmpty;
+            bool q4 = (q2 & q3) && ByteSequenceComparer.Equals(grantedToPublicKey, assemblyWantingAccessKey);
+
+            // Cases 2, 3, 7 and 8:
+            if (q2 && !q4)
+            {
+                return IVTConclusion.PublicKeyDoesntMatch;
+            }
+
+            // Cases 6 and 9:
+            if (!q1 && q3)
+            {
+                return IVTConclusion.OneSignedOneNot;
+            }
+
+            // Cases 1, 4, 5 and 10:
+            return IVTConclusion.Match;
+        }
+    }
+}

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -576,48 +576,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend MustOverride ReadOnly Property PublicKey As ImmutableArray(Of Byte)
 
-        Protected Enum IVTConclusion
-            Match
-            OneSignedOneNot
-            PublicKeyDoesntMatch
-            NoRelationshipClaimed
-        End Enum
-
-        Protected Function PerformIVTCheck(key As ImmutableArray(Of Byte), otherIdentity As AssemblyIdentity) As IVTConclusion
-            ' Implementation of this function in C# compiler is somewhat different, but we believe
-            ' that the difference doesn't affect any real world scenarios that we know/care about.
-            ' At the moment we don't feel it is worth porting the logic, but we might reconsider in the future. 
-
-            ' We also have an easy out here. Suppose Smith names Jones as a friend, And Jones Is 
-            ' being compiled as a module, Not as an assembly. You can only strong-name an assembly. So if this module
-            ' Is named Jones, And Smith Is extending friend access to Jones, then we are going to optimistically 
-            ' assume that Jones Is going to be compiled into an assembly with a matching strong name, if necessary.
-            Dim compilation As Compilation = Me.DeclaringCompilation
-            If compilation IsNot Nothing AndAlso compilation.Options.OutputKind.IsNetModule() Then
-                Return IVTConclusion.Match
-            End If
-
-            Dim result As IVTConclusion
-
-            If Me.PublicKey.IsDefaultOrEmpty OrElse key.IsDefaultOrEmpty Then
-                If Me.PublicKey.IsDefaultOrEmpty AndAlso key.IsDefaultOrEmpty Then
-                    'we are not signed, therefore the other assembly shouldn't be signed
-                    result = If(otherIdentity.IsStrongName, IVTConclusion.OneSignedOneNot, IVTConclusion.Match)
-                ElseIf Me.PublicKey.IsDefaultOrEmpty Then
-                    result = IVTConclusion.PublicKeyDoesntMatch
-                Else
-                    ' key is NullOrEmpty, Me.PublicKey is not.
-                    result = IVTConclusion.NoRelationshipClaimed
-                End If
-            ElseIf ByteSequenceComparer.Equals(key, Me.PublicKey) Then
-                result = If(otherIdentity.IsStrongName, IVTConclusion.Match, IVTConclusion.OneSignedOneNot)
-            Else
-                result = IVTConclusion.PublicKeyDoesntMatch
-            End If
-
-            Return result
-        End Function
-
         Friend Function IsValidWellKnownType(result As NamedTypeSymbol) As Boolean
             If result Is Nothing OrElse result.TypeKind = TypeKind.Error Then
                 Return False
@@ -637,19 +595,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private Function IAssemblySymbol_GivesAccessTo(toAssembly As IAssemblySymbol) As Boolean Implements IAssemblySymbol.GivesAccessTo
-            If Equals(Me, toAssembly) Then
+        Private Function IAssemblySymbol_GivesAccessTo(assemblyWantingAccess As IAssemblySymbol) As Boolean Implements IAssemblySymbol.GivesAccessTo
+            If Equals(Me, assemblyWantingAccess) Then
                 Return True
             End If
 
-            Dim assembly = TryCast(toAssembly, AssemblySymbol)
-            If assembly Is Nothing Then
-                Return False
+            Dim myKeys = Me.GetInternalsVisibleToPublicKeys(assemblyWantingAccess.Name)
+
+            ' We have an easy out here. Suppose the assembly wanting access is
+            ' being compiled as a module. You can only strong-name an assembly. So we are going to optimistically
+            ' assume that it Is going to be compiled into an assembly with a matching strong name, if necessary
+            If myKeys.Any() AndAlso assemblyWantingAccess.IsNetModule() Then
+                Return True
             End If
 
-            Dim myKeys = Me.GetInternalsVisibleToPublicKeys(assembly.Identity.Name)
             For Each key In myKeys
-                If assembly.PerformIVTCheck(key, Me.Identity) = IVTConclusion.Match Then
+                Dim conclusion As IVTConclusion = Me.Identity.PerformIVTCheck(assemblyWantingAccess.Identity.PublicKey, key)
+                Debug.Assert(conclusion <> IVTConclusion.NoRelationshipClaimed)
+                If conclusion = IVTConclusion.Match Then
+                    ' Note that C# includes  OrElse conclusion = IVTConclusion.OneSignedOneNot
                     Return True
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -451,8 +451,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(Me._lazyNetModuleAttributesBag.IsSealed)
             Debug.Assert(index >= 0)
             Debug.Assert(index < Me.GetAttributes().Length)
-            Debug.Assert(Me._lazyDuplicateAttributeIndices Is Nothing OrElse
-                         Not Me.DeclaringCompilation.Options.OutputKind.IsNetModule())
+            Debug.Assert(Me._lazyDuplicateAttributeIndices Is Nothing OrElse Not IsNetModule)
 
             Return Me._lazyDuplicateAttributeIndices IsNot Nothing AndAlso Me._lazyDuplicateAttributeIndices.Contains(index)
         End Function
@@ -1186,7 +1185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 'strong name key settings are not validated when building netmodules.
                 'They are validated when the netmodule is added to an assembly.
-                If StrongNameKeys.DiagnosticOpt IsNot Nothing AndAlso Not DeclaringCompilation.Options.OutputKind.IsNetModule() Then
+                If StrongNameKeys.DiagnosticOpt IsNot Nothing AndAlso Not IsNetModule Then
                     diagnostics.Add(StrongNameKeys.DiagnosticOpt)
                 End If
 
@@ -1200,7 +1199,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 If DeclaringCompilation.Options.PublicSign Then
-                    If DeclaringCompilation.Options.OutputKind.IsNetModule() Then
+                    If IsNetModule Then
                         diagnostics.Add(ERRID.ERR_PublicSignNetModule, NoLocation.Singleton)
                     ElseIf Not Identity.HasPublicKey Then
                         diagnostics.Add(ERRID.ERR_PublicSignNoKey, NoLocation.Singleton)
@@ -1605,8 +1604,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
             End If
 
-
-            Return MakeFinalIVTDetermination(potentialGiverOfAccess) = IVTConclusion.Match
+            Dim conclusion As IVTConclusion = MakeFinalIVTDetermination(potentialGiverOfAccess)
+            Return conclusion = IVTConclusion.Match
+            ' Note that C#, for error recovery, includes OrElse conclusion = IVTConclusion.OneSignedOneNot
         End Function
 
         Friend ReadOnly Property StrongNameKeys As StrongNameKeys

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -595,7 +595,7 @@ Print(4);
 ", runner.Console.Out.ToString());
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26510")]
         public void ReferenceSearchPaths1()
         {
             var main = Temp.CreateFile(extension: ".csx").WriteAllText(@"


### PR DESCRIPTION
It now has a shared core implementation that permits operation across IAssemblySymbol implementations.
Fixes #26459
Fixes #26723
One remaining difference is in the treatment of a strong named assembly and a weak named assembly.  C# treats them as being (capable of being) related for error recovery.  VB does not. We would like to strengthen C# but that may be a breaking change, so we're leaving it as is, at least for now.
See also #26722
