### PR TITLE
Escape keywords in object initializer completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -820,6 +820,36 @@ class Program
             await VerifyItemExistsAsync(markup, "Value");
         }
 
+        [WorkItem(26560, "https://github.com/dotnet/roslyn/issues/26560")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task ObjectInitializerEscapeKeywords()
+        {
+            var markup = @"
+class c
+{
+    public int @new { get; set; }
+
+    public int @this { get; set; }
+
+    public int now { get; set; }
+}
+
+class d
+{
+    static void Main(string[] args)
+    {
+        var t = new c() { $$ };
+    }
+}";
+
+            await VerifyItemExistsAsync(markup, "@new");
+            await VerifyItemExistsAsync(markup, "@this");
+            await VerifyItemExistsAsync(markup, "now");
+
+            await VerifyItemIsAbsentAsync(markup, "new");
+            await VerifyItemIsAbsentAsync(markup, "this");
+        }
+
         private async Task VerifyExclusiveAsync(string markup, bool exclusive)
         {
             using (var workspace = TestWorkspace.CreateCSharp(markup))

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
@@ -435,6 +435,32 @@ End Program"
             Await VerifySendEnterThroughToEditorAsync(code, "bar", expected:=False)
         End Function
 
+        <WorkItem(26560, "https://github.com/dotnet/roslyn/issues/26560")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestKeywordsEscaped() As Task
+            Dim text = <a>Class C
+    Public Property [Wend] As Integer
+
+    Public Property [New] As Integer
+
+    Public Property A As Integer
+End Class
+
+
+Class Program
+    Sub Main()
+        Dim c As New C With { .$$ }
+    End Sub
+End Class</a>.Value
+
+            Await VerifyItemExistsAsync(text, "[Wend]")
+            Await VerifyItemExistsAsync(text, "[New]")
+            Await VerifyItemExistsAsync(text, "A")
+
+            Await VerifyItemIsAbsentAsync(text, "Wend")
+            Await VerifyItemIsAbsentAsync(text, "New")
+        End Function
+
         Friend Overrides Function CreateCompletionProvider() As CompletionProvider
             Return New ObjectInitializerCompletionProvider()
         End Function

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.cs
@@ -178,5 +178,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
             return base.IsInitializable(member, containingType);
         }
+
+        protected override string EscapeIdentifier(ISymbol symbol)
+        {
+            return symbol.Name.EscapeIdentifier();
+        }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
     {
         protected abstract Tuple<ITypeSymbol, Location> GetInitializedType(Document document, SemanticModel semanticModel, int position, CancellationToken cancellationToken);
         protected abstract HashSet<string> GetInitializedMembers(SyntaxTree tree, int position, CancellationToken cancellationToken);
+        protected abstract string EscapeIdentifier(ISymbol symbol);
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
@@ -62,9 +63,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             foreach (var uninitializedMember in uninitializedMembers)
             {
-                var displayText = uninitializedMember.GetParameters().Length == 0 ? uninitializedMember.ToNameDisplayString() : uninitializedMember.Name;
                 context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
-                    displayText: displayText,
+                    displayText: EscapeIdentifier(uninitializedMember),
                     insertionText: null,
                     symbols: ImmutableArray.Create(uninitializedMember),
                     contextPosition: initializerLocation.SourceSpan.Start,

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
@@ -62,8 +62,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             foreach (var uninitializedMember in uninitializedMembers)
             {
+                var displayText = uninitializedMember.GetParameters().Length == 0 ? uninitializedMember.ToNameDisplayString() : uninitializedMember.Name;
                 context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
-                    displayText: uninitializedMember.ToNameDisplayString(),
+                    displayText: displayText,
                     insertionText: null,
                     symbols: ImmutableArray.Create(uninitializedMember),
                     contextPosition: initializerLocation.SourceSpan.Start,

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             foreach (var uninitializedMember in uninitializedMembers)
             {
                 context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
-                    displayText: uninitializedMember.Name,
+                    displayText: uninitializedMember.ToNameDisplayString(),
                     insertionText: null,
                     symbols: ImmutableArray.Create(uninitializedMember),
                     contextPosition: initializerLocation.SourceSpan.Start,

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.vb
@@ -93,6 +93,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 member.IsAccessibleWithin(containingType)
         End Function
 
+        Protected Overrides Function EscapeIdentifier(symbol As ISymbol) As String
+            Return symbol.Name.EscapeIdentifier()
+        End Function
+
         Private Function IsValidProperty(member As ISymbol) As Boolean
             Dim [property] = TryCast(member, IPropertySymbol)
             If [property] IsNot Nothing Then


### PR DESCRIPTION
Fixes #26560

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
