### PR TITLE
made "foreach to for" to only support rank1 array.

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
@@ -1721,5 +1721,23 @@ class Explicit : IReadOnlyList<int>
 ";
             await TestInRegularAndScriptAsync(text, expected, options: ImplicitTypeEverywhere);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)]
+        public async Task ArrayRank2()
+        {
+            var text = @"
+class Test
+{
+    void Method()
+    {
+        foreach [||] (int a in new int[,] { {1, 2} })
+        {
+            Console.WriteLine(a);
+        }
+    }
+}
+";
+            await TestMissingAsync(text);
+        }
     }
 }

--- a/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
@@ -217,8 +217,17 @@ namespace Microsoft.CodeAnalysis.ConvertForEachToFor
             // go through explicit types first.
 
             // check array case
-            if (collectionType is IArrayTypeSymbol array && array.Rank == 1)
+            if (collectionType is IArrayTypeSymbol array)
             {
+                if (array.Rank != 1)
+                {
+                    // array type supports IList and other interfaces, but implementation
+                    // only supports Rank == 1 case. other case, it will throw on runtime
+                    // even if there is no error on compile time.
+                    // we explicitly mark that we only support Rank == 1 case
+                    return;
+                }
+
                 if (!IsExchangable(semanticFact, array.ElementType, foreachType, model.Compilation))
                 {
                     return;


### PR DESCRIPTION
otherwise, it will pick up IList but Array implementation only support Rank==1 on runtime even if there is no compile time error.

fixes - https://github.com/dotnet/roslyn/issues/26748