### PR TITLE
Suggest the most overridden members when looking for named attribute parameters

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -3618,6 +3618,28 @@ class SomeAttribute : Attribute
                 Documentation("ctor comment"));
         }
 
+        [WorkItem(26768, "https://github.com/dotnet/roslyn/issues/26768")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task AttributeConstructorShadowedMemberType()
+        {
+            await TestAsync(
+@"class SomethingAttribute : System.Attribute
+{
+    public int Goo { get; set; }
+}
+
+class DerivedAttribute : SomethingAttribute
+{
+    new public long Goo { get; set; }
+}
+
+[Derived($$Goo = )]
+class C
+{
+}",
+                MainDescription("long DerivedAttribute.Goo { get; set; }"));
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task TestLabel()
         {

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
@@ -356,6 +356,32 @@ class D
             await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
         }
 
+        [Fact]
+        [WorkItem(23664, "https://github.com/dotnet/roslyn/issues/23664")]
+        public async Task TestAttributeWithInvalidPropertyAbstract()
+        {
+            var markup = @"
+abstract class SomethingAttribute : System.Attribute
+{
+    public abstract int goo { get; set; }
+}
+
+class DerivedAttribute : SomethingAttribute
+{
+    public override int goo { get => 0; set { } }
+}
+
+[[|Derived($$|])]
+class D
+{
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"DerivedAttribute({CSharpFeaturesResources.Properties}: [goo = int])", string.Empty, null, currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public async Task TestAttributeWithInvalidPropertyStatic()
         {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -397,6 +397,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     if (!propertySymbol.IsReadOnly &&
                         !propertySymbol.IsWriteOnly &&
                         !propertySymbol.IsStatic &&
+                        !propertySymbol.IsAbstract &&
                         propertySymbol.GetMethod != null &&
                         propertySymbol.SetMethod != null &&
                         propertySymbol.GetMethod.IsAccessibleWithin(within) &&

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -351,6 +351,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             var systemAttributeType = compilation.AttributeType();
 
+            var suggestedMembers = new HashSet<string>();
             foreach (var type in attributeSymbol.GetBaseTypesAndThis())
             {
                 if (type.Equals(systemAttributeType))
@@ -361,8 +362,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 foreach (var member in type.GetMembers())
                 {
                     var namedParameter = IsAttributeNamedParameter(member, within ?? compilation.Assembly);
-                    if (namedParameter != null)
+                    if (namedParameter != null && !suggestedMembers.Contains(namedParameter.Name))
                     {
+                        // Remember this type. Any named parameter with the same name we encounter further down the
+                        // inheritance chain will be less overriden than the one we already picked, so we can ignore them.
+                        suggestedMembers.Add(namedParameter.Name);
                         yield return namedParameter;
                     }
                 }


### PR DESCRIPTION
Fixes #23664.

Only non-abstract attribute classes can be used as attributes. Non-abstract classes inheriting from abstract classes must also override all abstract members, so all properties that were abstract in base classes must have been implemented somewhere in the inheritance chain. For that reason we can ignore abstract properties when looking for named attribute parameters.