### PR TITLE
Suggest parameter documentation tags on delegates

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
@@ -465,6 +465,16 @@ static void Goo(string str)
 ", "str");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(26713, "https://github.com/dotnet/roslyn/issues/26713")]
+        public async Task DelegateParams()
+        {
+            await VerifyItemExistsAsync(@"
+/// $$
+delegate void D(object o);
+", "param name=\"o\"");
+        }
+
         [WorkItem(17872, "https://github.com/dotnet/roslyn/issues/17872")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task TypeParamRefNamesInEmptyAttribute()

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -223,6 +223,12 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 {
                     items.Add(GetItem(ReturnsElementName));
                 }
+
+                var namedType = symbol as INamedTypeSymbol;
+                if (namedType != null && namedType.IsDelegateType())
+                {
+                    items.AddRange(GetParameterItems(namedType.DelegateInvokeMethod.GetParameters(), syntax, ParameterElementName));
+                }
             }
 
             return items;

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -224,10 +224,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     items.Add(GetItem(ReturnsElementName));
                 }
 
-                var namedType = symbol as INamedTypeSymbol;
-                if (namedType != null && namedType.IsDelegateType())
+                if (symbol is INamedTypeSymbol namedType && namedType.IsDelegateType())
                 {
-                    items.AddRange(GetParameterItems(namedType.DelegateInvokeMethod.GetParameters(), syntax, ParameterElementName));
+                    var delegateInvokeMethod = namedType.DelegateInvokeMethod;
+                    if (delegateInvokeMethod != null)
+                    {
+                        items.AddRange(GetParameterItems(delegateInvokeMethod.GetParameters(), syntax, ParameterElementName));
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR addresses the first part of issue #26713.

When searching for top level items to suggest, the completion provider now checks whether the symbol is a) a named type, and b) a delegate type. If both are true, all of the delegate's Invoke method's parameters (which are equivalent to the delegate's parameters) are added to the suggestion list.