### PR TITLE
When comparing an expression to a constant, put the constant on the right.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -265,33 +265,33 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (loweredLiteral.Type.SpecialType)
                 {
                     case SpecialType.System_Boolean:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.BoolEqual, loweredLiteral, input, booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.BoolEqual, input, loweredLiteral, booleanType, method: null);
                     case SpecialType.System_Byte:
                     case SpecialType.System_Char:
                     case SpecialType.System_Int16:
                     case SpecialType.System_SByte:
                     case SpecialType.System_UInt16:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.IntEqual, _factory.Convert(intType, loweredLiteral), _factory.Convert(intType, input), booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.IntEqual, _factory.Convert(intType, input), _factory.Convert(intType, loweredLiteral), booleanType, method: null);
                     case SpecialType.System_Decimal:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.DecimalEqual, loweredLiteral, input, booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.DecimalEqual, input, loweredLiteral, booleanType, method: null);
                     case SpecialType.System_Double:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.DoubleEqual, loweredLiteral, input, booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.DoubleEqual, input, loweredLiteral, booleanType, method: null);
                     case SpecialType.System_Int32:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.IntEqual, loweredLiteral, input, booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.IntEqual, input, loweredLiteral, booleanType, method: null);
                     case SpecialType.System_Int64:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.LongEqual, loweredLiteral, input, booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.LongEqual, input, loweredLiteral, booleanType, method: null);
                     case SpecialType.System_Single:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.FloatEqual, loweredLiteral, input, booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.FloatEqual, input, loweredLiteral, booleanType, method: null);
                     case SpecialType.System_String:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.StringEqual, loweredLiteral, input, booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.StringEqual, input, loweredLiteral, booleanType, method: null);
                     case SpecialType.System_UInt32:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.UIntEqual, loweredLiteral, input, booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.UIntEqual, input, loweredLiteral, booleanType, method: null);
                     case SpecialType.System_UInt64:
-                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.ULongEqual, loweredLiteral, input, booleanType, method: null);
+                        return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.ULongEqual, input, loweredLiteral, booleanType, method: null);
                     default:
                         if (loweredLiteral.Type.IsEnumType())
                         {
-                            return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.EnumEqual, loweredLiteral, input, booleanType, method: null);
+                            return _localRewriter.MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.EnumEqual, input, loweredLiteral, booleanType, method: null);
                         }
 
                         // This is the (correct but inefficient) fallback for any type that isn't yet implemented.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
@@ -5347,44 +5347,41 @@ class C
             var compilation = CompileAndVerify(source, expectedOutput: @"True");
             compilation.VerifyIL("C.Main",
 @"{
-  // Code size       92 (0x5c)
+  // Code size       90 (0x5a)
   .maxstack  3
   .locals init (int? V_0, //i
                 C.<>c__DisplayClass0_0 V_1, //CS$<>8__locals0
-                System.Func<object> V_2, //f
-                int V_3)
+                System.Func<object> V_2) //f
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""int?""
   IL_0008:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
   IL_000d:  stloc.1
   IL_000e:  ldloca.s   V_0
   IL_0010:  call       ""bool int?.HasValue.get""
-  IL_0015:  brfalse.s  IL_0022
+  IL_0015:  brfalse.s  IL_0020
   IL_0017:  ldloca.s   V_0
   IL_0019:  call       ""int int?.GetValueOrDefault()""
-  IL_001e:  stloc.3
-  IL_001f:  ldloc.3
-  IL_0020:  brfalse.s  IL_004f
-  IL_0022:  ldloc.1
-  IL_0023:  ldnull
-  IL_0024:  stfld      ""object C.<>c__DisplayClass0_0.o""
-  IL_0029:  ldloc.1
-  IL_002a:  ldftn      ""object C.<>c__DisplayClass0_0.<Main>b__0()""
-  IL_0030:  newobj     ""System.Func<object>..ctor(object, System.IntPtr)""
-  IL_0035:  stloc.2
-  IL_0036:  ldstr      ""{0}""
-  IL_003b:  ldloc.2
-  IL_003c:  callvirt   ""object System.Func<object>.Invoke()""
-  IL_0041:  ldnull
-  IL_0042:  ceq
-  IL_0044:  box        ""bool""
-  IL_0049:  call       ""void System.Console.Write(string, object)""
-  IL_004e:  ret
-  IL_004f:  ldloc.1
-  IL_0050:  ldc.i4.1
-  IL_0051:  box        ""int""
-  IL_0056:  stfld      ""object C.<>c__DisplayClass0_0.o""
-  IL_005b:  ret
+  IL_001e:  brfalse.s  IL_004d
+  IL_0020:  ldloc.1
+  IL_0021:  ldnull
+  IL_0022:  stfld      ""object C.<>c__DisplayClass0_0.o""
+  IL_0027:  ldloc.1
+  IL_0028:  ldftn      ""object C.<>c__DisplayClass0_0.<Main>b__0()""
+  IL_002e:  newobj     ""System.Func<object>..ctor(object, System.IntPtr)""
+  IL_0033:  stloc.2
+  IL_0034:  ldstr      ""{0}""
+  IL_0039:  ldloc.2
+  IL_003a:  callvirt   ""object System.Func<object>.Invoke()""
+  IL_003f:  ldnull
+  IL_0040:  ceq
+  IL_0042:  box        ""bool""
+  IL_0047:  call       ""void System.Console.Write(string, object)""
+  IL_004c:  ret
+  IL_004d:  ldloc.1
+  IL_004e:  ldc.i4.1
+  IL_004f:  box        ""int""
+  IL_0054:  stfld      ""object C.<>c__DisplayClass0_0.o""
+  IL_0059:  ret
 }");
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -2573,9 +2573,9 @@ class Program
   IL_0010:  ldarg.0
   IL_0011:  ldc.i4.m1
   IL_0012:  stfld      ""int Program.<Iter1>d__1.<>1__state""
-  IL_0017:  ldc.i4.1
-  IL_0018:  ldarg.0
-  IL_0019:  ldfld      ""int Program.<Iter1>d__1.i""
+  IL_0017:  ldarg.0
+  IL_0018:  ldfld      ""int Program.<Iter1>d__1.i""
+  IL_001d:  ldc.i4.1
   IL_001e:  bne.un.s   IL_0024
   IL_0020:  ldc.i4.1
   IL_0021:  stloc.1

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -454,8 +454,8 @@ class Program
 @"{
   // Code size       13 (0xd)
   .maxstack  2
-  IL_0000:  ldc.r8     3.14
-  IL_0009:  ldarg.0
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.r8     3.14
   IL_000a:  ceq
   IL_000c:  ret
 }");
@@ -463,8 +463,8 @@ class Program
 @"{
   // Code size        9 (0x9)
   .maxstack  2
-  IL_0000:  ldc.r4     3.14
-  IL_0005:  ldarg.0
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.r4     3.14
   IL_0006:  ceq
   IL_0008:  ret
 }");
@@ -491,8 +491,8 @@ class Program
   IL_0014:  ldloc.1
   IL_0015:  call       ""bool double.IsNaN(double)""
   IL_001a:  brtrue.s   IL_004b
-  IL_001c:  ldc.r8     3.14
-  IL_0025:  ldloc.1
+  IL_001c:  ldloc.1
+  IL_001d:  ldc.r8     3.14
   IL_0026:  beq.s      IL_0055
   IL_0028:  br.s       IL_005f
   IL_002a:  ldloc.0
@@ -504,8 +504,8 @@ class Program
   IL_0039:  ldloc.2
   IL_003a:  call       ""bool float.IsNaN(float)""
   IL_003f:  brtrue.s   IL_0050
-  IL_0041:  ldc.r4     3.14
-  IL_0046:  ldloc.2
+  IL_0041:  ldloc.2
+  IL_0042:  ldc.r4     3.14
   IL_0047:  beq.s      IL_005a
   IL_0049:  br.s       IL_005f
   IL_004b:  ldc.i4.1
@@ -569,7 +569,7 @@ public class C
             compVerifier.VerifyIL("C.M1",
 @"{
   // Code size       39 (0x27)
-  .maxstack  5
+  .maxstack  6
   .locals init (bool V_0,
                 decimal V_1,
                 int V_2)
@@ -577,13 +577,13 @@ public class C
   IL_0001:  ldarg.0
   IL_0002:  call       ""decimal C.M(decimal)""
   IL_0007:  stloc.1
-  IL_0008:  ldc.i4.s   10
-  IL_000a:  ldc.i4.0
+  IL_0008:  ldloc.1
+  IL_0009:  ldc.i4.s   10
   IL_000b:  ldc.i4.0
   IL_000c:  ldc.i4.0
-  IL_000d:  ldc.i4.1
-  IL_000e:  newobj     ""decimal..ctor(int, int, int, bool, byte)""
-  IL_0013:  ldloc.1
+  IL_000d:  ldc.i4.0
+  IL_000e:  ldc.i4.1
+  IL_000f:  newobj     ""decimal..ctor(int, int, int, bool, byte)""
   IL_0014:  call       ""bool decimal.op_Equality(decimal, decimal)""
   IL_0019:  stloc.0
   IL_001a:  ldloc.0
@@ -631,25 +631,22 @@ public class C
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("C.M1",
 @"{
-  // Code size       30 (0x1e)
-  .maxstack  5
-  .locals init (decimal V_0)
+  // Code size       28 (0x1c)
+  .maxstack  6
   IL_0000:  ldarg.0
   IL_0001:  call       ""decimal C.M(decimal)""
-  IL_0006:  stloc.0
-  IL_0007:  ldc.i4.s   10
+  IL_0006:  ldc.i4.s   10
+  IL_0008:  ldc.i4.0
   IL_0009:  ldc.i4.0
   IL_000a:  ldc.i4.0
-  IL_000b:  ldc.i4.0
-  IL_000c:  ldc.i4.1
-  IL_000d:  newobj     ""decimal..ctor(int, int, int, bool, byte)""
-  IL_0012:  ldloc.0
-  IL_0013:  call       ""bool decimal.op_Equality(decimal, decimal)""
-  IL_0018:  brfalse.s  IL_001c
-  IL_001a:  ldc.i4.1
+  IL_000b:  ldc.i4.1
+  IL_000c:  newobj     ""decimal..ctor(int, int, int, bool, byte)""
+  IL_0011:  call       ""bool decimal.op_Equality(decimal, decimal)""
+  IL_0016:  brfalse.s  IL_001a
+  IL_0018:  ldc.i4.1
+  IL_0019:  ret
+  IL_001a:  ldc.i4.0
   IL_001b:  ret
-  IL_001c:  ldc.i4.0
-  IL_001d:  ret
 }");
             compVerifier.VerifyIL("C.M2",
 @"{
@@ -770,8 +767,8 @@ public class C
 @"{
   // Code size        6 (0x6)
   .maxstack  2
-  IL_0000:  ldc.i4.s   42
-  IL_0002:  ldarg.0
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   42
   IL_0003:  ceq
   IL_0005:  ret
 }");
@@ -1233,8 +1230,8 @@ Closed Open -> Opened
         IL_001c,
         IL_0025)
   IL_0014:  br.s       IL_0039
-  IL_0016:  ldc.i4.1
-  IL_0017:  ldarg.1
+  IL_0016:  ldarg.1
+  IL_0017:  ldc.i4.1
   IL_0018:  beq.s      IL_002b
   IL_001a:  br.s       IL_0039
   IL_001c:  ldarg.1
@@ -1243,8 +1240,8 @@ Closed Open -> Opened
   IL_0020:  ldc.i4.2
   IL_0021:  beq.s      IL_002f
   IL_0023:  br.s       IL_0039
-  IL_0025:  ldc.i4.3
-  IL_0026:  ldarg.1
+  IL_0025:  ldarg.1
+  IL_0026:  ldc.i4.3
   IL_0027:  beq.s      IL_0034
   IL_0029:  br.s       IL_0039
   IL_002b:  ldc.i4.1
@@ -1273,8 +1270,8 @@ Closed Open -> Opened
         IL_001a,
         IL_0023)
   IL_0012:  br.s       IL_003f
-  IL_0014:  ldc.i4.1
-  IL_0015:  ldarg.1
+  IL_0014:  ldarg.1
+  IL_0015:  ldc.i4.1
   IL_0016:  beq.s      IL_0029
   IL_0018:  br.s       IL_003f
   IL_001a:  ldarg.1
@@ -1283,8 +1280,8 @@ Closed Open -> Opened
   IL_001e:  ldc.i4.2
   IL_001f:  beq.s      IL_0031
   IL_0021:  br.s       IL_003f
-  IL_0023:  ldc.i4.3
-  IL_0024:  ldarg.1
+  IL_0023:  ldarg.1
+  IL_0024:  ldc.i4.3
   IL_0025:  beq.s      IL_0038
   IL_0027:  br.s       IL_003f
   IL_0029:  ldc.i4.1
@@ -1547,23 +1544,20 @@ False
 }");
             compVerifier.VerifyIL("Program.Test2<T>(T)",
 @"{
-  // Code size       32 (0x20)
+  // Code size       30 (0x1e)
   .maxstack  2
-  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  box        ""T""
   IL_0006:  isinst     ""int""
-  IL_000b:  brfalse.s  IL_001e
+  IL_000b:  brfalse.s  IL_001c
   IL_000d:  ldarg.0
   IL_000e:  box        ""T""
   IL_0013:  unbox.any  ""int""
-  IL_0018:  stloc.0
-  IL_0019:  ldloc.0
-  IL_001a:  ldc.i4.0
-  IL_001b:  ceq
+  IL_0018:  ldc.i4.0
+  IL_0019:  ceq
+  IL_001b:  ret
+  IL_001c:  ldc.i4.0
   IL_001d:  ret
-  IL_001e:  ldc.i4.0
-  IL_001f:  ret
 }");
             compVerifier.VerifyIL("Program.Test3<T>(T)",
 @"{
@@ -1576,8 +1570,8 @@ False
   IL_000b:  stloc.0
   IL_000c:  ldloc.0
   IL_000d:  brfalse.s  IL_001b
-  IL_000f:  ldstr      ""frog""
-  IL_0014:  ldloc.0
+  IL_000f:  ldloc.0
+  IL_0010:  ldstr      ""frog""
   IL_0015:  call       ""bool string.op_Equality(string, string)""
   IL_001a:  ret
   IL_001b:  ldc.i4.0
@@ -1604,23 +1598,20 @@ False
             var compVerifier = CompileAndVerify(compilation);
             compVerifier.VerifyIL("C<T>.Test(C<T>.S)",
 @"{
-  // Code size       32 (0x20)
+  // Code size       30 (0x1e)
   .maxstack  2
-  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  box        ""C<T>.S""
   IL_0006:  isinst     ""int""
-  IL_000b:  brfalse.s  IL_001e
+  IL_000b:  brfalse.s  IL_001c
   IL_000d:  ldarg.0
   IL_000e:  box        ""C<T>.S""
   IL_0013:  unbox.any  ""int""
-  IL_0018:  stloc.0
-  IL_0019:  ldc.i4.1
-  IL_001a:  ldloc.0
-  IL_001b:  ceq
+  IL_0018:  ldc.i4.1
+  IL_0019:  ceq
+  IL_001b:  ret
+  IL_001c:  ldc.i4.0
   IL_001d:  ret
-  IL_001e:  ldc.i4.0
-  IL_001f:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -187,23 +187,20 @@ public class Test
             var compVerifier = CompileAndVerify(text, expectedOutput: "0");
             compVerifier.VerifyIL("Test.Main", @"
 {
-  // Code size       18 (0x12)
+  // Code size       16 (0x10)
   .maxstack  2
-  .locals init (int V_0, //ret
-                int V_1) //value
+  .locals init (int V_0) //ret
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   IL_0002:  ldc.i4.1
-  IL_0003:  stloc.1
-  IL_0004:  ldc.i4.2
-  IL_0005:  ldloc.1
-  IL_0006:  bne.un.s   IL_000a
-  IL_0008:  ldc.i4.1
-  IL_0009:  stloc.0
-  IL_000a:  ldloc.0
-  IL_000b:  call       ""void System.Console.Write(int)""
-  IL_0010:  ldloc.0
-  IL_0011:  ret
+  IL_0003:  ldc.i4.2
+  IL_0004:  bne.un.s   IL_0008
+  IL_0006:  ldc.i4.1
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  call       ""void System.Console.Write(int)""
+  IL_000e:  ldloc.0
+  IL_000f:  ret
 }"
             );
         }
@@ -239,26 +236,23 @@ public class Test
             var compVerifier = CompileAndVerify(text, expectedOutput: "0");
             compVerifier.VerifyIL("Test.Main", @"
 {
-  // Code size       24 (0x18)
+  // Code size       22 (0x16)
   .maxstack  2
-  .locals init (int V_0, //ret
-                int V_1) //value
+  .locals init (int V_0) //ret
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldc.i4.s   23
-  IL_0004:  stloc.1
-  IL_0005:  ldc.i4.s   23
-  IL_0007:  ldloc.1
-  IL_0008:  bne.un.s   IL_000e
-  IL_000a:  ldc.i4.0
-  IL_000b:  stloc.0
-  IL_000c:  br.s       IL_0010
-  IL_000e:  ldc.i4.1
-  IL_000f:  stloc.0
-  IL_0010:  ldloc.0
-  IL_0011:  call       ""void System.Console.Write(int)""
-  IL_0016:  ldloc.0
-  IL_0017:  ret
+  IL_0004:  ldc.i4.s   23
+  IL_0006:  bne.un.s   IL_000c
+  IL_0008:  ldc.i4.0
+  IL_0009:  stloc.0
+  IL_000a:  br.s       IL_000e
+  IL_000c:  ldc.i4.1
+  IL_000d:  stloc.0
+  IL_000e:  ldloc.0
+  IL_000f:  call       ""void System.Console.Write(int)""
+  IL_0014:  ldloc.0
+  IL_0015:  ret
 }"
             );
         }
@@ -1516,7 +1510,7 @@ public class Test
             var compVerifier = CompileAndVerify(text, expectedOutput: "0");
             compVerifier.VerifyIL("Test.DoEnum", @"
 {
-  // Code size      111 (0x6f)
+  // Code size      109 (0x6d)
   .maxstack  2
   .locals init (int V_0, //ret
                 Test.eTypes? V_1, //e
@@ -1543,42 +1537,40 @@ public class Test
   IL_0024:  stloc.0
   IL_0025:  ldloca.s   V_1
   IL_0027:  call       ""bool Test.eTypes?.HasValue.get""
-  IL_002c:  brfalse.s  IL_003e
+  IL_002c:  brfalse.s  IL_003c
   IL_002e:  ldloca.s   V_1
   IL_0030:  call       ""Test.eTypes Test.eTypes?.GetValueOrDefault()""
-  IL_0035:  stloc.2
-  IL_0036:  ldc.i4.m1
-  IL_0037:  ldloc.2
-  IL_0038:  beq.s      IL_003e
-  IL_003a:  ldloc.0
-  IL_003b:  ldc.i4.1
-  IL_003c:  sub
-  IL_003d:  stloc.0
-  IL_003e:  ldloca.s   V_1
-  IL_0040:  initobj    ""Test.eTypes?""
-  IL_0046:  ldloca.s   V_1
-  IL_0048:  call       ""bool Test.eTypes?.HasValue.get""
-  IL_004d:  brfalse.s  IL_0063
-  IL_004f:  ldloca.s   V_1
-  IL_0051:  call       ""Test.eTypes Test.eTypes?.GetValueOrDefault()""
-  IL_0056:  stloc.2
-  IL_0057:  ldloc.2
-  IL_0058:  ldc.i4.m1
-  IL_0059:  beq.s      IL_0067
-  IL_005b:  ldloc.2
+  IL_0035:  ldc.i4.m1
+  IL_0036:  beq.s      IL_003c
+  IL_0038:  ldloc.0
+  IL_0039:  ldc.i4.1
+  IL_003a:  sub
+  IL_003b:  stloc.0
+  IL_003c:  ldloca.s   V_1
+  IL_003e:  initobj    ""Test.eTypes?""
+  IL_0044:  ldloca.s   V_1
+  IL_0046:  call       ""bool Test.eTypes?.HasValue.get""
+  IL_004b:  brfalse.s  IL_0061
+  IL_004d:  ldloca.s   V_1
+  IL_004f:  call       ""Test.eTypes Test.eTypes?.GetValueOrDefault()""
+  IL_0054:  stloc.2
+  IL_0055:  ldloc.2
+  IL_0056:  ldc.i4.m1
+  IL_0057:  beq.s      IL_0065
+  IL_0059:  ldloc.2
+  IL_005a:  ldc.i4.1
+  IL_005b:  sub
   IL_005c:  ldc.i4.1
-  IL_005d:  sub
-  IL_005e:  ldc.i4.1
-  IL_005f:  ble.un.s   IL_0067
-  IL_0061:  br.s       IL_0067
-  IL_0063:  ldloc.0
-  IL_0064:  ldc.i4.1
-  IL_0065:  sub
-  IL_0066:  stloc.0
-  IL_0067:  ldloc.0
-  IL_0068:  call       ""void System.Console.Write(int)""
-  IL_006d:  ldloc.0
-  IL_006e:  ret
+  IL_005d:  ble.un.s   IL_0065
+  IL_005f:  br.s       IL_0065
+  IL_0061:  ldloc.0
+  IL_0062:  ldc.i4.1
+  IL_0063:  sub
+  IL_0064:  stloc.0
+  IL_0065:  ldloc.0
+  IL_0066:  call       ""void System.Console.Write(int)""
+  IL_006b:  ldloc.0
+  IL_006c:  ret
 }");
         }
 
@@ -1772,18 +1764,15 @@ public class Test
             var compVerifier = CompileAndVerify(text, expectedOutput: "0");
             compVerifier.VerifyIL("Test.M", @"
 {
-  // Code size       10 (0xa)
+  // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0) //i
   IL_0000:  ldc.i4.5
-  IL_0001:  stloc.0
-  IL_0002:  ldc.i4.1
-  IL_0003:  ldloc.0
-  IL_0004:  bne.un.s   IL_0008
-  IL_0006:  ldc.i4.1
+  IL_0001:  ldc.i4.1
+  IL_0002:  bne.un.s   IL_0006
+  IL_0004:  ldc.i4.1
+  IL_0005:  ret
+  IL_0006:  ldc.i4.0
   IL_0007:  ret
-  IL_0008:  ldc.i4.0
-  IL_0009:  ret
 }"
             );
         }
@@ -1818,18 +1807,15 @@ public class Test
             var compVerifier = CompileAndVerify(text, expectedOutput: "0");
             compVerifier.VerifyIL("Test.M", @"
 {
-  // Code size       10 (0xa)
+  // Code size        8 (0x8)
   .maxstack  2
-  .locals init (int V_0) //i
   IL_0000:  ldc.i4.5
-  IL_0001:  stloc.0
-  IL_0002:  ldc.i4.5
-  IL_0003:  ldloc.0
-  IL_0004:  bne.un.s   IL_0008
-  IL_0006:  ldc.i4.0
+  IL_0001:  ldc.i4.5
+  IL_0002:  bne.un.s   IL_0006
+  IL_0004:  ldc.i4.0
+  IL_0005:  ret
+  IL_0006:  ldc.i4.1
   IL_0007:  ret
-  IL_0008:  ldc.i4.1
-  IL_0009:  ret
 }"
             );
         }
@@ -1875,45 +1861,40 @@ class Class1
             var compVerifier = CompileAndVerify(text, expectedOutput: "0");
             compVerifier.VerifyIL("Class1.Main", @"
 {
-  // Code size       30 (0x1e)
-  .maxstack  1
-  .locals init (int V_0, //j
-                int V_1) //i
+  // Code size       26 (0x1a)
+  .maxstack  2
+  .locals init (int V_0) //i
   IL_0000:  ldc.i4.0
-  IL_0001:  stloc.0
-  IL_0002:  ldc.i4.3
-  IL_0003:  stloc.1
-  IL_0004:  ldloc.0
-  IL_0005:  brtrue.s   IL_0014
-  IL_0007:  nop
+  IL_0001:  ldc.i4.3
+  IL_0002:  stloc.0
+  IL_0003:  brtrue.s   IL_0010
+  IL_0005:  nop
   .try
   {
     .try
     {
-      IL_0008:  ldc.i4.0
-      IL_0009:  stloc.1
-      IL_000a:  leave.s    IL_0016
+      IL_0006:  ldc.i4.0
+      IL_0007:  stloc.0
+      IL_0008:  leave.s    IL_0012
     }
     catch object
     {
-      IL_000c:  pop
-      IL_000d:  ldc.i4.1
-      IL_000e:  stloc.1
-      IL_000f:  leave.s    IL_0016
+      IL_000a:  pop
+      IL_000b:  ldc.i4.1
+      IL_000c:  stloc.0
+      IL_000d:  leave.s    IL_0012
     }
   }
   finally
   {
-    IL_0011:  ldc.i4.2
-    IL_0012:  stloc.0
-    IL_0013:  endfinally
+    IL_000f:  endfinally
   }
-  IL_0014:  ldc.i4.2
-  IL_0015:  stloc.1
-  IL_0016:  ldloc.1
-  IL_0017:  call       ""void System.Console.Write(int)""
-  IL_001c:  ldloc.1
-  IL_001d:  ret
+  IL_0010:  ldc.i4.2
+  IL_0011:  stloc.0
+  IL_0012:  ldloc.0
+  IL_0013:  call       ""void System.Console.Write(int)""
+  IL_0018:  ldloc.0
+  IL_0019:  ret
 }"
             );
         }
@@ -2326,32 +2307,29 @@ class Program
             var verifier = CompileAndVerify(text, expectedOutput: "null 1");
             verifier.VerifyIL("Program.Main", @"
 {
-  // Code size       66 (0x42)
+  // Code size       64 (0x40)
   .maxstack  2
-  .locals init (sbyte? V_0, //local
-                sbyte V_1)
+  .locals init (sbyte? V_0) //local
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""sbyte?""
   IL_0008:  ldloca.s   V_0
   IL_000a:  call       ""bool sbyte?.HasValue.get""
-  IL_000f:  brfalse.s  IL_001f
+  IL_000f:  brfalse.s  IL_001d
   IL_0011:  ldloca.s   V_0
   IL_0013:  call       ""sbyte sbyte?.GetValueOrDefault()""
-  IL_0018:  stloc.1
-  IL_0019:  ldc.i4.1
-  IL_001a:  ldloc.1
-  IL_001b:  beq.s      IL_002b
-  IL_001d:  br.s       IL_0035
-  IL_001f:  ldstr      ""null ""
-  IL_0024:  call       ""void System.Console.Write(string)""
-  IL_0029:  br.s       IL_0035
-  IL_002b:  ldstr      ""1 ""
-  IL_0030:  call       ""void System.Console.Write(string)""
-  IL_0035:  ldc.i4.1
-  IL_0036:  conv.i1
-  IL_0037:  newobj     ""sbyte?..ctor(sbyte)""
-  IL_003c:  call       ""void Program.Goo(sbyte?)""
-  IL_0041:  ret
+  IL_0018:  ldc.i4.1
+  IL_0019:  beq.s      IL_0029
+  IL_001b:  br.s       IL_0033
+  IL_001d:  ldstr      ""null ""
+  IL_0022:  call       ""void System.Console.Write(string)""
+  IL_0027:  br.s       IL_0033
+  IL_0029:  ldstr      ""1 ""
+  IL_002e:  call       ""void System.Console.Write(string)""
+  IL_0033:  ldc.i4.1
+  IL_0034:  conv.i1
+  IL_0035:  newobj     ""sbyte?..ctor(sbyte)""
+  IL_003a:  call       ""void Program.Goo(sbyte?)""
+  IL_003f:  ret
 }");
         }
 
@@ -2602,23 +2580,20 @@ class Program
             var compVerifier = CompileAndVerify(text, expectedOutput: "True");
             compVerifier.VerifyIL("C.F(long?)",
 @"{
-  // Code size       26 (0x1a)
+  // Code size       24 (0x18)
   .maxstack  2
-  .locals init (long V_0)
   IL_0000:  ldarga.s   V_0
   IL_0002:  call       ""bool long?.HasValue.get""
-  IL_0007:  brfalse.s  IL_0018
+  IL_0007:  brfalse.s  IL_0016
   IL_0009:  ldarga.s   V_0
   IL_000b:  call       ""long long?.GetValueOrDefault()""
-  IL_0010:  stloc.0
-  IL_0011:  ldc.i4.1
-  IL_0012:  conv.i8
-  IL_0013:  ldloc.0
-  IL_0014:  bne.un.s   IL_0018
-  IL_0016:  ldc.i4.1
+  IL_0010:  ldc.i4.1
+  IL_0011:  conv.i8
+  IL_0012:  bne.un.s   IL_0016
+  IL_0014:  ldc.i4.1
+  IL_0015:  ret
+  IL_0016:  ldc.i4.0
   IL_0017:  ret
-  IL_0018:  ldc.i4.0
-  IL_0019:  ret
 }"
             );
         }
@@ -2706,25 +2681,21 @@ class Program
 }";
             var compVerifier = CompileAndVerify(text, expectedOutput: "True");
             compVerifier.VerifyIL("C.F(long?)",
-@"
-{
-  // Code size       26 (0x1a)
+@"{
+  // Code size       24 (0x18)
   .maxstack  2
-  .locals init (long V_0)
   IL_0000:  ldarga.s   V_0
   IL_0002:  call       ""bool long?.HasValue.get""
-  IL_0007:  brfalse.s  IL_0018
+  IL_0007:  brfalse.s  IL_0016
   IL_0009:  ldarga.s   V_0
   IL_000b:  call       ""long long?.GetValueOrDefault()""
-  IL_0010:  stloc.0
-  IL_0011:  ldc.i4.1
-  IL_0012:  conv.i8
-  IL_0013:  ldloc.0
-  IL_0014:  bne.un.s   IL_0018
-  IL_0016:  ldc.i4.1
+  IL_0010:  ldc.i4.1
+  IL_0011:  conv.i8
+  IL_0012:  bne.un.s   IL_0016
+  IL_0014:  ldc.i4.1
+  IL_0015:  ret
+  IL_0016:  ldc.i4.0
   IL_0017:  ret
-  IL_0018:  ldc.i4.0
-  IL_0019:  ret
 }"
             );
         }
@@ -2780,8 +2751,8 @@ public class Test
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
   IL_0007:  brfalse.s  IL_0018
-  IL_0009:  ldstr      ""hello""
-  IL_000e:  ldloc.0
+  IL_0009:  ldloc.0
+  IL_000a:  ldstr      ""hello""
   IL_000f:  call       ""bool string.op_Equality(string, string)""
   IL_0014:  brtrue.s   IL_001a
   IL_0016:  ldc.i4.1
@@ -6724,8 +6695,8 @@ class A
 {
   // Code size        7 (0x7)
   .maxstack  2
-  IL_0000:  ldc.i4.1
-  IL_0001:  ldarg.0
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.1
   IL_0002:  bne.un.s   IL_0006
   IL_0004:  br.s       IL_0004
   IL_0006:  ret
@@ -7000,8 +6971,8 @@ public class Test
   IL_0003:  stloc.0
   IL_0004:  ldloc.0
   IL_0005:  brfalse.s  IL_001a
-  IL_0007:  ldstr      ""A""
-  IL_000c:  ldloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  ldstr      ""A""
   IL_000d:  call       ""bool string.op_Equality(string, string)""
   IL_0012:  brfalse.s  IL_001a
   IL_0014:  ldc.i4.1
@@ -7402,8 +7373,8 @@ class Program {
   // Code size       28 (0x1c)
   .maxstack  2
   .locals init (string V_0) //x
-  IL_0000:  ldc.i4.s   42
-  IL_0002:  ldarg.0
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   42
   IL_0003:  bne.un.s   IL_001a
   IL_0005:  ldstr      ""goo""
   IL_000a:  stloc.0
@@ -7446,12 +7417,11 @@ class Program {
 ";
             var compVerifier = CompileAndVerify(text, expectedOutput: "");
             compVerifier.VerifyIL("Program.boo",
-@"
-{
+@"{
   // Code size       23 (0x17)
   .maxstack  2
-  IL_0000:  ldc.i4.s   42
-  IL_0002:  ldarg.0
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   42
   IL_0003:  bne.un.s   IL_0015
   IL_0005:  ldstr      ""goo""
   IL_000a:  ldstr      ""bar""
@@ -7493,26 +7463,22 @@ class Program {
 ";
             var compVerifier = CompileAndVerify(text, expectedOutput: "");
             compVerifier.VerifyIL("Program.boo",
-@"
-{
-  // Code size       30 (0x1e)
+@"{
+  // Code size       28 (0x1c)
   .maxstack  2
-  .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.1
   IL_0002:  add
-  IL_0003:  stloc.0
-  IL_0004:  ldc.i4.s   42
-  IL_0006:  ldloc.0
-  IL_0007:  bne.un.s   IL_001c
-  IL_0009:  ldstr      ""goo""
-  IL_000e:  ldstr      ""bar""
-  IL_0013:  call       ""bool string.op_Inequality(string, string)""
-  IL_0018:  brfalse.s  IL_001c
-  IL_001a:  ldc.i4.0
+  IL_0003:  ldc.i4.s   42
+  IL_0005:  bne.un.s   IL_001a
+  IL_0007:  ldstr      ""goo""
+  IL_000c:  ldstr      ""bar""
+  IL_0011:  call       ""bool string.op_Inequality(string, string)""
+  IL_0016:  brfalse.s  IL_001a
+  IL_0018:  ldc.i4.0
+  IL_0019:  ret
+  IL_001a:  ldc.i4.1
   IL_001b:  ret
-  IL_001c:  ldc.i4.1
-  IL_001d:  ret
 }"
             );
         }
@@ -7547,24 +7513,20 @@ class Program {
 ";
             var compVerifier = CompileAndVerify(text, expectedOutput: "");
             compVerifier.VerifyIL("Program.boo",
-@"
-{
-  // Code size       28 (0x1c)
+@"{
+  // Code size       26 (0x1a)
   .maxstack  2
-  .locals init (int V_0)
   IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldc.i4.s   42
-  IL_0004:  ldloc.0
-  IL_0005:  bne.un.s   IL_001a
-  IL_0007:  ldstr      ""goo""
-  IL_000c:  ldstr      ""bar""
-  IL_0011:  call       ""bool string.op_Inequality(string, string)""
-  IL_0016:  brfalse.s  IL_001a
-  IL_0018:  ldc.i4.0
+  IL_0001:  ldc.i4.s   42
+  IL_0003:  bne.un.s   IL_0018
+  IL_0005:  ldstr      ""goo""
+  IL_000a:  ldstr      ""bar""
+  IL_000f:  call       ""bool string.op_Inequality(string, string)""
+  IL_0014:  brfalse.s  IL_0018
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldc.i4.1
   IL_0019:  ret
-  IL_001a:  ldc.i4.1
-  IL_001b:  ret
 }"
             );
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2450,8 +2450,8 @@ class C
   IL_0013:  ldloc.3
   IL_0014:  unbox.any  ""int""
   IL_0019:  stloc.1
-  IL_001a:  ldc.i4.1
-  IL_001b:  ldloc.1
+  IL_001a:  ldloc.1
+  IL_001b:  ldc.i4.1
   IL_001c:  beq.s      IL_003c
   IL_001e:  br.s       IL_005b
   IL_0020:  ldloc.3
@@ -2461,8 +2461,8 @@ class C
   IL_0029:  unbox.any  ""byte""
   IL_002e:  stloc.0
   IL_002f:  br.s       IL_0049
-  IL_0031:  ldc.i4.1
-  IL_0032:  ldloc.0
+  IL_0031:  ldloc.0
+  IL_0032:  ldc.i4.1
   IL_0033:  beq.s      IL_006d
   IL_0035:  br.s       IL_0087
   IL_0037:  ldloc.3
@@ -2533,8 +2533,8 @@ class C
   IL_0013:  ldloc.3
   IL_0014:  unbox.any  ""int""
   IL_0019:  stloc.1
-  IL_001a:  ldc.i4.1
-  IL_001b:  ldloc.1
+  IL_001a:  ldloc.1
+  IL_001b:  ldc.i4.1
   IL_001c:  beq.s      IL_003c
   IL_001e:  br.s       IL_005b
   IL_0020:  ldloc.3
@@ -2544,8 +2544,8 @@ class C
   IL_0029:  unbox.any  ""byte""
   IL_002e:  stloc.0
   IL_002f:  br.s       IL_0049
-  IL_0031:  ldc.i4.1
-  IL_0032:  ldloc.0
+  IL_0031:  ldloc.0
+  IL_0032:  ldc.i4.1
   IL_0033:  beq.s      IL_006d
   IL_0035:  br.s       IL_0087
   IL_0037:  ldloc.3

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -8386,8 +8386,8 @@ partial class C
   IL_005c:  ldloc.3
   IL_005d:  unbox.any  ""int""
   IL_0062:  stloc.s    V_4
-  IL_0064:  ldc.i4.1
-  IL_0065:  ldloc.s    V_4
+  IL_0064:  ldloc.s    V_4
+  IL_0066:  ldc.i4.1
   IL_0067:  beq.s      IL_006b
   IL_0069:  br.s       IL_006d
   IL_006b:  br.s       IL_006f
@@ -8579,9 +8579,9 @@ class Program
     IL_0017:  ldloc.1
     IL_0018:  stfld      ""int Program.<Test>d__0.<>s__2""
     // sequence point: <hidden>
-    IL_001d:  ldc.i4.1
-    IL_001e:  ldarg.0
-    IL_001f:  ldfld      ""int Program.<Test>d__0.<>s__2""
+    IL_001d:  ldarg.0
+    IL_001e:  ldfld      ""int Program.<Test>d__0.<>s__2""
+    IL_0023:  ldc.i4.1
     IL_0024:  beq.s      IL_0028
     IL_0026:  br.s       IL_002a
     // sequence point: break;


### PR DESCRIPTION
Fixes #26493
