### PR TITLE
DeclareAsNullable: recognize 'as' expressions as nullable

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -261,5 +261,25 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
     static void M(string? x = null) { }
 }", parameters: s_nullableFeature);
         }
+
+        [Fact]
+        public async Task FixLocalWithAs()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    static void M(object o)
+    {
+        string x = [|o as string|];
+    }
+}",
+@"class Program
+{
+    static void M(object o)
+    {
+        string? x = o as string;
+    }
+}", parameters: s_nullableFeature);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
 
         private static TypeSyntax TryGetDeclarationTypeToFix(SyntaxNode node)
         {
-            if (!node.IsKind(SyntaxKind.NullLiteralExpression))
+            if (!node.IsKind(SyntaxKind.NullLiteralExpression, SyntaxKind.AsExpression))
             {
                 return null;
             }


### PR DESCRIPTION
The compiler puts a nullable warning on the expression in `string s = o as string;`, just like it does for `string s = null;`. With this PR, the DeclareAsNullable fixer can recognize the expression as nullable (the code should have used a cast otherwise) and offer to fix the type of the local.

Fixes https://github.com/dotnet/roslyn/issues/26738

@sharwell @dpoeschl for review (one line fix). Thanks