### PR TITLE
Relax the requirement in WithChanges that changes be ordered

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -101,7 +101,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 new TextChange(new TextSpan(0, 5), "Halo")
             };
 
-            Assert.Throws<ArgumentException>(() => text.WithChanges(changes));
+            var newText = text.WithChanges(changes);
+            Assert.Equal("Halo Universe", newText.ToString());
         }
 
         [Fact]
@@ -138,8 +139,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 new TextChange(new TextSpan(6, 0), "Super ")
             };
 
-            // this causes overlap
-            Assert.Throws<ArgumentException>(() => text.WithChanges(changes));
+            var newText = text.WithChanges(changes);
+            Assert.Equal("Hello Super Vurld", newText.ToString());
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -306,11 +306,11 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The changes must be ordered and not overlapping..
+        ///   Looks up a localized string similar to The changes must not overlap..
         /// </summary>
-        internal static string ChangesMustBeOrderedAndNotOverlapping {
+        internal static string ChangesMustNotOverlap {
             get {
-                return ResourceManager.GetString("ChangesMustBeOrderedAndNotOverlapping", resourceCulture);
+                return ResourceManager.GetString("ChangesMustNotOverlap", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -413,8 +413,8 @@
   <data name="PEImageDoesntContainManagedMetadata" xml:space="preserve">
     <value>PE image doesn't contain managed metadata.</value>
   </data>
-  <data name="ChangesMustBeOrderedAndNotOverlapping" xml:space="preserve">
-    <value>The changes must be ordered and not overlapping.</value>
+  <data name="ChangesMustNotOverlap" xml:space="preserve">
+    <value>The changes must not overlap.</value>
   </data>
   <data name="DiagnosticIdCantBeNullOrWhitespace" xml:space="preserve">
     <value>A DiagnosticDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</value>

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -633,7 +633,19 @@ namespace Microsoft.CodeAnalysis.Text
                 // there can be no overlapping changes
                 if (change.Span.Start < position)
                 {
-                    throw new ArgumentException(CodeAnalysisResources.ChangesMustBeOrderedAndNotOverlapping, nameof(changes));
+                    // Handle the case of unordered changes by sorting the input and retrying. This is inefficient, but
+                    // downstream consumers have been known to hit this case in the past and we want to avoid crashes.
+                    // https://github.com/dotnet/roslyn/pull/26339
+                    if (change.Span.End <= changeRanges.Last().Span.Start)
+                    {
+                        changes = from c in changes
+                                  where !c.Span.IsEmpty || c.NewText?.Length > 0
+                                  orderby c.Span.Start, c.Span.End
+                                  select c;
+                        return WithChanges(changes);
+                    }
+
+                    throw new ArgumentException(CodeAnalysisResources.ChangesMustNotOverlap, nameof(changes));
                 }
 
                 var newTextLength = change.NewText?.Length ?? 0;

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -638,10 +638,10 @@ namespace Microsoft.CodeAnalysis.Text
                     // https://github.com/dotnet/roslyn/pull/26339
                     if (change.Span.End <= changeRanges.Last().Span.Start)
                     {
-                        changes = from c in changes
-                                  where !c.Span.IsEmpty || c.NewText?.Length > 0
-                                  orderby c.Span
-                                  select c;
+                        changes = (from c in changes
+                                   where !c.Span.IsEmpty || c.NewText?.Length > 0
+                                   orderby c.Span
+                                   select c).ToList();
                         return WithChanges(changes);
                     }
 

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -640,7 +640,7 @@ namespace Microsoft.CodeAnalysis.Text
                     {
                         changes = from c in changes
                                   where !c.Span.IsEmpty || c.NewText?.Length > 0
-                                  orderby c.Span.Start, c.Span.End
+                                  orderby c.Span
                                   select c;
                         return WithChanges(changes);
                     }

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
@@ -496,9 +496,9 @@
         <target state="translated">Image PE neobsahuje spravovaná metadata.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">Změny musí být seřazené a nesmí se překrývat.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">Změny musí být seřazené a nesmí se překrývat.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
@@ -496,9 +496,9 @@
         <target state="translated">PE-Abbild enthält keine verwalteten Metadaten.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">Die Änderungen müssen sortiert sein und dürfen sich nicht überschneiden.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">Die Änderungen müssen sortiert sein und dürfen sich nicht überschneiden.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
@@ -496,9 +496,9 @@
         <target state="translated">La imagen PE no contiene metadatos administrados.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">Los cambios deben estar ordenados y no superponerse.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">Los cambios deben estar ordenados y no superponerse.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
@@ -496,9 +496,9 @@
         <target state="translated">L'image PE ne contient pas de métadonnées gérées.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">Les modifications doivent être ordonnées et ne pas se chevaucher.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">Les modifications doivent être ordonnées et ne pas se chevaucher.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
@@ -496,9 +496,9 @@
         <target state="translated">L'immagine PE non contiene metadati gestiti.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">Le modifiche devono essere ordinate e non sovrapposte.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">Le modifiche devono essere ordinate e non sovrapposte.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
@@ -496,9 +496,9 @@
         <target state="translated">PE イメージには、管理されたメタデータが含まれていません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">変更は順序付けする必要があり、重複は許可されません。</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">変更は順序付けする必要があり、重複は許可されません。</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
@@ -496,9 +496,9 @@
         <target state="translated">PE 이미지에 관리된 메타데이터가 포함되어 있지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">변경 내용의 순서를 지정해야 하고 겹쳐서는 안 됩니다.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">변경 내용의 순서를 지정해야 하고 겹쳐서는 안 됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
@@ -496,9 +496,9 @@
         <target state="translated">Obraz PE nie zawiera zarządzanych metadanych.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">Zmiany muszą być uporządkowane i nie mogą nakładać się na siebie.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">Zmiany muszą być uporządkowane i nie mogą nakładać się na siebie.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
@@ -496,9 +496,9 @@
         <target state="translated">Imagem PE não contém metadados gerenciados.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">As alterações devem ser ordenadas e não sobrepostas.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">As alterações devem ser ordenadas e não sobrepostas.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
@@ -496,9 +496,9 @@
         <target state="translated">Образ среды предустановки не содержит управляемые метаданные.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">Изменения должны идти в строгом порядке и не накладываться.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">Изменения должны идти в строгом порядке и не накладываться.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
@@ -496,9 +496,9 @@
         <target state="translated">PE görüntüsü yönetilen meta verileri içermiyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">Değişiklikler sıralanmalı ve çakışmamalıdır.</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">Değişiklikler sıralanmalı ve çakışmamalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
@@ -496,9 +496,9 @@
         <target state="translated">PE 映像不包含任何托管元数据。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">更改必须有序且不重叠。</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">更改必须有序且不重叠。</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
@@ -496,9 +496,9 @@
         <target state="translated">PE 映像不包含 Managed 中繼資料。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChangesMustBeOrderedAndNotOverlapping">
-        <source>The changes must be ordered and not overlapping.</source>
-        <target state="translated">變更必須排序且不可重疊。</target>
+      <trans-unit id="ChangesMustNotOverlap">
+        <source>The changes must not overlap.</source>
+        <target state="needs-review-translation">變更必須排序且不可重疊。</target>
         <note />
       </trans-unit>
       <trans-unit id="DiagnosticIdCantBeNullOrWhitespace">


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/604150

/cc @minestarks

### Customer scenario

A customer attempts to reformat an HTML document, and Visual Studio crashes.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/604150

### Workarounds, if any

None.

### Risk

Low. This change relaxes the preconditions of an internal fallback method to produce expected results when the input is unordered but also unambiguous.

### Performance impact

Performance is not changed in normal usage scenarios.

### Is this a regression from a previous update?

Yes, introduced by #25558.

### Root cause analysis

See #26339 for the primary RCA.

This change corrects an additional edge case for `ITextBuffer` instances created before `VisualStudioWorkspace` attaches event handlers to `ITextBufferFactoryService` and `IProjectionBufferFactoryService`. This case is only believed to occur in IDE initialization scenarios where the workspace load is triggered by opening a document.

### How was the bug found?

Watson.

### Test documentation updated?

N/A