### PR TITLE
Add support for IEmptyOperation to control flow graph

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IEmptyOperation.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IEmptyOperation.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     {
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
         [Fact]
-        public void TestWhile()
+        public void TestEmptyStatementInWhile()
         {
             string source = @"
 using System;

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IEmptyOperation.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IEmptyOperation.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public partial class IOperationTests : SemanticModelTestBase
+    {
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void TestWhile()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    void M(string s)
+    {
+        while (true)
+        /*<bind>*/{
+            ;
+        }/*</bind>*/
+    }
+}
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            string expectedOperationTree = @"
+IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+  IEmptyOperation (OperationKind.Empty, Type: null) (Syntax: ';')
+";
+            VerifyOperationTreeAndDiagnosticsForTest<BlockSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void EmptyFlow_01()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    void M(string s)
+    /*<bind>*/{
+        while (true)
+        {
+            ;
+        }
+    }/*</bind>*/
+}
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            string expectedFlowGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+Block[B1] - Block
+    Predecessors: [B0] [B1]
+    Statements (0)
+    Jump if False (Regular) to Block[B2]
+        ILiteralOperation (OperationKind.Literal, Type: System.Boolean, Constant: True) (Syntax: 'true')
+
+    Next (Regular) Block[B1]
+Block[B2] - Exit [UnReachable]
+    Predecessors: [B1]
+    Statements (0)
+";
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -2356,6 +2356,12 @@ oneMoreTime:
             return null;
         }
 
+        public override IOperation VisitEmpty(IEmptyOperation operation, int? captureIdForResult)
+        {
+            Debug.Assert(_currentStatement == operation);
+            return null;
+        }
+        
         public override IOperation VisitThrow(IThrowOperation operation, int? captureIdForResult)
         {
             bool isStatement = (_currentStatement == operation);
@@ -4565,12 +4571,6 @@ oneMoreTime:
             return new TypeOfExpression(operation.TypeOperand, semanticModel: null, operation.Syntax, operation.Type, operation.ConstantValue, IsImplicit(operation));
         }
 
-        public override IOperation VisitEmpty(IEmptyOperation operation, int? captureIdForResult)
-        {
-            Debug.Assert(_currentStatement == operation);
-            return null;
-        }
-        
         public override IOperation VisitParenthesized(IParenthesizedOperation operation, int? captureIdForResult)
         {
             return new ParenthesizedExpression(Visit(operation.Operand), semanticModel: null, operation.Syntax, operation.Type, operation.ConstantValue, IsImplicit(operation));

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -2361,7 +2361,7 @@ oneMoreTime:
             Debug.Assert(_currentStatement == operation);
             return null;
         }
-        
+
         public override IOperation VisitThrow(IThrowOperation operation, int? captureIdForResult)
         {
             bool isStatement = (_currentStatement == operation);

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -2354,12 +2354,6 @@ oneMoreTime:
             return null;
         }
 
-        public override IOperation VisitEmpty(IEmptyOperation operation, int? captureIdForResult)
-        {
-            Debug.Assert(_currentStatement == operation);
-            return null;
-        }
-
         public override IOperation VisitThrow(IThrowOperation operation, int? captureIdForResult)
         {
             bool isStatement = (_currentStatement == operation);
@@ -4542,6 +4536,12 @@ oneMoreTime:
         public override IOperation VisitTypeOf(ITypeOfOperation operation, int? captureIdForResult)
         {
             return new TypeOfExpression(operation.TypeOperand, semanticModel: null, operation.Syntax, operation.Type, operation.ConstantValue, IsImplicit(operation));
+        }
+
+        public override IOperation VisitEmpty(IEmptyOperation operation, int? captureIdForResult)
+        {
+            Debug.Assert(_currentStatement == operation);
+            return null;
         }
 
         private T Visit<T>(T node) where T : IOperation


### PR DESCRIPTION
I also added an iOperation test since there weren't any.