### PR TITLE
Produce errors on emitting attributes using default constructor of structs

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/AttributeDataAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/AttributeDataAdapter.cs
@@ -28,8 +28,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return builder.ToImmutableAndFree();
         }
 
-        Cci.IMethodReference Cci.ICustomAttribute.Constructor(EmitContext context)
+        Cci.IMethodReference Cci.ICustomAttribute.Constructor(EmitContext context, bool reportDiagnostics)
         {
+            if (this.AttributeConstructor.IsDefaultValueTypeConstructor())
+            {
+                // Parameter constructors for structs exist in symbol table, but are not emitted.
+                // Produce an error since we cannot use it (instead of crashing):
+                // Details: https://github.com/dotnet/roslyn/issues/19394
+
+                if (reportDiagnostics)
+                {
+                    context.Diagnostics.Add(ErrorCode.ERR_NotAnAttributeClass, NoLocation.Singleton, this.AttributeClass);
+                }
+
+                return null;
+            }
+
             PEModuleBuilder moduleBeingBuilt = (PEModuleBuilder)context.Module;
             return (Cci.IMethodReference)moduleBeingBuilt.Translate(this.AttributeConstructor, (CSharpSyntaxNode)context.SyntaxNodeOpt, context.Diagnostics);
         }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/AttributeDataAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/AttributeDataAdapter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (reportDiagnostics)
                 {
-                    context.Diagnostics.Add(ErrorCode.ERR_NotAnAttributeClass, NoLocation.Singleton, this.AttributeClass);
+                    context.Diagnostics.Add(ErrorCode.ERR_NotAnAttributeClass, context.SyntaxNodeOpt?.Location ?? NoLocation.Singleton, this.AttributeClass);
                 }
 
                 return null;

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1159,6 +1159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             BoundArgListOperator optArgList = null,
             bool needDeclaration = false)
         {
+            Debug.Assert(!methodSymbol.IsDefaultValueTypeConstructor());
             Debug.Assert(optArgList == null || (methodSymbol.IsVararg && !needDeclaration));
 
             Cci.IMethodReference unexpandedMethodRef = Translate(methodSymbol, syntaxNodeOpt, diagnostics, needDeclaration);

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -8878,5 +8878,50 @@ class Test
                 // using static BothObsoleteParent.BothObsoleteChild;
                 Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "BothObsoleteParent.BothObsoleteChild").WithArguments("BothObsoleteParent.BothObsoleteChild").WithLocation(5, 14));
         }
+
+        [Fact, WorkItem(19394, "https://github.com/dotnet/roslyn/issues/19394")]
+        public void WellKnownTypeAsStruct_DefaultConstructor_DynamicAttribute()
+        {
+            var code = @"
+namespace System.Runtime.CompilerServices
+{
+    public struct DynamicAttribute
+    {
+        public DynamicAttribute(bool[] transformFlags)
+        {
+        }
+    }
+}
+class T
+{
+    void M(dynamic x) {}
+}";
+
+            CreateCompilation(code).VerifyDiagnostics().VerifyEmitDiagnostics(
+                // error CS0616: 'System.Runtime.CompilerServices.DynamicAttribute' is not an attribute class
+                Diagnostic(ErrorCode.ERR_NotAnAttributeClass).WithArguments("System.Runtime.CompilerServices.DynamicAttribute").WithLocation(1, 1));
+        }
+
+        [Fact, WorkItem(19394, "https://github.com/dotnet/roslyn/issues/19394")]
+        public void WellKnownTypeAsStruct_DefaultConstructor_IsReadOnlyAttribute()
+        {
+            var code = @"
+namespace System.Runtime.CompilerServices
+{
+    public struct IsReadOnlyAttribute
+    {
+    }
+}
+class Test
+{
+    void M(in int x)
+    {
+    }
+}";
+
+            CreateCompilation(code).VerifyDiagnostics().VerifyEmitDiagnostics(
+                // error CS0616: 'IsReadOnlyAttribute' is not an attribute class
+                Diagnostic(ErrorCode.ERR_NotAnAttributeClass).WithArguments("System.Runtime.CompilerServices.IsReadOnlyAttribute").WithLocation(1, 1));
+        }
     }
 }

--- a/src/Compilers/Core/Portable/CodeGen/PermissionSetAttribute.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PermissionSetAttribute.cs
@@ -51,8 +51,8 @@ namespace Microsoft.CodeAnalysis.CodeGen
         /// <summary>
         /// A reference to the constructor that will be used to instantiate this custom attribute during execution (if the attribute is inspected via Reflection).
         /// </summary>
-        public Cci.IMethodReference Constructor(EmitContext context)
-            => _sourceAttribute.Constructor(context);
+        public Cci.IMethodReference Constructor(EmitContext context, bool reportDiagnostics)
+            => _sourceAttribute.Constructor(context, reportDiagnostics);
 
         /// <summary>
         /// Zero or more named arguments that specify values for fields and properties of the attribute.

--- a/src/Compilers/Core/Portable/PEWriter/ICustomAttribute.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ICustomAttribute.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Cci
         /// <summary>
         /// A reference to the constructor that will be used to instantiate this custom attribute during execution (if the attribute is inspected via Reflection).
         /// </summary>
-        IMethodReference Constructor(EmitContext context);
+        IMethodReference Constructor(EmitContext context, bool reportDiagnostics);
 
         /// <summary>
         /// Zero or more named arguments that specify values for fields and properties of the attribute.

--- a/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
@@ -48,14 +48,14 @@ namespace Microsoft.Cci
 
         public virtual void Visit(ICustomAttribute customAttribute)
         {
-            this.Visit(customAttribute.GetArguments(Context));
-
             IMethodReference constructor = customAttribute.Constructor(Context, reportDiagnostics: false);
-            if (constructor != null)
+            if (constructor is null)
             {
-                this.Visit(constructor);
+                return;
             }
 
+            this.Visit(customAttribute.GetArguments(Context));
+            this.Visit(constructor);
             this.Visit(customAttribute.GetNamedArguments(Context));
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
@@ -49,7 +49,13 @@ namespace Microsoft.Cci
         public virtual void Visit(ICustomAttribute customAttribute)
         {
             this.Visit(customAttribute.GetArguments(Context));
-            this.Visit(customAttribute.Constructor(Context));
+
+            IMethodReference constructor = customAttribute.Constructor(Context, reportDiagnostics: false);
+            if (constructor != null)
+            {
+                this.Visit(constructor);
+            }
+
             this.Visit(customAttribute.GetNamedArguments(Context));
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -717,7 +717,7 @@ namespace Microsoft.Cci
             return this.GetOrAddModuleReferenceHandle(moduleName);
         }
 
-        private BlobHandle GetCustomAttributeSignatureIndex(ICustomAttribute customAttribute, IMethodReference constructor)
+        private BlobHandle GetCustomAttributeSignatureIndex(ICustomAttribute customAttribute)
         {
             BlobHandle result;
             if (_customAttributeSignatureIndex.TryGetValue(customAttribute, out result))
@@ -726,7 +726,7 @@ namespace Microsoft.Cci
             }
 
             var writer = PooledBlobBuilder.GetInstance();
-            this.SerializeCustomAttributeSignature(customAttribute, constructor, writer);
+            this.SerializeCustomAttributeSignature(customAttribute, writer);
             result = metadata.GetOrAddBlob(writer);
             _customAttributeSignatureIndex.Add(customAttribute, result);
             writer.Free();
@@ -2149,7 +2149,7 @@ namespace Microsoft.Cci
                 metadata.AddCustomAttribute(
                     parent: parentHandle,
                     constructor: GetCustomAttributeTypeCodedIndex(constructor),
-                    value: GetCustomAttributeSignatureIndex(customAttribute, constructor));
+                    value: GetCustomAttributeSignatureIndex(customAttribute));
             }
         }
 
@@ -3356,9 +3356,9 @@ namespace Microsoft.Cci
             }
         }
 
-        private void SerializeCustomAttributeSignature(ICustomAttribute customAttribute, IMethodReference constructor, BlobBuilder builder)
+        private void SerializeCustomAttributeSignature(ICustomAttribute customAttribute, BlobBuilder builder)
         {
-            var parameters = constructor.GetParameters(Context);
+            var parameters = customAttribute.Constructor(Context, reportDiagnostics: false).GetParameters(Context);
             var arguments = customAttribute.GetArguments(Context);
             Debug.Assert(parameters.Length == arguments.Length);
 

--- a/src/Compilers/VisualBasic/Portable/Emit/AttributeDataAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/AttributeDataAdapter.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' Details: https://github.com/dotnet/roslyn/issues/19394
 
                 If reportDiagnostics Then
-                    context.Diagnostics.Add(ERRID.ERR_AttributeMustBeClassNotStruct1, NoLocation.Singleton, Me.AttributeClass)
+                    context.Diagnostics.Add(ERRID.ERR_AttributeMustBeClassNotStruct1, If(context.SyntaxNodeOpt?.GetLocation(), NoLocation.Singleton), Me.AttributeClass)
                 End If
 
                 Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Emit/AttributeDataAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/AttributeDataAdapter.vb
@@ -14,7 +14,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return CommonConstructorArguments.SelectAsArray(Function(arg) CreateMetadataExpression(arg, context))
         End Function
 
-        Private Function Constructor1(context As EmitContext) As Cci.IMethodReference Implements Cci.ICustomAttribute.Constructor
+        Private Function Constructor1(context As EmitContext, reportDiagnostics As Boolean) As Cci.IMethodReference Implements Cci.ICustomAttribute.Constructor
+            If Me.AttributeConstructor.IsDefaultValueTypeConstructor() Then
+                ' Parameter constructors for structs exist in symbol table, but are not emitted.
+                ' Produce an error since we cannot use it (instead of crashing):
+                ' Details: https://github.com/dotnet/roslyn/issues/19394
+
+                If reportDiagnostics Then
+                    context.Diagnostics.Add(ERRID.ERR_AttributeMustBeClassNotStruct1, NoLocation.Singleton, Me.AttributeClass)
+                End If
+
+                Return Nothing
+            End If
+
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Return moduleBeingBuilt.Translate(AttributeConstructor, needDeclaration:=False,
                                               syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)

--- a/src/Compilers/VisualBasic/Portable/Emit/SymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SymbolTranslator.vb
@@ -362,10 +362,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             diagnostics As DiagnosticBag,
             Optional needDeclaration As Boolean = False
         ) As Microsoft.Cci.IMethodReference
-            Dim container As NamedTypeSymbol = methodSymbol.ContainingType
-
+            Debug.Assert(Not methodSymbol.IsDefaultValueTypeConstructor())
             Debug.Assert(methodSymbol Is methodSymbol.OriginalDefinition OrElse
                                             Not methodSymbol.Equals(methodSymbol.OriginalDefinition))
+
+            Dim container As NamedTypeSymbol = methodSymbol.ContainingType
 
             ' Method of anonymous type being translated
             If container.IsAnonymousType Then

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -5660,5 +5660,51 @@ End Class
 BC31503: 'ParamArrayAttribute' cannot be used as an attribute because it is not a class.
 ]]></expected>)
         End Sub
+
+        <Fact>
+        <WorkItem(19394, "https://github.com/dotnet/roslyn/issues/19394")>
+        Public Sub WellKnownTypeAsStruct_NonDefaultConstructor_TupleElementNamesAttribute()
+            Dim compilation = CreateCompilationWithMscorlib45AndVBRuntime(
+<compilation>
+    <file name="errors.vb"><![CDATA[
+Imports System
+
+Namespace System.Runtime.CompilerServices
+    Public Structure TupleElementNamesAttribute
+        Public Sub New(transformNames As String())
+        End Sub
+    End Structure
+End Namespace
+
+Module Program
+    Public Sub Main(args As String())
+        Test(("first", "second"))
+    End Sub
+
+    Public Sub Test(tuple As (a As String, b As String))
+        Console.WriteLine(tuple.a)
+        Console.WriteLine(tuple.b)
+    End Sub
+End Module
+]]></file>
+</compilation>,
+                references:={ValueTupleRef, SystemRuntimeFacadeRef},
+                options:=TestOptions.ReleaseExe)
+
+            CompileAndVerify(
+                compilation,
+                expectedOutput:="
+first
+second",
+                symbolValidator:=
+                    Sub([module] As ModuleSymbol)
+                        Dim attribute = [module].ContainingAssembly.GetTypeByMetadataName("Program").GetMethod("Test").Parameters.Single().GetAttributes().Single()
+
+                        Assert.Equal("System.Runtime.CompilerServices.TupleElementNamesAttribute", attribute.AttributeClass.ToTestDisplayString())
+                        Assert.True(attribute.AttributeClass.IsStructureType())
+                        Assert.Equal([module].ContainingAssembly, attribute.AttributeClass.ContainingAssembly)
+                        Assert.Equal("transformNames", attribute.AttributeConstructor.Parameters.Single().Name)
+                    End Sub)
+        End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -5641,5 +5641,24 @@ Imports TestAssembly.BothObsoleteParent.BothObsoleteChild
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ]]></expected>)
         End Sub
+
+        <Fact>
+        <WorkItem(19394, "https://github.com/dotnet/roslyn/issues/19394")>
+        Public Sub WellKnownTypeAsStruct_DefaultConstructor_ParamArrayAttribute()
+            Dim code = <compilation><file name="a.vb"><![CDATA[
+Namespace System
+	public Structure ParamArrayAttribute
+	End Structure
+End Namespace
+Public Class C
+    Public Sub Test(ByVal ParamArray args() As Double)
+    End Sub
+End Class
+]]></file></compilation>
+
+            CreateCompilationWithMscorlib40AndVBRuntime(code).VerifyDiagnostics().AssertTheseEmitDiagnostics(<expected><![CDATA[
+BC31503: 'ParamArrayAttribute' cannot be used as an attribute because it is not a class.
+]]></expected>)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #19394

Note: This is such a corner case that I chose to produce that error on all attributes (regardless of being optional or not) instead of crashing. This can be relaxed in the future if needed.
I also believe that getting an error about a user-defined system struct not being a class is better than having the type in your compilation, and compiling successfully without emitting the attribute.