### PR TITLE
Remove value that is not used in fix all.

### DIFF
--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
@@ -44,12 +44,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// <summary>
         /// Get node on which to add simplifier and formatter annotation for fixing the given diagnostic.
         /// </summary>
-        protected virtual SyntaxNode GetNodeToSimplify(SyntaxNode root, SemanticModel model, Diagnostic diagnostic, DocumentOptionSet options, out string codeActionEquivalenceKey, CancellationToken cancellationToken)
-        {
-            codeActionEquivalenceKey = null;
-            var span = diagnostic.Location.SourceSpan;
-            return root.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true);
-        }
+        protected abstract SyntaxNode GetNodeToSimplify(SyntaxNode root, SemanticModel model, Diagnostic diagnostic, DocumentOptionSet options, out string codeActionEquivalenceKey, CancellationToken cancellationToken);
 
         private async Task<Document> AddSimplifierAnnotationsAsync(
             Document document, ImmutableArray<Diagnostic> diagnostics,

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
@@ -51,27 +51,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             return root.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true);
         }
 
-        /// <summary>
-        /// Override this method to add simplify annotations/fixup any parent nodes of original nodes to simplify.
-        /// Additionally, this method should also add simplifier annotation to the given nodeToSimplify.
-        /// See doc comments on <see cref="NeedsParentFixup"/>.
-        /// </summary>
-        protected virtual Task<Document> AddSimplifyAnnotationsAsync(Document document, SyntaxNode nodeToSimplify, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// By default, this property returns false and <see cref="AddSimplifierAnnotationsAsync(Document, ImmutableArray{Diagnostic}, FixAllState, CancellationToken)"/> will just add <see cref="Simplifier.Annotation"/> to each node to simplify
-        /// returned by <see cref="GetNodeToSimplify(SyntaxNode, SemanticModel, Diagnostic, DocumentOptionSet, out string, CancellationToken)"/>.
-        /// 
-        /// Override this property to return true if the fix all provider needs to add simplify annotations/fixup any of the parent nodes of the nodes to simplify.
-        /// This could be the case if simplifying certain nodes can enable cascaded simplifications, such as parentheses removal on parenting node.
-        /// <see cref="AddSimplifierAnnotationsAsync(Document, ImmutableArray{Diagnostic}, FixAllState, CancellationToken)"/> will end up invoking <see cref="AddSimplifyAnnotationsAsync(Document, SyntaxNode, CancellationToken)"/> for each node to simplify.
-        /// Ensure that you override <see cref="AddSimplifyAnnotationsAsync(Document, SyntaxNode, CancellationToken)"/> method when this property returns true.
-        /// </summary>
-        protected virtual bool NeedsParentFixup => false;
-
         private async Task<Document> AddSimplifierAnnotationsAsync(
             Document document, ImmutableArray<Diagnostic> diagnostics,
             FixAllState fixAllState, CancellationToken cancellationToken)
@@ -94,40 +73,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             }
 
             // Add simplifier and formatter annotations to all nodes to simplify.
-            // If the fix all provider needs to fixup any of the parent nodes, then we iterate through each of the nodesToSimplify
-            // and fixup any parenting node, computing a new document with required simplifier annotations in each iteration.
-            // Otherwise, if the fix all provider doesn't need parent fixup, we just add simplifier annotation to all nodesToSimplify.
-            if (!NeedsParentFixup)
-            {
-                root = root.ReplaceNodes(nodesToSimplify, (o, n) =>
-                    n.WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation));
-            }
-            else
-            {
-                // Add a custom annotation to nodesToSimplify so we can get back to them later.
-                var annotation = new SyntaxAnnotation();
-                root = root.ReplaceNodes(nodesToSimplify, (o, n) =>
-                    o.WithAdditionalAnnotations(annotation));
-                document = document.WithSyntaxRoot(root);
-
-                while (true)
-                {
-                    root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-                    var annotatedNodes = root.GetAnnotatedNodes(annotation);
-
-                    // Get the next un-processed node to simplify, processed nodes should have simplifier annotation.
-                    var annotatedNode = annotatedNodes.FirstOrDefault(n => !n.HasAnnotation(Simplifier.Annotation));
-                    if (annotatedNode == null)
-                    {
-                        // All nodesToSimplify have been processed.
-                        // Remove all the custom annotations added for tracking nodesToSimplify.
-                        root = root.ReplaceNodes(annotatedNodes, (o, n) => o.WithoutAnnotations(annotation));
-                        break;
-                    }
-
-                    document = await AddSimplifyAnnotationsAsync(document, annotatedNode, cancellationToken).ConfigureAwait(false);
-                }
-            }
+            root = root.ReplaceNodes(nodesToSimplify, (o, n) =>
+                n.WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation));
 
             return document.WithSyntaxRoot(root);
         }

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
@@ -19,10 +19,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     /// This provider batches all the simplifier annotation actions within a document into a single code action,
     /// instead of creating separate code actions for each added annotation.
     /// </summary>
-    internal class BatchSimplificationFixAllProvider : BatchFixAllProvider
+    internal abstract class BatchSimplificationFixAllProvider : BatchFixAllProvider
     {
-        public static new readonly FixAllProvider Instance = new BatchSimplificationFixAllProvider();
-
         protected BatchSimplificationFixAllProvider() { }
 
         protected override async Task AddDocumentFixesAsync(

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/WellKnownFixAllProviders.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/WellKnownFixAllProviders.cs
@@ -22,14 +22,5 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// operations present within these fixes are ignored.
         /// </remarks>
         public static FixAllProvider BatchFixer => BatchFixAllProvider.Instance;
-
-        /// <summary>
-        /// Default batch fix all provider for simplification fixers which only add Simplifier annotations to documents.
-        /// This provider batches all the simplifier annotation actions within a document into a single code action,
-        /// instead of creating separate code actions for each added annotation.
-        /// This fixer supports fixes for the following fix all scopes:
-        /// <see cref="FixAllScope.Document"/>, <see cref="FixAllScope.Project"/> and <see cref="FixAllScope.Solution"/>.
-        /// </summary>
-        internal static FixAllProvider BatchSimplificationFixer => BatchSimplificationFixAllProvider.Instance;
     }
 }


### PR DESCRIPTION
I'm generally trying to clean up the last remaining use of specialized fix-all (which is in simplify type names).  I expect to make several refactorings in this area.  But i will try my best to keep commits clean and independent when possible.