### PR TITLE
Fix out var behavior, including with NotNullWhenTrue/False

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -374,7 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         case BoundKind.Local:
                             var local = (BoundLocal)variable.Single;
-                            if (local.IsDeclaration)
+                            if (local.DeclarationKind != BoundLocalDeclarationKind.None)
                             {
                                 ((SourceLocalSymbol)local.LocalSymbol).SetValEscape(rhsValEscape);
                             }
@@ -826,7 +826,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if ((object)declType != null)
                 {
-                    return new BoundLocal(syntax, localSymbol, isDeclaration: true, constantValueOpt: null, isNullableUnknown: false, type: declType.TypeSymbol, hasErrors: hasErrors);
+                    return new BoundLocal(syntax, localSymbol, BoundLocalDeclarationKind.WithExplicitType, constantValueOpt: null, isNullableUnknown: false, type: declType.TypeSymbol, hasErrors: hasErrors);
                 }
 
                 return new DeconstructionVariablePendingInference(syntax, localSymbol, receiverOpt: null);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1549,7 +1549,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         var constantValueOpt = localSymbol.IsConst && !IsInsideNameof && !type.IsErrorType()
                             ? localSymbol.GetConstantValue(node, this.LocalInProgress, diagnostics) : null;
-                        return new BoundLocal(node, localSymbol, isDeclaration: false, constantValueOpt: constantValueOpt, isNullableUnknown: isNullableUnknown, type: type, hasErrors: isError);
+                        return new BoundLocal(node, localSymbol, BoundLocalDeclarationKind.None, constantValueOpt: constantValueOpt, isNullableUnknown: isNullableUnknown, type: type, hasErrors: isError);
                     }
 
                 case SymbolKind.Parameter:
@@ -2345,7 +2345,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 CheckRestrictedTypeInAsync(this.ContainingMemberOrLambda, declType.TypeSymbol, diagnostics, typeSyntax);
 
-                return new BoundLocal(declarationExpression, localSymbol, isDeclaration: true, constantValueOpt: null, isNullableUnknown: false, type: declType.TypeSymbol);
+                return new BoundLocal(declarationExpression, localSymbol, BoundLocalDeclarationKind.WithExplicitType, constantValueOpt: null, isNullableUnknown: false, type: declType.TypeSymbol);
             }
 
             // Is this a field?

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -133,13 +133,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors = false)
-            : this(syntax, localSymbol, false, constantValueOpt, false, type, hasErrors)
+            : this(syntax, localSymbol, BoundLocalDeclarationKind.None, constantValueOpt, false, type, hasErrors)
         {
         }
 
         public BoundLocal Update(LocalSymbol localSymbol, ConstantValue constantValueOpt, TypeSymbol type)
         {
-            return this.Update(localSymbol, this.IsDeclaration, constantValueOpt, this.IsNullableUnknown, type);
+            return this.Update(localSymbol, this.DeclarationKind, constantValueOpt, this.IsNullableUnknown, type);
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundLocalDeclarationKind.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundLocalDeclarationKind.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// Indicates whether a bound local is also a declaration, and if so was it a declaration with an explicit or an inferred type.
+    /// Ex:
+    /// - In `M(x)`, `x` has `LocalDeclarationKind.None`
+    /// - In `M(out int x)`, `x` has `LocalDeclarationKind.WithExplicitType`
+    /// - In `M(out var x)`, `x` has `LocalDeclarationKind.WithInferredType`
+    /// </summary>
+    internal enum BoundLocalDeclarationKind
+    {
+        None = 0,
+        WithExplicitType,
+        WithInferredType
+    }
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -30,6 +30,7 @@
   <ValueType Name="NoOpStatementFlavor"/>
   <ValueType Name="RefKind"/>
   <ValueType Name="BoundTypeOrValueData"/>
+  <ValueType Name="BoundLocalDeclarationKind"/>
 
   <AbstractNode Name="BoundInitializer" Base="BoundNode"/>
 
@@ -1050,7 +1051,7 @@
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="LocalSymbol" Type="LocalSymbol"/>
-    <Field Name="IsDeclaration" Type="bool"/>
+    <Field Name="DeclarationKind" Type="BoundLocalDeclarationKind" Null="NotApplicable"/>
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>
     <!-- True if LocalSymbol.Type.IsNullable could not be inferred. -->
     <Field Name="IsNullableUnknown" Type="bool"/>
@@ -1719,7 +1720,7 @@
   <!-- Special node, used only during nullability flow analysis -->
   <!-- PROTOTYPE(NullableReferenceTypes): Derive from BoundValuePlaceholderBase and give specific name. -->
   <Node Name="BoundValuePlaceholder" Base="BoundExpression">
-    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="allow"/> <!-- We use null Type for placeholders representing out vars -->
     <Field Name="IsNullable" Type="bool?" Null="allow"/>
   </Node>
 </Tree>

--- a/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     localSymbol.SetTypeSymbol(TypeSymbolWithAnnotations.Create(type));
-                    return new BoundLocal(this.Syntax, localSymbol, isDeclaration: true, constantValueOpt: null, isNullableUnknown: false, type: type, hasErrors: this.HasErrors || inferenceFailed);
+                    return new BoundLocal(this.Syntax, localSymbol, BoundLocalDeclarationKind.WithInferredType, constantValueOpt: null, isNullableUnknown: false, type: type, hasErrors: this.HasErrors || inferenceFailed);
 
                 case SymbolKind.Field:
                     var fieldSymbol = (GlobalExpressionVariable)this.VariableSymbol;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.VariableIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.VariableIdentifier.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             internal string GetDebuggerDisplay()
             {
-                return $"ContainingSlot={ContainingSlot}, Symbol={Symbol}";
+                return $"ContainingSlot={ContainingSlot}, Symbol={Symbol.GetDebuggerDisplay()}";
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLocal(BoundLocal node)
         {
-            if (IsInside && node.IsDeclaration)
+            if (IsInside && node.DeclarationKind != BoundLocalDeclarationKind.None)
             {
                 _variablesDeclared.Add(node.LocalSymbol);
             }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -187,6 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 
 
+
     internal abstract partial class BoundInitializer : BoundNode
     {
         protected BoundInitializer(BoundKind kind, SyntaxNode syntax, bool hasErrors)
@@ -3761,7 +3762,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundLocal : BoundExpression
     {
-        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, bool isDeclaration, ConstantValue constantValueOpt, bool isNullableUnknown, TypeSymbol type, bool hasErrors)
+        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, BoundLocalDeclarationKind declarationKind, ConstantValue constantValueOpt, bool isNullableUnknown, TypeSymbol type, bool hasErrors)
             : base(BoundKind.Local, syntax, type, hasErrors)
         {
 
@@ -3769,12 +3770,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.LocalSymbol = localSymbol;
-            this.IsDeclaration = isDeclaration;
+            this.DeclarationKind = declarationKind;
             this.ConstantValueOpt = constantValueOpt;
             this.IsNullableUnknown = isNullableUnknown;
         }
 
-        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, bool isDeclaration, ConstantValue constantValueOpt, bool isNullableUnknown, TypeSymbol type)
+        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, BoundLocalDeclarationKind declarationKind, ConstantValue constantValueOpt, bool isNullableUnknown, TypeSymbol type)
             : base(BoundKind.Local, syntax, type)
         {
 
@@ -3782,7 +3783,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.LocalSymbol = localSymbol;
-            this.IsDeclaration = isDeclaration;
+            this.DeclarationKind = declarationKind;
             this.ConstantValueOpt = constantValueOpt;
             this.IsNullableUnknown = isNullableUnknown;
         }
@@ -3790,7 +3791,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public LocalSymbol LocalSymbol { get; }
 
-        public bool IsDeclaration { get; }
+        public BoundLocalDeclarationKind DeclarationKind { get; }
 
         public ConstantValue ConstantValueOpt { get; }
 
@@ -3801,11 +3802,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.VisitLocal(this);
         }
 
-        public BoundLocal Update(LocalSymbol localSymbol, bool isDeclaration, ConstantValue constantValueOpt, bool isNullableUnknown, TypeSymbol type)
+        public BoundLocal Update(LocalSymbol localSymbol, BoundLocalDeclarationKind declarationKind, ConstantValue constantValueOpt, bool isNullableUnknown, TypeSymbol type)
         {
-            if (localSymbol != this.LocalSymbol || isDeclaration != this.IsDeclaration || constantValueOpt != this.ConstantValueOpt || isNullableUnknown != this.IsNullableUnknown || type != this.Type)
+            if (localSymbol != this.LocalSymbol || declarationKind != this.DeclarationKind || constantValueOpt != this.ConstantValueOpt || isNullableUnknown != this.IsNullableUnknown || type != this.Type)
             {
-                var result = new BoundLocal(this.Syntax, localSymbol, isDeclaration, constantValueOpt, isNullableUnknown, type, this.HasErrors);
+                var result = new BoundLocal(this.Syntax, localSymbol, declarationKind, constantValueOpt, isNullableUnknown, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -6380,18 +6381,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundValuePlaceholder(SyntaxNode syntax, bool? isNullable, TypeSymbol type, bool hasErrors)
             : base(BoundKind.ValuePlaceholder, syntax, type, hasErrors)
         {
-
-            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-
             this.IsNullable = isNullable;
         }
 
         public BoundValuePlaceholder(SyntaxNode syntax, bool? isNullable, TypeSymbol type)
             : base(BoundKind.ValuePlaceholder, syntax, type)
         {
-
-            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-
             this.IsNullable = isNullable;
         }
 
@@ -9341,7 +9336,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitLocal(BoundLocal node)
         {
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(node.LocalSymbol, node.IsDeclaration, node.ConstantValueOpt, node.IsNullableUnknown, type);
+            return node.Update(node.LocalSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, type);
         }
         public override BoundNode VisitPseudoVariable(BoundPseudoVariable node)
         {
@@ -10669,7 +10664,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new TreeDumperNode("local", null, new TreeDumperNode[]
             {
                 new TreeDumperNode("localSymbol", node.LocalSymbol, null),
-                new TreeDumperNode("isDeclaration", node.IsDeclaration, null),
+                new TreeDumperNode("declarationKind", node.DeclarationKind, null),
                 new TreeDumperNode("constantValueOpt", node.ConstantValueOpt, null),
                 new TreeDumperNode("isNullableUnknown", node.IsNullableUnknown, null),
                 new TreeDumperNode("type", node.Type, null)

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -371,7 +371,7 @@ namespace Microsoft.CodeAnalysis.Operations
         private IOperation CreateBoundLocalOperation(BoundLocal boundLocal)
         {
             ILocalSymbol local = boundLocal.LocalSymbol;
-            bool isDeclaration = boundLocal.IsDeclaration;
+            bool isDeclaration = boundLocal.DeclarationKind != BoundLocalDeclarationKind.None;
             SyntaxNode syntax = boundLocal.Syntax;
             ITypeSymbol type = boundLocal.Type;
             Optional<object> constantValue = ConvertToOptional(boundLocal.ConstantValue);

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -106,7 +106,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public abstract int Ordinal { get; }
 
         /// <summary>
-        /// Returns true if the parameter was declared as a parameter array. 
+        /// Returns true if the parameter was declared as a parameter array.
+        /// Note: it is possible for any parameter to have the [ParamArray] attribute (for instance, in IL),
+        ///     even if it is not the last parameter. So check for that.
         /// </summary>
         public abstract bool IsParams { get; }
 
@@ -388,22 +390,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal abstract AttributeAnnotations FlowAnalysisAnnotations { get; }
 
         /// <summary>
-        /// If there are any annotations on the member (not just that parameter), then memberHasExtra is true. The purpose is to ensure
+        /// If there are no annotations on the member (not just that parameter), then returns null. The purpose is to ensure
         /// that if some annotations are present on the member, then annotations win over the attributes on the member in all positions.
         /// That could mean removing an attribute.
         /// </summary>
-        protected (bool memberHasExtra, AttributeAnnotations annotations) TryGetExtraAttributeAnnotations()
+        protected AttributeAnnotations? TryGetExtraAttributeAnnotations()
         {
             ParameterSymbol originalParameter = this.OriginalDefinition;
             var containingMethod = originalParameter.ContainingSymbol as MethodSymbol;
 
             if (containingMethod is null)
             {
-                return (false, AttributeAnnotations.None);
+                return null;
             }
 
             string key = ExtraAnnotations.MakeMethodKey(containingMethod);
-            return ExtraAnnotations.GetExtraAttributes(key, this.Ordinal);
+            return ExtraAnnotations.TryGetExtraAttributes(key, this.Ordinal);
         }
 
         protected sealed override int HighestPriorityUseSiteError

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -131,18 +131,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                (bool memberHasAny, AttributeAnnotations annotations) = TryGetExtraAttributeAnnotations();
-                if (memberHasAny)
+                AttributeAnnotations? annotations = TryGetExtraAttributeAnnotations();
+                if (annotations.HasValue)
                 {
                     // PROTOTYPE(NullableReferenceTypes): Make sure this is covered by test
-                    return annotations;
+                    return annotations.Value;
                 }
 
                 CommonParameterWellKnownAttributeData attributeData = GetDecodedWellKnownAttributeData();
+                bool hasEnsuresNotNull = attributeData?.HasEnsuresNotNullAttribute == true;
 
                 return AttributeAnnotations.None
-                    .With(notNullWhenFalse: attributeData?.HasNotNullWhenFalseAttribute == true,
-                        ensuresNotNull: attributeData?.HasEnsuresNotNullAttribute == true);
+                    .With(notNullWhenTrue: hasEnsuresNotNull || attributeData?.HasNotNullWhenTrueAttribute == true,
+                        notNullWhenFalse: hasEnsuresNotNull || attributeData?.HasNotNullWhenFalseAttribute == true);
             }
         }
 
@@ -623,6 +624,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // NullableAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullWhenTrueAttribute))
+            {
+                arguments.GetOrCreateData<CommonParameterWellKnownAttributeData>().HasNotNullWhenTrueAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullWhenFalseAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceSimpleParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceSimpleParameterSymbol.cs
@@ -84,11 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override AttributeAnnotations FlowAnalysisAnnotations
         {
-            get
-            {
-                (_, AttributeAnnotations annotations) = TryGetExtraAttributeAnnotations();
-                return annotations;
-            }
+            get { return TryGetExtraAttributeAnnotations() ?? AttributeAnnotations.None; }
         }
 
         internal override MarshalPseudoCustomAttributeData MarshallingInformation

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -258,6 +258,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfOutAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfIsReadOnlyAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfIsUnmanagedAttribute = { s_signature_HasThis_Void };
+        private static readonly byte[][] s_signaturesOfNotNullWhenTrueAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfNotNullWhenFalseAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfEnsuresNotNullAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfFixedBufferAttribute = { s_signature_HasThis_Void_Type_Int32 };
@@ -456,6 +457,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription StructLayoutAttribute = new AttributeDescription("System.Runtime.InteropServices", "StructLayoutAttribute", s_signaturesOfStructLayoutAttribute);
         internal static readonly AttributeDescription FieldOffsetAttribute = new AttributeDescription("System.Runtime.InteropServices", "FieldOffsetAttribute", s_signaturesOfFieldOffsetAttribute);
         internal static readonly AttributeDescription FixedBufferAttribute = new AttributeDescription("System.Runtime.CompilerServices", "FixedBufferAttribute", s_signaturesOfFixedBufferAttribute);
+        internal static readonly AttributeDescription NotNullWhenTrueAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NotNullWhenTrueAttribute", s_signaturesOfNotNullWhenTrueAttribute);
         internal static readonly AttributeDescription NotNullWhenFalseAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NotNullWhenFalseAttribute", s_signaturesOfNotNullWhenFalseAttribute);
         internal static readonly AttributeDescription EnsuresNotNullAttribute = new AttributeDescription("System.Runtime.CompilerServices", "EnsuresNotNullAttribute", s_signaturesOfEnsuresNotNullAttribute);
         internal static readonly AttributeDescription MarshalAsAttribute = new AttributeDescription("System.Runtime.InteropServices", "MarshalAsAttribute", s_signaturesOfMarshalAsAttribute);

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonParameterWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonParameterWellKnownAttributeData.cs
@@ -110,7 +110,23 @@ namespace Microsoft.CodeAnalysis
         }
         #endregion
 
-        // PROTOTYPE(NullableReferenceTypes): Consider moving the attribute for nullability to C#-specific type
+        // PROTOTYPE(NullableReferenceTypes): Consider moving the attributes for nullability to C#-specific type
+        private bool _hasNotNullWhenTrueAttribute;
+        public bool HasNotNullWhenTrueAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasNotNullWhenTrueAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasNotNullWhenTrueAttribute = value;
+                SetDataStored();
+            }
+        }
+
         private bool _hasNotNullWhenFalseAttribute;
         public bool HasNotNullWhenFalseAttribute
         {


### PR DESCRIPTION
The driving scenario for this PR is `TryGetValue`.

This PR does the following:
- removes the warnings for misused attributes (see issue https://github.com/dotnet/roslyn/issues/26783)
- adds `NotNullWhenTrue` attribute
- fixes the behavior of `out var`s with the flow attributes (`NullableWalker.VisitCall` had a bug with `out var`s) and fixing some pre-existing issues to make that work (initial binding should account for nullability in `VariablesPendingInference`; the type of `out var`s should not contribute to re-inference on methods; and the nullability resulting from re-inference should coerce `out var`s instead).

This PR leaves the following issues (marked with PROTOTYPE markers):

In `var s = Copy(nullableString);` with a generic `Copy` method, initial binding infers the `T` and `var` types to be `string!` instead of `string?`. This is visible through the semantic model.
The same happens with `Copy(nullableString, out var s)`.
The reason for this is that method inference uses the types from the arguments to infer the method signature, but `BoundExpression` only has a `TypeSymbol` (no `TypeSymbolWithAnnotations`).
This does not affect diagnostics produced, since `NullableWalker` re-infers methods and `var` locals.

Also, there is a small issue that needs confirmation regarding the result type of a suppressed expression.

Relates to https://github.com/dotnet/roslyn/issues/25347