### PR TITLE
Show parameter documentation for delegates in Signature Help

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -206,6 +206,28 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [WorkItem(26713, "https://github.com/dotnet/roslyn/issues/26713")]
+        public async Task TestDelegateParameterWithXmlComment()
+        {
+            var markup = @"
+class C
+{
+    /// <param name=""a"">Parameter docs</param>
+    delegate void SomeDelegate(int a);
+
+    void M(SomeDelegate theDelegate)
+    {
+        [|theDelegate($$|]);
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("void SomeDelegate(int a)", parameterDocumentation: "Parameter docs", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public async Task TestInvocationWithoutClosingParen()
         {
             var markup = @"


### PR DESCRIPTION
This is the second PR for #26713.

With this PR, Signature Help will show documentation for delegate parameters.

Previously `ISymbolExtensions2.GetDocumentation` would pick the documentation tags of the symbol containing the parameter. However, for delegates this symbol would be the `Invoke` method, which does not have documentation.  
Now we check whether the symbol containing the parameter's containing symbol (i.e. the parameter's "grandparent" symbol) is a delegate, and if so, take the documentation of that symbol.  
The behaviour for all other parameters is not changed.