### PR TITLE
Updates to our IOperation testing

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -159,10 +159,6 @@ function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]
         $args += " /p:BootstrapBuildPath=$bootstrapDir"
     }
 
-    if ($testIOperation) {
-        $args += " /p:TestIOperationInterface=true"
-    }
-
     $args += " $buildArgs"
     $args += " $projectFilePath"
 
@@ -500,6 +496,10 @@ function Test-XUnit() {
         Deploy-VsixViaTool
     }
 
+    if ($testIOperation) {
+        $env:ROSLYN_TEST_IOPERATION = "true"
+    }
+
     $unitDir = Join-Path $configDir "UnitTests"
     $runTests = Join-Path $configDir "Exes\RunTests\RunTests.exe"
     $xunitDir = Join-Path (Get-PackageDir "xunit.runner.console") "tools\net452"
@@ -507,7 +507,7 @@ function Test-XUnit() {
     $args += " -logpath:$logsDir"
     $args += " -nocache"
 
-    if ($testDesktop) {
+    if ($testDesktop -or $testIOperation) {
         if ($test32) {
             $dlls = Get-ChildItem -re -in "*.UnitTests.dll" $unitDir
         }
@@ -559,6 +559,9 @@ function Test-XUnit() {
     }
     finally {
         Get-Process "xunit*" -ErrorAction SilentlyContinue | Stop-Process    
+        if ($testIOperation) { 
+            Remove-Item env:\ROSLYN_TEST_IOPERATION
+        }
     }
 }
 
@@ -743,7 +746,7 @@ try {
         Build-Artifacts
     }
 
-    if ($testDesktop -or $testCoreClr -or $testVsi -or $testVsiNetCore) {
+    if ($testDesktop -or $testCoreClr -or $testVsi -or $testVsiNetCore -or $testIOperation) {
         Test-XUnit
     } 
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -97,6 +97,23 @@ commitPullList.each { isPr ->
   addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
 }
 
+// IOperation unit test verification
+commitPullList.each { isPr ->
+  def jobName = Utilities.getFullJobName(projectName, "windows_debug_ioperation_unit32", isPr)
+  def myJob = job(jobName) {
+    description("Windows debug unit tests on unit32 for IOperation")
+          steps {
+            batchFile(""".\\build\\scripts\\cibuild.cmd -debug -test32 -testIOperation""")
+          }
+  }
+
+  def triggerPhraseOnly = false
+  def triggerPhraseExtra = ""
+  Utilities.setMachineAffinity(myJob, 'Windows_NT', windowsUnitTestMachine)
+  Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
+  addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
+}
+
 // Windows CoreCLR
 commitPullList.each { isPr ->
   ['debug', 'release'].each { configuration ->

--- a/netci.groovy
+++ b/netci.groovy
@@ -97,23 +97,6 @@ commitPullList.each { isPr ->
   addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
 }
 
-// IOperation unit test verification
-commitPullList.each { isPr ->
-  def jobName = Utilities.getFullJobName(projectName, "windows_debug_ioperation_unit32", isPr)
-  def myJob = job(jobName) {
-    description("Windows debug unit tests on unit32 for IOperation")
-          steps {
-            batchFile(""".\\build\\scripts\\cibuild.cmd -debug -test32 -testIOperation""")
-          }
-  }
-
-  def triggerPhraseOnly = false
-  def triggerPhraseExtra = ""
-  Utilities.setMachineAffinity(myJob, 'Windows_NT', windowsUnitTestMachine)
-  Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
-  addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
-}
-
 // Windows CoreCLR
 commitPullList.each { isPr ->
   ['debug', 'release'].each { configuration ->

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -310,6 +310,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             // Bind the expression for error recovery, but discard all new diagnostics
                             iterationErrorExpression = BindExpression(node.Variable, new DiagnosticBag());
+                            if (iterationErrorExpression.Kind == BoundKind.DiscardExpression)
+                            {
+                                iterationErrorExpression = ((BoundDiscardExpression)iterationErrorExpression).FailInference(this, diagnosticsOpt: null);
+                            }
                             hasErrors = true;
 
                             if (!node.HasErrors)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -6749,6 +6749,13 @@ class C
                 //         foreach (_ in M())
                 Diagnostic(ErrorCode.ERR_MustDeclareForeachIteration, "_").WithLocation(6, 18)
                 );
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            var discard = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().First();
+
+            var symbol = (DiscardSymbol)model.GetSymbolInfo(discard).Symbol;
+            Assert.True(symbol.Type.IsErrorType());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ITupleBinaryOperatorExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ITupleBinaryOperatorExpression.cs
@@ -25,7 +25,7 @@ class C
 
             string expectedOperationTree =
 @"
-ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: 'x == y')
+ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.TupleBinaryOperator, Type: System.Boolean) (Syntax: 'x == y')
   Left: 
     IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: (System.Int32, System.Int32)) (Syntax: 'x')
   Right: 
@@ -49,7 +49,7 @@ class C
 
             string expectedOperationTree =
 @"
-ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: 'x == (1, 2)')
+ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.TupleBinaryOperator, Type: System.Boolean) (Syntax: 'x == (1, 2)')
   Left: 
     IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: (System.Int32, System.Int32)) (Syntax: 'x')
   Right: 
@@ -77,7 +77,7 @@ class C
 
             string expectedOperationTree =
 @"
-ITupleBinaryOperation (BinaryOperatorKind.NotEquals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: '(1, 2) != y')
+ITupleBinaryOperation (BinaryOperatorKind.NotEquals) (OperationKind.TupleBinaryOperator, Type: System.Boolean) (Syntax: '(1, 2) != y')
   Left: 
     ITupleOperation (OperationKind.Tuple, Type: (System.Int64, System.Int32)) (Syntax: '(1, 2)')
       NaturalType: (System.Int32, System.Int32)
@@ -111,7 +111,7 @@ class C
 
             string expectedOperationTree =
 @"
-ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: '(null, (1,  ... l, (3L, 4))')
+ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.TupleBinaryOperator, Type: System.Boolean) (Syntax: '(null, (1,  ... l, (3L, 4))')
   Left: 
     ITupleOperation (OperationKind.Tuple, Type: null) (Syntax: '(null, (1, 2L))')
       NaturalType: null
@@ -157,7 +157,7 @@ class C
 
             string expectedOperationTree =
 @"
-ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.BinaryOperator, Type: System.Boolean) (Syntax: 'y == default')
+ITupleBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.TupleBinaryOperator, Type: System.Boolean) (Syntax: 'y == default')
   Left: 
     IParameterReferenceOperation: y (OperationKind.ParameterReference, Type: (System.Int32, System.String)) (Syntax: 'y')
   Right: 

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -873,7 +873,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract class BaseTupleBinaryOperatorExpression : Operation, ITupleBinaryOperation
     {
         public BaseTupleBinaryOperatorExpression(BinaryOperatorKind operatorKind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
-            : base(OperationKind.BinaryOperator, semanticModel, syntax, type, constantValue, isImplicit)
+            : base(OperationKind.TupleBinaryOperator, semanticModel, syntax, type, constantValue, isImplicit)
         {
             OperatorKind = operatorKind;
         }

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -100,13 +100,7 @@ namespace Roslyn.Test.Utilities
 
     public class NoIOperationValidation : ExecutionCondition
     {
-
-#if TEST_IOPERATION_INTERFACE
-        public override bool ShouldSkip => true;
-#else
-        public override bool ShouldSkip => false;
-#endif
-
+        public override bool ShouldSkip => !CompilationExtensions.EnableVerifyIOperation;
         public override string SkipReason => "Test not supported in TEST_IOPERATION_INTERFACE";
     }
 }

--- a/src/Test/Utilities/Portable/Compilation/CompilationExtensions.cs
+++ b/src/Test/Utilities/Portable/Compilation/CompilationExtensions.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 {
     public static class CompilationExtensions
     {
+        internal static bool EnableVerifyIOperation { get; } = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ROSLYN_TEST_IOPERATION"));
+
         internal static ImmutableArray<byte> EmitToArray(
             this Compilation compilation,
             EmitOptions options = null,
@@ -255,7 +257,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public static void ValidateIOperations(Func<Compilation> createCompilation)
         {
-#if TEST_IOPERATION_INTERFACE
+            if (!EnableVerifyIOperation)
+            {
+                return;
+            }
+
             var compilation = createCompilation();
             var roots = ArrayBuilder<IOperation>.GetInstance();
             var stopWatch = new Stopwatch();
@@ -322,7 +328,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             roots.Free();
             stopWatch.Stop();
-#endif
         }
     }
 }

--- a/src/Test/Utilities/Portable/Compilation/NoIOperationValidationFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Compilation/NoIOperationValidationFactAttribute.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
 namespace Roslyn.Test.Utilities
@@ -8,9 +9,10 @@ namespace Roslyn.Test.Utilities
     {
         public NoIOperationValidationFactAttribute()
         {
-#if TEST_IOPERATION_INTERFACE
-            Skip = "TEST_IOPERATION_INTERFACE is set";
-#endif 
+            if (CompilationExtensions.EnableVerifyIOperation)
+            {
+                Skip = "Test not run during IOperation verification";
+            }
         }
     }
 }

--- a/src/Test/Utilities/Portable/TestUtilities.csproj
+++ b/src/Test/Utilities/Portable/TestUtilities.csproj
@@ -22,9 +22,6 @@
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(TestIOperationInterface)' == 'true'">
-    <DefineConstants>$(DefineConstants);TEST_IOPERATION_INTERFACE</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Roslyn.Test.Utilities.CoreClr" />
     <InternalsVisibleToTest Include="Roslyn.Test.Utilities.Desktop" />


### PR DESCRIPTION
The IOperation verification includes running an extra validation walker over our trees for virtually every compilation done in our unit tests. This validation is not suitable for every test, due to the computations needed, and hence is disabled where necessary. 

Previously this ran via a conditional compilation approach. This made testing IOperation a bit awkward. Had to first do a recompile and then run a test. This PR changes the IOperation leg to instead look for an environment variable: `%ROSLYN_TEST_IOPERATION%`. 

I was a bit leery about using an environment variable here. But there really isn't any other supported mechanism for feeding options to tests via xunit. Other tests in our system have decided to use environment variables as well hence this isn't adding a new mechanism, rather unifying our tests. 

This won't yet move the IOperation testing into our normal PR flow. Want to get our Spanish tests stable first before we add another leg into the mix. 

Note: these changes have all already gone through full review. This is just merging features/optest into master.