### PR TITLE
Add -launch flag to the build script

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -29,6 +29,7 @@ param (
     [switch]$packAll = $false,
     [switch]$binaryLog = $false,
     [switch]$deployExtensions = $false,
+    [switch]$launch = $false,
     [switch]$procdump = $false,
     [string]$signType = "",
     [switch]$skipBuildExtras = $false,
@@ -113,6 +114,11 @@ function Process-Arguments() {
 
     if ($testDeterminism -and ($anyUnit -or $anyVsi)) {
         Write-Host "Cannot combine special testing with any other action"
+        exit 1
+    }
+
+    if ($build -and $launch -and -not $deployExtensions) {
+        Write-Host -ForegroundColor Red "Cannot combine -build and -launch without -deployExtensions"
         exit 1
     }
 
@@ -746,6 +752,12 @@ try {
     if ($testDesktop -or $testCoreClr -or $testVsi -or $testVsiNetCore) {
         Test-XUnit
     } 
+
+    if ($launch) {
+        $devenvExe = Get-VisualStudioDir
+        $devenvExe = Join-Path $devenvExe 'Common7\IDE\devenv.exe'
+        &$devenvExe /rootSuffix RoslynDev
+    }
 
     exit 0
 }

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -250,7 +250,7 @@ function Build-Artifacts() {
         Run-MSBuild "Compilers.sln" -useDotnetBuild
     }
     elseif ($build) {
-        Run-MSBuild "Roslyn.sln" "/p:DeployExtension=$deployExtensions"
+        Run-MSBuild "Roslyn.sln" $(if (-not $deployExtensions) {"/p:DeployExtension=false"})
         if (-not $skipBuildExtras) {
             Build-ExtraSignArtifacts
         }


### PR DESCRIPTION
Example usage:

```text
.\build.cmd -release -deployExtensions -launch
```

Also made the `-deployExtensions` flag omit the build property unless false.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
