### PR TITLE
Pass /fullpaths option to compiler to get full paths in diagnostics

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -50,6 +50,7 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <SignAssembly>true</SignAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateFullPaths>true</GenerateFullPaths>
     <!-- The new SDK introduced a GenerateAssemblyInfo target, which is disabled by GenerateAssemblyInfo=false.
          Otherwise, it writes to the same file (GeneratedAssemblyInfoFile) as our GenerateAssemblyInfoFile target.
          Follow-up issue to reconcile the two: https://github.com/dotnet/roslyn/issues/19645 -->


### PR DESCRIPTION
This is an infra change so that diagnostics produced by Roslyn projects include the full path of the source file (rather than relative paths). In some cases, this caused VS to open the wrong file when double-clicking on a diagnostic (because we have multiple files with same name in different projects).

Fixes https://github.com/dotnet/roslyn/issues/26620

Tagging @dotnet/roslyn-infrastructure @jaredpar for review.