### PR TITLE
fix for CLR_EXCEPTION_System.NullReferenceException_80004003_Microsoft.VisualStudio.InteractiveWindow.dll (master)

### DIFF
--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -137,8 +137,8 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
                 _currentWindow = value;
                 _workspace.Window = value;
 
-                _interactiveHost.Output = _currentWindow.OutputWriter;
-                _interactiveHost.ErrorOutput = _currentWindow.ErrorOutputWriter;
+                _interactiveHost.SetOutput( _currentWindow.OutputWriter);
+                _interactiveHost.SetErrorOutput(_currentWindow.ErrorOutputWriter);
 
                 _currentWindow.SubmissionBufferAdded += SubmissionBufferAdded;
                 _interactiveCommands = _commandsFactory.CreateInteractiveCommands(_currentWindow, CommandPrefix, _commands);
@@ -171,8 +171,8 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         public Task<ExecutionResult> InitializeAsync()
         {
             var window = GetCurrentWindowOrThrow();
-            _interactiveHost.Output = window.OutputWriter;
-            _interactiveHost.ErrorOutput = window.ErrorOutputWriter;
+            _interactiveHost.SetOutput(window.OutputWriter);
+            _interactiveHost.SetErrorOutput(window.ErrorOutputWriter);
             return ResetAsyncWorker();
         }
 

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -81,8 +81,8 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                     if (!initializationResult.Success)
                     {
-                        remoteService.Dispose(joinThreads: false);
                         Host.ReportProcessExited(remoteService.Process);
+                        remoteService.Dispose(joinThreads: false);
 
                         return default(InitializedRemoteService);
                     }

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -77,7 +77,11 @@ namespace Microsoft.CodeAnalysis.Interactive
                         }
                     }
 
-                    await (_host?.OnProcessExited(Process)).ConfigureAwait(false);
+                    var host = _host;
+                    if (host != null)
+                    {
+                        await host.OnProcessExited(Process).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception e) when (FatalError.Report(e))
                 {

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -74,9 +74,11 @@ namespace Microsoft.CodeAnalysis.Interactive
                             _processExitHandlerStatus = ProcessExitHandlerStatus.Handled;
                             // Should set _processExitHandlerStatus before calling OnProcessExited to avoid deadlocks.
                             // Calling the host should be within the lock to prevent its disposing during the execution.
-                            await _host.OnProcessExited(Process).ConfigureAwait(false);
+                            _host.ReportProcessExited(Process);
                         }
                     }
+
+                    await _host.TryGetOrCreateRemoteServiceAsync(processPendingOutput: true).ConfigureAwait(false);
                 }
                 catch (Exception e) when (FatalError.Report(e))
                 {

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -74,11 +74,10 @@ namespace Microsoft.CodeAnalysis.Interactive
                             _processExitHandlerStatus = ProcessExitHandlerStatus.Handled;
                             // Should set _processExitHandlerStatus before calling OnProcessExited to avoid deadlocks.
                             // Calling the host should be within the lock to prevent its disposing during the execution.
-                            _host.ReportProcessExited(Process);
                         }
                     }
 
-                    await _host.TryGetOrCreateRemoteServiceAsync(processPendingOutput: true).ConfigureAwait(false);
+                    await (_host?.OnProcessExited(Process)).ConfigureAwait(false);
                 }
                 catch (Exception e) when (FatalError.Report(e))
                 {
@@ -116,6 +115,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 }
             }
 
+            // Dispose may called anytime.
             internal void Dispose(bool joinThreads)
             {
                 // There can be a call from host initiated from OnProcessExit. 

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -117,16 +117,13 @@ namespace Microsoft.CodeAnalysis.Interactive
             internal void Dispose(bool joinThreads)
             {
                 // There can be a call from host initiated from OnProcessExit. 
-                // This check on the beginning helps to avoid a reentrancy.
-                if (_processExitHandlerStatus == ProcessExitHandlerStatus.Hooked)
+                // We should not proceed with disposing if _disposeSemaphore is locked.
+                using (_disposeSemaphore.DisposableWait())
                 {
-                    using (_disposeSemaphore.DisposableWait())
+                    if (_processExitHandlerStatus == ProcessExitHandlerStatus.Hooked)
                     {
-                        if (_processExitHandlerStatus == ProcessExitHandlerStatus.Hooked)
-                        {
-                            Process.Exited -= ProcessExitedHandler;
-                            _processExitHandlerStatus = ProcessExitHandlerStatus.Handled;
-                        }
+                       Process.Exited -= ProcessExitedHandler;
+                       _processExitHandlerStatus = ProcessExitHandlerStatus.Handled;
                     }
                 }
 

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
@@ -300,12 +300,6 @@ namespace Microsoft.CodeAnalysis.Interactive
             return new LazyRemoteService(this, options, Interlocked.Increment(ref _remoteServiceInstanceId), skipInitialization);
         }
 
-        private Task OnProcessExited(Process process)
-        {
-            ReportProcessExited(process);
-            return TryGetOrCreateRemoteServiceAsync(processPendingOutput: true);
-        }
-
         private void ReportProcessExited(Process process)
         {
             int? exitCode;

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -92,8 +92,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
             _synchronizedOutput = new SynchronizedStringWriter();
             _synchronizedErrorOutput = new SynchronizedStringWriter();
             ClearOutput();
-            _host.Output = _synchronizedOutput;
-            _host.ErrorOutput = _synchronizedErrorOutput;
+            _host.SetOutput(_synchronizedOutput);
+            _host.SetErrorOutput(_synchronizedErrorOutput);
         }
 
         private bool LoadReference(string reference)


### PR DESCRIPTION
This is a copy of https://github.com/dotnet/roslyn/pull/26770 but targeting `master` instead of `dev15.7.x`

### Customer scenario

Visual Studio closes or restarts and attempts to close and restart Roslyn which attempts to do the same with Interactive Host. Interactive Host attempts to send a message that it is closing back to Roslyn. However, Roslyn disappears just before. This is a race condition.

### Bugs this fixes
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/514822

### Workarounds, if any
No

### Risk
Low

### Performance impact
None

### Is this a regression from a previous update?
No

### Root cause analysis
We haven't considered all possible timing combinations happening between threads.

### How was the bug found?
Customer reports (Watson)