### PR TITLE
Add TextDocument.GetText[Version]Synchronously

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/InterpolatedStringCompletionSession.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/InterpolatedStringCompletionSession.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
         public static bool IsContext(Document document, int position, CancellationToken cancellationToken)
         {
             // Check to see if we're to the right of an $ or an @$
-            var text = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+            var text = document.GetTextSynchronously(cancellationToken);
 
             var start = position - 1;
             if (start < 0)

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/InterpolationCompletionSession.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/Sessions/InterpolationCompletionSession.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion.Sessions
         {
             // First, check to see if the character to the left of the position is an open curly. If it is,
             // we shouldn't complete because the user may be trying to escape a curly.
-            var text = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+            var text = document.GetTextSynchronously(cancellationToken);
             var index = position - 1;
             var openCurlyCount = 0;
             while (index >= 0)

--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/Extensions.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/Extensions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
         public static Solution UpdateDocument(this Solution solution, DocumentId id, IEnumerable<TextChange> textChanges, CancellationToken cancellationToken = default)
         {
             var oldDocument = solution.GetDocument(id);
-            var newText = oldDocument.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken).WithChanges(textChanges);
+            var newText = oldDocument.GetTextSynchronously(cancellationToken).WithChanges(textChanges);
             return solution.WithDocumentText(id, newText);
         }
 

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
                             if (pathToRenameToken.TryResolve(openRoot, out resolvedRenameToken) &&
                                 resolvedRenameToken.IsToken)
                             {
-                                var snapshot = openDocument.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken).FindCorrespondingEditorTextSnapshot();
+                                var snapshot = openDocument.GetTextSynchronously(cancellationToken).FindCorrespondingEditorTextSnapshot();
                                 if (snapshot != null)
                                 {
                                     _renameService.StartInlineSession(openDocument, resolvedRenameToken.AsToken().Span, cancellationToken);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             // We haven't finished computing the model, but we may need to dismiss.
             // Get the context span and see if we're outside it.
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
             var contextSpan = completionService.GetDefaultCompletionListSpan(text, caretPoint);
             var newCaretPoint = GetCaretPointInViewBuffer();
             return !contextSpan.IntersectsWith(new TextSpan(newCaretPoint, 0));

--- a/src/EditorFeatures/Core/Implementation/Peek/PeekableItemSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Peek/PeekableItemSource.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
                     var document = item.Document;
                     if (navigationService.CanNavigateToPosition(workspace, document.Id, item.SourceSpan.Start))
                     {
-                        var text = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+                        var text = document.GetTextSynchronously(cancellationToken);
                         var linePositionSpan = text.Lines.GetLinePositionSpan(item.SourceSpan);
                         yield return new ExternalFilePeekableItem(
                             new FileLinePositionSpan(document.FilePath, linePositionSpan),

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 var syntaxTreeWithOriginalName = syntaxTree.WithChangedText(newFullText);
                 var documentWithOriginalName = document.WithSyntaxRoot(syntaxTreeWithOriginalName.GetRoot(cancellationToken));
 
-                Contract.Requires(newFullText.ToString() == documentWithOriginalName.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken).ToString());
+                Contract.Requires(newFullText.ToString() == documentWithOriginalName.GetTextSynchronously(cancellationToken).ToString());
 #endif
 
                 // Apply the original name to all linked documents to construct a consistent solution

--- a/src/EditorFeatures/Core/Shared/Extensions/WorkspaceExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/WorkspaceExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
         internal static Solution UpdateDocument(this Solution solution, DocumentId id, IEnumerable<TextChange> textChanges, CancellationToken cancellationToken)
         {
             var oldDocument = solution.GetDocument(id);
-            var oldText = oldDocument.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+            var oldText = oldDocument.GetTextSynchronously(cancellationToken);
             var newText = oldText.WithChanges(textChanges);
             return solution.WithDocumentText(id, newText, PreservationMode.PreserveIdentity);
         }

--- a/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
             }
 
             var document = this.CurrentSolution.GetDocument(documentId);
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
 
             this.OnDocumentOpened(documentId, text.Container);
         }
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
         public override void OpenAdditionalDocument(DocumentId documentId, bool activate = true)
         {
             var document = this.CurrentSolution.GetAdditionalDocument(documentId);
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
 
             this.OnAdditionalDocumentOpened(documentId, text.Container);
         }
@@ -71,8 +71,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
         public override void CloseDocument(DocumentId documentId)
         {
             var document = this.CurrentSolution.GetDocument(documentId);
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
-            var version = document.GetTextVersionAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
+            var version = document.GetTextVersionSynchronously(CancellationToken.None);
 
             this.OnDocumentClosed(documentId, TextLoader.From(TextAndVersion.Create(text, version)));
         }
@@ -80,8 +80,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
         public override void CloseAdditionalDocument(DocumentId documentId)
         {
             var document = this.CurrentSolution.GetAdditionalDocument(documentId);
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
-            var version = document.GetTextVersionAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
+            var version = document.GetTextVersionSynchronously(CancellationToken.None);
 
             this.OnAdditionalDocumentClosed(documentId, TextLoader.From(TextAndVersion.Create(text, version)));
         }

--- a/src/EditorFeatures/VisualBasic/AutomaticCompletion/Sessions/InterpolatedStringCompletionSession.vb
+++ b/src/EditorFeatures/VisualBasic/AutomaticCompletion/Sessions/InterpolatedStringCompletionSession.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion.Sessions
                 Return False
             End If
 
-            Dim text = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken)
+            Dim text = document.GetTextSynchronously(cancellationToken)
 
             Return text(position - 1) = "$"c
         End Function

--- a/src/EditorFeatures/VisualBasic/AutomaticCompletion/Sessions/InterpolationCompletionSession.vb
+++ b/src/EditorFeatures/VisualBasic/AutomaticCompletion/Sessions/InterpolationCompletionSession.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion.Sessions
 
             ' Check to see if the character to the left of the position is an open curly brace. Note that we have to
             ' count braces to ensure that the character isn't actually an escaped brace.
-            Dim text = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken)
+            Dim text = document.GetTextSynchronously(cancellationToken)
             Dim index = position - 1
             Dim openCurlyCount = 0
             For index = index To 0 Step -1

--- a/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
@@ -516,7 +516,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
 
         Private Sub GenerateCodeForItem(document As Document, generateCodeItem As AbstractGenerateCodeItem, textView As ITextView, cancellationToken As CancellationToken)
             ' We'll compute everything up front before we go mutate state
-            Dim text = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken)
+            Dim text = document.GetTextSynchronously(cancellationToken)
             Dim newDocument = generateCodeItem.GetGeneratedDocumentAsync(document, cancellationToken).WaitAndGetResult(cancellationToken)
             Dim generatedTree = newDocument.GetSyntaxRootSynchronously(cancellationToken)
             Dim generatedNode = generatedTree.GetAnnotatedNodes(AbstractGenerateCodeItem.GeneratedSymbolAnnotation).Single().FirstAncestorOrSelf(Of MethodBlockBaseSyntax)

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveDocumentNavigationService.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveDocumentNavigationService.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             var textView = interactiveWorkspace.Window.TextView;
             var document = interactiveWorkspace.CurrentSolution.GetDocument(documentId);
 
-            var textSnapshot = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None).FindCorrespondingEditorTextSnapshot();
+            var textSnapshot = document.GetTextSynchronously(CancellationToken.None).FindCorrespondingEditorTextSnapshot();
             if (textSnapshot == null)
             {
                 return false;

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_TabKeyCommand.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_TabKeyCommand.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
                                                .Single().Span.End;
 
             return document.Project.Solution.WithDocumentText(
-                formattedDocument.Id, formattedDocument.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken));
+                formattedDocument.Id, formattedDocument.GetTextSynchronously(cancellationToken));
         }
 
         private Document AddMethodNameAndAnnotationsToSolution(
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 
             // Next, perform a textual insertion of the event handler method name.
             var textChange = new TextChange(new TextSpan(position, 0), textToInsert);
-            var newText = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken).WithChanges(textChange);
+            var newText = document.GetTextSynchronously(cancellationToken).WithChanges(textChange);
             var documentWithNameAdded = document.WithText(newText);
 
             // Now find the event hookup again to add the appropriate annotations.

--- a/src/VisualStudio/CSharp/Impl/Snippets/SnippetFunctions/SnippetFunctionGenerateSwitchCases.cs
+++ b/src/VisualStudio/CSharp/Impl/Snippets/SnippetFunctions/SnippetFunctionGenerateSwitchCases.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets.SnippetFunctio
             var textChange = new TextChange(new TextSpan(startPosition, endPosition - startPosition), str);
             var typeSpanToAnnotate = new TextSpan(startPosition + "case ".Length, fullyQualifiedTypeName.Length);
 
-            var textWithCaseAdded = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken).WithChanges(textChange);
+            var textWithCaseAdded = document.GetTextSynchronously(cancellationToken).WithChanges(textChange);
             var documentWithCaseAdded = document.WithText(textWithCaseAdded);
 
             var syntaxRoot = documentWithCaseAdded.GetSyntaxRootSynchronously(cancellationToken);

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -285,7 +285,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             var documentOptions = addedDocument.GetOptionsAsync(cancellationToken).WaitAndGetResult(cancellationToken);
 
             var formattedTextChanges = Formatter.GetFormattedTextChanges(rootToFormat, workspace, documentOptions, cancellationToken);
-            var formattedText = addedDocument.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken).WithChanges(formattedTextChanges);
+            var formattedText = addedDocument.GetTextSynchronously(cancellationToken).WithChanges(formattedTextChanges);
 
             // Ensure the line endings are normalized. The formatter doesn't touch everything if it doesn't need to.
             string targetLineEnding = documentOptions.GetOption(FormattingOptions.NewLine);

--- a/src/VisualStudio/Core/Def/Implementation/Extensions/DocumentExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Extensions/DocumentExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Extensions
             var codeBlocks = new List<Tuple<TextSpan, uint>>();
 
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
-            var text = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+            var text = document.GetTextSynchronously(cancellationToken);
 
             int start = 0;
             uint cookie = 0;

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -240,7 +240,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 var document = breakpoint.Document;
                 var filePath = _languageService.Workspace.GetFilePath(document.Id);
-                var text = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+                var text = document.GetTextSynchronously(cancellationToken);
                 var span = text.GetVsTextSpanForSpan(breakpoint.TextSpan);
                 // If we're inside an Venus code nugget, we need to map the span to the surface buffer.
                 // Otherwise, we'll just use the original span.

--- a/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
@@ -49,8 +49,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
             _componentModel = componentModel;
             var bufferFactory = componentModel.GetService<ITextBufferFactoryService>();
             var bufferText = left != null
-                ? left.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None)
-                : right.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+                ? left.GetTextSynchronously(CancellationToken.None)
+                : right.GetTextSynchronously(CancellationToken.None);
             _buffer = bufferFactory.CreateTextBuffer(bufferText.ToString(), bufferFactory.InertContentType);
             _encoding = bufferText.Encoding;
 
@@ -71,8 +71,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                 return GetEntireDocumentAsSpanChange(left);
             }
 
-            var oldText = left.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var newText = right.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+            var oldText = left.GetTextSynchronously(cancellationToken);
+            var newText = right.GetTextSynchronously(cancellationToken);
 
             var diffSelector = _componentModel.GetService<ITextDifferencingSelectorService>();
             var diffService = diffSelector.GetTextDifferencingService(
@@ -237,8 +237,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
             //       current way of just using text differ has its own issue, and using syntax differ in compiler that are for incremental parser
             //       has its own drawbacks.
 
-            var oldText = left.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var newText = right.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+            var oldText = left.GetTextSynchronously(cancellationToken);
+            var newText = right.GetTextSynchronously(cancellationToken);
 
             var oldString = oldText.ToString();
             var newString = newText.ToString();

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -719,7 +719,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (hostDocument != null)
             {
                 var document = this.CurrentSolution.GetDocument(documentId);
-                var text = this.GetTextForced(document);
+                var text = document.GetTextSynchronously(CancellationToken.None);
 
                 var project = hostDocument.Project.Hierarchy as IVsProject3;
 

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/SnippetFunctions/AbstractSnippetFunctionSimpleTypeName.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/SnippetFunctions/AbstractSnippetFunctionSimpleTypeName.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets.Snippe
             updatedTextSpan = new TextSpan(subjectBufferFieldSpan.Start, _fullyQualifiedName.Length);
 
             var textChange = new TextChange(originalTextSpan, _fullyQualifiedName);
-            var newText = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None).WithChanges(textChange);
+            var newText = document.GetTextSynchronously(CancellationToken.None).WithChanges(textChange);
 
             documentWithFullyQualifiedTypeName = document.WithText(newText);
             return true;

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -791,7 +791,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 return;
             }
 
-            var originalText = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var originalText = document.GetTextSynchronously(CancellationToken.None);
             Contract.Requires(object.ReferenceEquals(originalText, snapshot.AsText()));
 
             var root = document.GetSyntaxRootSynchronously(CancellationToken.None);
@@ -845,7 +845,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                     workspace, options, formattingRules, CancellationToken.None);
 
                 visibleSpans.Add(visibleSpan);
-                var newChanges = FilterTextChanges(document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None), visibleSpans, changes.ToReadOnlyCollection()).Where(t => visibleSpan.Contains(t.Span));
+                var newChanges = FilterTextChanges(document.GetTextSynchronously(CancellationToken.None), visibleSpans, changes.ToReadOnlyCollection()).Where(t => visibleSpan.Contains(t.Span));
 
                 foreach (var change in newChanges)
                 {

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguageCodeSupport.cs
@@ -316,7 +316,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 return false;
             }
 
-            if (CodeAnalysis.Workspace.TryGetWorkspace(document.GetTextAsync(cancellationToken).WaitAndGetResult_Venus(cancellationToken).Container, out var workspace))
+            if (CodeAnalysis.Workspace.TryGetWorkspace(document.GetTextSynchronously(cancellationToken).Container, out var workspace))
             {
                 var newName = newFullyQualifiedName.Substring(newFullyQualifiedName.LastIndexOf('.') + 1);
                 var optionSet = document.Project.Solution.Workspace.Options;

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             var document = workspace.CurrentSolution.GetDocument(documentId);
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
 
             var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
             if (boundedTextSpan != textSpan)
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             var document = workspace.CurrentSolution.GetDocument(documentId);
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
             var vsTextSpan = text.GetVsTextSpanForLineOffset(lineNumber, offset);
 
             return CanMapFromSecondaryBufferToPrimaryBuffer(workspace, documentId, vsTextSpan);
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             var document = workspace.CurrentSolution.GetDocument(documentId);
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
 
             var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);
             if (boundedPosition != position)
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return false;
             }
 
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
             var textBuffer = text.Container.GetTextBuffer();
 
             var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return false;
             }
 
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
             var textBuffer = text.Container.GetTextBuffer();
 
             var vsTextSpan = text.GetVsTextSpanForLineOffset(lineNumber, offset);
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return false;
             }
 
-            var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var text = document.GetTextSynchronously(CancellationToken.None);
             var textBuffer = text.Container.GetTextBuffer();
 
             var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     return _noopRule;
                 }
 
-                var textContainer = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None).Container;
+                var textContainer = document.GetTextSynchronously(CancellationToken.None).Container;
                 var buffer = textContainer.TryGetTextBuffer() as IProjectionBuffer;
                 if (buffer == null)
                 {

--- a/src/VisualStudio/Core/Def/Utilities/IVsEditorAdaptersFactoryServiceExtensions.cs
+++ b/src/VisualStudio/Core/Def/Utilities/IVsEditorAdaptersFactoryServiceExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Utilities
                 return null;
             }
 
-            var text = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+            var text = document.GetTextSynchronously(cancellationToken);
             var textSnapshot = text.FindCorrespondingEditorTextSnapshot();
             var textBuffer = textSnapshot?.TextBuffer;
             return editorAdaptersFactoryService.TryGetUndoManager(textBuffer);

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -518,7 +518,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         {
             var lineNumber = point.Line - 1;
             var column = point.LineCharOffset - 1;
-            var line = GetDocument().GetTextAsync(CancellationToken.None).WaitAndGetResult_CodeModel(CancellationToken.None).Lines[lineNumber];
+            var line = GetDocument().GetTextSynchronously(CancellationToken.None).Lines[lineNumber];
             var position = line.Start + column;
 
             return position;

--- a/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetFunctions/SnippetFunctionGenerateSwitchCases.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetFunctions/SnippetFunctionGenerateSwitchCases.vb
@@ -74,7 +74,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets.SnippetFu
             Dim textChange = New TextChange(New TextSpan(startPosition, endPosition - startPosition), str)
             Dim typeSpanToAnnotate = New TextSpan(startPosition + "Case ".Length, fullyQualifiedTypeName.Length)
 
-            Dim textWithCaseAdded = document.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken).WithChanges(textChange)
+            Dim textWithCaseAdded = document.GetTextSynchronously(cancellationToken).WithChanges(textChange)
             Dim documentWithCaseAdded = document.WithText(textWithCaseAdded)
 
             Dim syntaxRoot = documentWithCaseAdded.GetSyntaxRootSynchronously(cancellationToken)

--- a/src/VisualStudio/VisualBasic/Impl/Venus/ContainedLanguageStaticEventBinding.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/ContainedLanguageStaticEventBinding.vb
@@ -69,7 +69,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
                 Return
             End If
 
-            Dim textBuffer = targetDocument.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken).Container.TryGetTextBuffer()
+            Dim textBuffer = targetDocument.GetTextSynchronously(cancellationToken).Container.TryGetTextBuffer()
             If textBuffer Is Nothing Then
                 Using visualStudioWorkspace.OpenInvisibleEditor(targetDocument.Id)
                     targetDocument = visualStudioWorkspace.CurrentSolution.GetDocument(targetDocument.Id)
@@ -98,7 +98,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
                 Return
             End If
 
-            Dim textBuffer = targetDocument.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken).Container.TryGetTextBuffer()
+            Dim textBuffer = targetDocument.GetTextSynchronously(cancellationToken).Container.TryGetTextBuffer()
             If textBuffer Is Nothing Then
                 Using visualStudioWorkspace.OpenInvisibleEditor(targetDocument.Id)
                     targetDocument = visualStudioWorkspace.CurrentSolution.GetDocument(targetDocument.Id)

--- a/src/Workspaces/Core/Portable/Workspace/AdhocWorkspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/AdhocWorkspace.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis
             var doc = this.CurrentSolution.GetDocument(documentId);
             if (doc != null)
             {
-                var text = doc.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+                var text = doc.GetTextSynchronously(CancellationToken.None);
                 this.OnDocumentOpened(documentId, text.Container, activate);
             }
         }
@@ -167,8 +167,8 @@ namespace Microsoft.CodeAnalysis
             var doc = this.CurrentSolution.GetDocument(documentId);
             if (doc != null)
             {
-                var text = doc.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
-                var version = doc.GetTextVersionAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+                var text = doc.GetTextSynchronously(CancellationToken.None);
+                var version = doc.GetTextVersionSynchronously(CancellationToken.None);
                 var loader = TextLoader.From(TextAndVersion.Create(text, version, doc.FilePath));
                 this.OnDocumentClosed(documentId, loader);
             }
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis
             var doc = this.CurrentSolution.GetAdditionalDocument(documentId);
             if (doc != null)
             {
-                var text = doc.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+                var text = doc.GetTextSynchronously(CancellationToken.None);
                 this.OnAdditionalDocumentOpened(documentId, text.Container, activate);
             }
         }
@@ -195,8 +195,8 @@ namespace Microsoft.CodeAnalysis
             var doc = this.CurrentSolution.GetAdditionalDocument(documentId);
             if (doc != null)
             {
-                var text = doc.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
-                var version = doc.GetTextVersionAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+                var text = doc.GetTextSynchronously(CancellationToken.None);
+                var version = doc.GetTextVersionSynchronously(CancellationToken.None);
                 var loader = TextLoader.From(TextAndVersion.Create(text, version, doc.FilePath));
                 this.OnAdditionalDocumentClosed(documentId, loader);
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
@@ -76,11 +76,31 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Fetches the current text for the document synchronously.
+        /// </summary>
+        /// <remarks>This is internal for the same reason <see cref="Document.GetSyntaxTreeSynchronously(CancellationToken)"/> is internal:
+        /// we have specialized cases where we need it, but we worry that making it public will do more harm than good.</remarks>
+        internal SourceText GetTextSynchronously(CancellationToken cancellationToken)
+        {
+            return State.GetTextSynchronously(cancellationToken);
+        }
+
+        /// <summary>
         /// Gets the version of the document's text.
         /// </summary>
         public Task<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken = default)
         {
             return State.GetTextVersionAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Fetches the current version for the document synchronously.
+        /// </summary>
+        /// <remarks>This is internal for the same reason <see cref="Document.GetSyntaxTreeSynchronously(CancellationToken)"/> is internal:
+        /// we have specialized cases where we need it, but we worry that making it public will do more harm than good.</remarks>
+        internal VersionStamp GetTextVersionSynchronously(CancellationToken cancellationToken)
+        {
+            return State.GetTextVersionSynchronously(cancellationToken);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis
             return textAndVersion.Text;
         }
 
-        public VersionStamp GetVersionSynchronously(CancellationToken cancellationToken)
+        public VersionStamp GetTextVersionSynchronously(CancellationToken cancellationToken)
         {
             var textAndVersion = this.textAndVersionSource.GetValue(cancellationToken);
             return textAndVersion.Version;

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis
             internal override TextAndVersion LoadTextAndVersionSynchronously(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
             {
                 var oldText = _oldDocumentState.GetTextSynchronously(cancellationToken);
-                var version = _oldDocumentState.GetVersionSynchronously(cancellationToken);
+                var version = _oldDocumentState.GetTextVersionSynchronously(cancellationToken);
 
                 return GetProperTextAndVersion(oldText, _newText, version, _oldDocumentState.FilePath);
             }
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis
             {
                 var oldSolution = this.CurrentSolution;
                 var oldDocument = oldSolution.GetAdditionalDocument(documentId);
-                var oldText = oldDocument.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+                var oldText = oldDocument.GetTextSynchronously(CancellationToken.None);
 
                 // keep open document text alive by using PreserveIdentity
                 var newText = textContainer.CurrentText;
@@ -539,7 +539,7 @@ namespace Microsoft.CodeAnalysis
                 if (oldText == newText || oldText.ContentEquals(newText))
                 {
                     // if the supplied text is the same as the previous text, then also use same version
-                    var version = oldDocument.GetTextVersionAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+                    var version = oldDocument.GetTextVersionSynchronously(CancellationToken.None);
                     var newTextAndVersion = TextAndVersion.Create(newText, version, oldDocument.FilePath);
                     currentSolution = oldSolution.WithAdditionalDocumentText(documentId, newTextAndVersion, PreservationMode.PreserveIdentity);
                 }

--- a/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var doc = this.CurrentSolution.GetDocument(documentId);
                 if (doc != null)
                 {
-                    var text = doc.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+                    var text = doc.GetTextSynchronously(CancellationToken.None);
                     this.OnDocumentOpened(documentId, text.Container, activate);
                 }
             }
@@ -131,8 +131,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 var doc = this.CurrentSolution.GetDocument(documentId);
                 if (doc != null)
                 {
-                    var text = doc.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
-                    var version = doc.GetTextVersionAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+                    var text = doc.GetTextSynchronously(CancellationToken.None);
+                    var version = doc.GetTextVersionSynchronously(CancellationToken.None);
                     var loader = TextLoader.From(TextAndVersion.Create(text, version, doc.FilePath));
                     this.OnDocumentClosed(documentId, loader);
                 }
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (doc != null)
                 {
                     var text = doc.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
-                    var version = doc.GetTextVersionAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
+                    var version = doc.GetTextVersionSynchronously(CancellationToken.None);
                     var loader = TextLoader.From(TextAndVersion.Create(text, version, doc.FilePath));
                     this.OnAdditionalDocumentClosed(documentId, loader);
                 }


### PR DESCRIPTION
We had lots of places doing GetTextAsync() and then blocking, which is an anti-pattern if we can avoid it. Awhile back we plumbed the ability to get syntax trees synchronusly in certain places, and so we had the plumbing to do this. We just never did it.

I suspect "most cases" this was fine because the GetTextAsync was operating on open files which isn't an issue. But there were a few places that looked suspicious and it's easier to just do a batch refactoring.

**NOTE:** discussion of whether we should make these APIs public is out of scope for this PR. Somebody else is more than welcome to drive that, but I'm not personally doing that in this PR.

<details><summary>Ask Mode template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Noticed we were still doing an anti-pattern in a place where we can easily do a better pattern. Did the mechanical refactoring accordingly.

### Bugs this fixes

No bug, observed during other work.

### Workarounds, if any

None.

### Risk

Very low -- just plumbing something we already have.

### Performance impact

Can potentially help in thread starvation situation.

### Is this a regression from a previous update?

No.

### Root cause analysis

I think we assumed we didn't have to do this when we plumbed the syntax tree synchronous support because most places it was being done on open files. But there are places in the workspace too that wasn't good.

### How was the bug found?

Observed while doing other refactoring.

</details>
