### PR TITLE
Parameter Shadowing Error Fix

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -14516,6 +14516,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Type parameter &apos;{0}&apos; has the same name as the type parameter from outer method &apos;{1}&apos;.
+        /// </summary>
+        internal static string WRN_TypeParameterSameAsOuterMethodTypeParameter {
+            get {
+                return ResourceManager.GetString("WRN_TypeParameterSameAsOuterMethodTypeParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Type parameter &apos;{0}&apos; has the same name as the type parameter from outer type &apos;{1}&apos;.
         /// </summary>
         internal static string WRN_TypeParameterSameAsOuterTypeParameter {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -14525,6 +14525,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Type parameter has the same type as the type parameter from outer method..
+        /// </summary>
+        internal static string WRN_TypeParameterSameAsOuterMethodTypeParameter_Title {
+            get {
+                return ResourceManager.GetString("WRN_TypeParameterSameAsOuterMethodTypeParameter_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Type parameter &apos;{0}&apos; has the same name as the type parameter from outer type &apos;{1}&apos;.
         /// </summary>
         internal static string WRN_TypeParameterSameAsOuterTypeParameter {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1940,11 +1940,14 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="WRN_TypeParameterSameAsOuterTypeParameter" xml:space="preserve">
     <value>Type parameter '{0}' has the same name as the type parameter from outer type '{1}'</value>
   </data>
+  <data name="WRN_TypeParameterSameAsOuterTypeParameter_Title" xml:space="preserve">
+    <value>Type parameter has the same name as the type parameter from outer type</value>
+  </data>
   <data name="WRN_TypeParameterSameAsOuterMethodTypeParameter" xml:space="preserve">
     <value>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</value>
   </data>
-  <data name="WRN_TypeParameterSameAsOuterTypeParameter_Title" xml:space="preserve">
-    <value>Type parameter has the same name as the type parameter from outer type</value>
+  <data name="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title" xml:space="preserve">
+    <value>Type parameter has the same type as the type parameter from outer method.</value>
   </data>
   <data name="ERR_TypeVariableSameAsParent" xml:space="preserve">
     <value>Type parameter '{0}' has the same name as the containing type, or method</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1941,7 +1941,7 @@ If such a class is used as a base class and if the deriving class defines a dest
     <value>Type parameter '{0}' has the same name as the type parameter from outer type '{1}'</value>
   </data>
   <data name="WRN_TypeParameterSameAsParentFunctionParameter" xml:space="preserve">
-    <value>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</value>
+    <value>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</value>
   </data>
   <data name="WRN_TypeParameterSameAsOuterTypeParameter_Title" xml:space="preserve">
     <value>Type parameter has the same name as the type parameter from outer type</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1940,7 +1940,7 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="WRN_TypeParameterSameAsOuterTypeParameter" xml:space="preserve">
     <value>Type parameter '{0}' has the same name as the type parameter from outer type '{1}'</value>
   </data>
-  <data name="WRN_TypeParameterSameAsParentFunctionParameter" xml:space="preserve">
+  <data name="WRN_TypeParameterSameAsOuterMethodTypeParameter" xml:space="preserve">
     <value>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</value>
   </data>
   <data name="WRN_TypeParameterSameAsOuterTypeParameter_Title" xml:space="preserve">

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1940,6 +1940,9 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="WRN_TypeParameterSameAsOuterTypeParameter" xml:space="preserve">
     <value>Type parameter '{0}' has the same name as the type parameter from outer type '{1}'</value>
   </data>
+  <data name="WRN_TypeParameterSameAsParentFunctionParameter" xml:space="preserve">
+    <value>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</value>
+  </data>
   <data name="WRN_TypeParameterSameAsOuterTypeParameter_Title" xml:space="preserve">
     <value>Type parameter has the same name as the type parameter from outer type</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_EscapeCall2 = 8348,
         ERR_EscapeOther = 8349,
         ERR_CallArgMixing = 8350,
-        ERR_MismatchedRefEscapeInTernary = 8351,
+,        ERR_MismatchedRefEscapeInTernary = 8351,
         ERR_EscapeLocal = 8352,
         ERR_EscapeStackAlloc = 8353,
         ERR_RefReturnThis = 8354,
@@ -1577,7 +1577,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExprCannotBeFixed = 8385,
         ERR_InvalidObjectCreation = 8386,
         #endregion diagnostics introduced for C# 7.3,
-        WRN_TypeParameterSameAsParentFunctionParameter = 8387
+        WRN_TypeParameterSameAsParentFunctionParameter = 8387,
         ERR_OutVariableCannotBeByRef = 8388,
     }
     // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_EscapeCall2 = 8348,
         ERR_EscapeOther = 8349,
         ERR_CallArgMixing = 8350,
-,        ERR_MismatchedRefEscapeInTernary = 8351,
+        ERR_MismatchedRefEscapeInTernary = 8351,
         ERR_EscapeLocal = 8352,
         ERR_EscapeStackAlloc = 8353,
         ERR_RefReturnThis = 8354,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1576,7 +1576,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExprCannotBeFixed = 8385,
         ERR_InvalidObjectCreation = 8386,
         #endregion diagnostics introduced for C# 7.3
-        WRN_TypeParameterSameAsParentFunctionParameter = 8387,
+        WRN_TypeParameterSameAsOuterMethodTypeParameter = 8387,
         ERR_OutVariableCannotBeByRef = 8388,
     }
     // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1576,7 +1576,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_TupleSizesMismatchForBinOps = 8384,
         ERR_ExprCannotBeFixed = 8385,
         ERR_InvalidObjectCreation = 8386,
-        #endregion diagnostics introduced for C# 7.3
+        #endregion diagnostics introduced for C# 7.3,
+        WRN_TypeParameterSameAsParentFunctionParameter = 8387
     }
     // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1527,7 +1527,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_RefStructInterfaceImpl = 8343,
         ERR_BadSpecialByRefIterator = 8344,
         ERR_FieldAutoPropCantBeByRefLike = 8345,
-
         ERR_StackAllocConversionNotPossible = 8346,
 
         ERR_EscapeCall = 8347,
@@ -1576,7 +1575,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_TupleSizesMismatchForBinOps = 8384,
         ERR_ExprCannotBeFixed = 8385,
         ERR_InvalidObjectCreation = 8386,
-        #endregion diagnostics introduced for C# 7.3,
+        #endregion diagnostics introduced for C# 7.3
         WRN_TypeParameterSameAsParentFunctionParameter = 8387,
         ERR_OutVariableCannotBeByRef = 8388,
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -174,6 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_IncorrectBooleanAssg:
                 case ErrorCode.WRN_BitwiseOrSignExtend:
                 case ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter:
+                case ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter:
                 case ErrorCode.WRN_InvalidAssemblyName:
                 case ErrorCode.WRN_UnifyReferenceBldRev:
                 case ErrorCode.WRN_AssignmentToSelf:

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -174,7 +174,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_IncorrectBooleanAssg:
                 case ErrorCode.WRN_BitwiseOrSignExtend:
                 case ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter:
-                case ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter:
                 case ErrorCode.WRN_InvalidAssemblyName:
                 case ErrorCode.WRN_UnifyReferenceBldRev:
                 case ErrorCode.WRN_AssignmentToSelf:
@@ -324,6 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_Experimental:
                 case ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable:
                 case ErrorCode.WRN_TupleBinopLiteralNameMismatch:
+                case ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -179,6 +179,7 @@
                 case ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch:
                 case ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable:
                 case ErrorCode.WRN_TupleBinopLiteralNameMismatch:
+                case ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (tpEnclosing.ContainingSymbol.Kind == SymbolKind.Method)
                     {
                         // Type parameter '{0}' has the same name as the type parameter from outer method '{1}'
-                        typeError = ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter;
+                        typeError = ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter;
                     }
                     else
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     ErrorCode typeError;
                     if (tpEnclosing.ContainingSymbol.Kind == SymbolKind.Method)
                     {
-                        // Type parameter '{0}' has the same name as the type parameter from parent function '{1}'
+                        // Type parameter '{0}' has the same name as the type parameter from outer method '{1}'
                         typeError = ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter;
                     }
                     else

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -407,7 +407,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         // Type parameter '{0}' has the same name as the type parameter from parent function '{1}'
                         typeError = ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter;
-                    } else
+                    }
+                    else
                     {
                         Debug.Assert(tpEnclosing.ContainingSymbol.Kind == SymbolKind.NamedType);
                         // Type parameter '{0}' has the same name as the type parameter from outer type '{1}'

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -402,8 +402,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var tpEnclosing = ContainingSymbol.FindEnclosingTypeParameter(name);
                 if ((object)tpEnclosing != null)
                 {
-                    // Type parameter '{0}' has the same name as the type parameter from outer type '{1}'
-                    diagnostics.Add(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, location, name, tpEnclosing.ContainingSymbol);
+                    ErrorCode typeError;
+                    if (tpEnclosing.ContainingSymbol.Kind == SymbolKind.Method)
+                    {
+                        // Type parameter '{0}' has the same name as the type parameter from parent function '{1}'
+                        typeError = ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter;
+                    } else
+                    {
+                        Debug.Assert(tpEnclosing.ContainingSymbol.Kind == SymbolKind.NamedType);
+                        // Type parameter '{0}' has the same name as the type parameter from outer type '{1}'
+                        typeError = ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter;
+                    }
+                    diagnostics.Add(typeError, location, name, tpEnclosing.ContainingSymbol);
                 }
 
                 var typeParameter = new SourceMethodTypeParameterSymbol(

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Znaky {0} se na tomto místě nedají použít.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Znaky {0} se na tomto místě nedají použít.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Zeichen "{0}" können an dieser Stelle nicht verwendet werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Zeichen "{0}" können an dieser Stelle nicht verwendet werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">El/los carácter/caracteres '{0}' no se puede/n usar en esta ubicación.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">El/los carácter/caracteres '{0}' no se puede/n usar en esta ubicación.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Impossible d'utiliser le(s) caractère(s) '{0}' à cet emplacement.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Impossible d'utiliser le(s) caractère(s) '{0}' à cet emplacement.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Non è possibile usare il carattere o i caratteri '{0}' in questa posizione.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Non è possibile usare il carattere o i caratteri '{0}' in questa posizione.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">文字 '{0}' はこの位置では使用できません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">文字 '{0}' はこの位置では使用できません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">{0}' 문자를 이 위치에 사용할 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">{0}' 문자를 이 위치에 사용할 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Znaków „{0}” nie można użyć w tej lokalizacji.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">Znaków „{0}” nie można użyć w tej lokalizacji.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">O(s) caractere(s) "{0}" não pode(m) ser usado(s) neste local.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">O(s) caractere(s) "{0}" não pode(m) ser usado(s) neste local.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">В этом месте нельзя использовать символы "{0}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">В этом месте нельзя использовать символы "{0}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">{0}' karakterleri bu konumda kullanılamaz.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">{0}' karakterleri bu konumda kullanılamaz.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">此位置无法使用字符“{0}”。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">此位置无法使用字符“{0}”。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -387,7 +387,7 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">
         <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -382,6 +382,11 @@
         <target state="new">SyntaxTree is not part of the compilation, so it cannot be removed</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
+        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">此位置不可使用字元 '{0}'。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -392,6 +392,11 @@
         <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter_Title">
+        <source>Type parameter has the same type as the type parameter from outer method.</source>
+        <target state="new">Type parameter has the same type as the type parameter from outer method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XML_InvalidToken">
         <source>The character(s) '{0}' cannot be used at this location.</source>
         <target state="translated">此位置不可使用字元 '{0}'。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsParentFunctionParameter">
-        <source>Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</source>
-        <target state="new">Type parameter '{0}' has the same name as the type parameter from parent function '{1}'</target>
+        <source>Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</source>
+        <target state="new">Type parameter '{0}' has the same name as the type parameter from outer method '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="XML_InvalidToken">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -1066,10 +1066,10 @@ class C
                 Diagnostic(ErrorCode.ERR_DuplicateTypeParameter, "T").WithArguments("T").WithLocation(18, 26),
                 // (25,23): warning CS8387: Type parameter 'T' has the same name as the type parameter from outer method 'C.M2<T>()'
                 //             int Local<T>() => 0;
-                Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(25, 23),
+                Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(25, 23),
                 // (31,28): warning CS8387: Type parameter 'V' has the same name as the type parameter from outer method 'Local1<V>()'
                 //                 int Local2<V>() => 0;
-                Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "V").WithArguments("V", "Local1<V>()").WithLocation(31, 28),
+                Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter, "V").WithArguments("V", "Local1<V>()").WithLocation(31, 28),
                 // (37,17): error CS0412: 'T': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //             int T() => 0;
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "T").WithArguments("T").WithLocation(37, 17),
@@ -1081,7 +1081,7 @@ class C
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "T").WithArguments("T").WithLocation(54, 25),
                 // (67,32): warning CS8387: Type parameter 'T' has the same name as the type parameter from outer method 'C.M2<T>()'
                 //                     int Local3<T>() => 0;
-                Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(67, 32));
+                Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(67, 32));
         }
 
         [Fact]
@@ -1805,7 +1805,7 @@ class Program
             VerifyDiagnostics(source,
     // (8,21): warning CS8387: Type parameter 'T' has the same name as the type parameter from outer method 'Outer<T>()'
     //             T Inner<T>()
-    Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "T").WithArguments("T", "Outer<T>()").WithLocation(8, 21)
+    Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter, "T").WithArguments("T", "Outer<T>()").WithLocation(8, 21)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -1064,12 +1064,12 @@ class C
                 // (18,26): error CS0692: Duplicate type parameter 'T'
                 //             int Local<T, T>() => 0;
                 Diagnostic(ErrorCode.ERR_DuplicateTypeParameter, "T").WithArguments("T").WithLocation(18, 26),
-                // (25,23): warning CS0693: Type parameter 'T' has the same name as the type parameter from outer type 'C.M2<T>()'
+                // (25,23): warning CS8387: Type parameter 'T' has the same name as the type parameter from parent function 'C.M2<T>()'
                 //             int Local<T>() => 0;
-                Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(25, 23),
-                // (31,28): warning CS0693: Type parameter 'V' has the same name as the type parameter from outer type 'Local1<V>()'
+                Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(25, 23),
+                // (31,28): warning CS8387: Type parameter 'V' has the same name as the type parameter from parent function 'Local1<V>()'
                 //                 int Local2<V>() => 0;
-                Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, "V").WithArguments("V", "Local1<V>()").WithLocation(31, 28),
+                Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "V").WithArguments("V", "Local1<V>()").WithLocation(31, 28),
                 // (37,17): error CS0412: 'T': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //             int T() => 0;
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "T").WithArguments("T").WithLocation(37, 17),
@@ -1079,9 +1079,9 @@ class C
                 // (54,25): error CS0412: 'T': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                     int T() => 0;
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "T").WithArguments("T").WithLocation(54, 25),
-                // (67,32): warning CS0693: Type parameter 'T' has the same name as the type parameter from outer type 'C.M2<T>()'
+                // (67,32): warning CS8387: Type parameter 'T' has the same name as the type parameter from parent function 'C.M2<T>()'
                 //                     int Local3<T>() => 0;
-                Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(67, 32));
+                Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(67, 32));
         }
 
         [Fact]
@@ -1803,9 +1803,9 @@ class Program
 }
 ";
             VerifyDiagnostics(source,
-    // (8,21): warning CS0693: Type parameter 'T' has the same name as the type parameter from outer type 'Outer<T>()'
+    // (8,21): warning CS8387: Type parameter 'T' has the same name as the type parameter from parent function 'Outer<T>()'
     //             T Inner<T>()
-    Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, "T").WithArguments("T", "Outer<T>()").WithLocation(8, 21)
+    Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "T").WithArguments("T", "Outer<T>()").WithLocation(8, 21)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -1064,10 +1064,10 @@ class C
                 // (18,26): error CS0692: Duplicate type parameter 'T'
                 //             int Local<T, T>() => 0;
                 Diagnostic(ErrorCode.ERR_DuplicateTypeParameter, "T").WithArguments("T").WithLocation(18, 26),
-                // (25,23): warning CS8387: Type parameter 'T' has the same name as the type parameter from parent function 'C.M2<T>()'
+                // (25,23): warning CS8387: Type parameter 'T' has the same name as the type parameter from outer method 'C.M2<T>()'
                 //             int Local<T>() => 0;
                 Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(25, 23),
-                // (31,28): warning CS8387: Type parameter 'V' has the same name as the type parameter from parent function 'Local1<V>()'
+                // (31,28): warning CS8387: Type parameter 'V' has the same name as the type parameter from outer method 'Local1<V>()'
                 //                 int Local2<V>() => 0;
                 Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "V").WithArguments("V", "Local1<V>()").WithLocation(31, 28),
                 // (37,17): error CS0412: 'T': a parameter, local variable, or local function cannot have the same name as a method type parameter
@@ -1079,7 +1079,7 @@ class C
                 // (54,25): error CS0412: 'T': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                     int T() => 0;
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "T").WithArguments("T").WithLocation(54, 25),
-                // (67,32): warning CS8387: Type parameter 'T' has the same name as the type parameter from parent function 'C.M2<T>()'
+                // (67,32): warning CS8387: Type parameter 'T' has the same name as the type parameter from outer method 'C.M2<T>()'
                 //                     int Local3<T>() => 0;
                 Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(67, 32));
         }
@@ -1803,7 +1803,7 @@ class Program
 }
 ";
             VerifyDiagnostics(source,
-    // (8,21): warning CS8387: Type parameter 'T' has the same name as the type parameter from parent function 'Outer<T>()'
+    // (8,21): warning CS8387: Type parameter 'T' has the same name as the type parameter from outer method 'Outer<T>()'
     //             T Inner<T>()
     Diagnostic(ErrorCode.WRN_TypeParameterSameAsParentFunctionParameter, "T").WithArguments("T", "Outer<T>()").WithLocation(8, 21)
     );

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -244,6 +244,7 @@ class X
                         case ErrorCode.WRN_Experimental:
                         case ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable:
                         case ErrorCode.WRN_TupleBinopLiteralNameMismatch:
+                        case ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:


### PR DESCRIPTION
### Customer scenario
When a type parameter is shadowed from a method with an identically named local function, the original error message addressed an outer type that may not be a type at all, rather a method or local function. An additional error message was created to more specifically handle this case, while maintaining the previous message for when the outer structure is a NamedType.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/14922

### Workarounds, if any

None, diagnostic fix.

### Risk

Negligible.

### Performance impact

Extremely low.

### Is this a regression from a previous update?

No.

### Root cause analysis

The error message had no type check on the outer structure.  Tests where the outer structure was a named type have been maintained while tests deriving from a method were updated to reflect the new message. 

### How was the bug found?

Overlooked in previous build due to technical debt.
