### PR TITLE
First Draft towards Razor FAR Support

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Windows;
 using System.Windows.Documents;
@@ -89,6 +90,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                     return _sourceText.Lines.GetLinePosition(SourceSpan.Start);
                 }
 
+                Debug.Assert(result[0].Document == _documentSpan.Document);
                 return result[0].LinePositionSpan.Start;
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/DocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/DocumentSpanEntry.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
                 var classifiedSpans = _classifiedSpansAndHighlights.ClassifiedSpans;
                 var classifiedTexts = classifiedSpans.SelectAsArray(
-                    cs => new ClassifiedText(cs.ClassificationType, _sourceText.ToString(cs.TextSpan)));
+                    cs => new ClassifiedText(cs.ClassificationType, OriginalSourceText.ToString(cs.TextSpan)));
 
                 var inlines = classifiedTexts.ToInlines(
                     Presenter.ClassificationFormatMap,
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 var contentType = contentTypeService.GetDefaultContentType();
 
                 var textBuffer = Presenter.TextBufferFactoryService.CreateTextBuffer(
-                    _sourceText.ToString(), contentType);
+                    SourceText.ToString(), contentType);
 
                 // Create an appropriate highlight span on that buffer for the reference.
                 var key = _spanKind == DocumentHighlighting.HighlightSpanKind.Definition
@@ -178,13 +178,13 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 const int AdditionalLineCountPerSide = 3;
 
                 var referenceSpan = this.SourceSpan;
-                var lineNumber = _sourceText.Lines.GetLineFromPosition(referenceSpan.Start).LineNumber;
+                var lineNumber = SourceText.Lines.GetLineFromPosition(referenceSpan.Start).LineNumber;
                 var firstLineNumber = Math.Max(0, lineNumber - AdditionalLineCountPerSide);
-                var lastLineNumber = Math.Min(_sourceText.Lines.Count - 1, lineNumber + AdditionalLineCountPerSide);
+                var lastLineNumber = Math.Min(SourceText.Lines.Count - 1, lineNumber + AdditionalLineCountPerSide);
 
                 return Span.FromBounds(
-                    _sourceText.Lines[firstLineNumber].Start,
-                    _sourceText.Lines[lastLineNumber].End);
+                    SourceText.Lines[firstLineNumber].Start,
+                    SourceText.Lines[lastLineNumber].End);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsContainedLanguageFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsContainedLanguageFactory.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.Experiment;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -68,6 +69,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         public int GetLanguage(IVsHierarchy hierarchy, uint itemid, IVsTextBufferCoordinator bufferCoordinator, out IVsContainedLanguage language)
         {
+            return GetLanguage(hierarchy, itemid, bufferCoordinator, serviceFactory: null, out language);
+        }
+
+        public int GetLanguage(IVsHierarchy hierarchy, uint itemid, IVsTextBufferCoordinator bufferCoordinator, IDocumentServiceFactory serviceFactory, out IVsContainedLanguage language)
+        {
             var project = FindMatchingProject(hierarchy, itemid);
             if (project == null)
             {
@@ -75,7 +81,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 return VSConstants.E_INVALIDARG;
             }
 
-            language = CreateContainedLanguage(bufferCoordinator, project, hierarchy, itemid);
+            language = CreateContainedLanguage(bufferCoordinator, serviceFactory, project, hierarchy, itemid);
 
             return VSConstants.S_OK;
         }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Implementation.Structure;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
+using Microsoft.CodeAnalysis.Experiment;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
@@ -387,12 +388,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         }
 
         protected virtual IVsContainedLanguage CreateContainedLanguage(
-            IVsTextBufferCoordinator bufferCoordinator, AbstractProject project,
-            IVsHierarchy hierarchy, uint itemid)
+            IVsTextBufferCoordinator bufferCoordinator, IDocumentServiceFactory documentServiceFactory,
+            AbstractProject project, IVsHierarchy hierarchy, uint itemid)
         {
             return new ContainedLanguage<TPackage, TLanguageService>(
                 bufferCoordinator, this.Package.ComponentModel, project, hierarchy, itemid,
-                (TLanguageService)this, SourceCodeKind.Regular);
+                (TLanguageService)this, SourceCodeKind.Regular, documentServiceFactory);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -986,7 +986,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 canUseTextBuffer: CanUseTextBuffer,
                 updatedOnDiskHandler: s_documentUpdatedEventHandler,
                 openedHandler: s_documentOpenedEventHandler,
-                closingHandler: s_documentClosingEventHandler);
+                closingHandler: s_documentClosingEventHandler,
+                documentServiceFactory: documentServiceFactory);
 
             if (document == null)
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Experiment;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
@@ -959,7 +960,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             string filename,
             SourceCodeKind sourceCodeKind,
             Func<IVisualStudioHostDocument, bool> getIsCurrentContext,
-            Func<uint, IReadOnlyList<string>> getFolderNames)
+            Func<uint, IReadOnlyList<string>> getFolderNames,
+            IDocumentServiceFactory documentServiceFactory)
         {
             AssertIsForeground();
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Experiment;
 
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
 {
@@ -30,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         void RemoveAnalyzerReference(string referencePath);
 
         // Files.
-        void AddSourceFile(string filePath, bool isInCurrentContext = true, IEnumerable<string> folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular);
+        void AddSourceFile(string filePath, bool isInCurrentContext = true, IEnumerable<string> folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, IDocumentServiceFactory documentServiceFactory = null);
         void RemoveSourceFile(string filePath);
         void AddAdditionalFile(string filePath, bool isInCurrentContext = true);
         void RemoveAdditionalFile(string filePath);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Experiment;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
 {
@@ -32,6 +33,8 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
 
         // Files.
         void AddSourceFile(string filePath, bool isInCurrentContext = true, IEnumerable<string> folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, IDocumentServiceFactory documentServiceFactory = null);
+        void AddSourceFile(string filePath, SourceTextContainer container, bool isInCurrentContext = true, IEnumerable<string> folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, IDocumentServiceFactory documentServiceFactory = null);
+
         void RemoveSourceFile(string filePath);
         void AddAdditionalFile(string filePath, bool isInCurrentContext = true);
         void RemoveAdditionalFile(string filePath);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Undo;
+using Microsoft.CodeAnalysis.Experiment;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
@@ -19,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     internal partial class DocumentProvider
     {
         [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-        private class StandardTextDocument : ForegroundThreadAffinitizedObject, IVisualStudioHostDocument
+        internal class StandardTextDocument : ForegroundThreadAffinitizedObject, IVisualStudioHostDocument
         {
             /// <summary>
             /// The IDocumentProvider that created us.
@@ -142,6 +143,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     return _doNotAccessDirectlyLoader;
                 }
             }
+
+            public IDocumentServiceFactory DocumentServiceFactory => null;
 
             public DocumentInfo GetInitialState()
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Experiment;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
@@ -106,6 +107,30 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 closingHandler);
         }
 
+        public IVisualStudioHostDocument TryGetDocumentForFile(
+            AbstractProject hostProject,
+            string filePath,
+            SourceCodeKind sourceCodeKind,
+            Func<ITextBuffer, bool> canUseTextBuffer,
+            Func<uint, IReadOnlyList<string>> getFolderNames,
+            EventHandler updatedOnDiskHandler = null,
+            EventHandler<bool> openedHandler = null,
+            EventHandler<bool> closingHandler = null,
+            IDocumentServiceFactory documentServiceFactory = null)
+        {
+            return TryGetDocumentForFile(
+                hostProject,
+                filePath,
+                sourceTextContainer: null,
+                sourceCodeKind,
+                canUseTextBuffer,
+                getFolderNames,
+                updatedOnDiskHandler,
+                openedHandler,
+                closingHandler,
+                documentServiceFactory);
+        }
+
         /// <summary>
         /// Gets the <see cref="IVisualStudioHostDocument"/> for the file at the given filePath.
         /// If we are on the foreground thread and this document is already open in the editor,
@@ -116,10 +141,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         public IVisualStudioHostDocument TryGetDocumentForFile(
             AbstractProject hostProject,
             string filePath,
+            SourceTextContainer sourceTextContainer,
             SourceCodeKind sourceCodeKind,
             Func<ITextBuffer, bool> canUseTextBuffer,
             Func<uint, IReadOnlyList<string>> getFolderNames,
-            EventHandler updatedOnDiskHandler = null,
+            EventHandler updatedHandler = null,
             EventHandler<bool> openedHandler = null,
             EventHandler<bool> closingHandler = null,
             IDocumentServiceFactory documentServiceFactory = null)
@@ -190,7 +216,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         _fileChangeService,
                         openTextBuffer,
                         id,
-                        updatedOnDiskHandler,
+                        updatedHandler,
                         openedHandler,
                         closingHandler);
                 }
@@ -208,10 +234,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         hostProject,
                         documentKey,
                         getFolderNames,
+                        sourceTextContainer,
                         sourceCodeKind,
-                        _fileChangeService,
                         id,
-                        updatedOnDiskHandler,
+                        updatedHandler,
                         documentServiceFactory);
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
@@ -8,8 +8,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Experiment;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;
@@ -43,7 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// <summary>
         /// The core data structure of this entire class.
         /// </summary>
-        private readonly Dictionary<DocumentKey, StandardTextDocument> _documentMap = new Dictionary<DocumentKey, StandardTextDocument>();
+        private readonly Dictionary<DocumentKey, IVisualStudioHostDocument> _documentMap = new Dictionary<DocumentKey, IVisualStudioHostDocument>();
         private readonly Dictionary<uint, List<DocumentKey>> _docCookiesToOpenDocumentKeys = new Dictionary<uint, List<DocumentKey>>();
         private readonly Dictionary<uint, ITextBuffer> _docCookiesToNonRoslynDocumentBuffers = new Dictionary<uint, ITextBuffer>();
         private readonly Dictionary<string, DocumentId> _documentIdHints = new Dictionary<string, DocumentId>(StringComparer.OrdinalIgnoreCase);
@@ -119,10 +121,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             Func<uint, IReadOnlyList<string>> getFolderNames,
             EventHandler updatedOnDiskHandler = null,
             EventHandler<bool> openedHandler = null,
-            EventHandler<bool> closingHandler = null)
+            EventHandler<bool> closingHandler = null,
+            IDocumentServiceFactory documentServiceFactory = null)
         {
             var documentKey = new DocumentKey(hostProject, filePath);
-            StandardTextDocument document;
+            IVisualStudioHostDocument document;
 
             lock (_gate)
             {
@@ -176,18 +179,41 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // already have a document ID that we should be using here.
                 _documentIdHints.TryGetValue(filePath, out var id);
 
-                document = new StandardTextDocument(
-                    this,
-                    hostProject,
-                    documentKey,
-                    getFolderNames,
-                    sourceCodeKind,
-                    _fileChangeService,
-                    openTextBuffer,
-                    id,
-                    updatedOnDiskHandler,
-                    openedHandler,
-                    closingHandler);
+                if (documentServiceFactory == null)
+                {
+                    document = new StandardTextDocument(
+                        this,
+                        hostProject,
+                        documentKey,
+                        getFolderNames,
+                        sourceCodeKind,
+                        _fileChangeService,
+                        openTextBuffer,
+                        id,
+                        updatedOnDiskHandler,
+                        openedHandler,
+                        closingHandler);
+                }
+                else
+                {
+                    // documentServiceFactory probably should be just an general abstraction that standardTextDocument accepts
+                    // along the line, we probabl merge ContainedDocument (open file for razor/venus) and SimplexContainedDocument (closed file for razor/venus) 
+                    // and StandardTextDocument and behavior difference is centralized in the abstraction (DocumentServiceFactory) not the concrete type
+                    // (changing architecture to Strategy pattern from (kind of) abstract factory pattern we use now)
+                    //
+                    // but again, for now, to not touch other parts and needs to think about its impliciation. I simply do bad and simpler thing here. which
+                    // is just add branch :)
+                    document = new SimpleContainedDocument(
+                        this,
+                        hostProject,
+                        documentKey,
+                        getFolderNames,
+                        sourceCodeKind,
+                        _fileChangeService,
+                        id,
+                        updatedOnDiskHandler,
+                        documentServiceFactory);
+                }
 
                 // Add this to our document map
                 _documentMap.Add(documentKey, document);
@@ -233,9 +259,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private void NewBufferOpened_NoLock(uint docCookie, ITextBuffer textBuffer, DocumentKey documentKey, bool isCurrentContext)
         {
-            if (_documentMap.TryGetValue(documentKey, out var document))
+            if (_documentMap.TryGetValue(documentKey, out var document) && document is StandardTextDocument openDocument)
             {
-                document.ProcessOpen(textBuffer, isCurrentContext);
+                openDocument.ProcessOpen(textBuffer, isCurrentContext);
                 AddCookieOpenDocumentPair_NoLock(docCookie, documentKey);
             }
         }
@@ -523,7 +549,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             foreach (var documentKey in documentsToClose)
             {
                 var document = _documentMap[documentKey];
-                document.ProcessClose(updateActiveContext);
+
+                ((StandardTextDocument)document).ProcessClose(updateActiveContext);
                 Contract.ThrowIfFalse(documentKeys.Remove(documentKey));
             }
 
@@ -629,7 +656,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // so clone the list so we can mutate while enumerating
                 documents = documentKeys
                     .Where(key => StringComparer.OrdinalIgnoreCase.Equals(key.Moniker, oldMoniker))
-                    .Select(key => _documentMap[key])
+                    .Select(key => _documentMap[key]).Cast<StandardTextDocument>()
                     .ToList();
             }
 
@@ -646,7 +673,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// Called by a VisualStudioDocument when that document is disposed.
         /// </summary>
         /// <param name="document">The document to stop tracking.</param>
-        private void StopTrackingDocument(StandardTextDocument document)
+        internal void StopTrackingDocument(IVisualStudioHostDocument document)
         {
             CancelPendingDocumentInitializationTask(document);
 
@@ -660,7 +687,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        private void StopTrackingDocument_Core(StandardTextDocument document)
+        private void StopTrackingDocument_Core(IVisualStudioHostDocument document)
         {
             AssertIsForeground();
 
@@ -670,7 +697,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        private void StopTrackingDocument_Core_NoLock(StandardTextDocument document)
+        private void StopTrackingDocument_Core_NoLock(IVisualStudioHostDocument document)
         {
             if (document.IsOpen)
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostDocument.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Experiment;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
@@ -54,6 +55,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// A loader that can access the current stored text of the document.
         /// </summary>
         TextLoader Loader { get; }
+
+        IDocumentServiceFactory DocumentServiceFactory { get; }
 
         /// <summary>
         /// Returns true if the document is currently open in an editor.

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
         protected void AddFile(string filename, SourceCodeKind sourceCodeKind)
         {
             bool getIsCurrentContext(IVisualStudioHostDocument document) => LinkedFileUtilities.IsCurrentContextHierarchy(document, RunningDocumentTable);
-            AddFile(filename, sourceCodeKind, getIsCurrentContext, GetFolderNamesFromHierarchy);
+            AddFile(filename, sourceCodeKind, getIsCurrentContext, GetFolderNamesFromHierarchy, documentServiceFactory: null);
         }
 
         protected void SetOutputPathAndRelatedData(string objOutputPath)

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
@@ -3,6 +3,7 @@
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Experiment;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
@@ -44,6 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             uint itemid,
             TLanguageService languageService,
             SourceCodeKind sourceCodeKind,
+            IDocumentServiceFactory documentServiceFactory,
             IFormattingRule vbHelperFormattingRule = null)
             : base(project)
         {
@@ -69,7 +71,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             SetDataBuffer(dataBuffer);
 
             this.ContainedDocument = new ContainedDocument(
-                this, sourceCodeKind, this.Workspace, hierarchy, itemid, componentModel, vbHelperFormattingRule);
+                this, sourceCodeKind, this.Workspace, hierarchy, itemid, componentModel,
+                documentServiceFactory, vbHelperFormattingRule);
 
             // TODO: Can contained documents be linked or shared?
             this.Project.AddDocument(this.ContainedDocument, isCurrentContext: true, hookupHandlers: true);

--- a/src/VisualStudio/Core/Def/Implementation/Venus/DefaultDocumentServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/DefaultDocumentServiceFactory.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Experiment;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Extensions;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServices.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
+{
+    internal sealed partial class ContainedDocument
+    {
+        internal class DefaultDocumentServiceFactory : IDocumentServiceFactory
+        {
+            private readonly SpanMapper _mapper;
+
+            public DefaultDocumentServiceFactory(ContainedDocument owner)
+            {
+                _mapper = new SpanMapper(owner);
+            }
+
+            public TService GetService<TService>()
+            {
+                if (_mapper is TService service)
+                {
+                    return service;
+                }
+
+                return default;
+            }
+
+            private class SpanMapper : ISpanMapper
+            {
+                private ContainedDocument owner;
+
+                public SpanMapper(ContainedDocument owner)
+                {
+                    this.owner = owner;
+                }
+
+                public async Task<ImmutableArray<SpanMapResult>> MapSpansAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
+                {
+                    var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                    // first find ITextSnapshot. we don't actually use this. 
+                    // but just as an example how to get editorsnapshot
+                    var snapshot = sourceText.FindCorrespondingEditorTextSnapshot();
+                    if (snapshot == null)
+                    {
+                        return spans.Select(s => new SpanMapResult(document, sourceText.Lines.GetLinePositionSpan(s))).ToImmutableArray();
+                    }
+
+                    var builder = ArrayBuilder<SpanMapResult>.GetInstance();
+
+                    var linePositionSpan = default(LinePositionSpan);
+                    foreach (var span in spans)
+                    {
+                        var vsSpan = sourceText.GetVsTextSpanForSpan(span);
+
+                        // If we're inside an Venus code nugget, we need to map the span to the surface buffer.
+                        // Otherwise, we'll just use the original span.
+                        //
+                        // this is slightly wrong since we should actually do mapping from snapshot not current buffer.
+                        // but buffer cordinator we use doesn't support that.
+                        //
+                        // to be correct, this should use IProjectionSnapshot.MapToSourceSnapshot
+                        // http://index/?query=MapSecondaryToPrimarySpan&rightProject=Microsoft.VisualStudio.Text.Data&file=Model%5CProjection%5CIProjectionSnapshot.cs&line=138
+                        //
+                        // but that require a bit more plumbing so, using short cut :)
+                        if (vsSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(document.Project.Solution.Workspace, document.Id, out var mappedSpan))
+                        {
+                            linePositionSpan = mappedSpan.ToLinePositionSpan();
+                        }
+                        else
+                        {
+                            linePositionSpan = sourceText.Lines.GetLinePositionSpan(span);
+                        }
+
+                        builder.Add(new SpanMapResult(document, linePositionSpan));
+                    }
+
+                    return builder.ToImmutableAndFree();
+                }
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Venus/SimpleContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/SimpleContainedDocument.cs
@@ -52,6 +52,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             Contract.ThrowIfNull(documentProvider);
 
             this.Project = project;
+
+            this.Key = documentKey;
+            this.SourceCodeKind = sourceCodeKind;
+
             this.Id = id ?? DocumentId.CreateNewId(project.Id, documentKey.Moniker);
 
             var itemid = this.GetItemId();
@@ -60,9 +64,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 : getFolderNames(itemid);
 
             _documentProvider = documentProvider;
-
-            this.Key = documentKey;
-            this.SourceCodeKind = sourceCodeKind;
 
             this.Loader = new SourceTextContainerTextLoader(sourceTextContainer, this.FilePath);
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/SimpleContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/SimpleContainedDocument.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Experiment;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
+{
+    using Workspace = Microsoft.CodeAnalysis.Workspace;
+
+    /// <summary>
+    /// An IVisualStudioDocument which represents the secondary buffer to the workspace API.
+    /// </summary>
+    internal sealed class SimpleContainedDocument : ForegroundThreadAffinitizedObject, IVisualStudioHostDocument
+    {
+        /// <summary>
+        /// The IDocumentProvider that created us.
+        /// </summary>
+        private readonly DocumentProvider _documentProvider;
+        private readonly FileChangeTracker _fileChangeTracker;
+        private readonly TextLoader _doNotAccessDirectlyLoader;
+
+        public DocumentId Id { get; }
+        public IReadOnlyList<string> Folders { get; }
+        public AbstractProject Project { get; }
+        public SourceCodeKind SourceCodeKind { get; }
+        public DocumentKey Key { get; }
+        public IDocumentServiceFactory DocumentServiceFactory { get; }
+
+        public SimpleContainedDocument(
+            DocumentProvider documentProvider,
+            AbstractProject project,
+            DocumentKey documentKey,
+            Func<uint, IReadOnlyList<string>> getFolderNames,
+            SourceCodeKind sourceCodeKind,
+            IVsFileChangeEx fileChangeService,
+            DocumentId id,
+            EventHandler updatedOnDiskHandler,
+            IDocumentServiceFactory documentServiceFactory)
+        {
+            Contract.ThrowIfNull(documentProvider);
+
+            this.Project = project;
+            this.Id = id ?? DocumentId.CreateNewId(project.Id, documentKey.Moniker);
+
+            var itemid = this.GetItemId();
+            this.Folders = itemid == (uint)VSConstants.VSITEMID.Nil
+                ? SpecializedCollections.EmptyReadOnlyList<string>()
+                : getFolderNames(itemid);
+
+            _documentProvider = documentProvider;
+
+            this.Key = documentKey;
+            this.SourceCodeKind = sourceCodeKind;
+
+            _fileChangeTracker = new FileChangeTracker(fileChangeService, this.FilePath);
+            _fileChangeTracker.UpdatedOnDisk += OnUpdatedOnDisk;
+
+            // The project system does not tell us the CodePage specified in the proj file, so
+            // we use null to auto-detect.
+            _doNotAccessDirectlyLoader = new FileTextLoader(documentKey.Moniker, defaultEncoding: null);
+
+            _fileChangeTracker.StartFileChangeListeningAsync();
+
+            if (updatedOnDiskHandler != null)
+            {
+                UpdatedOnDisk += updatedOnDiskHandler;
+            }
+
+            this.DocumentServiceFactory = documentServiceFactory;
+        }
+
+        public TextLoader Loader
+        {
+            get
+            {
+                _fileChangeTracker.EnsureSubscription();
+                return _doNotAccessDirectlyLoader;
+            }
+        }
+
+        public uint GetItemId()
+        {
+            AssertIsForeground();
+
+            if (this.Key.Moniker == null || Project.Hierarchy == null)
+            {
+                return (uint)VSConstants.VSITEMID.Nil;
+            }
+
+            return Project.Hierarchy.ParseCanonicalName(this.Key.Moniker, out var itemId) == VSConstants.S_OK
+                ? itemId
+                : (uint)VSConstants.VSITEMID.Nil;
+        }
+
+        public DocumentInfo GetInitialState()
+        {
+            return DocumentInfo.Create(
+                this.Id,
+                this.Name,
+                folders: this.Folders,
+                sourceCodeKind: SourceCodeKind,
+                loader: this.Loader,
+                filePath: this.Key.Moniker,
+                isGenerated: true,
+                documentServiceFactory: DocumentServiceFactory);
+        }
+
+        public string FilePath => Key.Moniker;
+        public bool IsOpen => false;
+
+#pragma warning disable 67
+
+        public event EventHandler UpdatedOnDisk;
+        public event EventHandler<bool> Opened;
+        public event EventHandler<bool> Closing;
+
+#pragma warning restore 67
+
+        public ITextBuffer GetOpenTextBuffer() => null;
+        public SourceTextContainer GetOpenTextContainer() => null;
+
+        public string Name
+        {
+            get
+            {
+                try
+                {
+                    return Path.GetFileName(this.FilePath);
+                }
+                catch (ArgumentException)
+                {
+                    return this.FilePath;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _fileChangeTracker.Dispose();
+            _fileChangeTracker.UpdatedOnDisk -= OnUpdatedOnDisk;
+
+            _documentProvider.StopTrackingDocument(this);
+        }
+        public void UpdateText(SourceText newText) => throw new NotSupportedException();
+        public ITextBuffer GetTextUndoHistoryBuffer() => null;
+
+        private void OnUpdatedOnDisk(object sender, EventArgs e)
+        {
+            UpdatedOnDisk?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Experiment;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Roslyn.Utilities;
 
@@ -202,6 +203,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             ExecuteForegroundAction(() =>
             {
                 AddFile(filePath, sourceCodeKind, _ => isInCurrentContext, _ => folderNames.ToImmutableArrayOrEmpty(), documentServiceFactory);
+            });
+        }
+
+        public void AddSourceFile(
+            string filePath, SourceTextContainer sourceTextContainer, bool isInCurrentContext = true, IEnumerable<string> folderNames = null,
+            SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, IDocumentServiceFactory documentServiceFactory = null)
+        {
+            ExecuteForegroundAction(() =>
+            {
+                AddFile(filePath, sourceTextContainer, sourceCodeKind, _ => isInCurrentContext, _ => folderNames.ToImmutableArrayOrEmpty(), documentServiceFactory);
             });
         }
 

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Experiment;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Roslyn.Utilities;
 
@@ -194,11 +195,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         #endregion
 
         #region Files
-        public void AddSourceFile(string filePath, bool isInCurrentContext = true, IEnumerable<string> folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
+        public void AddSourceFile(
+            string filePath, bool isInCurrentContext = true, IEnumerable<string> folderNames = null,
+            SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, IDocumentServiceFactory documentServiceFactory = null)
         {
             ExecuteForegroundAction(() =>
             {
-                AddFile(filePath, sourceCodeKind, _ => isInCurrentContext, _ => folderNames.ToImmutableArrayOrEmpty());
+                AddFile(filePath, sourceCodeKind, _ => isInCurrentContext, _ => folderNames.ToImmutableArrayOrEmpty(), documentServiceFactory);
             });
         }
 

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicLanguageService.vb
@@ -3,6 +3,7 @@
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor
+Imports Microsoft.CodeAnalysis.Experiment
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
@@ -72,6 +73,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
         Protected Overrides Function CreateContainedLanguage(
             bufferCoordinator As IVsTextBufferCoordinator,
+            serviceFactory As IDocumentServiceFactory,
             project As AbstractProject,
             hierarchy As IVsHierarchy,
             itemid As UInteger
@@ -83,7 +85,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                 project,
                 hierarchy,
                 itemid,
-                Me, SourceCodeKind.Regular)
+                Me, SourceCodeKind.Regular,
+                serviceFactory)
         End Function
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
@@ -4,6 +4,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities
+Imports Microsoft.CodeAnalysis.Experiment
 Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -27,8 +28,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
                 hierarchy As IVsHierarchy,
                 itemid As UInteger,
                 languageService As VisualBasicLanguageService,
-                sourceCodeKind As SourceCodeKind)
-            MyBase.New(bufferCoordinator, componentModel, project, hierarchy, itemid, languageService, sourceCodeKind, VisualBasicHelperFormattingRule.Instance)
+                sourceCodeKind As SourceCodeKind,
+                documentServiceFactory As IDocumentServiceFactory)
+            MyBase.New(bufferCoordinator, componentModel, project, hierarchy, itemid, languageService, sourceCodeKind, documentServiceFactory, VisualBasicHelperFormattingRule.Instance)
         End Sub
 
         Public Function AddStaticEventBinding(pszClassName As String,

--- a/src/Workspaces/Core/Portable/Workspace/Experiment/IDocumentServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Experiment/IDocumentServiceFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Experiment
+{
+    internal interface IDocumentServiceFactory
+    {
+        /// <summary>
+        /// For now, there is no constraint for the service. it is basically a backdoor to
+        /// get anything from this factory provider
+        /// </summary>
+        TService GetService<TService>();
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Experiment/ISpanMapper.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Experiment/ISpanMapper.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Experiment
+{
+    internal interface ISpanMapper
+    {
+        Task<ImmutableArray<SpanMapResult>> MapSpansAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken);
+    }
+
+    internal struct SpanMapResult
+    {
+        public readonly Document Document;
+        public readonly LinePositionSpan LinePositionSpan;
+
+        public SpanMapResult(Document document, LinePositionSpan linePositionSpan)
+        {
+            Document = document;
+            LinePositionSpan = linePositionSpan;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
@@ -76,6 +76,8 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        // this should hold onto SourceText not container. not sure why it is holding onto container.. perf (memory reason) ?
+        // anyway, seems wrong since _version is set but CurrentText can change if LoadTextAndVersion called multiple times.
         private class TextContainerLoader : TextLoader
         {
             private readonly SourceTextContainer _container;


### PR DESCRIPTION
this is first draft.

...

basically, one can add new project/document through this

first, MEF import this service
IWorkspaceProjectContextFactory (http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices/Implementation/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs,13)

and then call this method to add new project
IWorkspaceProjectContextFactory.CreateProjectContext (there are 2. only difference is whether you are going to control error reporting or not)
http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices/Implementation/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs,26 

and then use this to add new document
IWorkspaceProjectContext.AddSourceFile
http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs,33

examples are here.
https://github.com/dotnet/project-system/blob/6a0fb122a8682d5d8b9ca4b26013bf7ad20b5800/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs#L34

...

if you want to add file to existing project, you need to import VisualStudioWorkspaceImp and then do
IWorkspaceProjectContext context = VSWorkspaceImpl.GetHostProject(ProjectId);

and do the same. (all these require IVT by the way)

...

there is big "Catch" here though. since venus/razor has existing implemention on open file, I wasn't sure how to do transition between closed/open files of razor/venus file. so basically I gave up that part. and leave responsibility to you guys.

basically what that means is that, you can add closed razor, secondary buffer equivalent, code to us through the code path above, but when user tries to open that file (ex, cshtml), razor/venus MUST first remove that document from us through the same API above (http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs,34) 

and then go through the old ContainedLanguage API to open the file so that it gets hooked up to right code for open files.

...

I think after this experiement/prototype, it would be nice if we remove the old ContainedLanguage code path and merge everything (open/closed file) to same code path.

I didn't read through whole thing but most of code in old code path is about modifying secondary buffer, so if we do make change of design where we never modify buffer but just let you know how we want to change, 

I think we can do much more in much simpler way... such as supporting code fix in razor/venus file but we don't have any special code (or very little) for razor/venus in our side. 





