### PR TITLE
Do not offer to simplify a foreach collection initializer.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeRefactoringTests.cs
@@ -34,6 +34,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExp
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithNone),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithNone));
 
+        private IDictionary<OptionKey, object> PreferImplicitTypeWithInfo() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo));
+
         private IDictionary<OptionKey, object> PreferImplicitTypeWithNone() => OptionsSet(
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone),
@@ -307,8 +312,10 @@ class Program
     }
 }";
 
-            await TestMissingInRegularAndScriptAsync(code, options: PreferImplicitTypeWithNone());
-            await TestMissingInRegularAndScriptAsync(code, options: PreferExplicitTypeWithNone());
+            // We never want to get offered here under any circumstances.
+            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
             await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
         }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeRefactoringTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseExplicitType;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitType
@@ -287,6 +288,28 @@ class C
 }";
 
             await TestMissingInRegularAndScriptAsync(code, options: PreferImplicitTypeWithNone());
+        }
+
+        [Fact, WorkItem(26923, "https://github.com/dotnet/roslyn/issues/26923")]
+        public async Task NoSuggestionOnForeachCollectionExpression()
+        {
+            var code = @"using System;
+using System.Collections.Generic;
+
+class Program
+{
+    void Method(List<int> var)
+    {
+        foreach (int value in [|var|])
+        {
+            Console.WriteLine(value.Value);
+        }
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, options: PreferImplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, options: PreferExplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
         }
 
         private Task TestMissingInRegularAndScriptAsync(string initialMarkup, IDictionary<OptionKey, object> options)

--- a/src/EditorFeatures/CSharpTest/CodeActions/UseImplicitType/UseImplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseImplicitType/UseImplicitTypeRefactoringTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseImplicitType;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitType
@@ -265,6 +266,28 @@ class C
 
             await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithNone());
             await TestInRegularAndScriptAsync(code, expected, options: PreferExplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
+        }
+
+        [Fact, WorkItem(26923, "https://github.com/dotnet/roslyn/issues/26923")]
+        public async Task NoSuggestionOnForeachCollectionExpression()
+        {
+            var code = @"using System;
+using System.Collections.Generic;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        foreach (string arg in [|args|])
+        {
+
+        }
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithNone());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithNone());
             await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
         }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/UseImplicitType/UseImplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseImplicitType/UseImplicitTypeRefactoringTests.cs
@@ -286,9 +286,11 @@ class C
     }
 }";
 
+            // We never want to get offered here under any circumstances.
             await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithNone());
             await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithNone());
             await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
+            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
         }
 
         private Task TestMissingInRegularAndScriptAsync(string initialMarkup, IDictionary<OptionKey, object> options)

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.SimplifyTypeNames;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
@@ -3995,6 +3996,25 @@ class C
                 options: PreferIntrinsicTypeInMemberAccess);
         }
 
+        [Fact, WorkItem(26923, "https://github.com/dotnet/roslyn/issues/26923")]
+        public async Task NoSuggestionOnForeachCollectionExpression()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+using System.Collections.Generic;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        foreach (string arg in [|args|])
+        {
+
+        }
+    }
+}", new TestParameters(options: PreferImplicitTypeWithNone));
+        }
+
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
@@ -4046,6 +4066,11 @@ namespace Root
         private IDictionary<OptionKey, object> PreferIntrinsicTypeInMemberAccess => OptionsSet(
             SingleOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, true, NotificationOption.Error),
             SingleOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, this.offWithNone, GetLanguage()));
+
+        private IDictionary<OptionKey, object> PreferImplicitTypeWithNone => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithNone));
 
         private readonly CodeStyleOption<bool> onWithNone = new CodeStyleOption<bool>(true, NotificationOption.None);
         private readonly CodeStyleOption<bool> offWithNone = new CodeStyleOption<bool>(false, NotificationOption.None);

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -1802,5 +1802,25 @@ class Program
     }
 }", new TestParameters(options: ExplicitTypeForBuiltInTypesOnly()));
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(26923, "https://github.com/dotnet/roslyn/issues/26923")]
+        public async Task NoSuggestionOnForeachCollectionExpression()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+using System.Collections.Generic;
+
+class Program
+{
+    void Method(List<int> var)
+    {
+        foreach (int value in [|var|])
+        {
+            Console.WriteLine(value.Value);
+        }
+    }
+}", new TestParameters(options: ExplicitTypeEverywhere()));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -2347,5 +2347,24 @@ class C
     }
 }", new TestParameters(options: ImplicitTypeEverywhere()));
         }
+
+        [Fact, WorkItem(26923, "https://github.com/dotnet/roslyn/issues/26923")]
+        public async Task NoSuggestionOnForeachCollectionExpression()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+using System.Collections.Generic;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        foreach (string arg in [|args|])
+        {
+
+        }
+    }
+}", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Utilities/CSharpUseExplicitTypeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/CSharpUseExplicitTypeHelper.cs
@@ -96,9 +96,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                     return false;
                 }
             }
-            else if (typeName.Parent.IsKind(SyntaxKind.ForEachStatement))
+            else if (typeName.Parent is ForEachStatementSyntax foreachStatement &&
+                     foreachStatement.Type == typeName)
             {
-                var foreachStatement = (ForEachStatementSyntax)typeName.Parent;
                 if (!AssignmentSupportsStylePreference(
                         foreachStatement.Identifier, typeName, foreachStatement.Expression, 
                         semanticModel, optionSet, cancellationToken))

--- a/src/Workspaces/CSharp/Portable/Utilities/CSharpUseImplicitTypeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/CSharpUseImplicitTypeHelper.cs
@@ -150,7 +150,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                     return true;
                 }
             }
-            else if (typeName.Parent is ForEachStatementSyntax foreachStatement)
+            else if (typeName.Parent is ForEachStatementSyntax foreachStatement &&
+                     foreachStatement.Type == typeName)
             {
                 var foreachStatementInfo = semanticModel.GetForEachStatementInfo(foreachStatement);
                 if (foreachStatementInfo.ElementConversion.IsIdentity)


### PR DESCRIPTION
### Customer scenario

We show light bulb on wrong place in C# foreach statement and suggest users invalid fix.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/26923

### Workarounds, if any
No

### Risk
Low

### Performance impact
None

### Is this a regression from a previous update?
Yes

### Root cause analysis
We were improving sub system so that each code generation no longer need to explicitly write code to handle explicit/var code style pattern. by improving this subsystem, we could remove a lot of duplicated code all over code fixes doing basically same thing to one central system so that it just always work.

but while refactoring, this one case slipped.  

### How was the bug found?
Dogfooding.

