### PR TITLE
Add missing dependency of target _BeforeVBCSCoreCompile

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -9,16 +9,24 @@
   <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
           BeforeTargets="CoreCompile"
           Condition="'@(ReferencePathWithRefAssemblies)' == ''">
-    <!-- Common targets should populate this item from dev15.3, but this file
-         may be used (via NuGet package) on earlier MSBuilds. If the
-         adjusted-for-reference-assemblies item is not populated, just use
-         the older item's contents. -->
+    <!-- 
+      FindReferenceAssembliesForReferences target in Common targets populate this item 
+      since dev15.3. The compiler targets may be used (via NuGet package) on earlier MSBuilds. 
+      If the ReferencePathWithRefAssemblies item is not populated, just use ReferencePaths 
+      (implementation assemblies) as they are.
+      
+      Since XAML inner build runs CoreCompile directly (instead of Compile target),
+      it also doesn't invoke FindReferenceAssembliesForReferences listed in CompileDependsOn.
+      In that case we also populate ReferencePathWithRefAssemblies with implementation assemblies.
+    -->
     <ItemGroup>
       <ReferencePathWithRefAssemblies Include="@(ReferencePath)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="_BeforeVBCSCoreCompile">
+  <Target Name="_BeforeVBCSCoreCompile"
+          DependsOnTargets="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies">
+    
     <ItemGroup Condition="'$(TargetingClr2Framework)' == 'true'">
       <ReferencePathWithRefAssemblies>
         <EmbedInteropTypes />

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -283,5 +283,61 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 $@"[/_1/]=[https://raw.githubusercontent.com/Source/Package/*]",
                 File.ReadAllText(sourceLinkJsonPath));
         }
+
+        /// <summary>
+        /// Validates dependencies of _BeforeVBCSCoreCompile target. 
+        /// </summary>
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void BeforeVBCSCoreCompileDependencies()
+        {
+            VerifyValues(
+                props: $@"
+<Project>
+  <ItemGroup>
+    <ReferencePath Include=""A"" />
+  </ItemGroup>
+</Project>",
+                targets: new[]
+                {
+                    "_BeforeVBCSCoreCompile"
+                },
+                expressions: new[]
+                {
+                    "@(ReferencePathWithRefAssemblies)",
+                },
+                expectedResults: new[]
+                {
+                    "A",
+                });
+        }
+
+        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        public void ClearEmbedInteropTypes()
+        {
+            VerifyValues(
+                props: $@"
+<Project>
+  <PropertyGroup>
+    <TargetingClr2Framework>true</TargetingClr2Framework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ReferencePathWithRefAssemblies Include=""A"" EmbedInteropTypes=""false""/>
+    <ReferencePathWithRefAssemblies Include=""B"" EmbedInteropTypes=""true""/>
+  </ItemGroup>
+</Project>",
+                targets: new[]
+                {
+                    "CoreCompile"
+                },
+                expressions: new[]
+                {
+                    "@(ReferencePathWithRefAssemblies->'EmbedInteropTypes=`%(EmbedInteropTypes)`')",
+                },
+                expectedResults: new[]
+                {
+                    "EmbedInteropTypes=``",
+                    "EmbedInteropTypes=``"
+                });
+        }
     }
 }


### PR DESCRIPTION
### Customer scenario

Build of XAML project targeting .NET 3.5 may fail.

### Bugs this fixes

[VSO 616987](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/616987)

### Workarounds, if any

Customer can set `EmbedInteropTypes` to false on references.

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

The project generated for XAML build invokes CoreCompile directly without executing Compile target. Due to a missing dependency the target `ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies` may get executed after `_BeforeVBCSCoreCompile`, which depends on the results of the former.

### How was the bug found?

Customer reported.

### Test documentation updated?

