### PR TITLE
Add IVT for Razor tooling assemblies

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -135,6 +135,7 @@
     <InternalsVisibleToRemoteLS Include="Microsoft.VisualStudio.LanguageServices.Remote.CSharp" />
     <InternalsVisibleToFSharp Include="FSharp.Editor" />
     <InternalsVisibleToFSharp Include="FSharp.LanguageService" />
+    <InternalsVisibleToRazor Include="Microsoft.VisualStudio.LanguageServices.Razor"/>
   </ItemGroup>
   <ItemGroup>
     <None Include="ManagedEditAndContinueService.vsdconfigxml" />

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -296,6 +296,9 @@
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
     <InternalsVisibleToVisualStudio Include="Microsoft.Test.Apex.VisualStudio" />
     <InternalsVisibleToCompletionTests Include="Microsoft.VisualStudio.Completion.Tests" />
+    <InternalsVisibleToRazor Include="Microsoft.CodeAnalysis.Razor.Workspaces" />
+    <InternalsVisibleToRazor Include="Microsoft.VisualStudio.Editor.Razor" />
+    <InternalsVisibleToRazor Include="Microsoft.VisualStudio.LanguageServices.Razor" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\UnicodeCharacterUtilities.cs">


### PR DESCRIPTION
This change adds IVT access for some Razor tooling assemblies to access
IWorkspaceProjectContext, IDocumentServiceFactory, and ISpanMapper.

**This is for the experimental feature branch where we are working on
find-all-references for Razor.** We planned on doing things this way while prototyping in the feature branch to avoid churn. 