### PR TITLE
Add CompilationVerifier.Dump utility method

### DIFF
--- a/src/Test/Utilities/Portable/CompilationVerifier.cs
+++ b/src/Test/Utilities/Portable/CompilationVerifier.cs
@@ -78,6 +78,24 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
+#if NET46
+        public string Dump()
+        {
+            using (var testEnvironment = RuntimeEnvironmentFactory.Create(_dependencies))
+            {
+                string mainModuleFullName = Emit(testEnvironment, manifestResources: null, EmitOptions.Default);
+                IList<ModuleData> moduleDatas = testEnvironment.GetAllModuleData();
+                string mainModuleSimpleName = moduleDatas.Single(md => md.FullName == mainModuleFullName).SimpleName;
+                RuntimeEnvironmentUtilities.DumpAssemblyData(moduleDatas, out var dumpDir);
+
+                string modulePath = Path.Combine(dumpDir, mainModuleSimpleName + ".dll");
+                var decompiler = new ICSharpCode.Decompiler.CSharp.CSharpDecompiler(modulePath, new ICSharpCode.Decompiler.DecompilerSettings());
+                var syntaxTree = decompiler.DecompileWholeModuleAsSingleFile();
+                return syntaxTree.ToString();
+            }
+        }
+#endif
+
         public void Emit(string expectedOutput, int? expectedReturnCode, string[] args, IEnumerable<ResourceDescription> manifestResources, EmitOptions emitOptions, Verification peVerify, SignatureDescription[] expectedSignatures)
         {
             using (var testEnvironment = RuntimeEnvironmentFactory.Create(_dependencies))

--- a/src/Test/Utilities/Portable/TestUtilities.csproj
+++ b/src/Test/Utilities/Portable/TestUtilities.csproj
@@ -102,4 +102,7 @@
     <PackageReference Include="System.Threading.Thread" Version="$(SystemThreadingThreadVersion)" />
     <PackageReference Include="System.Xml.XmlDocument" Version="$(SystemXmlXmlDocumentVersion)" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PackageReference Include="ICSharpCode.Decompiler" Version="$(ICSharpCodeDecompilerVersion)" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This is a test-only change, which adds a `Dump()` method to `CompilationVerifier`.
I emits the compilation, dumps all the modules to a folder (`...\AppData\Local\Temp\RoslynTests`) and produces a decompiled C# string from the main module (via ILSpy API).
This emulates the decompiled C# view on SharpLab. 

I think that is helpful for working on new features that involve lowering/emitting, as it is easier to inspect C# than to troubleshoot IL.

@dotnet/roslyn-compiler for review. Thanks

![image](https://user-images.githubusercontent.com/12466233/40292622-2abd64dc-5c81-11e8-8ea3-8d18e04eca1d.png)

Note: in the pictured example, the type for the state machine is not getting included in the output. I don't think this is a problem with this change, but rather something wrong with the state machine I'm producing (that's WIP).