### PR TITLE
Fix https://github.com/mono/monodevelop/issues/4820

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/ClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/ClassificationUtilities.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
@@ -38,28 +37,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         {
             foreach (var classifiedSpan in list)
             {
-                IClassificationType classificationType;
-                switch (classifiedSpan.ClassificationType) // filter out unsupported classification types
-                {
-                    case ClassificationTypeNames.FieldName:
-                    case ClassificationTypeNames.EnumMemberName:
-                    case ClassificationTypeNames.ConstantName:
-                    case ClassificationTypeNames.LocalName:
-                    case ClassificationTypeNames.ParameterName:
-                    case ClassificationTypeNames.MethodName:
-                    case ClassificationTypeNames.ExtensionMethodName:
-                    case ClassificationTypeNames.PropertyName:
-                    case ClassificationTypeNames.EventName:
-                        classificationType = typeMap.GetClassificationType(ClassificationTypeNames.Identifier);
-                        break;
-                    default:
-                        classificationType = typeMap.GetClassificationType(classifiedSpan.ClassificationType);
-                        break;
-                }
-
                 addTag(new TagSpan<IClassificationTag>(
                     classifiedSpan.TextSpan.ToSnapshotSpan(snapshot),
-                    new ClassificationTag(classificationType)));
+                    new ClassificationTag(typeMap.GetClassificationType(classifiedSpan.ClassificationType))));
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpClassification.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpClassification.cs
@@ -47,7 +47,7 @@ namespace ConsoleApplication1
             VisualStudio.Editor.PlaceCaret("Program");
             VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "class name");
             VisualStudio.Editor.PlaceCaret("Main");
-            VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "identifier");
+            VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "method name");
             VisualStudio.Editor.PlaceCaret("Hello");
             VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "string");
             VisualStudio.Editor.PlaceCaret("<summary", charsOffset: -1);
@@ -124,7 +124,7 @@ namespace ClassLibrary1
 
             VisualStudio.ExecuteCommand(WellKnownCommandNames.Build_SolutionConfigurations, argument: "Debug");
             VisualStudio.Editor.PlaceCaret("Goo");
-            VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "identifier");
+            VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "method name");
             VisualStudio.Editor.PlaceCaret("Bar");
             VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "excluded code");
             VisualStudio.Editor.MoveCaret(0);
@@ -132,7 +132,7 @@ namespace ClassLibrary1
             VisualStudio.Editor.PlaceCaret("Goo");
             VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "excluded code");
             VisualStudio.Editor.PlaceCaret("Bar");
-            VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "identifier");
+            VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "method name");
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplClassification.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplClassification.cs
@@ -35,7 +35,7 @@ public static void Main(string[] args)
             VisualStudio.InteractiveWindow.PlaceCaret("{");
             VisualStudio.InteractiveWindow.Verify.CurrentTokenType(tokenType: "punctuation");
             VisualStudio.InteractiveWindow.PlaceCaret("Main");
-            VisualStudio.InteractiveWindow.Verify.CurrentTokenType(tokenType: "identifier");
+            VisualStudio.InteractiveWindow.Verify.CurrentTokenType(tokenType: "method name");
             VisualStudio.InteractiveWindow.PlaceCaret("Hello");
             VisualStudio.InteractiveWindow.Verify.CurrentTokenType(tokenType: "string");
             VisualStudio.InteractiveWindow.PlaceCaret("<summary", charsOffset: -1);


### PR DESCRIPTION
MonoDevelop(VSfM) recently switched from using `Microsoft.CodeAnalysis.Classification.Classifier` to using `IAccurateClassifier` from VS API.
But with this switch some classifications that were added in #24931 stopped working. Reason for this is that in that commit new classifications were filtered out by converting back to classification that was used before `ClassificationTypeNames.Identifier` so VS Windows would continue working fine. But later in #25723 this ClassificationTypes were added so I assume with removing this filtering VS Windows will work just fine since ClassificationTypes that were added #25723 have BaseType `ClassificationTypeNames.Identifier`.

### Customer scenario

In VSfM some themes differentiate between property and method name highlighting, and this is considered regression, hence this PR.

### Bugs this fixes

It's actually in monodevelop repository: https://github.com/mono/monodevelop/issues/4820 I can open another one here if you want...

### Workarounds, if any

None.

### Risk

I'm not sure if this will cause any regression in VS Windows.

### Performance impact

None to minimal improvement.

### Is this a regression from a previous update?

No.

### Root cause analysis

This was done intentionally so even if tests were added it wouldn't discover this problem.

### How was the bug found?

Internal dogfooding of VSfM.

### Test documentation updated?

This seems like too specific problem to be manually tested.
