### PR TITLE
Bump file version from 2.8.2 to 2.8.3

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -14,7 +14,7 @@
     <!-- This is the assembly version of Roslyn from the .NET assembly perspective. It should only be revved during significant point releases. -->
     <RoslynAssemblyVersionBase Condition="'$(RoslynAssemblyVersion)' == ''">2.8.0</RoslynAssemblyVersionBase>
     <!-- This is the file version of Roslyn, as placed in the PE header. It should be revved during point releases, and is also what provides the basis for our NuGet package versioning. -->
-    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.8.2</RoslynFileVersionBase>
+    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.8.3</RoslynFileVersionBase>
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>


### PR DESCRIPTION
This branch is now targeting 15.7.3, and we need to bump the file version for NuGet packages coming out of these changes.