### PR TITLE
ToBadExpression() checking incorrect HasAnyErrors API

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol resultType = expr.Type;
             BoundKind exprKind = expr.Kind;
 
-            if (expr.HasAnyErrors && ((object)resultType != null || exprKind == BoundKind.UnboundLambda))
+            if (expr.HasErrors && ((object)resultType != null || exprKind == BoundKind.UnboundLambda))
             {
                 return expr;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol resultType = expr.Type;
             BoundKind exprKind = expr.Kind;
 
-            if (expr.HasErrors && ((object)resultType != null || exprKind == BoundKind.UnboundLambda))
+            if (expr.HasAnyErrors && ((object)resultType != null || exprKind == BoundKind.UnboundLambda))
             {
                 return expr;
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -14,8 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         /// <summary>
         /// Returns the RefKind if the expression represents a symbol
-        /// that has a RefKind. This method is ILLEGAL to call for
-        /// other expressions.
+        /// that has a RefKind, or RefKind.None otherwise.
         /// </summary>
         public static RefKind GetRefKind(this BoundExpression node)
         {
@@ -34,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return ((BoundPropertyAccess)node).PropertySymbol.RefKind;
 
                 default:
-                    throw ExceptionUtilities.UnexpectedValue(node.Kind);
+                    return RefKind.None;
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -3831,5 +3831,30 @@ public class C
                 //     	M(ref void = ref x);
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "void").WithArguments("void").WithLocation(6, 12));
         }
+
+        [Fact]
+        [WorkItem(26978, "https://github.com/dotnet/roslyn/issues/26978")]
+        public void BindingRefDynamicObjAssignment()
+        {
+            CompileAndVerify(@"
+using System;
+class C
+{
+    public int P;
+
+    static void Main()
+    {
+        dynamic x = new C();
+        x.P = 5;
+        Console.WriteLine(x.P);
+        
+        dynamic y = new C();
+        y.P = ref x.P;
+        Console.WriteLine(y.P);
+    }
+}", references: new[] { SystemCoreRef, CSharpRef }, expectedOutput: @"
+5
+5");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -3814,5 +3814,22 @@ class Test
                 //         M(out in int x);
                 Diagnostic(ErrorCode.ERR_SyntaxError, "x").WithArguments(",", "").WithLocation(10, 22));
         }
+
+        [Fact]
+        [WorkItem(26516, "https://github.com/dotnet/roslyn/issues/26516")]
+        public void BindingRefVoidAssignment()
+        {
+            CreateCompilation(@"
+public class C
+{
+	public void M(ref int x)
+    {
+    	M(ref void = ref x);
+    }
+}").VerifyDiagnostics(
+                // (6,12): error CS1525: Invalid expression term 'void'
+                //     	M(ref void = ref x);
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "void").WithArguments("void").WithLocation(6, 12));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -3852,7 +3852,7 @@ class C
         y.P = ref x.P;
         Console.WriteLine(y.P);
     }
-}", references: new[] { SystemCoreRef, CSharpRef }, expectedOutput: @"
+}", references: new[] { CSharpRef }, expectedOutput: @"
 5
 5");
         }


### PR DESCRIPTION
Fixes #26516 
Fixes #26978

Bound nodes have two APIs to check for errors:
* `HasErrors` which is a fast flag that is set during creating the bound node (if an obvious semantic error). It does not guarentee that there are not other syntactical errors associated with the node.
* `HasAnyErrors` is slower, and used during binding to do a full check on including associated syntax nodes.

When calling the API `Binder.ToBadExpression()`, the caller should expect the returned `BoundBadExpression` to have `HasErrors` as true. However, as an optimization, this method checks the node if it `HasAnyErrors`, and returns it unchanged if so. Because of this mismatch, it will incorrectly return a node with `HasErrors=false` and `HasAnyErrors=true`, which violates the contract.

cc @dotnet/roslyn-compiler 