### PR TITLE
Ensure that EventAssignmentOperation always has a non-null EventRefer…

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -464,7 +464,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         private IEventAssignmentOperation CreateBoundEventAssignmentOperatorOperation(BoundEventAssignmentOperator boundEventAssignmentOperator)
         {
-            Lazy<IEventReferenceOperation> eventReference = new Lazy<IEventReferenceOperation>(() => CreateBoundEventAccessOperation(boundEventAssignmentOperator));
+            Lazy<IOperation> eventReference = new Lazy<IOperation>(() => CreateBoundEventAccessOperation(boundEventAssignmentOperator));
             Lazy<IOperation> handlerValue = new Lazy<IOperation>(() => Create(boundEventAssignmentOperator.Argument));
             SyntaxNode syntax = boundEventAssignmentOperator.Syntax;
             bool adds = boundEventAssignmentOperator.IsAddition;

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -1681,7 +1681,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// <summary>
         /// Instance used to refer to the event being bound.
         /// </summary>
-        public abstract IEventReferenceOperation EventReference { get; }
+        public abstract IOperation EventReference { get; }
 
         /// <summary>
         /// Handler supplied for the event.
@@ -1702,14 +1702,14 @@ namespace Microsoft.CodeAnalysis.Operations
     /// </summary>
     internal sealed partial class EventAssignmentOperation : BaseEventAssignmentOperation, IEventAssignmentOperation
     {
-        public EventAssignmentOperation(IEventReferenceOperation eventReference, IOperation handlerValue, bool adds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+        public EventAssignmentOperation(IOperation eventReference, IOperation handlerValue, bool adds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(adds, semanticModel, syntax, type, constantValue, isImplicit)
         {
             EventReference = SetParentOperation(eventReference, this);
             HandlerValue = SetParentOperation(handlerValue, this);
         }
 
-        public override IEventReferenceOperation EventReference { get; }
+        public override IOperation EventReference { get; }
         public override IOperation HandlerValue { get; }
     }
 
@@ -1718,17 +1718,17 @@ namespace Microsoft.CodeAnalysis.Operations
     /// </summary>
     internal sealed partial class LazyEventAssignmentOperation : BaseEventAssignmentOperation, IEventAssignmentOperation
     {
-        private readonly Lazy<IEventReferenceOperation> _lazyEventReference;
+        private readonly Lazy<IOperation> _lazyEventReference;
         private readonly Lazy<IOperation> _lazyHandlerValue;
 
-        public LazyEventAssignmentOperation(Lazy<IEventReferenceOperation> eventReference, Lazy<IOperation> handlerValue, bool adds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+        public LazyEventAssignmentOperation(Lazy<IOperation> eventReference, Lazy<IOperation> handlerValue, bool adds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(adds, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyEventReference = eventReference ?? throw new System.ArgumentNullException(nameof(eventReference));
             _lazyHandlerValue = handlerValue ?? throw new System.ArgumentNullException(nameof(handlerValue));
         }
 
-        public override IEventReferenceOperation EventReference => SetParentOperation(_lazyEventReference.Value, this);
+        public override IOperation EventReference => SetParentOperation(_lazyEventReference.Value, this);
         public override IOperation HandlerValue => SetParentOperation(_lazyHandlerValue.Value, this);
     }
 

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -5068,7 +5068,6 @@ oneMoreTime:
             
             return new EventAssignmentOperation(visitedEventReference, visitedHandler, operation.Adds, semanticModel: null,
                 operation.Syntax, operation.Type, operation.ConstantValue, IsImplicit(operation));
-
         }
 
         public override IOperation VisitRaiseEvent(IRaiseEventOperation operation, int? captureIdForResult)

--- a/src/Compilers/Core/Portable/Operations/IEventAssignmentOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IEventAssignmentOperation.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// <summary>
         /// Reference to the event being bound.
         /// </summary>
-        IEventReferenceOperation EventReference { get; }
+        IOperation EventReference { get; }
         
         /// <summary>
         /// Handler supplied for the event.

--- a/src/Compilers/Core/Portable/PublicAPI.Shipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Shipped.txt
@@ -1402,7 +1402,6 @@ Microsoft.CodeAnalysis.Operations.IEmptyOperation
 Microsoft.CodeAnalysis.Operations.IEndOperation
 Microsoft.CodeAnalysis.Operations.IEventAssignmentOperation
 Microsoft.CodeAnalysis.Operations.IEventAssignmentOperation.Adds.get -> bool
-Microsoft.CodeAnalysis.Operations.IEventAssignmentOperation.EventReference.get -> Microsoft.CodeAnalysis.Operations.IEventReferenceOperation
 Microsoft.CodeAnalysis.Operations.IEventAssignmentOperation.HandlerValue.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Operations.IEventReferenceOperation
 Microsoft.CodeAnalysis.Operations.IEventReferenceOperation.Event.get -> Microsoft.CodeAnalysis.IEventSymbol

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+*REMOVED*Microsoft.CodeAnalysis.Operations.IEventAssignmentOperation.EventReference.get -> Microsoft.CodeAnalysis.Operations.IEventReferenceOperation
 Microsoft.CodeAnalysis.CompilationOptions.MetadataImportOptions.get -> Microsoft.CodeAnalysis.MetadataImportOptions
 Microsoft.CodeAnalysis.CompilationOptions.WithMetadataImportOptions(Microsoft.CodeAnalysis.MetadataImportOptions value) -> Microsoft.CodeAnalysis.CompilationOptions
 Microsoft.CodeAnalysis.Emit.EmitOptions.EmitOptions(bool metadataOnly = false, Microsoft.CodeAnalysis.Emit.DebugInformationFormat debugInformationFormat = (Microsoft.CodeAnalysis.Emit.DebugInformationFormat)0, string pdbFilePath = null, string outputNameOverride = null, int fileAlignment = 0, ulong baseAddress = 0, bool highEntropyVirtualAddressSpace = false, Microsoft.CodeAnalysis.SubsystemVersion subsystemVersion = default(Microsoft.CodeAnalysis.SubsystemVersion), string runtimeMetadataVersion = null, bool tolerateErrors = false, bool includePrivateMembers = true, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind> instrumentationKinds = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind>), System.Security.Cryptography.HashAlgorithmName? pdbChecksumAlgorithm = null) -> void
@@ -80,6 +81,7 @@ Microsoft.CodeAnalysis.Operations.IConstructorBodyOperation.Initializer.get -> M
 Microsoft.CodeAnalysis.Operations.IConstructorBodyOperation.Locals.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ILocalSymbol>
 Microsoft.CodeAnalysis.Operations.IDiscardOperation
 Microsoft.CodeAnalysis.Operations.IDiscardOperation.DiscardSymbol.get -> Microsoft.CodeAnalysis.IDiscardSymbol
+Microsoft.CodeAnalysis.Operations.IEventAssignmentOperation.EventReference.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Operations.IFlowCaptureOperation
 Microsoft.CodeAnalysis.Operations.IFlowCaptureOperation.Id.get -> int
 Microsoft.CodeAnalysis.Operations.IFlowCaptureOperation.Value.get -> Microsoft.CodeAnalysis.IOperation

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -826,9 +826,12 @@ Public MustInherit Class BasicTestBase
 
     Protected Shared Sub VerifyFlowGraphForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, expectedFlowGraph As String, Optional which As Integer = 0)
         Dim tree = compilation.SyntaxTrees(0)
-        Dim model = compilation.GetSemanticModel(tree)
         Dim syntaxNode As SyntaxNode = CompilationUtils.FindBindingText(Of TSyntaxNode)(compilation, tree.FilePath, which, prefixMatch:=True)
+        VerifyFlowGraph(compilation, syntaxNode, expectedFlowGraph)
+    End Sub
 
+    Protected Shared Sub VerifyFlowGraph(compilation As VisualBasicCompilation, syntaxNode As SyntaxNode, expectedFlowGraph As String)
+        Dim model = compilation.GetSemanticModel(syntaxNode.SyntaxTree)
         Dim graph As Operations.ControlFlowGraph = ControlFlowGraphVerifier.GetControlFlowGraph(syntaxNode, model)
         ControlFlowGraphVerifier.VerifyGraph(compilation, expectedFlowGraph, graph)
     End Sub

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -868,9 +868,9 @@ Public MustInherit Class BasicTestBase
         VerifyOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, expectedOperationTree, which, additionalOperationTreeVerifier)
     End Sub
 
-    Friend Shared Sub VerifyFlowGraphAndDiagnosticsForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, expectedOperationTree As String, expectedDiagnostics As String, Optional which As Integer = 0)
+    Friend Shared Sub VerifyFlowGraphAndDiagnosticsForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, expectedFlowGraph As String, expectedDiagnostics As String, Optional which As Integer = 0)
         compilation.AssertTheseDiagnostics(FilterString(expectedDiagnostics))
-        VerifyFlowGraphForTest(Of TSyntaxNode)(compilation, expectedOperationTree, which)
+        VerifyFlowGraphForTest(Of TSyntaxNode)(compilation, expectedFlowGraph, which)
     End Sub
 
     Friend Shared Sub VerifyOperationTreeAndDiagnosticsForTest(Of TSyntaxNode As SyntaxNode)(
@@ -895,7 +895,7 @@ Public MustInherit Class BasicTestBase
 
     Friend Shared Sub VerifyFlowGraphAndDiagnosticsForTest(Of TSyntaxNode As SyntaxNode)(
         testSrc As String,
-        expectedOperationTree As String,
+        expectedFlowGraph As String,
         expectedDiagnostics As String,
         Optional compilationOptions As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
@@ -910,7 +910,7 @@ Public MustInherit Class BasicTestBase
         Dim references = defaultRefs.Concat({ValueTupleRef, SystemRuntimeFacadeRef})
         references = If(additionalReferences IsNot Nothing, references.Concat(additionalReferences), references)
         Dim compilation = CreateCompilationWithMscorlib45AndVBRuntime({syntaxTree}, references:=references, options:=If(compilationOptions, TestOptions.ReleaseDll))
-        VerifyFlowGraphAndDiagnosticsForTest(Of TSyntaxNode)(compilation, expectedOperationTree, expectedDiagnostics, which)
+        VerifyFlowGraphAndDiagnosticsForTest(Of TSyntaxNode)(compilation, expectedFlowGraph, expectedDiagnostics, which)
     End Sub
 
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
@@ -423,14 +423,9 @@ Namespace Microsoft.CodeAnalysis.Operations
         Private Function GetAddRemoveHandlerStatementExpression(statement As BoundAddRemoveHandlerStatement) As IOperation
             Dim eventAccess As IOperation = Create(statement.EventAccess)
             Dim handler As IOperation = Create(statement.Handler)
-            Dim eventReference = TryCast(eventAccess, IEventReferenceOperation)
-            If eventReference Is Nothing Then
-                Return OperationFactory.CreateInvalidExpression(_semanticModel, statement.Syntax, children:=ImmutableArray.Create(eventAccess, handler), isImplicit:=True)
-            Else
-                Dim adds = statement.Kind = BoundKind.AddHandlerStatement
-                Return New EventAssignmentOperation(
-                    eventReference, handler, adds:=adds, semanticModel:=_semanticModel, syntax:=statement.Syntax, type:=Nothing, constantValue:=Nothing, isImplicit:=True)
-            End If
+            Dim adds = statement.Kind = BoundKind.AddHandlerStatement
+            Return New EventAssignmentOperation(
+                eventAccess, handler, adds:=adds, semanticModel:=_semanticModel, syntax:=statement.Syntax, type:=Nothing, constantValue:=Nothing, isImplicit:=True)
         End Function
 
 #Region "Conversions"

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
@@ -421,11 +421,16 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function GetAddRemoveHandlerStatementExpression(statement As BoundAddRemoveHandlerStatement) As IOperation
-            Dim eventAccess As BoundEventAccess = TryCast(statement.EventAccess, BoundEventAccess)
-            Dim eventReference = If(eventAccess Is Nothing, Nothing, CreateBoundEventAccessOperation(eventAccess))
-            Dim adds = statement.Kind = BoundKind.AddHandlerStatement
-            Return New EventAssignmentOperation(
-                eventReference, Create(statement.Handler), adds:=adds, semanticModel:=_semanticModel, syntax:=statement.Syntax, type:=Nothing, constantValue:=Nothing, isImplicit:=True)
+            Dim eventAccess As IOperation = Create(statement.EventAccess)
+            Dim handler As IOperation = Create(statement.Handler)
+            Dim eventReference = TryCast(eventAccess, IEventReferenceOperation)
+            If eventReference Is Nothing Then
+                Return OperationFactory.CreateInvalidExpression(_semanticModel, statement.Syntax, children:=ImmutableArray.Create(eventAccess, handler), isImplicit:=True)
+            Else
+                Dim adds = statement.Kind = BoundKind.AddHandlerStatement
+                Return New EventAssignmentOperation(
+                    eventReference, handler, adds:=adds, semanticModel:=_semanticModel, syntax:=statement.Syntax, type:=Nothing, constantValue:=Nothing, isImplicit:=True)
+            End If
         End Function
 
 #Region "Conversions"

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IEventAssignmentExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IEventAssignmentExpression.vb
@@ -999,11 +999,9 @@ Block[B1] - Block
           Expression: 
             IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler( ... t), handler')
               Event Reference: 
-                IParenthesizedOperation (OperationKind.Parenthesized, Type: System.EventHandler) (Syntax: '(c.TestEvent)')
-                  Operand: 
-                    IEventReferenceOperation: Event C.TestEvent As System.EventHandler (OperationKind.EventReference, Type: System.EventHandler) (Syntax: 'c.TestEvent')
-                      Instance Receiver: 
-                        IParameterReferenceOperation: c (OperationKind.ParameterReference, Type: C) (Syntax: 'c')
+                IEventReferenceOperation: Event C.TestEvent As System.EventHandler (OperationKind.EventReference, Type: System.EventHandler) (Syntax: '(c.TestEvent)')
+                  Instance Receiver: 
+                    IParameterReferenceOperation: c (OperationKind.ParameterReference, Type: C) (Syntax: 'c')
               Handler: 
                 IParameterReferenceOperation: handler (OperationKind.ParameterReference, Type: System.EventHandler) (Syntax: 'handler')
 
@@ -1039,13 +1037,9 @@ Block[B0] - Entry
 Block[B1] - Block
     Predecessors: [B0]
     Statements (2)
-        IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: '(c.TestEvent)')
+        IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'c')
           Value: 
-            IParenthesizedOperation (OperationKind.Parenthesized, Type: System.EventHandler) (Syntax: '(c.TestEvent)')
-              Operand: 
-                IEventReferenceOperation: Event C.TestEvent As System.EventHandler (OperationKind.EventReference, Type: System.EventHandler) (Syntax: 'c.TestEvent')
-                  Instance Receiver: 
-                    IParameterReferenceOperation: c (OperationKind.ParameterReference, Type: C) (Syntax: 'c')
+            IParameterReferenceOperation: c (OperationKind.ParameterReference, Type: C) (Syntax: 'c')
 
         IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'handler1')
           Value: 
@@ -1080,7 +1074,9 @@ Block[B4] - Block
           Expression: 
             IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler( ... , handler2)')
               Event Reference: 
-                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.EventHandler, IsImplicit) (Syntax: '(c.TestEvent)')
+                IEventReferenceOperation: Event C.TestEvent As System.EventHandler (OperationKind.EventReference, Type: System.EventHandler) (Syntax: '(c.TestEvent)')
+                  Instance Receiver: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: C, IsImplicit) (Syntax: 'c')
               Handler: 
                 IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.EventHandler, IsImplicit) (Syntax: 'If(handler1, handler2)')
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NewOnInterfaceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NewOnInterfaceTests.vb
@@ -1732,7 +1732,23 @@ IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (S
   Expression: 
     IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler  ... essOf Quit2')
       Event Reference: 
-        null
+        IParenthesizedOperation (OperationKind.Parenthesized, Type: Goo2.QuitEventHandler) (Syntax: '(((Instance ... Quit).Quit)')
+          Operand: 
+            IEventReferenceOperation: Event Goo2.Quit() (OperationKind.EventReference, Type: Goo2.QuitEventHandler) (Syntax: '((Instance1 ... .Quit).Quit')
+              Instance Receiver: 
+                IParenthesizedOperation (OperationKind.Parenthesized, Type: Goo) (Syntax: '((Instance1).Quit.Quit)')
+                  Operand: 
+                    IInvocationOperation (virtual Function Goo1.Quit() As Goo) (OperationKind.Invocation, Type: Goo) (Syntax: '(Instance1).Quit.Quit')
+                      Instance Receiver: 
+                        IInvocationOperation (virtual Function Goo1.Quit() As Goo) (OperationKind.Invocation, Type: Goo) (Syntax: '(Instance1).Quit')
+                          Instance Receiver: 
+                            IParenthesizedOperation (OperationKind.Parenthesized, Type: GooGoo) (Syntax: '(Instance1)')
+                              Operand: 
+                                IFieldReferenceOperation: GooGooClass.Instance1 As GooGoo (OperationKind.FieldReference, Type: GooGoo) (Syntax: 'Instance1')
+                                  Instance Receiver: 
+                                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: GooGooClass, IsImplicit) (Syntax: 'Instance1')
+                          Arguments(0)
+                      Arguments(0)
       Handler: 
         IDelegateCreationOperation (OperationKind.DelegateCreation, Type: Goo2.QuitEventHandler, IsImplicit) (Syntax: 'AddressOf Quit2')
           Target: 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/EventTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/EventTests.vb
@@ -183,9 +183,7 @@ Public Class Form2
 End Class
                              </file>
                          </compilation>
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(source,
-                                                                                    options:=TestOptions.ReleaseDll.WithOptionStrict(OptionStrict.On),
-                                                                                    parseOptions:=TestOptions.RegularWithFlowAnalysisFeature)
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(source, TestOptions.ReleaseDll.WithOptionStrict(OptionStrict.On))
             CompilationUtils.AssertTheseCompileDiagnostics(comp,
 <Expected>
 BC30389: 'Form1.EventB' is not accessible in this context because it is 'Private'.
@@ -201,169 +199,6 @@ BC30389: 'Form1.EventB' is not accessible in this context because it is 'Private
         RemoveHandler EventB, Nothing
                       ~~~~~~
 </Expected>)
-
-            Dim tree = comp.SyntaxTrees.Single()
-            Dim node = tree.GetRoot().DescendantNodes().OfType(Of MethodBlockBaseSyntax).Single()
-            VerifyFlowGraph(comp, node, expectedFlowGraph:=<![CDATA[
-Block[B0] - Entry
-    Statements (0)
-    Next (Regular) Block[B1]
-Block[B1] - Block
-    Predecessors: [B0]
-    Statements (12)
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'AddHandler  ... tA, Nothing')
-          Expression: 
-            IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler  ... tA, Nothing')
-              Event Reference: 
-                IEventReferenceOperation: Event Form1.EventA As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'MyBase.EventA')
-                  Instance Receiver: 
-                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1) (Syntax: 'MyBase')
-              Handler: 
-                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
-                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    (WideningNothingLiteral)
-                  Operand: 
-                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'RemoveHandl ... tA, Nothing')
-          Expression: 
-            IEventAssignmentOperation (EventRemove) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'RemoveHandl ... tA, Nothing')
-              Event Reference: 
-                IEventReferenceOperation: Event Form1.EventA As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'MyBase.EventA')
-                  Instance Receiver: 
-                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1) (Syntax: 'MyBase')
-              Handler: 
-                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
-                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    (WideningNothingLiteral)
-                  Operand: 
-                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'AddHandler  ... tA, Nothing')
-          Expression: 
-            IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler  ... tA, Nothing')
-              Event Reference: 
-                IEventReferenceOperation: Event Form1.EventA As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'EventA')
-                  Instance Receiver: 
-                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsImplicit) (Syntax: 'EventA')
-              Handler: 
-                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
-                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    (WideningNothingLiteral)
-                  Operand: 
-                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'RemoveHandl ... tA, Nothing')
-          Expression: 
-            IEventAssignmentOperation (EventRemove) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'RemoveHandl ... tA, Nothing')
-              Event Reference: 
-                IEventReferenceOperation: Event Form1.EventA As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'EventA')
-                  Instance Receiver: 
-                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsImplicit) (Syntax: 'EventA')
-              Handler: 
-                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
-                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    (WideningNothingLiteral)
-                  Operand: 
-                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'AddHandler  ... tB, Nothing')
-          Expression: 
-            IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'AddHandler  ... tB, Nothing')
-              Children(2):
-                  IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: 'MyBase.EventB')
-                    Children(1):
-                        IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1, IsInvalid) (Syntax: 'MyBase')
-                  ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'RemoveHandl ... tB, Nothing')
-          Expression: 
-            IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'RemoveHandl ... tB, Nothing')
-              Children(2):
-                  IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: 'MyBase.EventB')
-                    Children(1):
-                        IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1, IsInvalid) (Syntax: 'MyBase')
-                  ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'AddHandler  ... tB, Nothing')
-          Expression: 
-            IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'AddHandler  ... tB, Nothing')
-              Children(2):
-                  IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'EventB')
-                    Children(1):
-                        IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsInvalid, IsImplicit) (Syntax: 'EventB')
-                  ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'RemoveHandl ... tB, Nothing')
-          Expression: 
-            IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'RemoveHandl ... tB, Nothing')
-              Children(2):
-                  IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'EventB')
-                    Children(1):
-                        IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsInvalid, IsImplicit) (Syntax: 'EventB')
-                  ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'AddHandler  ... tC, Nothing')
-          Expression: 
-            IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler  ... tC, Nothing')
-              Event Reference: 
-                IEventReferenceOperation: Event Form1.EventC As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'MyBase.EventC')
-                  Instance Receiver: 
-                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1) (Syntax: 'MyBase')
-              Handler: 
-                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
-                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    (WideningNothingLiteral)
-                  Operand: 
-                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'RemoveHandl ... tC, Nothing')
-          Expression: 
-            IEventAssignmentOperation (EventRemove) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'RemoveHandl ... tC, Nothing')
-              Event Reference: 
-                IEventReferenceOperation: Event Form1.EventC As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'MyBase.EventC')
-                  Instance Receiver: 
-                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1) (Syntax: 'MyBase')
-              Handler: 
-                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
-                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    (WideningNothingLiteral)
-                  Operand: 
-                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'AddHandler  ... tC, Nothing')
-          Expression: 
-            IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler  ... tC, Nothing')
-              Event Reference: 
-                IEventReferenceOperation: Event Form1.EventC As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'EventC')
-                  Instance Receiver: 
-                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsImplicit) (Syntax: 'EventC')
-              Handler: 
-                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
-                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    (WideningNothingLiteral)
-                  Operand: 
-                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'RemoveHandl ... tC, Nothing')
-          Expression: 
-            IEventAssignmentOperation (EventRemove) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'RemoveHandl ... tC, Nothing')
-              Event Reference: 
-                IEventReferenceOperation: Event Form1.EventC As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'EventC')
-                  Instance Receiver: 
-                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsImplicit) (Syntax: 'EventC')
-              Handler: 
-                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
-                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    (WideningNothingLiteral)
-                  Operand: 
-                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
-
-    Next (Regular) Block[B2]
-Block[B2] - Exit
-    Predecessors: [B1]
-    Statements (0)
-    ]]>.Value)
         End Sub
 
         <WorkItem(542806, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542806")>
@@ -1814,7 +1649,7 @@ Module Program
     End Sub
 End Module
     ]]></file>
-</compilation>, parseOptions:=TestOptions.RegularWithFlowAnalysisFeature)
+</compilation>)
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
@@ -1836,47 +1671,6 @@ End Module
             Assert.Equal(0, semanticSummary.MemberGroup.Length)
 
             Assert.False(semanticSummary.ConstantValue.HasValue)
-
-            Dim tree = compilation.SyntaxTrees.Single()
-            Dim node = tree.GetRoot().DescendantNodes().OfType(Of MethodBlockSyntax).Single()
-            VerifyFlowGraph(compilation, node, expectedFlowGraph:=<![CDATA[
-Block[B0] - Entry
-    Statements (0)
-    Next (Regular) Block[B1]
-        Entering: {R1}
-
-.locals {R1}
-{
-    Locals: [x As C]
-    Block[B1] - Block
-        Predecessors: [B0]
-        Statements (2)
-            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: C, IsImplicit) (Syntax: 'x = New C')
-              Left: 
-                ILocalReferenceOperation: x (IsDeclaration: True) (OperationKind.LocalReference, Type: C, IsImplicit) (Syntax: 'x')
-              Right: 
-                IObjectCreationOperation (Constructor: Sub C..ctor()) (OperationKind.ObjectCreation, Type: C) (Syntax: 'New C')
-                  Arguments(0)
-                  Initializer: 
-                    null
-
-            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'AddHandler  ... End Sub')
-              Expression: 
-                IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'AddHandler  ... End Sub')
-                  Children(2):
-                      IInvalidOperation (OperationKind.Invalid, Type: C.EEventHandler, IsInvalid) (Syntax: 'x.EEvent')
-                        Children(1):
-                            ILocalReferenceOperation: x (OperationKind.LocalReference, Type: C, IsInvalid) (Syntax: 'x')
-                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'Sub()'BIND: ... End Sub')
-
-        Next (Regular) Block[B2]
-            Leaving: {R1}
-}
-
-Block[B2] - Exit
-    Predecessors: [B1]
-    Statements (0)
-    ]]>.Value)
         End Sub
 
         <WorkItem(543447, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543447")>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/EventTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/EventTests.vb
@@ -183,7 +183,9 @@ Public Class Form2
 End Class
                              </file>
                          </compilation>
-            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(source, TestOptions.ReleaseDll.WithOptionStrict(OptionStrict.On))
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntime(source,
+                                                                                    options:=TestOptions.ReleaseDll.WithOptionStrict(OptionStrict.On),
+                                                                                    parseOptions:=TestOptions.RegularWithFlowAnalysisFeature)
             CompilationUtils.AssertTheseCompileDiagnostics(comp,
 <Expected>
 BC30389: 'Form1.EventB' is not accessible in this context because it is 'Private'.
@@ -199,6 +201,169 @@ BC30389: 'Form1.EventB' is not accessible in this context because it is 'Private
         RemoveHandler EventB, Nothing
                       ~~~~~~
 </Expected>)
+
+            Dim tree = comp.SyntaxTrees.Single()
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of MethodBlockBaseSyntax).Single()
+            VerifyFlowGraph(comp, node, expectedFlowGraph:=<![CDATA[
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+Block[B1] - Block
+    Predecessors: [B0]
+    Statements (12)
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'AddHandler  ... tA, Nothing')
+          Expression: 
+            IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler  ... tA, Nothing')
+              Event Reference: 
+                IEventReferenceOperation: Event Form1.EventA As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'MyBase.EventA')
+                  Instance Receiver: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1) (Syntax: 'MyBase')
+              Handler: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    (WideningNothingLiteral)
+                  Operand: 
+                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'RemoveHandl ... tA, Nothing')
+          Expression: 
+            IEventAssignmentOperation (EventRemove) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'RemoveHandl ... tA, Nothing')
+              Event Reference: 
+                IEventReferenceOperation: Event Form1.EventA As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'MyBase.EventA')
+                  Instance Receiver: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1) (Syntax: 'MyBase')
+              Handler: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    (WideningNothingLiteral)
+                  Operand: 
+                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'AddHandler  ... tA, Nothing')
+          Expression: 
+            IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler  ... tA, Nothing')
+              Event Reference: 
+                IEventReferenceOperation: Event Form1.EventA As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'EventA')
+                  Instance Receiver: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsImplicit) (Syntax: 'EventA')
+              Handler: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    (WideningNothingLiteral)
+                  Operand: 
+                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'RemoveHandl ... tA, Nothing')
+          Expression: 
+            IEventAssignmentOperation (EventRemove) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'RemoveHandl ... tA, Nothing')
+              Event Reference: 
+                IEventReferenceOperation: Event Form1.EventA As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'EventA')
+                  Instance Receiver: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsImplicit) (Syntax: 'EventA')
+              Handler: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    (WideningNothingLiteral)
+                  Operand: 
+                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'AddHandler  ... tB, Nothing')
+          Expression: 
+            IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'AddHandler  ... tB, Nothing')
+              Children(2):
+                  IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: 'MyBase.EventB')
+                    Children(1):
+                        IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1, IsInvalid) (Syntax: 'MyBase')
+                  ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'RemoveHandl ... tB, Nothing')
+          Expression: 
+            IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'RemoveHandl ... tB, Nothing')
+              Children(2):
+                  IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: 'MyBase.EventB')
+                    Children(1):
+                        IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1, IsInvalid) (Syntax: 'MyBase')
+                  ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'AddHandler  ... tB, Nothing')
+          Expression: 
+            IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'AddHandler  ... tB, Nothing')
+              Children(2):
+                  IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'EventB')
+                    Children(1):
+                        IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsInvalid, IsImplicit) (Syntax: 'EventB')
+                  ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'RemoveHandl ... tB, Nothing')
+          Expression: 
+            IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'RemoveHandl ... tB, Nothing')
+              Children(2):
+                  IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'EventB')
+                    Children(1):
+                        IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsInvalid, IsImplicit) (Syntax: 'EventB')
+                  ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'AddHandler  ... tC, Nothing')
+          Expression: 
+            IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler  ... tC, Nothing')
+              Event Reference: 
+                IEventReferenceOperation: Event Form1.EventC As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'MyBase.EventC')
+                  Instance Receiver: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1) (Syntax: 'MyBase')
+              Handler: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    (WideningNothingLiteral)
+                  Operand: 
+                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'RemoveHandl ... tC, Nothing')
+          Expression: 
+            IEventAssignmentOperation (EventRemove) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'RemoveHandl ... tC, Nothing')
+              Event Reference: 
+                IEventReferenceOperation: Event Form1.EventC As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'MyBase.EventC')
+                  Instance Receiver: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form1) (Syntax: 'MyBase')
+              Handler: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    (WideningNothingLiteral)
+                  Operand: 
+                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'AddHandler  ... tC, Nothing')
+          Expression: 
+            IEventAssignmentOperation (EventAdd) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'AddHandler  ... tC, Nothing')
+              Event Reference: 
+                IEventReferenceOperation: Event Form1.EventC As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'EventC')
+                  Instance Receiver: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsImplicit) (Syntax: 'EventC')
+              Handler: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    (WideningNothingLiteral)
+                  Operand: 
+                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'RemoveHandl ... tC, Nothing')
+          Expression: 
+            IEventAssignmentOperation (EventRemove) (OperationKind.EventAssignment, Type: null, IsImplicit) (Syntax: 'RemoveHandl ... tC, Nothing')
+              Event Reference: 
+                IEventReferenceOperation: Event Form1.EventC As System.Action (OperationKind.EventReference, Type: System.Action) (Syntax: 'EventC')
+                  Instance Receiver: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: Form2, IsImplicit) (Syntax: 'EventC')
+              Handler: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Action, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    (WideningNothingLiteral)
+                  Operand: 
+                    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'Nothing')
+
+    Next (Regular) Block[B2]
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)
+    ]]>.Value)
         End Sub
 
         <WorkItem(542806, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542806")>
@@ -1649,7 +1814,7 @@ Module Program
     End Sub
 End Module
     ]]></file>
-</compilation>)
+</compilation>, parseOptions:=TestOptions.RegularWithFlowAnalysisFeature)
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
@@ -1671,6 +1836,47 @@ End Module
             Assert.Equal(0, semanticSummary.MemberGroup.Length)
 
             Assert.False(semanticSummary.ConstantValue.HasValue)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of MethodBlockSyntax).Single()
+            VerifyFlowGraph(compilation, node, expectedFlowGraph:=<![CDATA[
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1}
+
+.locals {R1}
+{
+    Locals: [x As C]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (2)
+            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: C, IsImplicit) (Syntax: 'x = New C')
+              Left: 
+                ILocalReferenceOperation: x (IsDeclaration: True) (OperationKind.LocalReference, Type: C, IsImplicit) (Syntax: 'x')
+              Right: 
+                IObjectCreationOperation (Constructor: Sub C..ctor()) (OperationKind.ObjectCreation, Type: C) (Syntax: 'New C')
+                  Arguments(0)
+                  Initializer: 
+                    null
+
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: 'AddHandler  ... End Sub')
+              Expression: 
+                IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'AddHandler  ... End Sub')
+                  Children(2):
+                      IInvalidOperation (OperationKind.Invalid, Type: C.EEventHandler, IsInvalid) (Syntax: 'x.EEvent')
+                        Children(1):
+                            ILocalReferenceOperation: x (OperationKind.LocalReference, Type: C, IsInvalid) (Syntax: 'x')
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'Sub()'BIND: ... End Sub')
+
+        Next (Regular) Block[B2]
+            Leaving: {R1}
+}
+
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)
+    ]]>.Value)
         End Sub
 
         <WorkItem(543447, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543447")>

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -986,6 +986,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             LogString($"{nameof(IEventAssignmentOperation)} ({kindStr})");
             LogCommonPropertiesAndNewLine(operation);
 
+            Assert.NotNull(operation.EventReference);
             Visit(operation.EventReference, header: "Event Reference");
             Visit(operation.HandlerValue, header: "Handler");
         }

--- a/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
@@ -597,18 +597,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             Assert.Equal(OperationKind.EventAssignment, operation.Kind);
             var adds = operation.Adds;
-            // operation.EventReference shouldn't be null. The following conditional logic is
-            // a work around for https://github.com/dotnet/roslyn/issues/23810 and should 
-            // be removed once the issue is fixed
-            if (operation.EventReference == null)
-            {
-                Assert.Equal(LanguageNames.VisualBasic, operation.Language);
-                Assert.Same(operation.HandlerValue, operation.Children.Single());
-            }
-            else
-            {
-                AssertEx.Equal(new[] { operation.EventReference, operation.HandlerValue }, operation.Children);
-            }
+            AssertEx.Equal(new[] { operation.EventReference, operation.HandlerValue }, operation.Children);
         }
 
         public override void VisitConditionalAccess(IConditionalAccessOperation operation)

--- a/src/Test/Utilities/Portable/Diagnostics/OperationTestAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/OperationTestAnalyzer.cs
@@ -1052,7 +1052,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                      IEventAssignmentOperation eventAssignment = (IEventAssignmentOperation)operationContext.Operation;
                      operationContext.ReportDiagnostic(Diagnostic.Create(eventAssignment.Adds ? HandlerAddedDescriptor : HandlerRemovedDescriptor, operationContext.Operation.Syntax.GetLocation()));
 
-                     if (eventAssignment.EventReference?.Event == null && eventAssignment.HasErrors(operationContext.Compilation, operationContext.CancellationToken))
+                     if (eventAssignment.EventReference.Kind == OperationKind.Invalid || eventAssignment.HasErrors(operationContext.Compilation, operationContext.CancellationToken))
                      {
                          operationContext.ReportDiagnostic(Diagnostic.Create(InvalidEventDescriptor, eventAssignment.Syntax.GetLocation()));
                      }


### PR DESCRIPTION
…ence

For error cases, instead of generating an IEventAssignmentOperation with null EventReference, we now generate an IEventAssignmentOperation with an IInvalidOperation as the EventReference.

Fixes #23810
Also fixes NRE in CFG Builder found by @AlekseyTs for such error cases.