### PR TITLE
Disabling integration tests temporarily

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -227,7 +227,7 @@ commitPullList.each { isPr ->
         }
       }
 
-      def triggerPhraseOnly = false
+      def triggerPhraseOnly = true
       def triggerPhraseExtra = ""
       Utilities.setMachineAffinity(myJob, 'Windows.10.Amd64.ClientRS3.DevEx.Open')
       Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')


### PR DESCRIPTION
Pending Windows updates are preventing the integration tests from being run. We will be disabling them for now. 

The issue is being worked on and the tests will be re-enabled after the issue is resolved. 

@dotnet/roslyn-infrastructure
