### PR TITLE
Razor FAR: Fix nullref with new AddFile API

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -981,10 +981,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var document = this.DocumentProvider.TryGetDocumentForFile(
                 this,
                 filePath: filename,
+                sourceTextContainer: sourceTextContainer,
                 sourceCodeKind: sourceCodeKind,
                 getFolderNames: getFolderNames,
                 canUseTextBuffer: CanUseTextBuffer,
-                updatedOnDiskHandler: s_documentUpdatedEventHandler,
+                updatedHandler: s_documentUpdatedEventHandler,
                 openedHandler: s_documentOpenedEventHandler,
                 closingHandler: s_documentClosingEventHandler,
                 documentServiceFactory: documentServiceFactory);


### PR DESCRIPTION
For context this is a bug fix to some prototyping work going on in features/razorFar. We're working on enabling find-all-reference for .NET Core Razor 

----

/cc @heejaechang 

This wasn't fixed properly :( this method still isn't passing the
SourceTextContainer so it nullrefs later when the document tries to hook
up events.



