### PR TITLE
Add API Compilation.ClassifyCommonConverstion

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -881,7 +881,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // The MethodSymbol of CommonConversion only refers to UserDefined conversions, not method groups
             var methodSymbol = IsUserDefined ? MethodSymbol : null;
-            return new CommonConversion(Exists, IsIdentity, IsNumeric, IsReference, methodSymbol);
+            return new CommonConversion(Exists, IsIdentity, IsNumeric, IsReference, IsImplicit, methodSymbol);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.CodeAnalysis.Text;
@@ -1743,6 +1744,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             return Conversions.ClassifyConversionFromType(cssource, csdest, ref useSiteDiagnostics);
+        }
+
+        /// <summary>
+        /// Classifies a conversion from <paramref name="source"/> to <paramref name="destination"/> according
+        /// to this compilation's programming language.
+        /// </summary>
+        /// <param name="source">Source type of value to be converted</param>
+        /// <param name="destination">Destination type of value to be converted</param>
+        /// <returns>A <see cref="CommonConversion"/> that classifies the conversion from the
+        /// <paramref name="source"/> type to the <paramref name="destination"/> type.</returns>
+        public override CommonConversion ClassifyCommonConversion(ITypeSymbol source, ITypeSymbol destination)
+        {
+            return ClassifyConversion(source, destination).ToCommonConversion();
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Operations/CSharpArgument.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpArgument.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
         }
 
-        public override CommonConversion InConversion => new CommonConversion(exists:true, isIdentity:true, isNumeric:false, isReference:false, methodSymbol:null);
+        public override CommonConversion InConversion => new CommonConversion(exists:true, isIdentity:true, isNumeric:false, isReference:false, isImplicit: true, methodSymbol:null);
 
-        public override CommonConversion OutConversion => new CommonConversion(exists: true, isIdentity: true, isNumeric: false, isReference: false, methodSymbol: null);
+        public override CommonConversion OutConversion => new CommonConversion(exists: true, isIdentity: true, isNumeric: false, isReference: false, isImplicit: true, methodSymbol: null);
     }
 
     internal sealed class CSharpArgument : BaseCSharpArgument

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -80,3 +80,4 @@ Microsoft.CodeAnalysis.CSharp.Syntax.XmlAttributeSyntax.WithEndQuoteToken(Micros
 Microsoft.CodeAnalysis.CSharp.Syntax.XmlAttributeSyntax.WithEqualsToken(Microsoft.CodeAnalysis.SyntaxToken equalsToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.XmlAttributeSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.XmlAttributeSyntax.WithName(Microsoft.CodeAnalysis.CSharp.Syntax.XmlNameSyntax name) -> Microsoft.CodeAnalysis.CSharp.Syntax.XmlAttributeSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.XmlAttributeSyntax.WithStartQuoteToken(Microsoft.CodeAnalysis.SyntaxToken startQuoteToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.XmlAttributeSyntax
+override Microsoft.CodeAnalysis.CSharp.CSharpCompilation.ClassifyCommonConversion(Microsoft.CodeAnalysis.ITypeSymbol source, Microsoft.CodeAnalysis.ITypeSymbol destination) -> Microsoft.CodeAnalysis.Operations.CommonConversion

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.DiaSymReader;
@@ -1091,6 +1092,25 @@ namespace Microsoft.CodeAnalysis
             ImmutableArray<string> memberNames,
             ImmutableArray<Location> memberLocations,
             ImmutableArray<bool> memberIsReadOnly);
+
+        /// <summary>
+        /// Classifies a conversion from <paramref name="source"/> to <paramref name="destination"/> according
+        /// to this compilation's programming language.
+        /// </summary>
+        /// <param name="source">Source type of value to be converted</param>
+        /// <param name="destination">Destination type of value to be converted</param>
+        /// <returns>A <see cref="CommonConversion"/> that classifies the conversion from the
+        /// <paramref name="source"/> type to the <paramref name="destination"/> type.</returns>
+        public abstract CommonConversion ClassifyCommonConversion(ITypeSymbol source, ITypeSymbol destination);
+
+        /// <summary>
+        /// Returns true if there is an implicit (C#) or widening (VB) conversion from
+        /// <paramref name="fromType"/> to <paramref name="toType"/>. Returns false if
+        /// either <paramref name="fromType"/> or <paramref name="toType"/> is null, or
+        /// if no such conversion exists.
+        /// </summary>
+        public bool HasImplicitConversion(ITypeSymbol fromType, ITypeSymbol toType)
+            => fromType != null && toType != null && this.ClassifyCommonConversion(fromType, toType).IsImplicit;
 
         #endregion
 

--- a/src/Compilers/Core/Portable/Operations/CommonConversion.cs
+++ b/src/Compilers/Core/Portable/Operations/CommonConversion.cs
@@ -15,21 +15,23 @@ namespace Microsoft.CodeAnalysis.Operations
         [Flags]
         private enum ConversionKind
         {
-            None = 0b0000,
-            Exists = 0b0001,
-            IsIdentity = 0b0010,
-            IsNumeric = 0b0100,
-            IsReference = 0b1000
+            None = 0,
+            Exists =        1 << 0,
+            IsIdentity =    1 << 1,
+            IsNumeric =     1 << 2,
+            IsReference =   1 << 3,
+            IsImplicit =    1 << 4,
         }
 
         private readonly ConversionKind _conversionKind;
 
-        internal CommonConversion(bool exists, bool isIdentity, bool isNumeric, bool isReference, IMethodSymbol methodSymbol)
+        internal CommonConversion(bool exists, bool isIdentity, bool isNumeric, bool isReference, bool isImplicit, IMethodSymbol methodSymbol)
         {
             _conversionKind = (exists ? ConversionKind.Exists : ConversionKind.None) |
                               (isIdentity ? ConversionKind.IsIdentity : ConversionKind.None) |
                               (isNumeric ? ConversionKind.IsNumeric : ConversionKind.None) |
-                              (isReference ? ConversionKind.IsReference : ConversionKind.None);
+                              (isReference ? ConversionKind.IsReference : ConversionKind.None) |
+                              (isImplicit ? ConversionKind.IsImplicit : ConversionKind.None);
             MethodSymbol = methodSymbol;
         }
 
@@ -53,6 +55,10 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Returns true if the conversion is a reference conversion.
         /// </summary>
         public bool IsReference => (_conversionKind & ConversionKind.IsReference) == ConversionKind.IsReference;
+        /// <summary>
+        /// Returns true if the conversion is an implicit (C#) or widening (VB) conversion.
+        /// </summary>
+        public bool IsImplicit => (_conversionKind & ConversionKind.IsImplicit) == ConversionKind.IsImplicit;
         /// <summary>
         /// Returns true if the conversion is a user-defined conversion.
         /// </summary>

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
+Microsoft.CodeAnalysis.Compilation.HasImplicitConversion(Microsoft.CodeAnalysis.ITypeSymbol fromType, Microsoft.CodeAnalysis.ITypeSymbol toType) -> bool
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.Concurrent.get -> bool
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.Concurrent.set -> void
+Microsoft.CodeAnalysis.Operations.CommonConversion.IsImplicit.get -> bool
+abstract Microsoft.CodeAnalysis.Compilation.ClassifyCommonConversion(Microsoft.CodeAnalysis.ITypeSymbol source, Microsoft.CodeAnalysis.ITypeSymbol destination) -> Microsoft.CodeAnalysis.Operations.CommonConversion

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.InternalUtilities
+Imports Microsoft.CodeAnalysis.Operations
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Symbols
 Imports Microsoft.CodeAnalysis.Text
@@ -1757,6 +1758,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Return New Conversion(Conversions.ClassifyConversion(vbsource, vbdest, Nothing))
+        End Function
+
+        Public Overrides Function ClassifyCommonConversion(source As ITypeSymbol, destination As ITypeSymbol) As CommonConversion
+            Return ClassifyConversion(source, destination).ToCommonConversion()
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/VisualBasic/Portable/PublicAPI.Unshipped.txt
@@ -48,3 +48,4 @@ Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeStatementSyntax.WithAttributeLists
 Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeStatementSyntax.WithIdentifier(identifier As Microsoft.CodeAnalysis.SyntaxToken) -> Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeStatementSyntax
 Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeStatementSyntax.WithModifiers(modifiers As Microsoft.CodeAnalysis.SyntaxTokenList) -> Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeStatementSyntax
 Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeStatementSyntax.WithTypeParameterList(typeParameterList As Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeParameterListSyntax) -> Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeStatementSyntax
+Overrides Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation.ClassifyCommonConversion(source As Microsoft.CodeAnalysis.ITypeSymbol, destination As Microsoft.CodeAnalysis.ITypeSymbol) -> Microsoft.CodeAnalysis.Operations.CommonConversion

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -237,7 +237,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' from the <see cref="CommonConversion"/> struct.
         ''' </remarks>
         Public Function ToCommonConversion() As CommonConversion
-            Return New CommonConversion(Exists, IsIdentity, IsNumeric, IsReference, MethodSymbol)
+            Return New CommonConversion(Exists, IsIdentity, IsNumeric, IsReference, IsWidening, MethodSymbol)
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
@@ -2090,6 +2090,7 @@ Module M
             Assert.True(conv.IsWidening)
             Assert.False(conv.IsNarrowing)
             Assert.True(conv.IsIdentity)
+            Assert.True(compilation.HasImplicitConversion(listOfInt32_1, listOfInt32_2))
 
             ' Convert List(Of Integer) -> Integer : Should be no conversion
             conv = compilation.ClassifyConversion(listOfInt32_1, int32)
@@ -2097,6 +2098,7 @@ Module M
             Assert.False(conv.Exists)
             Assert.False(conv.IsWidening)
             Assert.False(conv.IsNarrowing)
+            Assert.False(compilation.HasImplicitConversion(listOfInt32_1, int32))
 
             ' Convert String -> Integer: Should be narrowing string conversion
             conv = compilation.ClassifyConversion(str, int32)
@@ -2106,6 +2108,7 @@ Module M
             Assert.True(conv.IsNarrowing)
             Assert.True(conv.IsString)
             Assert.Equal("NarrowingString", conv.ToString())
+            Assert.False(compilation.HasImplicitConversion(str, int32))
 
             ' Convert Enum -> Integer: Should be  widening numeric conversion
             conv = compilation.ClassifyConversion(enumType, int32)
@@ -2115,6 +2118,7 @@ Module M
             Assert.False(conv.IsNarrowing)
             Assert.True(conv.IsNumeric)
             Assert.Equal("WideningNumeric, InvolvesEnumTypeConversions", conv.ToString())
+            Assert.True(compilation.HasImplicitConversion(enumType, int32))
 
             ' Convert Enum -> String: Should be  narrowing string conversion
             conv = compilation.ClassifyConversion(enumType, str)
@@ -2123,6 +2127,7 @@ Module M
             Assert.False(conv.IsWidening)
             Assert.True(conv.IsNarrowing)
             Assert.True(conv.IsString)
+            Assert.False(compilation.HasImplicitConversion(enumType, str))
 
             ' Convert Long -> Integer: Should be narrowing numeric conversion
             conv = compilation.ClassifyConversion(int64, int32)
@@ -2131,6 +2136,7 @@ Module M
             Assert.False(conv.IsWidening)
             Assert.True(conv.IsNarrowing)
             Assert.True(conv.IsNumeric)
+            Assert.False(compilation.HasImplicitConversion(int64, int32))
 
             ' Convert Boolean -> Enum: Should be narrowing boolean conversion
             conv = compilation.ClassifyConversion(bool, enumType)
@@ -2140,6 +2146,7 @@ Module M
             Assert.True(conv.IsNarrowing)
             Assert.True(conv.IsBoolean)
             Assert.Equal("NarrowingBoolean, InvolvesEnumTypeConversions", conv.ToString())
+            Assert.False(compilation.HasImplicitConversion(bool, enumType))
 
             ' Convert List(Of Integer) -> Object: Should be widening reference conversion
             conv = compilation.ClassifyConversion(listOfInt32_1, objType)
@@ -2149,6 +2156,7 @@ Module M
             Assert.False(conv.IsNarrowing)
             Assert.True(conv.IsReference)
             Assert.Equal("WideningReference", conv.ToString())
+            Assert.True(compilation.HasImplicitConversion(listOfInt32_1, objType))
 
             ' Convert Object -> List(Of Integer): Should be narrow reference conversion
             conv = compilation.ClassifyConversion(objType, listOfInt32_1)
@@ -2157,6 +2165,7 @@ Module M
             Assert.False(conv.IsWidening)
             Assert.True(conv.IsNarrowing)
             Assert.True(conv.IsReference)
+            Assert.False(compilation.HasImplicitConversion(objType, listOfInt32_1))
 
             ' Convert AAA -> System.ICloneable: SHould be widening reference conversion
             conv = compilation.ClassifyConversion(classAAA, cloneableType)
@@ -2165,6 +2174,7 @@ Module M
             Assert.True(conv.IsWidening)
             Assert.False(conv.IsNarrowing)
             Assert.True(conv.IsReference)
+            Assert.True(compilation.HasImplicitConversion(classAAA, cloneableType))
 
             ' Convert AAA() -> Object(): SHould be widening array conversion
             conv = compilation.ClassifyConversion(aaaArray, objArray)
@@ -2173,6 +2183,7 @@ Module M
             Assert.True(conv.IsWidening)
             Assert.False(conv.IsNarrowing)
             Assert.True(conv.IsArray)
+            Assert.True(compilation.HasImplicitConversion(aaaArray, objArray))
 
             ' Convert Object() -> AAA(): SHould be narrowing array conversion
             conv = compilation.ClassifyConversion(objArray, aaaArray)
@@ -2182,6 +2193,7 @@ Module M
             Assert.True(conv.IsNarrowing)
             Assert.True(conv.IsArray)
             Assert.Equal("NarrowingArray", conv.ToString())
+            Assert.False(compilation.HasImplicitConversion(objArray, aaaArray))
 
             ' Convert Short -> Integer?: Should be widening nullable value type conversion
             conv = compilation.ClassifyConversion(int16, nullInt32)
@@ -2191,6 +2203,7 @@ Module M
             Assert.False(conv.IsNarrowing)
             Assert.True(conv.IsNullableValueType)
             Assert.Equal("WideningNullable", conv.ToString())
+            Assert.True(compilation.HasImplicitConversion(int16, nullInt32))
 
             ' Convert Integer? -> Integer: Should be narrowing nullable value type conversion
             conv = compilation.ClassifyConversion(nullInt32, int32)
@@ -2199,6 +2212,7 @@ Module M
             Assert.False(conv.IsWidening)
             Assert.True(conv.IsNarrowing)
             Assert.True(conv.IsNullableValueType)
+            Assert.False(compilation.HasImplicitConversion(nullInt32, int32))
 
             ' Convert T -> Object: Widening type parameter conversion
             conv = compilation.ClassifyConversion(typeParam, objType)
@@ -2207,6 +2221,7 @@ Module M
             Assert.True(conv.IsWidening)
             Assert.False(conv.IsNarrowing)
             Assert.True(conv.IsTypeParameter)
+            Assert.True(compilation.HasImplicitConversion(typeParam, objType))
 
             ' Convert Object -> T : Narrowing type parameter conversion
             conv = compilation.ClassifyConversion(objType, typeParam)
@@ -2216,6 +2231,7 @@ Module M
             Assert.True(conv.IsNarrowing)
             Assert.True(conv.IsTypeParameter)
             Assert.Equal("NarrowingTypeParameter", conv.ToString())
+            Assert.False(compilation.HasImplicitConversion(objType, typeParam))
 
             ' Check equality, hash code.
             Dim conv2 = compilation.ClassifyConversion(objType, typeParam)

--- a/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
@@ -347,8 +347,8 @@ namespace Microsoft.CodeAnalysis.ConvertForEachToFor
         private static bool IsExchangable(
             ISemanticFactsService semanticFact, ITypeSymbol type1, ITypeSymbol type2, Compilation compilation)
         {
-            return semanticFact.IsAssignableTo(type1, type2, compilation) ||
-                   semanticFact.IsAssignableTo(type2, type1, compilation);
+            return compilation.HasImplicitConversion(type1, type2) ||
+                   compilation.HasImplicitConversion(type2, type1);
         }
 
         private static bool IsNullOrErrorType(ITypeSymbol type)

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 {
                     var type2 = method.Parameters[i].Type;
 
-                    if (!semanticFactsService.IsAssignableTo(type1, type2, compilation))
+                    if (!compilation.HasImplicitConversion(fromType: type1, toType: type2))
                     {
                         return false;
                     }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
@@ -269,13 +269,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public bool IsAssignableTo(ITypeSymbol fromSymbol, ITypeSymbol toSymbol, Compilation compilation)
-        {
-            return fromSymbol != null &&
-                toSymbol != null &&
-                ((CSharpCompilation)compilation).ClassifyConversion(fromSymbol, toSymbol).IsImplicit;
-        }
-
         public bool IsNameOfContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
         {
             return semanticModel.SyntaxTree.IsNameOfContext(position, semanticModel, cancellationToken);

--- a/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
@@ -95,8 +95,6 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         ImmutableArray<IMethodSymbol> GetDeconstructionForEachMethods(SemanticModel semanticModel, SyntaxNode node);
 
-        bool IsAssignableTo(ITypeSymbol fromSymbol, ITypeSymbol toSymbol, Compilation compilation);
-
         bool IsPartial(ITypeSymbol typeSymbol, CancellationToken cancellationToken);
 
         IEnumerable<ISymbol> GetDeclaredSymbols(SemanticModel semanticModel, SyntaxNode memberDeclaration, CancellationToken cancellationToken);

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -264,10 +264,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return ImmutableArray(Of IMethodSymbol).Empty
         End Function
 
-        Public Function IsAssignableTo(fromSymbol As ITypeSymbol, toSymbol As ITypeSymbol, compilation As Compilation) As Boolean Implements ISemanticFactsService.IsAssignableTo
-            Return fromSymbol IsNot Nothing AndAlso toSymbol IsNot Nothing AndAlso DirectCast(compilation, VisualBasicCompilation).ClassifyConversion(fromSymbol, toSymbol).IsWidening
-        End Function
-
         Public Function IsNameOfContext(semanticModel As SemanticModel, position As Integer, cancellationToken As CancellationToken) As Boolean Implements ISemanticFactsService.IsNameOfContext
             Return semanticModel.SyntaxTree.IsNameOfContext(position, cancellationToken)
         End Function


### PR DESCRIPTION
Also add
- CommonConversion.IsImplicit
- Compilation.HasImplicitConversion
Fixes #9461

Note that a preliminary review of drafts of this API were in https://github.com/dotnet/roslyn/pull/26719
This is the version of the API approved by CodeAnalysis review group 2018-05-23.

@dotnet/roslyn-compiler Please review.
/cc @dotnet/roslyn-ide for removal of no-longer-needed APIs.
