### PR TITLE
if FSA is off, make compilation end analyzer build only analyzer.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -152,7 +152,7 @@ class C
         private void AccessSupportedDiagnostics(DiagnosticAnalyzer analyzer)
         {
             var diagnosticService = new TestDiagnosticAnalyzerService(LanguageNames.CSharp, analyzer);
-            diagnosticService.GetDiagnosticDescriptors(projectOpt: null);
+            diagnosticService.CreateDiagnosticDescriptorsPerReference(projectOpt: null);
         }
 
         private class ThrowingDoNotCatchDiagnosticAnalyzer<TLanguageKindEnum> : ThrowingDiagnosticAnalyzer<TLanguageKindEnum>, IBuiltInAnalyzer where TLanguageKindEnum : struct

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(LanguageNames.CSharp, workspaceDiagnosticAnalyzer)
 
                 ' Verify available diagnostic descriptors/analyzers
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
                 Assert.Equal(1, descriptors.Count())
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.WithAnalyzerReferences(projectAnalyzerReferences1)
 
                 ' Verify available diagnostic descriptors/analyzers
-                descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(2, descriptorsMap.Count)
                 descriptors = descriptorsMap.Values.SelectMany(Function(d) d).OrderBy(Function(d) d.Id).ToImmutableArray()
                 Assert.Equal(workspaceDiagnosticAnalyzer.DiagDescriptor.Id, descriptors(0).Id)
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.AddAnalyzerReference(projectAnalyzerReference2)
 
                 ' Verify available diagnostic descriptors/analyzers
-                descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(3, descriptorsMap.Count)
                 descriptors = descriptorsMap.Values.SelectMany(Function(d) d).OrderBy(Function(d) d.Id).ToImmutableArray()
                 Assert.Equal(workspaceDiagnosticAnalyzer.DiagDescriptor.Id, descriptors(0).Id)
@@ -99,7 +99,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.RemoveAnalyzerReference(projectAnalyzerReference1)
 
                 ' Verify available diagnostic descriptors/analyzers
-                descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(2, descriptorsMap.Count)
                 descriptors = descriptorsMap.Values.SelectMany(Function(d) d).OrderBy(Function(d) d.Id).ToImmutableArray()
                 Assert.Equal(workspaceDiagnosticAnalyzer.DiagDescriptor.Id, descriptors(0).Id)
@@ -112,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Assert.Equal(2, diagnostics.Count())
 
                 ' Verify available diagnostic descriptors/analyzers if not project specific
-                descriptorsMap = diagnosticService.GetDiagnosticDescriptors(projectOpt:=Nothing)
+                descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(projectOpt:=Nothing)
                 Assert.Equal(1, descriptorsMap.Count)
                 descriptors = descriptorsMap.First().Value
                 Assert.Equal(1, descriptors.Count)
@@ -123,7 +123,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.WithAnalyzerReferences({duplicateProjectAnalyzersReference})
 
                 ' Verify duplicate descriptors or diagnostics.
-                descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 descriptors = descriptorsMap.Values.SelectMany(Function(d) d).OrderBy(Function(d) d.Id).ToImmutableArray()
                 Assert.Equal(workspaceDiagnosticAnalyzer.DiagDescriptor.Id, descriptors(0).Id)
@@ -159,8 +159,8 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.WithAnalyzerReferences(projectAnalyzerReferences1)
 
                 ' Query descriptors twice: second query was hitting an assert in DiagnosticAnalyzersAndStates.
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
-                descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
+                descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
 
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
@@ -195,7 +195,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
 
                 project = project.WithAnalyzerReferences(ImmutableArray.Create(Of AnalyzerReference)(projectAnalyzerReference))
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
 
                 ' two references in the map
                 Assert.Equal(1, descriptorsMap.Count)
@@ -224,7 +224,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(LanguageNames.CSharp, workspaceDiagnosticAnalyzer)
 
                 ' Verify available diagnostic descriptors/analyzers
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
                 Assert.Equal(1, descriptors.Count())
@@ -294,15 +294,15 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
                 Dim analyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
 
-                Dim workspaceDescriptors = diagnosticService.GetDiagnosticDescriptors(projectOpt:=Nothing)
+                Dim workspaceDescriptors = diagnosticService.CreateDiagnosticDescriptorsPerReference(projectOpt:=Nothing)
                 Assert.Equal(0, workspaceDescriptors.Count)
 
-                Dim alphaDescriptors = diagnosticService.GetDiagnosticDescriptors(alpha)
+                Dim alphaDescriptors = diagnosticService.CreateDiagnosticDescriptorsPerReference(alpha)
                 Assert.Equal("XX0001", alphaDescriptors.Single().Value.Single().Id)
                 Dim alphaDiagnostics = diagnosticService.GetDiagnosticsForSpanAsync(alpha.Documents.Single(), New TextSpan(0, alpha.Documents.Single().GetTextAsync().Result.Length)).Result
                 Assert.Equal("XX0001", alphaDiagnostics.Single().Id)
 
-                Dim bravoDescriptors = diagnosticService.GetDiagnosticDescriptors(bravo)
+                Dim bravoDescriptors = diagnosticService.CreateDiagnosticDescriptorsPerReference(bravo)
                 Assert.Equal("XX0002", bravoDescriptors.Single().Value.Single().Id)
                 Dim bravoDiagnostics = diagnosticService.GetDiagnosticsForSpanAsync(bravo.Documents.Single(), New TextSpan(0, bravo.Documents.Single().GetTextAsync().Result.Length)).Result
                 Assert.Equal("XX0002", bravoDiagnostics.Single().Id)
@@ -328,7 +328,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 analyzersMap.Add(LanguageNames.VisualBasic, ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer2))
                 Dim diagnosticService2 = New TestDiagnosticAnalyzerService(analyzersMap.ToImmutableDictionary())
 
-                Dim descriptors = diagnosticService2.GetDiagnosticDescriptors(projectOpt:=Nothing)
+                Dim descriptors = diagnosticService2.CreateDiagnosticDescriptorsPerReference(projectOpt:=Nothing)
                 Assert.Equal(1, descriptors.Count)
                 Assert.Equal(2, descriptors.Single().Value.Count)
             End Using
@@ -375,7 +375,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(ImmutableArray.Create(Of AnalyzerReference)(analyzerReference2))
 
                 Dim analyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
 
                 ' Verify no duplicate diagnostics.
                 Dim document = project.Documents.Single()
@@ -431,7 +431,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
                 Assert.Equal(0, descriptors.Count())
@@ -467,7 +467,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=exceptionDiagnosticsSource, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -536,7 +536,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                     Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
                     project = project.AddAnalyzerReference(analyzerReference)
 
-                    Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                    Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                     Assert.Equal(1, descriptorsMap.Count)
 
                     Dim document = project.Documents.Single()
@@ -569,7 +569,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -604,7 +604,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
                 ' Ensure no duplicate diagnostics.
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -681,7 +681,7 @@ class AnonymousFunctions
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
                 ' Ensure no duplicate diagnostics.
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -720,7 +720,7 @@ class AnonymousFunctions
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 ' Ask for document diagnostics multiple times, and verify compilation diagnostics are reported.
@@ -837,7 +837,7 @@ class AnonymousFunctions
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 ' Verify no duplicate analysis/diagnostics.
@@ -874,7 +874,7 @@ class AnonymousFunctions
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single(Function(d) d.Name = "Test1.cs")
@@ -929,7 +929,7 @@ class AnonymousFunctions
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 ' Verify project diagnostics contains diagnostics reported on both partial definitions.
@@ -978,7 +978,7 @@ public class B
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1020,7 +1020,7 @@ public class B
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1062,7 +1062,7 @@ public class B
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1113,7 +1113,7 @@ End Class
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1175,7 +1175,7 @@ public class B
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1259,7 +1259,7 @@ public class B
         End Sub
 
         Private Shared Sub TestCompilationAnalyzerWithAnalyzerOptionsCore(project As Project, expectedDiagnosticMessage As String, diagnosticService As DiagnosticAnalyzerService)
-            Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+            Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
             Assert.Equal(1, descriptorsMap.Count)
 
             Dim document = project.Documents.Single()
@@ -1779,7 +1779,7 @@ End Class
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1839,7 +1839,7 @@ namespace ConsoleApplication1
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim document = project.Documents.Single()
@@ -1909,7 +1909,7 @@ class MyClass
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
 
                 ' Verify available diagnostic descriptors/analyzers
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Assert.Equal(0, descriptorsMap.First().Value.Length)
 
@@ -1949,7 +1949,7 @@ class MyClass
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
 
                 ' Verify available diagnostic descriptors
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
                 Assert.Equal(1, descriptors.Length)
@@ -2000,7 +2000,7 @@ class MyClass
                 Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(hostDiagnosticUpdateSource:=Nothing, mefExportProvider.GetExports(Of PrimaryWorkspace).Single.Value)
 
-                Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
+                Dim descriptorsMap = diagnosticService.CreateDiagnosticDescriptorsPerReference(project)
                 Assert.Equal(1, descriptorsMap.Count)
 
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
@@ -79,7 +79,7 @@ End Class
 
     Private Sub AccessSupportedDiagnostics(analyzer As DiagnosticAnalyzer)
         Dim diagnosticService = New TestDiagnosticAnalyzerService(LanguageNames.VisualBasic, analyzer)
-        diagnosticService.GetDiagnosticDescriptors(projectOpt:=Nothing)
+        diagnosticService.CreateDiagnosticDescriptorsPerReference(projectOpt:=Nothing)
     End Sub
 
     <Fact>

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics.Log;
+using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Options;
 using Roslyn.Utilities;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Diagnostics.Log;
-using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
@@ -290,6 +290,116 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private static IEnumerable<AnalyzerPerformanceInfo> Convert(IEnumerable<(DiagnosticAnalyzer analyzer, TimeSpan timeSpan)> analyzerPerf, IDiagnosticAnalyzerService serviceOpt = null)
         {
             return analyzerPerf.Select(kv => new AnalyzerPerformanceInfo(kv.analyzer.GetAnalyzerId(), DiagnosticAnalyzerLogger.AllowsTelemetry(kv.analyzer, serviceOpt), kv.timeSpan));
+        }
+
+        public static bool IsCompilationEndAnalyzer(this DiagnosticAnalyzer analyzer, Project project, Compilation compilation)
+        {
+            if (!project.SupportsCompilation)
+            {
+                return false;
+            }
+
+            Contract.ThrowIfNull(compilation);
+
+            // currently, this is only way to see whether analyzer has compilation end analysis or not.
+            // also, analyzer being compilation end analyzer or not is dynamic. so this can return different value based on
+            // given compilation or options.
+            //
+            // but for now, this is what we decided in design meeting until we decide how to deal with compilation end analyzer
+            // long term
+            var context = new CollectCompilationActionsContext(compilation, project.AnalyzerOptions);
+            analyzer.Initialize(context);
+
+            return context.IsCompilationEndAnalyzer;
+        }
+
+        /// <summary>
+        /// Right now, there is no API compiler will tell us whether DiagnosticAnalyzer has compilation end analysis or not
+        /// 
+        /// </summary>
+        private class CollectCompilationActionsContext : AnalysisContext
+        {
+            private readonly Compilation _compilation;
+            private readonly AnalyzerOptions _analyzerOptions;
+
+            public CollectCompilationActionsContext(Compilation compilation, AnalyzerOptions analyzerOptions)
+            {
+                _compilation = compilation;
+                _analyzerOptions = analyzerOptions;
+            }
+
+            public bool IsCompilationEndAnalyzer { get; private set; } = false;
+
+            public override void RegisterCompilationAction(Action<CompilationAnalysisContext> action)
+            {
+                if (action == null)
+                {
+                    return;
+                }
+
+                IsCompilationEndAnalyzer = true;
+            }
+
+            public override void RegisterCompilationStartAction(Action<CompilationStartAnalysisContext> action)
+            {
+                if (action == null)
+                {
+                    return;
+                }
+
+                var nestedContext = new CollectNestedCompilationContext(_compilation, _analyzerOptions, CancellationToken.None);
+                action(nestedContext);
+
+                IsCompilationEndAnalyzer |= nestedContext.IsCompilationEndAnalyzer;
+            }
+
+            #region not used
+            public override void RegisterCodeBlockAction(Action<CodeBlockAnalysisContext> action) { }
+            public override void RegisterCodeBlockStartAction<TLanguageKindEnum>(Action<CodeBlockStartAnalysisContext<TLanguageKindEnum>> action) { }
+            public override void RegisterSemanticModelAction(Action<SemanticModelAnalysisContext> action) { }
+            public override void RegisterSymbolAction(Action<SymbolAnalysisContext> action, ImmutableArray<SymbolKind> symbolKinds) { }
+            public override void RegisterSyntaxNodeAction<TLanguageKindEnum>(Action<SyntaxNodeAnalysisContext> action, ImmutableArray<TLanguageKindEnum> syntaxKinds) { }
+            public override void RegisterSyntaxTreeAction(Action<SyntaxTreeAnalysisContext> action) { }
+            public override void ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags analysisMode) { }
+            public override void EnableConcurrentExecution() { }
+            public override void RegisterOperationAction(Action<OperationAnalysisContext> action, ImmutableArray<OperationKind> operationKinds) { }
+            public override void RegisterOperationBlockAction(Action<OperationBlockAnalysisContext> action) { }
+            public override void RegisterOperationBlockStartAction(Action<OperationBlockStartAnalysisContext> action) { }
+            public override void RegisterSymbolStartAction(Action<SymbolStartAnalysisContext> action, SymbolKind symbolKind) { }
+            #endregion
+
+            private class CollectNestedCompilationContext : CompilationStartAnalysisContext
+            {
+                public bool IsCompilationEndAnalyzer { get; private set; } = false;
+
+                public CollectNestedCompilationContext(Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken) :
+                    base(compilation, options, cancellationToken)
+                {
+                }
+
+                public override void RegisterCompilationEndAction(Action<CompilationAnalysisContext> action)
+                {
+                    if (action == null)
+                    {
+                        return;
+                    }
+
+                    IsCompilationEndAnalyzer = true;
+                }
+
+                #region not used
+                public override void RegisterCodeBlockAction(Action<CodeBlockAnalysisContext> action) { }
+                public override void RegisterCodeBlockStartAction<TLanguageKindEnum>(Action<CodeBlockStartAnalysisContext<TLanguageKindEnum>> action) { }
+                public override void RegisterSemanticModelAction(Action<SemanticModelAnalysisContext> action) { }
+                public override void RegisterSymbolAction(Action<SymbolAnalysisContext> action, ImmutableArray<SymbolKind> symbolKinds) { }
+                public override void RegisterSyntaxNodeAction<TLanguageKindEnum>(Action<SyntaxNodeAnalysisContext> action, ImmutableArray<TLanguageKindEnum> syntaxKinds) { }
+                public override void RegisterSyntaxTreeAction(Action<SyntaxTreeAnalysisContext> action) { }
+                public override void RegisterOperationAction(Action<OperationAnalysisContext> action, ImmutableArray<OperationKind> operationKinds) { }
+                public override void RegisterOperationBlockAction(Action<OperationBlockAnalysisContext> action) { }
+                public override void RegisterOperationBlockStartAction(Action<OperationBlockStartAnalysisContext> action) { }
+                public override void RegisterSymbolStartAction(Action<SymbolStartAnalysisContext> action, SymbolKind symbolKind) { }
+                #endregion
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var project = document.Project;
 
                 // if project didn't successfully loaded, then it is same as FSA off
-                var fullAnalysis = ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project) && 
+                var fullAnalysis = ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project) &&
                                    await project.HasSuccessfullyLoadedAsync(CancellationToken.None).ConfigureAwait(false);
 
                 // keep from build flag if full analysis is off

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,10 +22,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             // analyzer version this state belong to
             private readonly VersionStamp _analyzerVersion;
-            private readonly AnalyzerTypeData _analyzerTypeData;
+            private readonly AnalyzerStateNames _analyzerStateNames;
 
             private readonly ConcurrentDictionary<DocumentId, ActiveFileState> _activeFileStates;
             private readonly ConcurrentDictionary<ProjectId, ProjectState> _projectStates;
+
+            // whether this analyzer has compilation end analysis or not
+            // -1 not set, 0 no, 1 yes.
+            private volatile int _compilationEndAnalyzer = -1;
 
             public StateSet(string language, DiagnosticAnalyzer analyzer, string errorSourceName)
             {
@@ -35,19 +37,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _analyzer = analyzer;
                 _errorSourceName = errorSourceName;
 
-                var (analyzerId, version) = _analyzer.GetAnalyzerIdAndVersion();
+                var (_, version) = _analyzer.GetAnalyzerIdAndVersion();
                 _analyzerVersion = version;
-                _analyzerTypeData = AnalyzerTypeData.ForType(_analyzer.GetType());
-                Debug.Assert(_analyzerTypeData.StateName == $"{AnalyzerTypeData.UserDiagnosticsPrefixTableName}_{analyzerId}", "Expected persistence information for analyzer instance to be derived from its type alone.");
+
+                _analyzerStateNames = AnalyzerStateNames.For(_analyzer);
 
                 _activeFileStates = new ConcurrentDictionary<DocumentId, ActiveFileState>(concurrencyLevel: 2, capacity: 10);
                 _projectStates = new ConcurrentDictionary<ProjectId, ProjectState>(concurrencyLevel: 2, capacity: 1);
             }
 
-            public string StateName => _analyzerTypeData.StateName;
-            public string SyntaxStateName => _analyzerTypeData.SyntaxStateName;
-            public string SemanticStateName => _analyzerTypeData.SemanticStateName;
-            public string NonLocalStateName => _analyzerTypeData.NonLocalStateName;
+            public string StateName => _analyzerStateNames.StateName;
+            public string SyntaxStateName => _analyzerStateNames.SyntaxStateName;
+            public string SemanticStateName => _analyzerStateNames.SemanticStateName;
+            public string NonLocalStateName => _analyzerStateNames.NonLocalStateName;
 
             public string Language => _language;
             public string ErrorSourceName => _errorSourceName;
@@ -255,15 +257,34 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 InMemoryStorage.DropCache(Analyzer);
             }
 
-            private sealed class AnalyzerTypeData
+            public void ComputeCompilationEndAnalyzer(Project project, Compilation compilation)
             {
-                internal const string UserDiagnosticsPrefixTableName = "<UserDiagnostics2>";
-                private static readonly ConcurrentDictionary<Type, AnalyzerTypeData> s_analyzerTypeData
-                    = new ConcurrentDictionary<Type, AnalyzerTypeData>();
-
-                private AnalyzerTypeData(Type type)
+                if (_compilationEndAnalyzer != -1)
                 {
-                    StateName = UserDiagnosticsPrefixTableName + "_" + type.AssemblyQualifiedName;
+                    return;
+                }
+
+                // running this multiple time is fine
+                _compilationEndAnalyzer = _analyzer.IsCompilationEndAnalyzer(project, compilation) ? 1 : 0;
+            }
+
+            public bool IsCompilationEndAnalyzer(Project project, Compilation compilation)
+            {
+                ComputeCompilationEndAnalyzer(project, compilation);
+
+                return _compilationEndAnalyzer == 1;
+            }
+
+            private sealed class AnalyzerStateNames
+            {
+                private const string UserDiagnosticsPrefixTableName = "<UserDiagnostics2>";
+
+                private static readonly ConcurrentDictionary<string, AnalyzerStateNames> s_analyzerStateNameCache
+                    = new ConcurrentDictionary<string, AnalyzerStateNames>(concurrencyLevel: 2, capacity: 10);
+
+                private AnalyzerStateNames(string assemblyQualifiedName)
+                {
+                    StateName = UserDiagnosticsPrefixTableName + "_" + assemblyQualifiedName;
                     SyntaxStateName = StateName + ".Syntax";
                     SemanticStateName = StateName + ".Semantic";
                     NonLocalStateName = StateName + ".NonLocal";
@@ -279,9 +300,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 public string SemanticStateName { get; }
                 public string NonLocalStateName { get; }
 
-                public static AnalyzerTypeData ForType(Type type)
+                public static AnalyzerStateNames For(DiagnosticAnalyzer diagnosticAnalyzer)
                 {
-                    return s_analyzerTypeData.GetOrAdd(type, t => new AnalyzerTypeData(t));
+                    return s_analyzerStateNameCache.GetOrAdd(diagnosticAnalyzer.GetAnalyzerId(), t => new AnalyzerStateNames(t));
                 }
             }
         }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -61,6 +61,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         internal HostAnalyzerManager HostAnalyzerManager { get; }
         internal DiagnosticLogAggregator DiagnosticLogAggregator { get; private set; }
 
+        public bool IsCompilationEndAnalyzer(DiagnosticAnalyzer diagnosticAnalyzer, Project project, Compilation compilation)
+        {
+            var stateSet = _stateManager.GetOrCreateStateSet(project, diagnosticAnalyzer);
+            return stateSet.IsCompilationEndAnalyzer(project, compilation);
+        }
+
         public bool ContainsDiagnostics(Workspace workspace, ProjectId projectId)
         {
             foreach (var stateSet in _stateManager.GetStateSets(projectId))

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -51,7 +51,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     RaiseProjectDiagnosticsIfNeeded(project, stateSets, result.OldResult, result.Result);
                 }
 
-                if (PreferLiveErrorsOnOpenedFiles(workspace))
+                // if we have updated errors, refresh open files
+                if (map.Count > 0 && PreferLiveErrorsOnOpenedFiles(workspace))
                 {
                     // enqueue re-analysis of open documents.
                     this.Owner.Reanalyze(workspace, documentIds: workspace.GetOpenDocumentIds(), highPriority: true);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -98,13 +98,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return;
                 }
 
+                var compilation = await GetCompilationAsync(analyzerDriverOpt).ConfigureAwait(false);
+
                 // no cancellation after this point.
                 // any analyzer that doesn't have result will be treated as returned empty set
                 // which means we will remove those from error list
                 foreach (var stateSet in stateSets)
                 {
                     var state = stateSet.GetProjectState(project.Id);
+
                     await state.SaveAsync(project, result.GetResult(stateSet.Analyzer)).ConfigureAwait(false);
+                    stateSet.ComputeCompilationEndAnalyzer(project, compilation);
                 }
 
                 RaiseProjectDiagnosticsIfNeeded(project, stateSets, result.OldResult, result.Result);
@@ -112,6 +116,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
+            }
+
+            async Task<Compilation> GetCompilationAsync(CompilationWithAnalyzers analyzerDriverOpt)
+            {
+                // we might not have analyzerDriver even if project supports compilation if we are called with
+                // no analyzers. 
+                return analyzerDriverOpt?.Compilation ??
+                    (project.SupportsCompilation ? await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false) : null);
             }
         }
 

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -70,17 +70,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         Task<IEnumerable<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, string diagnosticIdOpt = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets a list of the diagnostics that are provided by this service.
-        /// If the given <paramref name="projectOpt"/> is non-null, then gets the diagnostics for the project.
-        /// Otherwise, returns the global set of diagnostics enabled for the workspace.
+        /// Gets a list of <see cref="DiagnosticAnalyzer"/>s for the given <see cref="Project"/>
         /// </summary>
-        /// <returns>A mapping from analyzer name to the diagnostics produced by that analyzer</returns>
-        ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>> GetDiagnosticDescriptors(Project projectOpt);
+        ImmutableArray<DiagnosticAnalyzer> GetDiagnosticAnalyzers(Project project);
 
         /// <summary>
-        /// Gets a list of the diagnostics provided by the given <see cref="DiagnosticAnalyzer"/>.
+        /// Gets a list of <see cref="DiagnosticDescriptor"/>s per <see cref="AnalyzerReference"/>
+        /// If the given <paramref name="projectOpt"/> is non-null, then gets <see cref="DiagnosticDescriptor"/>s for the project.
+        /// Otherwise, returns the global set of <see cref="DiagnosticDescriptor"/>s enabled for the workspace.
         /// </summary>
-        /// <returns>A list of the diagnostics produced by the given analyzer</returns>
+        /// <returns>A mapping from <see cref="AnalyzerReference.Display"/> to the <see cref="DiagnosticDescriptor"/></returns>
+        ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>> CreateDiagnosticDescriptorsPerReference(Project projectOpt);
+
+        /// <summary>
+        /// Gets supported <see cref="DiagnosticDescriptor"/>s of <see cref="DiagnosticAnalyzer"/>.
+        /// </summary>
+        /// <returns>A list of the diagnostic descriptors of the analyzer</returns>
         ImmutableArray<DiagnosticDescriptor> GetDiagnosticDescriptors(DiagnosticAnalyzer analyzer);
 
         /// <summary>
@@ -97,6 +102,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Check whether given <see cref="DiagnosticAnalyzer"/> is compiler analyzer for the language or not.
         /// </summary>
         bool IsCompilerDiagnosticAnalyzer(string language, DiagnosticAnalyzer analyzer);
+
+        /// <summary>
+        /// Check whether given <see cref="DiagnosticAnalyzer"/> is compilation end analyzer
+        /// By compilation end analyzer, it means compilation end analysis here
+        /// </summary>
+        bool IsCompilationEndAnalyzer(DiagnosticAnalyzer analyzer, Project project, Compilation compilation);
 
         /// <summary>
         /// Return host <see cref="AnalyzerReference"/>s. (ex, analyzers installed by vsix)

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
         {
             if (hierarchyOpt == null)
             {
-                return Transform(_diagnosticService.GetDiagnosticDescriptors(projectOpt: null));
+                return Transform(_diagnosticService.CreateDiagnosticDescriptorsPerReference(projectOpt: null));
             }
 
             // Analyzers are only supported for C# and VB currently.
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             if (projectsWithHierarchy.Count() <= 1)
             {
-                return Transform(_diagnosticService.GetDiagnosticDescriptors(projectsWithHierarchy.FirstOrDefault()));
+                return Transform(_diagnosticService.CreateDiagnosticDescriptorsPerReference(projectsWithHierarchy.FirstOrDefault()));
             }
             else
             {
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 var descriptorsMap = ImmutableDictionary.CreateBuilder<string, IEnumerable<DiagnosticDescriptor>>();
                 foreach (var project in projectsWithHierarchy)
                 {
-                    var newDescriptorTuples = _diagnosticService.GetDiagnosticDescriptors(project);
+                    var newDescriptorTuples = _diagnosticService.CreateDiagnosticDescriptorsPerReference(project);
                     foreach (var kvp in newDescriptorTuples)
                     {
                         if (descriptorsMap.TryGetValue(kvp.Key, out var existingDescriptors))

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
+using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
@@ -179,38 +180,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 // pause live analyzer
                 using (var operation = _notificationService.Start("BuildDone"))
                 {
-                    bool liveDiagnosticChecker(DiagnosticData d)
-                    {
-                        // REVIEW: we probably need a better design on de-duplicating live and build errors. or don't de-dup at all.
-                        //         for now, we are special casing compiler error case.
-                        var project = inprogressState.Solution.GetProject(d.ProjectId);
-                        if (project == null)
-                        {
-                            // project doesn't exist
-                            return false;
-                        }
-
-                        // REVIEW: current design is that we special case compiler analyzer case and we accept only document level
-                        //         diagnostic as live. otherwise, we let them be build errors. we changed compiler analyzer accordingly as well
-                        //         so that it doesn't report project level diagnostic as live errors.
-                        if (_diagnosticService.IsCompilerDiagnostic(project.Language, d) && d.DocumentId == null)
-                        {
-                            // compiler error but project level error
-                            return false;
-                        }
-
-                        if (inprogressState.SupportedDiagnosticId(d.ProjectId, d.Id))
-                        {
-                            return true;
-                        }
-
-                        return false;
-                    }
-
                     if (_diagnosticService is DiagnosticAnalyzerService diagnosticService)
                     {
-                        await CleanupAllLiveErrorsAsync(diagnosticService, inprogressState.GetProjectsWithoutErrors(inprogressState.Solution)).ConfigureAwait(false);
-                        await SyncBuildErrorsAndReportAsync(diagnosticService, inprogressState.Solution, inprogressState.GetLiveDiagnosticsPerProject(liveDiagnosticChecker)).ConfigureAwait(false);
+                        await CleanupAllLiveErrorsAsync(diagnosticService, inprogressState.GetProjectsWithoutErrors()).ConfigureAwait(false);
+                        await SyncBuildErrorsAndReportAsync(diagnosticService, inprogressState).ConfigureAwait(false);
                     }
 
                     inprogressState.Done();
@@ -224,9 +197,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             return diagnosticService.SynchronizeWithBuildAsync(_workspace, map);
         }
 
-        private async System.Threading.Tasks.Task SyncBuildErrorsAndReportAsync(
-            DiagnosticAnalyzerService diagnosticService, Solution solution, ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>> map)
+        private async System.Threading.Tasks.Task SyncBuildErrorsAndReportAsync(DiagnosticAnalyzerService diagnosticService, InprogressState inprogressState)
         {
+            var solution = inprogressState.Solution;
+            var map = await inprogressState.GetLiveDiagnosticsPerProjectAsync().ConfigureAwait(false);
+
             // make those errors live errors
             await diagnosticService.SynchronizeWithBuildAsync(_workspace, map).ConfigureAwait(false);
 
@@ -399,10 +374,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             private int _incrementDoNotAccessDirectly = 0;
 
             private readonly ExternalErrorDiagnosticUpdateSource _owner;
-            private readonly Solution _solution;
-
             private readonly HashSet<ProjectId> _builtProjects = new HashSet<ProjectId>();
-            private readonly Dictionary<ProjectId, HashSet<string>> _diagnosticIdMap = new Dictionary<ProjectId, HashSet<string>>();
+
+            private readonly Dictionary<ProjectId, ImmutableHashSet<string>> _allDiagnosticIdMap = new Dictionary<ProjectId, ImmutableHashSet<string>>();
+            private readonly Dictionary<ProjectId, ImmutableHashSet<string>> _liveDiagnosticIdMap = new Dictionary<ProjectId, ImmutableHashSet<string>>();
 
             private readonly Dictionary<ProjectId, Dictionary<DiagnosticData, int>> _projectMap = new Dictionary<ProjectId, Dictionary<DiagnosticData, int>>();
             private readonly Dictionary<DocumentId, Dictionary<DiagnosticData, int>> _documentMap = new Dictionary<DocumentId, Dictionary<DiagnosticData, int>>();
@@ -410,13 +385,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             public InprogressState(ExternalErrorDiagnosticUpdateSource owner, Solution solution)
             {
                 _owner = owner;
-                _solution = solution;
+                Solution = solution;
 
                 // let people know build has started
                 _owner.RaiseBuildStarted(started: true);
             }
 
-            public Solution Solution => _solution;
+            public Solution Solution { get; }
 
             public void Done()
             {
@@ -425,28 +400,30 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
             public bool SupportedDiagnosticId(ProjectId projectId, string id)
             {
-                lock (_diagnosticIdMap)
+                lock (_allDiagnosticIdMap)
                 {
-                    if (_diagnosticIdMap.TryGetValue(projectId, out var ids))
+                    if (_allDiagnosticIdMap.TryGetValue(projectId, out var ids))
                     {
                         return ids.Contains(id);
                     }
 
-                    // set ids set
-                    var map = new HashSet<string>();
-                    _diagnosticIdMap.Add(projectId, map);
-
-                    var project = _solution.GetProject(projectId);
+                    var project = Solution.GetProject(projectId);
                     if (project == null)
                     {
                         // projectId no longer exist, return false;
+                        _allDiagnosticIdMap.Add(projectId, ImmutableHashSet<string>.Empty);
                         return false;
                     }
 
-                    var descriptorMap = _owner._diagnosticService.GetDiagnosticDescriptors(project);
-                    map.UnionWith(descriptorMap.Values.SelectMany(v => v.Select(d => d.Id)));
+                    // set ids set
+                    var builder = ImmutableHashSet.CreateBuilder<string>();
+                    var descriptorMap = _owner._diagnosticService.CreateDiagnosticDescriptorsPerReference(project);
+                    builder.UnionWith(descriptorMap.Values.SelectMany(v => v.Select(d => d.Id)));
 
-                    return map.Contains(id);
+                    var set = builder.ToImmutable();
+                    _allDiagnosticIdMap.Add(projectId, set);
+
+                    return set.Contains(id);
                 }
             }
 
@@ -462,29 +439,34 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 _builtProjects.Add(projectId);
             }
 
-            public IEnumerable<ProjectId> GetProjectsBuilt(Solution solution)
+            public IEnumerable<ProjectId> GetProjectsBuilt()
             {
-                return solution.ProjectIds.Where(p => _builtProjects.Contains(p));
+                return Solution.ProjectIds.Where(p => _builtProjects.Contains(p));
             }
 
-            public IEnumerable<ProjectId> GetProjectsWithErrors(Solution solution)
+            public IEnumerable<ProjectId> GetProjectsWithErrors()
             {
-                return GetProjectIds().Where(p => solution.GetProject(p) != null);
+                return GetProjectIds().Where(p => Solution.GetProject(p) != null);
             }
 
-            public IEnumerable<ProjectId> GetProjectsWithoutErrors(Solution solution)
+            public IEnumerable<ProjectId> GetProjectsWithoutErrors()
             {
-                return GetProjectsBuilt(solution).Except(GetProjectsWithErrors(solution));
+                return GetProjectsBuilt().Except(GetProjectsWithErrors());
             }
 
-            public ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>> GetLiveDiagnosticsPerProject(Func<DiagnosticData, bool> liveDiagnosticChecker)
+            public async Task<ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>>> GetLiveDiagnosticsPerProjectAsync()
             {
                 var builder = ImmutableDictionary.CreateBuilder<ProjectId, ImmutableArray<DiagnosticData>>();
-                foreach (var projectId in GetProjectIds())
+                foreach (var projectId in GetProjectsWithErrors())
                 {
+                    var project = Solution.GetProject(projectId);
+                    var compilation = project.SupportsCompilation ?
+                        await project.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false) : null;
+
                     var diagnostics = ImmutableArray.CreateRange(
                         _projectMap.Where(kv => kv.Key == projectId).SelectMany(kv => kv.Value).Concat(
-                            _documentMap.Where(kv => kv.Key.ProjectId == projectId).SelectMany(kv => kv.Value)).Select(kv => kv.Key).Where(liveDiagnosticChecker));
+                            _documentMap.Where(kv => kv.Key.ProjectId == projectId).SelectMany(kv => kv.Value))
+                                .Select(kv => kv.Key).Where(d => IsLive(project, compilation, d)));
 
                     builder.Add(projectId, diagnostics);
                 }
@@ -510,6 +492,63 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             public void AddError(ProjectId key, DiagnosticData diagnostic)
             {
                 AddError(_projectMap, key, diagnostic);
+            }
+
+            private bool IsLive(Project project, Compilation compilation, DiagnosticData diagnosticData)
+            {
+                // REVIEW: current design is that we special case compiler analyzer case and we accept only document level
+                //         diagnostic as live. otherwise, we let them be build errors. we changed compiler analyzer accordingly as well
+                //         so that it doesn't report project level diagnostic as live errors.
+                if (_owner._diagnosticService.IsCompilerDiagnostic(project.Language, diagnosticData) && diagnosticData.DocumentId == null)
+                {
+                    // compiler error but project level error
+                    return false;
+                }
+
+                if (SupportedLiveDiagnosticId(project, compilation, diagnosticData.Id))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            private bool SupportedLiveDiagnosticId(Project project, Compilation compilation, string id)
+            {
+                var projectId = project.Id;
+
+                lock (_liveDiagnosticIdMap)
+                {
+                    if (_liveDiagnosticIdMap.TryGetValue(projectId, out var ids))
+                    {
+                        return ids.Contains(id);
+                    }
+
+                    var fullSolutionAnalysis = ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project);
+                    if (!project.SupportsCompilation || fullSolutionAnalysis)
+                    {
+                        return SupportedDiagnosticId(project.Id, id);
+                    }
+
+                    // set ids set
+                    var builder = ImmutableHashSet.CreateBuilder<string>();
+                    var diagnosticService = _owner._diagnosticService;
+                    foreach (var analyzer in diagnosticService.GetDiagnosticAnalyzers(project))
+                    {
+                        if (diagnosticService.IsCompilationEndAnalyzer(analyzer, project, compilation))
+                        {
+                            continue;
+                        }
+
+                        var diagnosticIds = diagnosticService.GetDiagnosticDescriptors(analyzer).Select(d => d.Id);
+                        builder.UnionWith(diagnosticIds);
+                    }
+
+                    var set = builder.ToImmutable();
+                    _liveDiagnosticIdMap.Add(projectId, set);
+
+                    return set.Contains(id);
+                }
             }
 
             private void AddErrors<T>(Dictionary<T, Dictionary<DiagnosticData, int>> map, T key, HashSet<DiagnosticData> diagnostics)

--- a/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
             Public Sub Reanalyze(workspace As Microsoft.CodeAnalysis.Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing, Optional highPriority As Boolean = False) Implements IDiagnosticAnalyzerService.Reanalyze
             End Sub
 
-            Public Function GetDiagnosticDescriptors(projectOpt As Project) As ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticDescriptor)) Implements IDiagnosticAnalyzerService.GetDiagnosticDescriptors
+            Public Function GetDiagnosticDescriptors(projectOpt As Project) As ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticDescriptor)) Implements IDiagnosticAnalyzerService.CreateDiagnosticDescriptorsPerReference
                 Return ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticDescriptor)).Empty
             End Function
 
@@ -108,6 +108,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
             End Function
 
             Public Function GetHostAnalyzerReferences() As IEnumerable(Of AnalyzerReference) Implements IDiagnosticAnalyzerService.GetHostAnalyzerReferences
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function GetDiagnosticAnalyzers(project As Project) As ImmutableArray(Of DiagnosticAnalyzer) Implements IDiagnosticAnalyzerService.GetDiagnosticAnalyzers
+                Throw New NotImplementedException()
+            End Function
+
+            Public Function IsCompilationEndAnalyzer(analyzer As DiagnosticAnalyzer, project As Project, compilation As Compilation) As Boolean Implements IDiagnosticAnalyzerService.IsCompilationEndAnalyzer
                 Throw New NotImplementedException()
             End Function
         End Class


### PR DESCRIPTION
...

this has some issues where now when building,
1 . compilation is needed
2.  compilation end analysis is dynamic not static
3. can cause RPS regression.

