### PR TITLE
Fix assembly binding redirection in AnalyzerRunner

### DIFF
--- a/src/Tools/AnalyzerRunner/AnalyzerRunner.csproj
+++ b/src/Tools/AnalyzerRunner/AnalyzerRunner.csproj
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\build\Targets\GenerateCompilerExecutableBindingRedirects.targets" />
+
   <PropertyGroup>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Tools/AnalyzerRunner/app.config
+++ b/src/Tools/AnalyzerRunner/app.config
@@ -2,23 +2,5 @@
 <configuration>
   <runtime>
     <gcServer enabled="true" />
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-42.42.42.42" newVersion="42.42.42.42" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-42.42.42.42" newVersion="42.42.42.42" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-42.42.42.42" newVersion="42.42.42.42" />
-      </dependentAssembly>
-    </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Fixes the signed build by ensuring the correct assembly binding redirection is in place for AnalyzerRunner.