### PR TITLE
Add parser for EditorConfig section names

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
@@ -342,6 +342,7 @@ RoOt = TruE");
             Assert.Matches(regex, "ab\\c");
             Assert.DoesNotMatch(regex, "ab/c");
             Assert.DoesNotMatch(regex, "ab\\\\c");
+        }
 
         [Fact]
         public void CombineNonOverlapping()

--- a/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
@@ -332,5 +332,16 @@ RoOt = TruE");
             Assert.Matches(regex, "ab/def");
             Assert.Matches(regex, "ab\\def");
         }
+
+        [Fact]
+        public void LiteralBackslash()
+        {
+            string regex = EditorConfig.CompileSectionNameToRegEx("ab\\\\c");
+            Assert.Equal("^ab\\\\c$", regex);
+
+            Assert.Matches(regex, "ab\\c");
+            Assert.DoesNotMatch(regex, "ab/c");
+            Assert.DoesNotMatch(regex, "ab\\\\c");
+        }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EditorConfigTests.cs
@@ -259,7 +259,7 @@ RoOt = TruE");
         [Fact]
         public void SimpleNameMatch()
         {
-            string regex = EditorConfig.CompileSectionNameToRegEx("abc");
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("abc");
             Assert.Equal("^abc$", regex);
 
             Assert.Matches(regex, "abc");
@@ -271,7 +271,7 @@ RoOt = TruE");
         [Fact]
         public void StarOnlyMatch()
         {
-            string regex = EditorConfig.CompileSectionNameToRegEx("*");
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("*");
             Assert.Equal("^[^/]*$", regex);
 
             Assert.Matches(regex, "abc");
@@ -282,7 +282,7 @@ RoOt = TruE");
         [Fact]
         public void StarNameMatch()
         {
-            string regex = EditorConfig.CompileSectionNameToRegEx("*.cs");
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("*.cs");
             Assert.Equal("^[^/]*.cs$", regex);
 
             Assert.Matches(regex, "abc.cs");
@@ -299,7 +299,7 @@ RoOt = TruE");
         [Fact]
         public void StarStarNameMatch()
         {
-            string regex = EditorConfig.CompileSectionNameToRegEx("**.cs");
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("**.cs");
             Assert.Equal("^.*.cs$", regex);
 
             Assert.Matches(regex, "abc.cs");
@@ -309,21 +309,21 @@ RoOt = TruE");
         [Fact]
         public void BadEscapeMatch()
         {
-            string regex = EditorConfig.CompileSectionNameToRegEx("abc\\d.cs");
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("abc\\d.cs");
             Assert.Null(regex);
         }
 
         [Fact]
         public void EndBackslashMatch()
         {
-            string regex = EditorConfig.CompileSectionNameToRegEx("abc\\");
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("abc\\");
             Assert.Null(regex);
         }
 
         [Fact]
         public void QuestionMatch()
         {
-            string regex = EditorConfig.CompileSectionNameToRegEx("ab?def");
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("ab?def");
             Assert.Equal("^ab.def$", regex);
 
             Assert.Matches(regex, "abcdef");
@@ -336,12 +336,38 @@ RoOt = TruE");
         [Fact]
         public void LiteralBackslash()
         {
-            string regex = EditorConfig.CompileSectionNameToRegEx("ab\\\\c");
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("ab\\\\c");
             Assert.Equal("^ab\\\\c$", regex);
 
             Assert.Matches(regex, "ab\\c");
             Assert.DoesNotMatch(regex, "ab/c");
             Assert.DoesNotMatch(regex, "ab\\\\c");
+        }
+
+        [Fact]
+        public void LiteralStars()
+        {
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("\\***\\*\\**");
+            Assert.Equal("^\\*.*\\*\\*[^/]*$", regex);
+
+            Assert.Matches(regex, "*ab/cd**efg*");
+            Assert.DoesNotMatch(regex, "ab/cd**efg*");
+            Assert.DoesNotMatch(regex, "*ab/cd*efg*");
+            Assert.DoesNotMatch(regex, "*ab/cd**ef/gh");
+        }
+
+        [Fact]
+        public void LiteralQuestions()
+        {
+            string regex = EditorConfig.TryCompileSectionNameToRegEx("\\??\\?*\\??");
+            Assert.Equal("^\\?.\\?[^/]*\\?.$", regex);
+
+            Assert.Matches(regex, "?a?cde?f");
+            Assert.Matches(regex, "???????f");
+            Assert.DoesNotMatch(regex, "aaaaaaaa");
+            Assert.DoesNotMatch(regex, "aa?cde?f");
+            Assert.DoesNotMatch(regex, "?a?cdexf");
+            Assert.DoesNotMatch(regex, "?axcde?f");
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/CommandLine/EditorConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/EditorConfig.SectionNameMatching.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal sealed partial class EditorConfig
+    {
+        /// <summary>
+        /// Takes a <see cref="Section.Name"/> and compiles the file glob
+        /// inside to a regex which recognizes the given language.
+        /// </summary>
+        public static string CompileSectionNameToRegEx(string sectionName)
+        {
+            // An editorconfig section name is a language for recognizing file paths
+            // defined by the following grammar:
+            //
+            // <path> ::= <path-list>
+            // <path-list> ::= <path-item> | <path-item> <path-list>
+            // <path-item> ::= "*"  | "**" | "?" | <char> | <choice> | <range>
+            // <char> ::= any unicode character
+            //
+            // PROTOTYPE(editorconfig): Below remains unimplemented
+            //
+            // <choice> ::= "{" <choice-list> "}" 
+            // <choice-list> ::= <path-list> | <path-list> "," <choice-list>
+            // <range> ::= "{" <integer> ".." <integer> "}"
+            // <integer> ::= "-" <digit-list> | <digit-list>
+            // <digit-list> ::= <digit> | <digit> <digit-list>
+            // <digit> ::= 0-9
+
+            var sb = new StringBuilder();
+            sb.Append('^');
+            var lexer = new SectionNameLexer(sectionName);
+            while (!lexer.IsDone)
+            {
+                var tokenKind = lexer.Lex();
+                switch (tokenKind)
+                {
+                    case TokenKind.BadToken:
+                        // Parsing failure
+                        return null;
+                    case TokenKind.SimpleCharacter:
+                        // Matches just this character
+                        sb.Append(lexer.EatCurrentCharacter());
+                        break;
+                    case TokenKind.Question:
+                        // '?' matches any single character
+                        sb.Append('.');
+                        break;
+                    case TokenKind.Star:
+                        // Matches any string of characters except directory separator
+                        // Directory separator is defined in editorconfig spec as '/'
+                        sb.Append("[^/]*");
+                        break;
+                    case TokenKind.StarStar:
+                        // Matches any string of characters
+                        sb.Append(".*");
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(tokenKind);
+                }
+            }
+            sb.Append('$');
+
+            return sb.ToString();
+        }
+
+        private ref struct SectionNameLexer
+        {
+            private readonly string _sectionName;
+
+            private int _position;
+
+            public SectionNameLexer(string sectionName)
+            {
+                _sectionName = sectionName;
+                _position = 0;
+            }
+
+            public bool IsDone => _position >= _sectionName.Length;
+
+            public TokenKind Lex()
+            {
+                int lexemeStart = _position;
+                switch (_sectionName[_position])
+                {
+                    case '*':
+                    {
+                        int nextPos = _position + 1;
+                        if (nextPos < _sectionName.Length &&
+                            _sectionName[nextPos] == '*')
+                        {
+                            _position += 2;
+                            return TokenKind.StarStar;
+                        }
+                        else
+                        {
+                            _position++;
+                            return TokenKind.Star;
+                        }
+                    }
+
+                    case '?':
+                        _position++;
+                        return TokenKind.Question;
+
+                    case '\\':
+                    {
+                        // Backslash escapes the next character
+                        int nextPos = _position + 1;
+                        if (nextPos >= _sectionName.Length)
+                        {
+                            return TokenKind.BadToken;
+                        }
+
+                        // Check for all of the possible escapes
+                        switch (_sectionName[nextPos])
+                        {
+                            case '\\':
+                                // "\\" -> "\"
+                                _position += 2;
+                                return TokenKind.Backslash;
+
+                            default:
+                                return TokenKind.BadToken;
+                        }
+                    }
+
+                    default:
+                        // Don't increment position, since caller needs to fetch the character
+                        return TokenKind.SimpleCharacter;
+                }
+            }
+
+            /// <summary>
+            /// Call after getting <see cref="TokenKind.SimpleCharacter" /> from <see cref="Lex()" />
+            /// </summary>
+            public char EatCurrentCharacter() => _sectionName[_position++];
+        }
+
+        private enum TokenKind
+        {
+            BadToken,
+            SimpleCharacter,
+            Star,
+            StarStar,
+            Question,
+            Backslash
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CommandLine/EditorConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/EditorConfig.SectionNameMatching.cs
@@ -60,6 +60,10 @@ namespace Microsoft.CodeAnalysis
                         // Matches any string of characters
                         sb.Append(".*");
                         break;
+                    case TokenKind.Backslash:
+                        // Literal backslash
+                        sb.Append("\\\\");
+                        break;
                     default:
                         throw ExceptionUtilities.UnexpectedValue(tokenKind);
                 }

--- a/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/EditorConfig.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a single EditorConfig file, see http://editorconfig.org for details about the format.
     /// </summary>
-    internal sealed class EditorConfig
+    internal sealed partial class EditorConfig
     {
         // Matches EditorConfig section header such as "[*.{js,py}]", see http://editorconfig.org for details
         private static readonly Regex s_sectionMatcher = new Regex(@"^\s*\[(([^#;]|\\#|\\;)+)\]\s*([#;].*)?$", RegexOptions.Compiled);


### PR DESCRIPTION
EditorConfig section names define a language for matching paths. This
commit introduces a parser for that language and a compiler to translate
that language to regular expressions.

Two globbing patterns supported by the language (`{...,...}` and `{num..num}`)
are not yet implemented. PROTOTYPE comment markers have been left there
to denote future work.