### PR TITLE
Update Latebound Add Collection Initializer handling

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Latebound.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Latebound.vb
@@ -110,6 +110,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim lateMember = BindLateBoundMemberAccess(memberSyntax, memberName, typeArguments, receiver, containingType, diagnostics,
                                                        suppressLateBindingResolutionDiagnostics:=True) ' BindLateBoundInvocation will take care of the diagnostics.
 
+            If group.WasCompilerGenerated Then
+                lateMember.SetWasCompilerGenerated()
+            End If
+
             If receiver IsNot Nothing AndAlso receiver.Type IsNot Nothing AndAlso receiver.Type.IsInterfaceType Then
                 ReportDiagnostic(diagnostics, GetLocationForOverloadResolutionDiagnostic(node, group), ERRID.ERR_LateBoundOverloadInterfaceCall1, memberName)
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
@@ -905,6 +905,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                           callerInfoOpt:=topLevelInitializer)
                 invocation.SetWasCompilerGenerated()
 
+                If invocation.Kind = BoundKind.LateInvocation Then
+                    invocation = DirectCast(invocation, BoundLateInvocation).SetLateBoundAccessKind(LateBoundAccessKind.Call)
+                End If
+
                 Return invocation
             Else
                 Return New BoundBadExpression(topLevelInitializer,

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundCollectionInitializerExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundCollectionInitializerExpression.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Sub Validate()
             If Not Me.HasErrors Then
                 For Each initializer In Me.Initializers
-                    Debug.Assert(initializer.Kind = BoundKind.Call)
+                    Debug.Assert(initializer.Kind = BoundKind.Call OrElse initializer.Kind = BoundKind.LateInvocation)
                 Next
             End If
         End Sub


### PR DESCRIPTION
Adjusted assert and lateboundaccesskind for latebound
Add method on a collection initializer. Additionally
adjusted compiler-generated detection and added a test.

Fixes https://github.com/dotnet/roslyn/issues/27034.

@dotnet/roslyn-compiler @AlekseyTs @dotnet/analyzer-ioperation for review.