### PR TITLE
Fix initialization in CSharpReplIntellisense

### DIFF
--- a/src/VisualStudio/Core/Def/Telemetry/ProjectTypeLookupService.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/ProjectTypeLookupService.cs
@@ -13,12 +13,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
     {
         public string GetProjectType(Workspace workspace, ProjectId projectId)
         {
-            if (workspace == null || projectId == null)
+            if (!(workspace is VisualStudioWorkspace vsWorkspace) || projectId == null)
             {
                 return string.Empty;
             }
-
-            var vsWorkspace = workspace as VisualStudioWorkspace;
 
             var aggregatableProject = vsWorkspace.GetHierarchy(projectId) as IVsAggregatableProject;
             if (aggregatableProject == null)

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
@@ -14,6 +15,11 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         public CSharpReplIntellisense(VisualStudioInstanceFactory instanceFactory)
             : base(instanceFactory)
         {
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync().ConfigureAwait(true);
             VisualStudio.Workspace.SetUseSuggestionMode(true);
         }
 


### PR DESCRIPTION
Fixes a failure to initialize the test class

Also fixes #27128

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
