### PR TITLE
Explicitly handle the start of a solution open to update state

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -645,5 +645,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // called.
             FinishLoad();
         }
+
+        internal void OnBeforeOpenSolution()
+        {
+            AssertIsForeground();
+
+            _solutionLoadComplete = false;
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl_IVsSolutionLoadEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl_IVsSolutionLoadEvents.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     {
         int IVsSolutionLoadEvents.OnBeforeOpenSolution(string pszSolutionFilename)
         {
+            GetProjectTrackerAndInitializeIfNecessary(ServiceProvider.GlobalProvider).OnBeforeOpenSolution();
             return VSConstants.S_OK;
         }
 


### PR DESCRIPTION
We update _solutionLoadComplete in various places as a way to approximate a "should we batch this load" flag. We never explicitly listened to a begin solution load event -- we just assumed VS starts this way, and reset it during solution close. Sometimes solutions can be re-opened before a close, and our flag would then be off and cause extra processing when unintended.

<details><summary>Ask Mode template</summary>

### Customer scenario

Opens a file for diffing (say from team explorer), and then opens a solution. The solution load will be slower than it should be.

### Bugs this fixes

https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/520280

### Workarounds, if any

Open a different solution before you open the big solution, or restart Visual Studio.

### Risk

Moderate: the change is simple, but this area is subtle.

### Performance impact

Improved.

### Is this a regression from a previous update?

Nope, seems to have always been there.

### Root cause analysis

When files are opened for diff, Roslyn set a flag tracking that as meaning the solution was open, and further projects should be loaded interactively. This happens because the Roslyn's expectations for the events being raised didn't match reality. It's a combination of Roslyn having strange code, and the events being raised aren't quite right anyways. The shell looked into fixing their issues but saw further regressions in other areas.

### How was the bug found?

Customer report.

</details>
