### PR TITLE
Implement GetSymbolInfo for the identifier in a property pattern.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1756,9 +1756,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundNode boundNodeForSyntacticParent,
             Binder binderOpt)
         {
-            LookupResultKind resultKind;
-            ImmutableArray<Symbol> symbols;
-
             if (lowestBoundNode is BoundSubpattern subpattern)
             {
                 return GetSymbolInfoForSubpattern(subpattern);
@@ -1776,14 +1773,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Get symbols and result kind from the lowest and highest nodes associated with the
             // syntax node.
-            symbols = GetSemanticSymbols(boundExpr, boundNodeForSyntacticParent, binderOpt, options, out bool isDynamic, out resultKind, out ImmutableArray<Symbol> unusedMemberGroup);
+            ImmutableArray<Symbol> symbols = GetSemanticSymbols(
+                boundExpr, boundNodeForSyntacticParent, binderOpt, options, out bool isDynamic, out LookupResultKind resultKind, out ImmutableArray<Symbol> unusedMemberGroup);
 
             if (highestBoundNode is BoundExpression highestBoundExpr)
             {
                 LookupResultKind highestResultKind;
                 bool highestIsDynamic;
                 ImmutableArray<Symbol> unusedHighestMemberGroup;
-                ImmutableArray<Symbol> highestSymbols = GetSemanticSymbols(highestBoundExpr, boundNodeForSyntacticParent, binderOpt, options, out highestIsDynamic, out highestResultKind, out unusedHighestMemberGroup);
+                ImmutableArray<Symbol> highestSymbols = GetSemanticSymbols(
+                    highestBoundExpr, boundNodeForSyntacticParent, binderOpt, options, out highestIsDynamic, out highestResultKind, out unusedHighestMemberGroup);
 
                 if ((symbols.Length != 1 || resultKind == LookupResultKind.OverloadResolutionFailure) && highestSymbols.Length > 0)
                 {
@@ -1853,7 +1852,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (subpattern.Symbol?.OriginalDefinition is ErrorTypeSymbol originalErrorType)
             {
-                return new SymbolInfo(null, originalErrorType.CandidateSymbols.CastArray<ISymbol>(), originalErrorType.ResultKind.ToCandidateReason());
+                return new SymbolInfo(symbol: null, originalErrorType.CandidateSymbols.CastArray<ISymbol>(), originalErrorType.ResultKind.ToCandidateReason());
             }
 
             return new SymbolInfo(subpattern.Symbol, CandidateReason.None);
@@ -4086,7 +4085,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Get the semantic info of a named argument in an invocation-like expression.
+        /// Get the semantic info of a named argument in an invocation-like expression (e.g. `x` in `M(x: 3)`)
+        /// or the name in a Subpattern (e.g. either `Name` in `e is (Name: 3){Name: 3}`).
         /// </summary>
         private SymbolInfo GetNamedArgumentSymbolInfo(IdentifierNameSyntax identifierNameSyntax, CancellationToken cancellationToken)
         {

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1853,6 +1853,7 @@ done:
                 case SyntaxKind.OperatorDeclaration:
                 case SyntaxKind.ConversionOperatorDeclaration:
                 case SyntaxKind.GlobalStatement:
+                case SyntaxKind.Subpattern:
                     return node;
             }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -2162,6 +2162,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     break;
+
+                case SyntaxKind.NameColon:
+                    if (parent.Parent.IsKind(SyntaxKind.Subpattern))
+                    {
+                        return parent.Parent;
+                    }
+
+                    break;
             }
 
             return node;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -2046,12 +2046,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Gets the containing expression that is actually a language expression and not just typed
+        /// Gets the containing expression that is actually a language expression (or something that
+        /// GetSymbolInfo can be applied to) and not just typed
         /// as an ExpressionSyntax for convenience. For example, NameSyntax nodes on the right side
         /// of qualified names and member access expressions are not language expressions, yet the
         /// containing qualified names or member access expressions are indeed expressions.
         /// Similarly, if the input node is a cref part that is not independently meaningful, then
-        /// the result will be the full cref.
+        /// the result will be the full cref. Besides an expression, an input that is a NameSyntax
+        /// of a SubpatternSyntax, e.g. in `name: 3` may cause this method to return the enclosing
+        /// SubpatternSyntax.
         /// </summary>
         internal static CSharpSyntaxNode GetStandaloneNode(CSharpSyntaxNode node)
         {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static bool IsNamedArgumentName(SyntaxNode node)
         {
             // An argument name is an IdentifierName inside a NameColon, inside an Argument, inside an ArgumentList, inside an
-            // Invocation, ObjectCreation, ObjectInitializer, or ElementAccess.
+            // Invocation, ObjectCreation, ObjectInitializer, ElementAccess or Subpattern.
 
             if (!node.IsKind(IdentifierName))
             { 
@@ -260,6 +260,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var parent2 = parent1.Parent;
+            if (parent2.IsKind(SyntaxKind.Subpattern))
+            {
+                return true;
+            }
+
             if (parent2 == null || !(parent2.IsKind(Argument) || parent2.IsKind(AttributeArgument)))
             {
                 return false;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTestBase.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTestBase.cs
@@ -365,6 +365,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Empty(tree.GetRoot().DescendantNodes().OfType<GlobalStatementSyntax>());
         }
 
+        protected CSharpCompilation CreatePatternCompilation(string source)
+        {
+            return CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularWithRecursivePatterns);
+        }
+
         #endregion helpers
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
@@ -16,11 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     [CompilerTrait(CompilerFeature.Patterns)]
     public class PatternMatchingTests2 : PatternMatchingTestBase
     {
-        CSharpCompilation CreatePatternCompilation(string source)
-        {
-            return CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularWithRecursivePatterns);
-        }
-
         [Fact]
         public void Patterns2_00()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     [CompilerTrait(CompilerFeature.Patterns)]
     public class PatternMatchingTests3 : PatternMatchingTestBase
     {
-        void AssertEmpty(SymbolInfo info)
+        private static void AssertEmpty(SymbolInfo info)
         {
             Assert.NotNull(info);
             Assert.Null(info.Symbol);
@@ -236,7 +236,7 @@ class Program
     public static void Main()
     {
         Point p = null;
-        Console.WriteLine(p is ( X: 3, Y: 4 ));
+        Console.WriteLine(p is (X: 3, Y: 4));
     }
 }
 class Point
@@ -246,12 +246,12 @@ class Point
 ";
             var compilation = CreatePatternCompilation(source);
             compilation.VerifyDiagnostics(
-                // (8,34): error CS8417: The name 'X' does not match the corresponding 'Deconstruct' parameter 'Z'.
-                //         Console.WriteLine(p is ( X: 3, Y: 4 ));
-                Diagnostic(ErrorCode.ERR_DeconstructParameterNameMismatch, "X").WithArguments("X", "Z").WithLocation(8, 34),
-                // (8,40): error CS8417: The name 'Y' does not match the corresponding 'Deconstruct' parameter 'W'.
-                //         Console.WriteLine(p is ( X: 3, Y: 4 ));
-                Diagnostic(ErrorCode.ERR_DeconstructParameterNameMismatch, "Y").WithArguments("Y", "W").WithLocation(8, 40)
+                // (8,33): error CS8417: The name 'X' does not match the corresponding 'Deconstruct' parameter 'Z'.
+                //         Console.WriteLine(p is (X: 3, Y: 4));
+                Diagnostic(ErrorCode.ERR_DeconstructParameterNameMismatch, "X").WithArguments("X", "Z").WithLocation(8, 33),
+                // (8,39): error CS8417: The name 'Y' does not match the corresponding 'Deconstruct' parameter 'W'.
+                //         Console.WriteLine(p is (X: 3, Y: 4));
+                Diagnostic(ErrorCode.ERR_DeconstructParameterNameMismatch, "Y").WithArguments("Y", "W").WithLocation(8, 39)
                 );
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);
@@ -289,7 +289,7 @@ class Program
     public static void Main()
     {
         var p = (X: 3, Y: 4);
-        Console.WriteLine(p is ( X: 3, Y: 4 ));
+        Console.WriteLine(p is (X: 3, Y: 4));
     }
 }
 ";
@@ -330,18 +330,18 @@ class Program
     public static void Main()
     {
         var p = (Z: 3, W: 4);
-        Console.WriteLine(p is ( X: 3, Y: 4 ));
+        Console.WriteLine(p is (X: 3, Y: 4));
     }
 }
 ";
             var compilation = CreatePatternCompilation(source);
             compilation.VerifyDiagnostics(
-                // (8,34): error CS8416: The name 'X' does not identify tuple element 'Item1'.
-                //         Console.WriteLine(p is ( X: 3, Y: 4 ));
-                Diagnostic(ErrorCode.ERR_TupleElementNameMismatch, "X").WithArguments("X", "Item1").WithLocation(8, 34),
-                // (8,40): error CS8416: The name 'Y' does not identify tuple element 'Item2'.
-                //         Console.WriteLine(p is ( X: 3, Y: 4 ));
-                Diagnostic(ErrorCode.ERR_TupleElementNameMismatch, "Y").WithArguments("Y", "Item2").WithLocation(8, 40)
+                // (8,33): error CS8416: The name 'X' does not identify tuple element 'Item1'.
+                //         Console.WriteLine(p is (X: 3, Y: 4));
+                Diagnostic(ErrorCode.ERR_TupleElementNameMismatch, "X").WithArguments("X", "Item1").WithLocation(8, 33),
+                // (8,39): error CS8416: The name 'Y' does not identify tuple element 'Item2'.
+                //         Console.WriteLine(p is (X: 3, Y: 4));
+                Diagnostic(ErrorCode.ERR_TupleElementNameMismatch, "Y").WithArguments("Y", "Item2").WithLocation(8, 39)
                 );
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -1,0 +1,369 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    [CompilerTrait(CompilerFeature.Patterns)]
+    public class PatternMatchingTests3 : PatternMatchingTestBase
+    {
+        void AssertEmpty(SymbolInfo info)
+        {
+            Assert.NotNull(info);
+            Assert.Null(info.Symbol);
+            Assert.Equal(CandidateReason.None, info.CandidateReason);
+        }
+
+        [Fact]
+        public void PropertyPatternSymbolInfo_01()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        Point p = new Point();
+        Console.WriteLine(p is { X: 3, Y: 4 });
+    }
+}
+class Point
+{
+    public int X = 3;
+    public int Y => 4;
+}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.VerifyDiagnostics(
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var model = compilation.GetSemanticModel(tree);
+
+            var subpatterns = tree.GetRoot().DescendantNodes().OfType<SubpatternSyntax>().ToArray();
+            Assert.Equal(2, subpatterns.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0].NameColon));
+            var x = subpatterns[0].NameColon.Name;
+            var xSymbol = model.GetSymbolInfo(x);
+            Assert.Equal(CandidateReason.None, xSymbol.CandidateReason);
+            Assert.Equal("System.Int32 Point.X", xSymbol.Symbol.ToTestDisplayString());
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1].NameColon));
+            var y = subpatterns[1].NameColon.Name;
+            var ySymbol = model.GetSymbolInfo(y);
+            Assert.NotNull(ySymbol);
+            Assert.Equal(CandidateReason.None, ySymbol.CandidateReason);
+            Assert.Equal("System.Int32 Point.Y { get; }", ySymbol.Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void PropertyPatternSymbolInfo_02()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        Point p = null;
+        Console.WriteLine(p is { X: 3, Y: 4 });
+    }
+}
+interface I1
+{
+    int X { get; }
+    int Y { get; }
+}
+interface I2
+{
+    int X { get; }
+    int Y { get; }
+}
+interface Point : I1, I2
+{
+    // X and Y inherited ambiguously
+}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.VerifyDiagnostics(
+                // (8,34): error CS0229: Ambiguity between 'I1.X' and 'I2.X'
+                //         Console.WriteLine(p is { X: 3, Y: 4 });
+                Diagnostic(ErrorCode.ERR_AmbigMember, "X").WithArguments("I1.X", "I2.X").WithLocation(8, 34),
+                // (8,40): error CS0229: Ambiguity between 'I1.Y' and 'I2.Y'
+                //         Console.WriteLine(p is { X: 3, Y: 4 });
+                Diagnostic(ErrorCode.ERR_AmbigMember, "Y").WithArguments("I1.Y", "I2.Y").WithLocation(8, 40)
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var model = compilation.GetSemanticModel(tree);
+
+            var subpatterns = tree.GetRoot().DescendantNodes().OfType<SubpatternSyntax>().ToArray();
+            Assert.Equal(2, subpatterns.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0].NameColon));
+            var x = subpatterns[0].NameColon.Name;
+            var xSymbol = model.GetSymbolInfo(x);
+            Assert.Equal(CandidateReason.Ambiguous, xSymbol.CandidateReason);
+            Assert.Null(xSymbol.Symbol);
+            Assert.Equal(2, xSymbol.CandidateSymbols.Length);
+            Assert.Equal("System.Int32 I1.X { get; }", xSymbol.CandidateSymbols[0].ToTestDisplayString());
+            Assert.Equal("System.Int32 I2.X { get; }", xSymbol.CandidateSymbols[1].ToTestDisplayString());
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1].NameColon));
+            var y = subpatterns[1].NameColon.Name;
+            var ySymbol = model.GetSymbolInfo(y);
+            Assert.Equal(CandidateReason.Ambiguous, ySymbol.CandidateReason);
+            Assert.Null(ySymbol.Symbol);
+            Assert.Equal(2, ySymbol.CandidateSymbols.Length);
+            Assert.Equal("System.Int32 I1.Y { get; }", ySymbol.CandidateSymbols[0].ToTestDisplayString());
+            Assert.Equal("System.Int32 I2.Y { get; }", ySymbol.CandidateSymbols[1].ToTestDisplayString());
+        }
+
+        [Fact]
+        public void PropertyPatternSymbolInfo_03()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        Point p = null;
+        Console.WriteLine(p is { X: 3, Y: 4 });
+    }
+}
+class Point
+{
+}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.VerifyDiagnostics(
+                // (8,34): error CS0117: 'Point' does not contain a definition for 'X'
+                //         Console.WriteLine(p is { X: 3, Y: 4 });
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "X").WithArguments("Point", "X").WithLocation(8, 34)
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var model = compilation.GetSemanticModel(tree);
+
+            var subpatterns = tree.GetRoot().DescendantNodes().OfType<SubpatternSyntax>().ToArray();
+            Assert.Equal(2, subpatterns.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0].NameColon));
+            var x = subpatterns[0].NameColon.Name;
+            var xSymbol = model.GetSymbolInfo(x);
+            Assert.Equal(CandidateReason.None, xSymbol.CandidateReason);
+            Assert.Null(xSymbol.Symbol);
+            Assert.Equal(0, xSymbol.CandidateSymbols.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1].NameColon));
+            var y = subpatterns[1].NameColon.Name;
+            var ySymbol = model.GetSymbolInfo(y);
+            Assert.Equal(CandidateReason.None, ySymbol.CandidateReason);
+            Assert.Null(ySymbol.Symbol);
+            Assert.Equal(0, ySymbol.CandidateSymbols.Length);
+        }
+
+        [Fact]
+        public void PositionalPatternSymbolInfo_01()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        Point p = null;
+        Console.WriteLine(p is ( X: 3, Y: 4 ));
+    }
+}
+class Point
+{
+    public void Deconstruct(out int X, out int Y) => (X, Y) = (3, 4);
+}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.VerifyDiagnostics(
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var model = compilation.GetSemanticModel(tree);
+
+            var subpatterns = tree.GetRoot().DescendantNodes().OfType<SubpatternSyntax>().ToArray();
+            Assert.Equal(2, subpatterns.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0].NameColon));
+            var x = subpatterns[0].NameColon.Name;
+            var xSymbol = model.GetSymbolInfo(x);
+            Assert.Equal(CandidateReason.None, xSymbol.CandidateReason);
+            Assert.Equal("out System.Int32 X", xSymbol.Symbol.ToTestDisplayString());
+            Assert.Equal(0, xSymbol.CandidateSymbols.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1].NameColon));
+            var y = subpatterns[1].NameColon.Name;
+            var ySymbol = model.GetSymbolInfo(y);
+            Assert.Equal(CandidateReason.None, ySymbol.CandidateReason);
+            Assert.Equal("out System.Int32 Y", ySymbol.Symbol.ToTestDisplayString());
+            Assert.Equal(0, ySymbol.CandidateSymbols.Length);
+        }
+
+        [Fact]
+        public void PositionalPatternSymbolInfo_02()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        Point p = null;
+        Console.WriteLine(p is ( X: 3, Y: 4 ));
+    }
+}
+class Point
+{
+    public void Deconstruct(out int Z, out int W) => (Z, W) = (3, 4);
+}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.VerifyDiagnostics(
+                // (8,34): error CS8417: The name 'X' does not match the corresponding 'Deconstruct' parameter 'Z'.
+                //         Console.WriteLine(p is ( X: 3, Y: 4 ));
+                Diagnostic(ErrorCode.ERR_DeconstructParameterNameMismatch, "X").WithArguments("X", "Z").WithLocation(8, 34),
+                // (8,40): error CS8417: The name 'Y' does not match the corresponding 'Deconstruct' parameter 'W'.
+                //         Console.WriteLine(p is ( X: 3, Y: 4 ));
+                Diagnostic(ErrorCode.ERR_DeconstructParameterNameMismatch, "Y").WithArguments("Y", "W").WithLocation(8, 40)
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var model = compilation.GetSemanticModel(tree);
+
+            var subpatterns = tree.GetRoot().DescendantNodes().OfType<SubpatternSyntax>().ToArray();
+            Assert.Equal(2, subpatterns.Length);
+
+            // No matter what you write for the name, it is deemed to designate the parameter in that position.
+            // The name if present is checked against the parameter name.
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0].NameColon));
+            var x = subpatterns[0].NameColon.Name;
+            var xSymbol = model.GetSymbolInfo(x);
+            Assert.Equal(CandidateReason.None, xSymbol.CandidateReason);
+            Assert.Equal("out System.Int32 Z", xSymbol.Symbol.ToTestDisplayString());
+            Assert.Equal(0, xSymbol.CandidateSymbols.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1].NameColon));
+            var y = subpatterns[1].NameColon.Name;
+            var ySymbol = model.GetSymbolInfo(y);
+            Assert.Equal(CandidateReason.None, ySymbol.CandidateReason);
+            Assert.Equal("out System.Int32 W", ySymbol.Symbol.ToTestDisplayString());
+            Assert.Equal(0, ySymbol.CandidateSymbols.Length);
+        }
+
+        [Fact]
+        public void PositionalPatternSymbolInfo_03()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        var p = (X: 3, Y: 4);
+        Console.WriteLine(p is ( X: 3, Y: 4 ));
+    }
+}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.VerifyDiagnostics(
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var model = compilation.GetSemanticModel(tree);
+
+            var subpatterns = tree.GetRoot().DescendantNodes().OfType<SubpatternSyntax>().ToArray();
+            Assert.Equal(2, subpatterns.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0].NameColon));
+            var x = subpatterns[0].NameColon.Name;
+            var xSymbol = model.GetSymbolInfo(x);
+            Assert.Equal(CandidateReason.None, xSymbol.CandidateReason);
+            Assert.Equal("System.Int32 (System.Int32 X, System.Int32 Y).X", xSymbol.Symbol.ToTestDisplayString());
+            Assert.Equal(0, xSymbol.CandidateSymbols.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1].NameColon));
+            var y = subpatterns[1].NameColon.Name;
+            var ySymbol = model.GetSymbolInfo(y);
+            Assert.Equal(CandidateReason.None, ySymbol.CandidateReason);
+            Assert.Equal("System.Int32 (System.Int32 X, System.Int32 Y).Y", ySymbol.Symbol.ToTestDisplayString());
+            Assert.Equal(0, ySymbol.CandidateSymbols.Length);
+        }
+
+        [Fact]
+        public void PositionalPatternSymbolInfo_04()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        var p = (Z: 3, W: 4);
+        Console.WriteLine(p is ( X: 3, Y: 4 ));
+    }
+}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.VerifyDiagnostics(
+                // (8,34): error CS8416: The name 'X' does not identify tuple element 'Item1'.
+                //         Console.WriteLine(p is ( X: 3, Y: 4 ));
+                Diagnostic(ErrorCode.ERR_TupleElementNameMismatch, "X").WithArguments("X", "Item1").WithLocation(8, 34),
+                // (8,40): error CS8416: The name 'Y' does not identify tuple element 'Item2'.
+                //         Console.WriteLine(p is ( X: 3, Y: 4 ));
+                Diagnostic(ErrorCode.ERR_TupleElementNameMismatch, "Y").WithArguments("Y", "Item2").WithLocation(8, 40)
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var model = compilation.GetSemanticModel(tree);
+
+            var subpatterns = tree.GetRoot().DescendantNodes().OfType<SubpatternSyntax>().ToArray();
+            Assert.Equal(2, subpatterns.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[0].NameColon));
+            var x = subpatterns[0].NameColon.Name;
+            var xSymbol = model.GetSymbolInfo(x);
+            Assert.Equal(CandidateReason.None, xSymbol.CandidateReason);
+            Assert.Null(xSymbol.Symbol);
+            Assert.Equal(0, xSymbol.CandidateSymbols.Length);
+
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1]));
+            AssertEmpty(model.GetSymbolInfo(subpatterns[1].NameColon));
+            var y = subpatterns[1].NameColon.Name;
+            var ySymbol = model.GetSymbolInfo(y);
+            Assert.Equal(CandidateReason.None, ySymbol.CandidateReason);
+            Assert.Null(ySymbol.Symbol);
+            Assert.Equal(0, ySymbol.CandidateSymbols.Length);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -8148,7 +8148,7 @@ class C
 @"
 class C
 {
-    private const object Y;
+    private const int Y;
 
     void M2()
     {


### PR DESCRIPTION
Fixes #9284
Fixes #26607
Fixes #26139

@cston @agocke Please review this pattern-matching change to implement GetSymbolInfo for subpatterns.
/cc @dotnet/roslyn-compiler 
