### PR TITLE
Make the implementation lazily evaluated.

### DIFF
--- a/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
@@ -14,39 +14,29 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Progression
     Partial Friend Class VisualBasicProgressionLanguageService
         Implements IProgressionLanguageService
 
-        Public Function GetTopLevelNodesFromDocument(root As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of SyntaxNode) Implements IProgressionLanguageService.GetTopLevelNodesFromDocument
-            ' TODO: Implement this lazily like in C#?
+        Public Iterator Function GetTopLevelNodesFromDocument(root As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of SyntaxNode) Implements IProgressionLanguageService.GetTopLevelNodesFromDocument
+            If cancellationToken.IsCancellationRequested Then Exit Function
             Dim nodes = New Stack(Of SyntaxNode)()
-
-            Dim result = New List(Of SyntaxNode)
-
             nodes.Push(root)
 
             While nodes.Count > 0
-                cancellationToken.ThrowIfCancellationRequested()
+
+                If cancellationToken.IsCancellationRequested Then Continue While
 
                 Dim node = nodes.Pop()
 
-                If node.Kind = SyntaxKind.ClassBlock OrElse
-                    node.Kind = SyntaxKind.DelegateFunctionStatement OrElse
-                    node.Kind = SyntaxKind.DelegateSubStatement OrElse
-                    node.Kind = SyntaxKind.EnumBlock OrElse
-                    node.Kind = SyntaxKind.ModuleBlock OrElse
-                    node.Kind = SyntaxKind.InterfaceBlock OrElse
-                    node.Kind = SyntaxKind.StructureBlock OrElse
-                    node.Kind = SyntaxKind.FieldDeclaration OrElse
-                    node.Kind = SyntaxKind.SubBlock OrElse
-                    node.Kind = SyntaxKind.FunctionBlock OrElse
-                    node.Kind = SyntaxKind.PropertyBlock Then
-                    result.Add(node)
-                Else
-                    For Each child In node.ChildNodes()
-                        nodes.Push(child)
-                    Next
-                End If
+                Select Case node.Kind
+                    Case SyntaxKind.ClassBlock, SyntaxKind.DelegateFunctionStatement, SyntaxKind.DelegateSubStatement,
+                         SyntaxKind.EnumBlock, SyntaxKind.ModuleBlock, SyntaxKind.InterfaceBlock,
+                         SyntaxKind.StructureBlock, SyntaxKind.FieldDeclaration, SyntaxKind.SubBlock,
+                         SyntaxKind.FunctionBlock, SyntaxKind.PropertyBlock
+                        Yield node
+                    Case Else
+                        For Each child In node.ChildNodes()
+                            nodes.Push(child)
+                        Next
+                End Select
             End While
-
-            Return result
         End Function
 
         Private Shared ReadOnly s_descriptionFormat As SymbolDisplayFormat = New SymbolDisplayFormat(

--- a/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Progression
         Implements IProgressionLanguageService
 
         Public Iterator Function GetTopLevelNodesFromDocument(root As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of SyntaxNode) Implements IProgressionLanguageService.GetTopLevelNodesFromDocument
-            If cancellationToken.IsCancellationRequested Then Exit Function
+            If cancellationToken.IsCancellationRequested Then Return
             Dim nodes = New Stack(Of SyntaxNode)()
             nodes.Push(root)
 

--- a/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
@@ -21,9 +21,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Progression
 
             While nodes.Count > 0
 
-                If cancellationToken.IsCancellationRequested Then Exit While
-
                 Dim node = nodes.Pop()
+
+                If cancellationToken.IsCancellationRequested Then Continue While
 
                 Select Case node.Kind
                     Case SyntaxKind.ClassBlock, SyntaxKind.DelegateFunctionStatement, SyntaxKind.DelegateSubStatement,
@@ -37,6 +37,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Progression
                         Next
                 End Select
             End While
+            nodes.Clear()
+            nodes = Nothing
         End Function
 
         Private Shared ReadOnly s_descriptionFormat As SymbolDisplayFormat = New SymbolDisplayFormat(

--- a/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
@@ -39,9 +39,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Progression
                          SyntaxKind.PropertyBlock
                         Yield node
                     Case Else
-                        For Each child In node.ChildNodes()
-                            nodes.Push(child)
-                        Next
+                        nodes.Push(node.ChildNodes)
                 End Select
             End While
         End Function

--- a/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
@@ -26,10 +26,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Progression
                 If cancellationToken.IsCancellationRequested Then Continue While
 
                 Select Case node.Kind
-                    Case SyntaxKind.ClassBlock, SyntaxKind.DelegateFunctionStatement, SyntaxKind.DelegateSubStatement,
-                         SyntaxKind.EnumBlock, SyntaxKind.ModuleBlock, SyntaxKind.InterfaceBlock,
-                         SyntaxKind.StructureBlock, SyntaxKind.FieldDeclaration, SyntaxKind.SubBlock,
-                         SyntaxKind.FunctionBlock, SyntaxKind.PropertyBlock
+                    Case SyntaxKind.ClassBlock,
+                         SyntaxKind.DelegateFunctionStatement,
+                         SyntaxKind.DelegateSubStatement,
+                         SyntaxKind.EnumBlock,
+                         SyntaxKind.ModuleBlock,
+                         SyntaxKind.InterfaceBlock,
+                         SyntaxKind.StructureBlock,
+                         SyntaxKind.FieldDeclaration,
+                         SyntaxKind.SubBlock,
+                         SyntaxKind.FunctionBlock,
+                         SyntaxKind.PropertyBlock
                         Yield node
                     Case Else
                         For Each child In node.ChildNodes()
@@ -37,8 +44,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Progression
                         Next
                 End Select
             End While
-            nodes.Clear()
-            nodes = Nothing
         End Function
 
         Private Shared ReadOnly s_descriptionFormat As SymbolDisplayFormat = New SymbolDisplayFormat(

--- a/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Progression/VisualBasicProgressionLanguageService.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Progression
 
             While nodes.Count > 0
 
-                If cancellationToken.IsCancellationRequested Then Continue While
+                If cancellationToken.IsCancellationRequested Then Exit While
 
                 Dim node = nodes.Pop()
 


### PR DESCRIPTION
As the `ToDo:` recommends.