### PR TITLE
Remove an invalid assert in CFG builder

### DIFF
--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -5320,8 +5320,7 @@ oneMoreTime:
             else
             {
                 Debug.Assert(operation.EventReference != null);
-                Debug.Assert(operation.EventReference.Kind == OperationKind.Invalid);
-
+                
                 _evalStack.Push(Visit(operation.EventReference));
                 visitedHandler = Visit(operation.HandlerValue);
                 visitedEventReference = _evalStack.Pop();


### PR DESCRIPTION
Verified there is now just a single unit test failure with `build.cmd -testIOperation`, which is unrelated to this assert (`TestBinaryOperator_Unchecked_Comparisons`)