### PR TITLE
Report Obsolete diagnostics on operators involved in tuple equality

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -130,3 +130,4 @@ Example:
 
 - Visual Studio 2017 version 15.8: https://github.com/dotnet/roslyn/issues/22455 C# compiler will now produce errors if there was an "in" or an "out" argument to an "__arglist" call. "out" was always allowed, and "in" was introduced in 15.5.
 - Visual Studio 2017 version 15.8: https://github.com/dotnet/roslyn/issues/26418 C# compiler will now produce errors on out variable declarations that have "ref" or "ref readonly" ref kinds. Example: M(out ref int x);
+- Visual Studio 2017 version 15.8: https://github.com/dotnet/roslyn/issues/27047 The C# compiler will now produce diagnostics for operators marked as obsolete when they are used as part of a tuple comparison.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -109,6 +109,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 ReportBinaryOperatorError(node, diagnostics, node.OperatorToken, left, right, resultKind);
             }
+            ReportDiagnosticsIfObsolete(diagnostics, analysisResult.LeftConversion, left.Syntax, hasBaseReceiver: false);
+            ReportDiagnosticsIfObsolete(diagnostics, analysisResult.RightConversion, right.Syntax, hasBaseReceiver: false);
 
             PrepareBoolConversionAndTruthOperator(signature.ReturnType, node, kind, diagnostics, out Conversion conversionIntoBoolOperator, out UnaryOperatorSignature boolOperator);
 
@@ -134,6 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (conversion.IsImplicit)
             {
+                ReportDiagnosticsIfObsolete(diagnostics, conversion, node, hasBaseReceiver: false);
                 conversionForBool = conversion;
                 boolOperator = default;
                 return;


### PR DESCRIPTION
### Customer scenario
Mark some implicit conversion operators, comparison or truth operators as obsolete. Then write a tuple comparison expression that involves those operators.
In 15.7 tuple comparisons failed to report such obsolete diagnostics.
In 15.8, we will properly report those diagnostics. This is a small compat break which will be reviewed with the compat council.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/27047

### Risk
### Performance impact
Low. The change is localized to tuple binding and leveraging a common helper to check for obsolete conversions and report on them.

### Is this a regression from a previous update?
No. This is a bug in the tuple-equality feature (in C# 7.3, shipped in 15.7).

### How was the bug found?
Reported by customer