### PR TITLE
Update our build options

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,2 +1,6 @@
 @echo off
-powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\build\scripts\build.ps1" -build -skipBuildExtras %*
+if "%~1" == "" (
+    powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\build\scripts\build.ps1" -build -skipBuildExtras %*
+) else (
+    powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\build\scripts\build.ps1" %*
+)


### PR DESCRIPTION
The PR #26416 broke our ability to run `-pack` from Build.cmd. Restoring
that by changing the behavior to be the following:

- Build.cmd without argumens: call build.ps1 with -build -pack
- Build.cmd arguments: call build.ps1 with specified arguments only

Now packing can be done with:

> build.cmd -build -pack

Or afterwards

> build.cmd -pack

Additionally attempted to document all of the existing options.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
