### PR TITLE
UseType analyzers/fixers should handle ref types

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -185,6 +185,23 @@ class Program
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(27221, "https://github.com/dotnet/roslyn/issues/27221")]
+        public async Task NotIfRefTypeAlreadyExplicitlyTyped()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+struct Program
+{
+    void Method()
+    {
+        ref [|Program|] p = Ref();
+    }
+    ref Program Ref() => throw null;
+}", new TestParameters(options: ExplicitTypeEverywhere()));
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnRHS()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -289,6 +306,68 @@ class Program
     void Method(int? x)
     {
         int? y = x;
+    }
+}";
+            // The type is intrinsic and not apparent
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeForBuiltInTypesOnly());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeExceptWhereApparent());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(27221, "https://github.com/dotnet/roslyn/issues/27221")]
+        public async Task WithRefIntrinsicType()
+        {
+            var before = @"
+class Program
+{
+    void Method()
+    {
+        ref [|var|] y = Ref();
+    }
+    ref int Ref() => throw null;
+}";
+            var after = @"
+class Program
+{
+    void Method()
+    {
+        ref int y = Ref();
+    }
+    ref int Ref() => throw null;
+}";
+            // The type is intrinsic and not apparent
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeForBuiltInTypesOnly());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeExceptWhereApparent());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(27221, "https://github.com/dotnet/roslyn/issues/27221")]
+        public async Task WithRefIntrinsicTypeInForeach()
+        {
+            var before = @"
+class E
+{
+    public ref int Current => throw null;
+    public bool MoveNext() => throw null;
+    public E GetEnumerator() => throw null;
+
+    void M()
+    {
+        foreach (ref [|var|] x in this) { }
+    }
+}";
+            var after = @"
+class E
+{
+    public ref int Current => throw null;
+    public bool MoveNext() => throw null;
+    public E GetEnumerator() => throw null;
+
+    void M()
+    {
+        foreach (ref int x in this) { }
     }
 }";
             // The type is intrinsic and not apparent

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -118,6 +118,21 @@ class Program
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(27221, "https://github.com/dotnet/roslyn/issues/27221")]
+        public async Task NotOnRefVar()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+class Program
+{
+    void Method()
+    {
+        ref [|var|] x = Method2();
+    }
+    ref int Method2() => throw null;
+}", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnDynamic()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -445,6 +460,64 @@ class C
         var s = 5;
     }
 }", options: ImplicitTypeEverywhere());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(27221, "https://github.com/dotnet/roslyn/issues/27221")]
+        public async Task SuggestVarOnRefIntrinsicType()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    static void M()
+    {
+        ref [|int|] s = Ref();
+    }
+    static ref int Ref() => throw null;
+}",
+@"using System;
+
+class C
+{
+    static void M()
+    {
+        ref var s = Ref();
+    }
+    static ref int Ref() => throw null;
+}", options: ImplicitTypeEverywhere());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(27221, "https://github.com/dotnet/roslyn/issues/27221")]
+        public async Task WithRefIntrinsicTypeInForeach()
+        {
+            var before = @"
+class E
+{
+    public ref int Current => throw null;
+    public bool MoveNext() => throw null;
+    public E GetEnumerator() => throw null;
+
+    void M()
+    {
+        foreach (ref [|int|] x in this) { }
+    }
+}";
+            var after = @"
+class E
+{
+    public ref int Current => throw null;
+    public bool MoveNext() => throw null;
+    public E GetEnumerator() => throw null;
+
+    void M()
+    {
+        foreach (ref var x in this) { }
+    }
+}";
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeEverywhere());
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
             // The severity preference is not Hidden, as indicated by IsStylePreferred.
             var descriptor = GetDescriptorWithSeverity(typeStyle.Severity);
-            context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, declaredType.Span));
+            context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, declaredType.StripRefIfNeeded().Span));
         }
 
         private Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode declaration, TextSpan diagnosticSpan) 

--- a/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -55,6 +55,11 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
 
             TypeSyntax typeSyntax = null;
             ParenthesizedVariableDesignationSyntax parensDesignation = null;
+            if (declarationContext is RefTypeSyntax refType)
+            {
+                declarationContext = declarationContext.Parent;
+            }
+
             if (declarationContext is VariableDeclarationSyntax varDecl)
             {
                 typeSyntax = varDecl.Type;
@@ -78,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
 
             if (parensDesignation is null)
             {
-                var typeSymbol = semanticModel.GetTypeInfo(typeSyntax).ConvertedType;
+                var typeSymbol = semanticModel.GetTypeInfo(typeSyntax.StripRefIfNeeded()).ConvertedType;
 
                 // We're going to be passed through the simplifier.  Tell it to not just convert
                 // this back to var (as that would defeat the purpose of this refactoring entirely).

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static IEnumerable<SyntaxTrivia> GetAllPrecedingTriviaToPreviousToken(
-            this SyntaxNode node, SourceText sourceText = null, 
+            this SyntaxNode node, SourceText sourceText = null,
             bool includePreviousTokenTrailingTriviaOnlyIfOnSameLine = false)
             => node.GetFirstToken().GetAllPrecedingTriviaToPreviousToken(
                 sourceText, includePreviousTokenTrailingTriviaOnlyIfOnSameLine);
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         /// the previous token's trailing trivia and this token's leading trivia).
         /// </summary>
         public static IEnumerable<SyntaxTrivia> GetAllPrecedingTriviaToPreviousToken(
-            this SyntaxToken token, SourceText sourceText = null, 
+            this SyntaxToken token, SourceText sourceText = null,
             bool includePreviousTokenTrailingTriviaOnlyIfOnSameLine = false)
         {
             var prevToken = token.GetPreviousToken(includeSkipped: true);
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return token.LeadingTrivia;
             }
 
-            if (includePreviousTokenTrailingTriviaOnlyIfOnSameLine && 
+            if (includePreviousTokenTrailingTriviaOnlyIfOnSameLine &&
                 !sourceText.AreOnSameLine(prevToken, token))
             {
                 return token.LeadingTrivia;
@@ -735,7 +735,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static StatementSyntax GetEmbeddedStatement(this SyntaxNode node)
         {
             switch (node)
-            { 
+            {
                 case DoStatementSyntax n: return n.Statement;
                 case ElseClauseSyntax n: return n.Statement;
                 case FixedStatementSyntax n: return n.Statement;
@@ -1021,9 +1021,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             deconstructionLeft = null;
             return false;
         }
-
-
-        public static TypeSyntax StripRefIfNeeded(this TypeSyntax type)
-            => type is RefTypeSyntax refType ? refType.Type : type;
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -1021,5 +1021,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             deconstructionLeft = null;
             return false;
         }
+
+
+        public static TypeSyntax StripRefIfNeeded(this TypeSyntax type)
+            => type is RefTypeSyntax refType ? refType.Type : type;
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
@@ -122,5 +122,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return property.Type.GenerateTypeSyntax();
             }
         }
+
+        public static TypeSyntax StripRefIfNeeded(this TypeSyntax type)
+            => type is RefTypeSyntax refType ? refType.Type : type;
     }
 }

--- a/src/Workspaces/CSharp/Portable/Utilities/CSharpTypeStyleHelper.State.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/CSharpTypeStyleHelper.State.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 }
 
                 var initializerExpression = CSharpUseImplicitTypeHelper.GetInitializerExpression(initializer.Value);
-                var declaredTypeSymbol = semanticModel.GetTypeInfo(variableDeclaration.Type, cancellationToken).Type;
+                var declaredTypeSymbol = semanticModel.GetTypeInfo(variableDeclaration.Type.StripRefIfNeeded(), cancellationToken).Type;
                 return TypeStyleHelper.IsTypeApparentInAssignmentExpression(stylePreferences, initializerExpression, semanticModel, cancellationToken, declaredTypeSymbol);
             }
 
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 var typeSyntax = GetTypeSyntaxFromDeclaration(declarationStatement);
 
                 return typeSyntax != null
-                    ? IsMadeOfSpecialTypes(semanticModel.GetTypeInfo(typeSyntax).Type)
+                    ? IsMadeOfSpecialTypes(semanticModel.GetTypeInfo(typeSyntax.StripRefIfNeeded()).Type)
                     : false;
             }
 

--- a/src/Workspaces/CSharp/Portable/Utilities/CSharpUseExplicitTypeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/CSharpUseExplicitTypeHelper.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         protected override bool ShouldAnalyzeVariableDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
-            if (!variableDeclaration.Type.IsVar)
+            if (!variableDeclaration.Type.StripRefIfNeeded().IsVar)
             {
                 // If the type is not 'var', this analyze has no work to do
                 return false;
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         protected override bool ShouldAnalyzeForEachStatement(ForEachStatementSyntax forEachStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
-            if (!forEachStatement.Type.IsVar)
+            if (!forEachStatement.Type.StripRefIfNeeded().IsVar)
             {
                 // If the type is not 'var', this analyze has no work to do
                 return false;
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
             // If it is currently not var, explicit typing exists, return. 
             // this also takes care of cases where var is mapped to a named type via an alias or a class declaration.
-            if (!typeName.IsTypeInferred(semanticModel))
+            if (!typeName.StripRefIfNeeded().IsTypeInferred(semanticModel))
             {
                 return false;
             }
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             // cases :
             //        var anon = new { Num = 1 };
             //        var enumerableOfAnons = from prod in products select new { prod.Color, prod.Price };
-            var declaredType = semanticModel.GetTypeInfo(typeName, cancellationToken).Type;
+            var declaredType = semanticModel.GetTypeInfo(typeName.StripRefIfNeeded(), cancellationToken).Type;
             if (declaredType.ContainsAnonymousType())
             {
                 return false;

--- a/src/Workspaces/CSharp/Portable/Utilities/CSharpUseImplicitTypeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/CSharpUseImplicitTypeHelper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             TypeSyntax typeName, SemanticModel semanticModel, 
             OptionSet optionSet, CancellationToken cancellationToken)
         {
-            if (typeName.IsVar)
+            if (typeName.StripRefIfNeeded().IsVar)
             {
                 return default;
             }
@@ -47,9 +47,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         protected override bool ShouldAnalyzeVariableDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
-            if (variableDeclaration.Type.IsVar)
+            var type = variableDeclaration.Type.StripRefIfNeeded();
+            if (type.IsVar)
             {
-                // If the type is already 'var', this analyze has no work to do
+                // If the type is already 'var' or 'ref var', this analyzer has no work to do
                 return false;
             }
 
@@ -94,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             TypeSyntax typeName, SemanticModel semanticModel,
             OptionSet optionSet, CancellationToken cancellationToken)
         {
-            Debug.Assert(!typeName.IsVar, "'var' special case should have prevented analysis of this variable.");
+            Debug.Assert(!typeName.StripRefIfNeeded().IsVar, "'var' special case should have prevented analysis of this variable.");
 
             var candidateReplacementNode = SyntaxFactory.IdentifierName("var");
 
@@ -252,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             }
 
             // cannot use implicit typing on method group or on dynamic
-            var declaredType = semanticModel.GetTypeInfo(typeName, cancellationToken).Type;
+            var declaredType = semanticModel.GetTypeInfo(typeName.StripRefIfNeeded(), cancellationToken).Type;
             if (declaredType != null && declaredType.TypeKind == TypeKind.Dynamic)
             {
                 return false;


### PR DESCRIPTION
### Customer scenario
Use a `ref var` in a local declaration or foreach loop.
In 15.7, you would get a gold bar for an analyzer crash.
With this fix, the UseExplicitType and UseImplicitType analyzers and fixers can handle ref types (ie. only fix the type portion, leaving the `ref` alone).

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/27221

### Risk
### Performance impact
Low. The core of this change is to strip the `ref` in a few places in the analysis logic.

### Is this a regression from a previous update?
No.

### Root cause analysis
The bug exists since C# 7.2 (VS 2017 version 15.5) which introduced ref locals. It was compounded by `foreach ref` loops in C# 7.3 (15.7).

### How was the bug found?
Reported by customer.

Tagging @CyrusNajmabadi @dotnet/roslyn-ide for review. Thanks