### PR TITLE
[WIP] Apply updated editorconfig settings without requiring files do be reopened

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -75,6 +75,7 @@
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
     <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.0.26730-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.0.26730-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>
+    <MicrosoftVisualStudioCodingConventionsVersion>1.1.20180503.2</MicrosoftVisualStudioCodingConventionsVersion>
     <MicrosoftVisualStudioComponentModelHostVersion>15.0.26730-alpha</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioCompositionVersion>15.5.23</MicrosoftVisualStudioCompositionVersion>
     <MicrosoftVisualStudioCoreUtilityVersion>15.6.253-preview</MicrosoftVisualStudioCoreUtilityVersion>
@@ -232,7 +233,6 @@
     <SQLitePCLRawbundle_greenVersion>1.1.2</SQLitePCLRawbundle_greenVersion>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.8.68-develop-g109a00ff</MicrosoftVSSDKBuildToolsVersion>
-    <VSExternalAPIsCodingConventionsVersion>1.0.60704.2</VSExternalAPIsCodingConventionsVersion>
     <VSLangProjVersion>7.0.3300</VSLangProjVersion>
     <VSLangProj140Version>14.3.25407-alpha</VSLangProj140Version>
     <VSLangProj2Version>7.0.5000</VSLangProj2Version>

--- a/src/EditorFeatures/Core.Wpf/EditorFeatures.Wpf.csproj
+++ b/src/EditorFeatures/Core.Wpf/EditorFeatures.Wpf.csproj
@@ -31,6 +31,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
+    <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="$(MicrosoftVisualStudioCodingConventionsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.InteractiveWindow" Version="$(MicrosoftVisualStudioInteractiveWindowVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.NavigateTo.Interfaces" Version="$(MicrosoftVisualStudioLanguageNavigateToInterfacesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
@@ -39,9 +40,6 @@
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="$(MicrosoftVisualStudioRemoteControlVersion)" />
-    <PackageReference Include="VS.ExternalAPIs.CodingConventions" Version="$(VSExternalAPIsCodingConventionsVersion)" />
-    <!-- The VS.ExternalAPIs.CodingConventions package isn't a "true" NuGet package and doesn't have the right lib folders. Manually reference the binary. -->
-    <Reference Include="$(NuGetPackageRoot)\VS.ExternalAPIs.CodingConventions\$(VSExternalAPIsCodingConventionsVersion)\Microsoft.VisualStudio.CodingConventions.dll" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices" />

--- a/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProvider.cs
@@ -28,9 +28,9 @@ namespace Microsoft.CodeAnalysis.Editor.Options
         private readonly ICodingConventionsManager _codingConventionsManager;
         private readonly IErrorLoggerService _errorLogger;
 
-        internal EditorConfigDocumentOptionsProvider(Workspace workspace)
+        internal EditorConfigDocumentOptionsProvider(Workspace workspace, ICodingConventionsManager codingConventionsManager)
         {
-            _codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager();
+            _codingConventionsManager = codingConventionsManager;
             _errorLogger = workspace.Services.GetService<IErrorLoggerService>();
 
             workspace.DocumentOpened += Workspace_DocumentOpened;

--- a/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProviderFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProviderFactory.cs
@@ -2,16 +2,27 @@
 
 using System;
 using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.CodingConventions;
 
 namespace Microsoft.CodeAnalysis.Editor.Options
 {
     [Export(typeof(IDocumentOptionsProviderFactory))]
     class EditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
     {
+        private readonly ICodingConventionsManager _codingConventionsManager;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public EditorConfigDocumentOptionsProviderFactory(ICodingConventionsManager codingConventionsManager)
+        {
+            _codingConventionsManager = codingConventionsManager;
+        }
+
         public IDocumentOptionsProvider Create(Workspace workspace)
         {
-            return new EditorConfigDocumentOptionsProvider(workspace);
+            return new EditorConfigDocumentOptionsProvider(workspace, _codingConventionsManager);
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProviderFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProviderFactory.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.ComponentModel.Composition;
+using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.CodingConventions;
 
 namespace Microsoft.CodeAnalysis.Editor.Options
 {
-    [Export(typeof(IDocumentOptionsProviderFactory))]
+    [Export(typeof(IDocumentOptionsProviderFactory)), Shared]
     class EditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
     {
         private readonly ICodingConventionsManager _codingConventionsManager;

--- a/src/Workspaces/Remote/Core/RemoteWorkspaces.csproj
+++ b/src/Workspaces/Remote/Core/RemoteWorkspaces.csproj
@@ -10,6 +10,12 @@
     <TargetFramework>net46</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\EditorFeatures\Core.Wpf\Options\EditorConfigDocumentOptionsProvider.cs" Link="Services\Options\EditorConfigDocumentOptionsProvider.cs" />
+    <Compile Include="..\..\..\EditorFeatures\Core.Wpf\Options\EditorConfigDocumentOptionsProvider.DocumentOptions.cs" Link="Services\Options\EditorConfigDocumentOptionsProvider.DocumentOptions.cs" />
+    <Compile Include="..\..\..\EditorFeatures\Core.Wpf\Options\EditorConfigDocumentOptionsProvider.EmptyCodingConventionContext.cs" Link="Services\Options\EditorConfigDocumentOptionsProvider.EmptyCodingConventionContext.cs" />
+    <Compile Include="..\..\..\EditorFeatures\Core.Wpf\Options\EditorConfigDocumentOptionsProviderFactory.cs" Link="Services\Options\EditorConfigDocumentOptionsProviderFactory.cs" />
+  </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\Features\Core\Portable\Features.csproj" />
@@ -25,6 +31,7 @@
     <Reference Include="System.Core" />
     <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="$(MicrosoftVisualStudioCodingConventionsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />

--- a/src/Workspaces/Remote/Core/Services/Options/FileWatcher.cs
+++ b/src/Workspaces/Remote/Core/Services/Options/FileWatcher.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.IO;
+using System.Threading;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.CodingConventions;
+
+namespace Microsoft.CodeAnalysis.Editor.Options
+{
+    [Export(typeof(IFileWatcher)), Shared]
+    internal sealed class FileWatcher : IFileWatcher
+    {
+        private ImmutableDictionary<(string fileName, string directoryPath), FileSystemWatcher> _watchers = ImmutableDictionary<(string fileName, string directoryPath), FileSystemWatcher>.Empty;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FileWatcher()
+        {
+        }
+
+        public event ConventionsFileChangedAsyncEventHandler ConventionFileChanged;
+        public event ContextFileMovedAsyncEventHandler ContextFileMoved;
+
+        public void Dispose()
+        {
+            var watchers = Interlocked.Exchange(ref _watchers, null);
+            if (watchers == null)
+            {
+                return;
+            }
+
+            ConventionFileChanged = null;
+            ContextFileMoved = null;
+        }
+
+        public void StartWatching(string fileName, string directoryPath)
+        {
+            FileSystemWatcher watcher = null;
+            var updated = ImmutableInterlocked.Update(
+                ref _watchers,
+                watchers =>
+                {
+                    if (!watchers.TryGetValue((fileName, directoryPath), out var existingWatcher))
+                    {
+                        if (watcher == null)
+                        {
+                            watcher = new FileSystemWatcher(directoryPath, fileName);
+                        }
+
+                        return watchers.Add((fileName, directoryPath), watcher);
+                    }
+
+                    return watchers;
+                });
+
+            if (updated)
+            {
+                FileSystemEventHandler handler = (sender, e) => HandleFileSystemEvent(fileName, directoryPath, e);
+                watcher.Changed += handler;
+                watcher.Created += handler;
+                watcher.Deleted += handler;
+                watcher.Renamed += HandleRenamedEvent;
+            }
+            else
+            {
+                watcher?.Dispose();
+            }
+        }
+
+        private void HandleFileSystemEvent(string fileName, string directoryPath, FileSystemEventArgs e)
+        {
+            if (e.ChangeType.HasFlag(WatcherChangeTypes.Created))
+            {
+                ConventionFileChanged?.Invoke(this, new ConventionsFileChangeEventArgs(fileName, directoryPath, ChangeType.FileCreated));
+            }
+
+            if (e.ChangeType.HasFlag(WatcherChangeTypes.Changed))
+            {
+                ConventionFileChanged?.Invoke(this, new ConventionsFileChangeEventArgs(fileName, directoryPath, ChangeType.FileCreated));
+            }
+
+            if (e.ChangeType.HasFlag(WatcherChangeTypes.Deleted))
+            {
+                ConventionFileChanged?.Invoke(this, new ConventionsFileChangeEventArgs(fileName, directoryPath, ChangeType.FileDeleted));
+            }
+        }
+
+        private void HandleRenamedEvent(object sender, RenamedEventArgs e)
+        {
+            ContextFileMoved?.Invoke(this, new ContextFileMovedEventArgs(e.OldFullPath, e.FullPath));
+        }
+
+        public void StopWatching(string fileName, string directoryPath)
+        {
+            FileSystemWatcher watcher = null;
+            var updated = ImmutableInterlocked.Update(
+                ref _watchers,
+                watchers =>
+                {
+                    if (watchers.TryGetValue((fileName, directoryPath), out watcher))
+                    {
+                        return watchers.Remove((fileName, directoryPath));
+                    }
+
+                    return watchers;
+                });
+
+            watcher?.Dispose();
+        }
+    }
+}

--- a/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Roslyn.Utilities;
 
@@ -26,6 +28,11 @@ namespace Microsoft.CodeAnalysis.Remote
             var exportProvider = (IMefHostExportProvider)Services.HostServices;
             var primaryWorkspace = exportProvider.GetExports<PrimaryWorkspace>().Single().Value;
             primaryWorkspace.Register(this);
+
+            foreach (var providerFactory in exportProvider.GetExports<IDocumentOptionsProviderFactory>())
+            {
+                Services.GetRequiredService<IOptionService>().RegisterDocumentOptionsProvider(providerFactory.Value.Create(this));
+            }
 
             Options = Options.WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0);
 

--- a/src/Workspaces/Remote/Core/Services/RoslynServices.cs
+++ b/src/Workspaces/Remote/Core/Services/RoslynServices.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.CodingConventions;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -32,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 .Add(typeof(Host.TemporaryStorageServiceFactory.TemporaryStorageService).Assembly)
                 // This adds the exported MEF services from the RemoteWorkspaces assembly.
                 .Add(typeof(RoslynServices).Assembly)
+                .Add(typeof(ICodingConventionsManager).Assembly)
                 .Add(typeof(CSharp.CodeLens.CSharpCodeLensDisplayInfoService).Assembly)
                 .Add(typeof(VisualBasic.CodeLens.VisualBasicDisplayInfoService).Assembly);
 


### PR DESCRIPTION
`CreateCodingConventionsManager` creates an `ICodingConventionsManager` that never updates snapshots when content on disk changes. Roslyn already requested new configuration snapshots before analyzing new document content, but needed a copy of the coding conventions manager that provided updated configuration snapshots after changes occured. The MEF-imported `ICodingConventionsManager` provides these updates.

:memo: This change does not force documents to be reanalyzed after changes to .editorconfig are made. However, as soon as any edit is made to the document, the analysis results are updated using the latest configuration. This is the same limitation that applied to #26386, so this pull request supersedes the .editorconfig refresh changes in #26386.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
