### PR TITLE
Validate full path of file instead of file name in parsing /resource args

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1796,7 +1796,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            if (fullPath == null || !PathUtilities.IsValidFilePath(fileName))
+            if (!PathUtilities.IsValidFilePath(fullPath))
             {
                 AddDiagnostic(diagnostics, ErrorCode.FTL_InvalidInputFileName, filePath);
                 return null;

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -697,18 +697,16 @@ namespace Roslyn.Utilities
         /// 
         /// The more accurate way is to let the framework parse the path and throw on any errors.
         /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
-        public static bool IsValidFilePath(string path)
+        public static bool IsValidFilePath(string fullPath)
         {
             try
             {
-                if (string.IsNullOrEmpty(path))
+                if (string.IsNullOrEmpty(fullPath))
                 {
                     return false;
                 }
 
-                var fileInfo = new FileInfo(path);
+                var fileInfo = new FileInfo(fullPath);
                 return !string.IsNullOrEmpty(fileInfo.Name);
             }
             catch (Exception ex) when (

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -706,7 +706,8 @@ namespace Roslyn.Utilities
                     return false;
                 }
 
-                Debug.Assert(IsAbsolute(fullPath));
+                // Uncomment when this is fixed: https://github.com/dotnet/roslyn/issues/19592
+                // Debug.Assert(IsAbsolute(fullPath));
 
                 var fileInfo = new FileInfo(fullPath);
                 return !string.IsNullOrEmpty(fileInfo.Name);

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -706,6 +706,8 @@ namespace Roslyn.Utilities
                     return false;
                 }
 
+                Debug.Assert(IsAbsolute(fullPath));
+
                 var fileInfo = new FileInfo(fullPath);
                 return !string.IsNullOrEmpty(fileInfo.Name);
             }

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1625,7 +1625,7 @@ lVbRuntimePlus:
                 Return Nothing
             End If
 
-            If fullPath Is Nothing OrElse Not PathUtilities.IsValidFilePath(fileName) Then
+            If Not PathUtilities.IsValidFilePath(fullPath) Then
                 AddDiagnostic(diagnostics, ERRID.FTL_InvalidInputFileName, filePath)
                 Return Nothing
             End If


### PR DESCRIPTION
Fixes #27045 

The original bug is that the file name was checked instead of the full path. This makes the `FileInfo` constructor consider the execution path as the base path for the (relative) file name.

This change has no tests associated, as I talked with a couple of people on the team, and I believe this case is exteremely hard to put in a unit test, as the test needs to move the executed tests/compiler somewhere long enough to repro, and the scenario is corner case enough I don't think it is worth modifying the test harness at this point.