### PR TITLE
Handle anonymous method conversions in NullableWalker

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1350,7 +1350,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return HasIdentityConversionInternal(type1, type2, IncludeNullability);
         }
 
-        private static bool HasTopLevelNullabilityIdentityConversion(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations destination)
+        internal static bool HasTopLevelNullabilityIdentityConversion(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations destination)
         {
             // PROTOTYPE(NullableReferenceTypes): If two types differ only by nullability and
             // one has IsNullable unset and the other doesn't, which do we choose in inference?

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2228,7 +2228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundLambda lambda = ((UnboundLambda)node).BindForReturnTypeInference(d);
 
                 // - an inferred return type X exists for E in the context of the parameter list of D(§7.5.2.12), and an identity conversion exists from X to Y
-                var x = lambda.InferredReturnType(ref useSiteDiagnostics);
+                var x = lambda.GetInferredReturnType(ref useSiteDiagnostics);
                 if ((object)x != null && Conversions.HasIdentityConversion(x.TypeSymbol, y))
                 {
                     return true;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1083,7 +1083,7 @@
   <Node Name="BoundParameter" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-
+    
     <Field Name="ParameterSymbol" Type="ParameterSymbol"/>
   </Node>
 
@@ -1592,6 +1592,7 @@
   </Node>
 
   <Node Name="BoundLambda" Base="BoundExpression">
+    <Field Name="UnboundLambda" Type="UnboundLambda" Null="disallow" SkipInVisitor="true"/>
     <!-- LambdaSymbol may differ from Binder.MemberSymbol after rewriting. -->
     <Field Name="Symbol" Type="LambdaSymbol" Null="disallow"/>
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="allow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             );
         }
 
-        public TypeSymbolWithAnnotations GetInferredReturnType(ref HashSet<DiagnosticInfo> useSiteDiagnostics, NullableWalker.VariableState rewriterState = null)
+        public TypeSymbolWithAnnotations GetInferredReturnType(ref HashSet<DiagnosticInfo> useSiteDiagnostics, NullableWalker.VariableState nullableState = null)
         {
             if (!InferredReturnType.UseSiteDiagnostics.IsEmpty)
             {
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     useSiteDiagnostics.Add(info);
                 }
             }
-            if (rewriterState == null)
+            if (nullableState == null)
             {
                 return InferredReturnType.Type;
             }
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var delegateType = Type.GetDelegateType();
                 var compilation = Binder.Compilation;
                 var conversions = Binder.Conversions.WithNullability(includeNullability: true);
-                NullableWalker.Analyze(compilation, this, diagnostics, delegateInvokeMethod: delegateType?.DelegateInvokeMethod, returnTypes: builder, initialState: rewriterState);
+                NullableWalker.Analyze(compilation, this, diagnostics, delegateInvokeMethod: delegateType?.DelegateInvokeMethod, returnTypes: builder, initialState: nullableState);
                 diagnostics.Free();
                 var inferredReturnType = InferReturnType(builder, compilation, conversions, delegateType, Symbol.IsAsync);
                 builder.Free();
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class UnboundLambda
     {
-        private readonly NullableWalker.VariableState _rewriterState;
+        private readonly NullableWalker.VariableState _nullableState;
 
         public UnboundLambda(
             CSharpSyntaxNode syntax,
@@ -270,16 +270,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Data = new PlainUnboundLambdaState(this, binder, names, types, refKinds, isAsync);
         }
 
-        private UnboundLambda(UnboundLambda other, Binder binder, NullableWalker.VariableState rewriterState) :
+        private UnboundLambda(UnboundLambda other, Binder binder, NullableWalker.VariableState nullableState) :
             base(BoundKind.UnboundLambda, other.Syntax, null, other.HasErrors)
         {
-            this._rewriterState = rewriterState;
+            this._nullableState = nullableState;
             this.Data = other.Data;
         }
 
-        internal UnboundLambda WithRewriter(Binder binder, NullableWalker.VariableState rewriterState)
+        internal UnboundLambda WithNullableState(Binder binder, NullableWalker.VariableState nullableState)
         {
-            return new UnboundLambda(this, binder, rewriterState);
+            return new UnboundLambda(this, binder, nullableState);
         }
 
         public MessageID MessageID { get { return Data.MessageID; } }
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool HasSignature { get { return Data.HasSignature; } }
         public bool HasExplicitlyTypedParameterList { get { return Data.HasExplicitlyTypedParameterList; } }
         public int ParameterCount { get { return Data.ParameterCount; } }
-        public TypeSymbolWithAnnotations InferReturnType(NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics) { return BindForReturnTypeInference(delegateType).GetInferredReturnType(ref useSiteDiagnostics, _rewriterState);  }
+        public TypeSymbolWithAnnotations InferReturnType(NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics) { return BindForReturnTypeInference(delegateType).GetInferredReturnType(ref useSiteDiagnostics, _nullableState);  }
         public RefKind RefKind(int index) { return Data.RefKind(index); }
         public void GenerateAnonymousFunctionConversionError(DiagnosticBag diagnostics, TypeSymbol targetType) { Data.GenerateAnonymousFunctionConversionError(diagnostics, targetType); }
         public bool GenerateSummaryErrors(DiagnosticBag diagnostics) { return Data.GenerateSummaryErrors(diagnostics); }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var delegateType = Type.GetDelegateType();
                 var compilation = Binder.Compilation;
                 var conversions = Binder.Conversions.WithNullability(includeNullability: true);
-                NullableWalker.Analyze(compilation, this, diagnostics, delegateInvokeMethod: delegateType?.DelegateInvokeMethod, returnTypes: returnTypes, initialState: nullableState);
+                NullableWalker.Analyze(compilation, lambda: this, diagnostics, delegateInvokeMethod: delegateType?.DelegateInvokeMethod, returnTypes: returnTypes, initialState: nullableState);
                 diagnostics.Free();
                 var inferredReturnType = InferReturnType(returnTypes, compilation, conversions, delegateType, Symbol.IsAsync);
                 returnTypes.Free();

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             );
         }
 
-        public TypeSymbolWithAnnotations GetInferredReturnType(ref HashSet<DiagnosticInfo> useSiteDiagnostics, NullableWalker.InitialState rewriterState = null)
+        public TypeSymbolWithAnnotations GetInferredReturnType(ref HashSet<DiagnosticInfo> useSiteDiagnostics, NullableWalker.VariableState rewriterState = null)
         {
             if (!InferredReturnType.UseSiteDiagnostics.IsEmpty)
             {
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class UnboundLambda
     {
-        private readonly NullableWalker.InitialState _rewriterState;
+        private readonly NullableWalker.VariableState _rewriterState;
 
         public UnboundLambda(
             CSharpSyntaxNode syntax,
@@ -270,14 +270,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Data = new PlainUnboundLambdaState(this, binder, names, types, refKinds, isAsync);
         }
 
-        private UnboundLambda(UnboundLambda other, Binder binder, NullableWalker.InitialState rewriterState) :
+        private UnboundLambda(UnboundLambda other, Binder binder, NullableWalker.VariableState rewriterState) :
             base(BoundKind.UnboundLambda, other.Syntax, null, other.HasErrors)
         {
             this._rewriterState = rewriterState;
             this.Data = other.Data;
         }
 
-        internal UnboundLambda WithRewriter(Binder binder, NullableWalker.InitialState rewriterState)
+        internal UnboundLambda WithRewriter(Binder binder, NullableWalker.VariableState rewriterState)
         {
             return new UnboundLambda(this, binder, rewriterState);
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.VariableIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.VariableIdentifier.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal partial class DataFlowPassBase<TLocalState>
     {
         [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-        protected struct VariableIdentifier : IEquatable<VariableIdentifier>
+        internal struct VariableIdentifier : IEquatable<VariableIdentifier>
         {
             public readonly Symbol Symbol;
             public readonly int ContainingSlot;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
@@ -49,12 +49,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             _emptyStructTypeCache = emptyStructs;
             if (variableSlot != null)
             {
-                foreach (var pair in variableSlot)
+                nextVariableSlot = variableBySlot.Length;
+                foreach (var (variable, slot) in variableSlot)
                 {
-                    _variableSlot.Add(pair.Key, pair.Value);
+                    Debug.Assert(slot < nextVariableSlot);
+                    _variableSlot.Add(variable, slot);
                 }
                 this.variableBySlot = variableBySlot.ToArray();
-                nextVariableSlot = variableBySlot.Length;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
@@ -41,22 +41,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Symbol member,
             BoundNode node,
             EmptyStructTypeCache emptyStructs,
-            bool trackUnassignments,
-            ImmutableDictionary<VariableIdentifier, int> variableSlot = null,
-            ImmutableArray<VariableIdentifier> variableBySlot = default)
+            bool trackUnassignments)
             : base(compilation, member, node, trackUnassignments: trackUnassignments)
         {
             _emptyStructTypeCache = emptyStructs;
-            if (variableSlot != null)
-            {
-                nextVariableSlot = variableBySlot.Length;
-                foreach (var (variable, slot) in variableSlot)
-                {
-                    Debug.Assert(slot < nextVariableSlot);
-                    _variableSlot.Add(variable, slot);
-                }
-                this.variableBySlot = variableBySlot.ToArray();
-            }
         }
 
         protected DataFlowPassBase(

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -15,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// A mapping from local variables to the index of their slot in a flow analysis local state.
         /// </summary>
-        private readonly PooledDictionary<VariableIdentifier, int> _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
+        protected readonly PooledDictionary<VariableIdentifier, int> _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
 
         /// <summary>
         /// A mapping from the local variable slot to the symbol for the local variable itself.  This
@@ -40,10 +41,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             Symbol member,
             BoundNode node,
             EmptyStructTypeCache emptyStructs,
-            bool trackUnassignments)
+            bool trackUnassignments,
+            ImmutableDictionary<VariableIdentifier, int> variableSlot = null,
+            ImmutableArray<VariableIdentifier> variableBySlot = default)
             : base(compilation, member, node, trackUnassignments: trackUnassignments)
         {
             _emptyStructTypeCache = emptyStructs;
+            if (variableSlot != null)
+            {
+                foreach (var pair in variableSlot)
+                {
+                    _variableSlot.Add(pair.Key, pair.Value);
+                }
+                this.variableBySlot = variableBySlot.ToArray();
+                nextVariableSlot = variableBySlot.Length;
+            }
         }
 
         protected DataFlowPassBase(

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2680,6 +2680,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case ConversionKind.AnonymousFunction:
+                    if (operandOpt.Kind == BoundKind.Lambda)
                     {
                         var lambda = (BoundLambda)operandOpt;
                         var delegateType = targetType.GetDelegateType();
@@ -2696,6 +2697,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         return TypeSymbolWithAnnotations.Create(targetType, isNullableIfReferenceType: false);
                     }
+                    break;
 
                 case ConversionKind.InterpolatedString:
                     isNullableIfReferenceType = false;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -119,9 +119,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             ArrayBuilder<(RefKind, TypeSymbolWithAnnotations)> returnTypes,
             VariableState initialState,
             Action<BoundExpression, TypeSymbolWithAnnotations> callbackOpt)
-            : base(compilation, method, node, new EmptyStructTypeCache(compilation, dev12CompilerCompatibility: false), trackUnassignments: false, variableSlot: initialState?.VariableSlot, variableBySlot: (initialState is null) ? default : initialState.VariableBySlot)
+            : base(
+                  compilation,
+                  method,
+                  node,
+                  new EmptyStructTypeCache(compilation, dev12CompilerCompatibility: false),
+                  trackUnassignments: false,
+                  variableSlot: initialState?.VariableSlot,
+                  variableBySlot: (initialState is null) ? default : initialState.VariableBySlot)
         {
-            _sourceAssembly = ((object)method == null) ? null : (SourceAssemblySymbol)method.ContainingAssembly;
+            _sourceAssembly = (method is null) ? null : (SourceAssemblySymbol)method.ContainingAssembly;
             _callbackOpt = callbackOpt;
             // PROTOTYPE(NullableReferenceTypes): Do we really need a Binder?
             // If so, are we interested in an InMethodBinder specifically?

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1880,7 +1880,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)method != null && method.IsGenericMethod && HasImplicitTypeArguments(node))
             {
-                method = InferMethod((BoundCall)node, method, GetArgumentsForMethodTypeInference(arguments, results));
+                method = InferMethodTypeArguments((BoundCall)node, method, GetArgumentsForMethodTypeInference(arguments, results));
                 parameters = method.Parameters;
             }
 
@@ -2223,7 +2223,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (parameter, type);
         }
 
-        private MethodSymbol InferMethod(BoundCall node, MethodSymbol method, ImmutableArray<BoundExpression> arguments)
+        private MethodSymbol InferMethodTypeArguments(BoundCall node, MethodSymbol method, ImmutableArray<BoundExpression> arguments)
         {
             Debug.Assert(method.IsGenericMethod);
             // PROTOTYPE(NullableReferenceTypes): OverloadResolution.IsMemberApplicableInNormalForm and

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -723,22 +723,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void EnterParameters()
         {
             var methodParameters = ((MethodSymbol)_member).Parameters;
-            var signatureParameters = _useMethodSignatureParameterTypes ? _methodSignatureOpt.Parameters : default;
-            Debug.Assert(signatureParameters.IsDefault || signatureParameters.Length == methodParameters.Length);
+            var signatureParameters = _useMethodSignatureParameterTypes ? _methodSignatureOpt.Parameters : methodParameters;
+            Debug.Assert(signatureParameters.Length == methodParameters.Length);
             int n = methodParameters.Length;
             for (int i = 0; i < n; i++)
             {
                 var parameter = methodParameters[i];
-                TypeSymbolWithAnnotations parameterType;
-                if (signatureParameters.IsDefault)
-                {
-                    parameterType = parameter.Type;
-                }
-                else
-                {
-                    parameterType = signatureParameters[i].Type;
-                    _variableTypes[parameter] = parameterType;
-                }
+                var parameterType = signatureParameters[i].Type;
+                _variableTypes[parameter] = parameterType;
                 EnterParameter(parameter, parameterType);
             }
         }
@@ -2668,8 +2660,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             if (requireIdentity)
             {
-                return source.Equals(destination, TypeCompareKind.AllIgnoreOptions) &&
-                    !source.Equals(destination, TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes | TypeCompareKind.UnknownNullableModifierMatchesAny);
+                return IsNullabilityMismatch(source, destination);
             }
             var sourceType = source.TypeSymbol;
             var destinationType = destination.TypeSymbol;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -61,14 +61,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly Conversions _conversions;
 
         /// <summary>
-        /// Use the return type and nullability from _methodSignatureOpt to calculate
-        /// return expression conversions. If false, the signature of _member is used instead.
+        /// Use the return type and nullability from _methodSignatureOpt to calculate return
+        /// expression conversions. If false, the signature of _member is used instead.
         /// </summary>
         private readonly bool _useMethodSignatureReturnType;
 
         /// <summary>
         /// Use the the parameter types and nullability from _methodSignatureOpt for initial
-        /// parameter state.If false, the signature of _member is used instead.
+        /// parameter state. If false, the signature of _member is used instead.
         /// </summary>
         private readonly bool _useMethodSignatureParameterTypes;
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2297,7 +2297,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // By using a generic BoundValuePlaceholder, we're losing inference in those cases.
             // PROTOTYPE(NullableReferenceTypes): Inference should be based on
             // unconverted arguments. Consider cases such as `default`, lambdas, tuples.
-            return arguments.ZipAsArray(argumentResults, (argument, result) => getArgumentForMethodTypeInference(argument, result));
+            int n = arguments.Length;
+            var builder = ArrayBuilder<BoundExpression>.GetInstance(n);
+            for (int i = 0; i < n; i++)
+            {
+                builder.Add(getArgumentForMethodTypeInference(arguments[i], argumentResults[i]));
+            }
+            return builder.ToImmutableAndFree();
 
             BoundExpression getArgumentForMethodTypeInference(BoundExpression argument, Result argumentResult)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2171,6 +2171,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private VariableState GetVariableState()
         {
+            // PROTOTYPE(NullableReferenceTypes): To track nullability of captured variables inside and
+            // outside a lambda, the lambda should be considered executed at the location the lambda
+            // is converted to a delegate.
             return new VariableState(
                 _variableSlot.ToImmutableDictionary(),
                 ImmutableArray.Create(variableBySlot, start: 0, length: nextVariableSlot),
@@ -2640,6 +2643,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // (Compare with method group conversions which pass `requireIdentity: false`.)
                 if (IsNullabilityMismatch(invokeParameter.Type, unboundLambda.ParameterType(i), requireIdentity: true))
                 {
+                    // PROTOTYPE(NullableReferenceTypes): Consider using location of specific lambda parameter.
                     ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, syntax,
                         unboundLambda.ParameterName(i),
                         unboundLambda.MessageID.Localize(),

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -127,14 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ArrayBuilder<(RefKind, TypeSymbolWithAnnotations)> returnTypes,
             VariableState initialState,
             Action<BoundExpression, TypeSymbolWithAnnotations> callbackOpt)
-            : base(
-                  compilation,
-                  method,
-                  node,
-                  new EmptyStructTypeCache(compilation, dev12CompilerCompatibility: false),
-                  trackUnassignments: false,
-                  variableSlot: initialState?.VariableSlot,
-                  variableBySlot: (initialState is null) ? default : initialState.VariableBySlot)
+            : base(compilation, method, node, new EmptyStructTypeCache(compilation, dev12CompilerCompatibility: false), trackUnassignments: false)
         {
             _sourceAssembly = (method is null) ? null : (SourceAssemblySymbol)method.ContainingAssembly;
             _callbackOpt = callbackOpt;
@@ -149,6 +142,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             _returnTypes = returnTypes;
             if (initialState != null)
             {
+                var variableBySlot = initialState.VariableBySlot;
+                nextVariableSlot = variableBySlot.Length;
+                foreach (var (variable, slot) in initialState.VariableSlot)
+                {
+                    Debug.Assert(slot < nextVariableSlot);
+                    _variableSlot.Add(variable, slot);
+                }
+                this.variableBySlot = variableBySlot.ToArray();
                 foreach (var pair in initialState.VariableTypes)
                 {
                     _variableTypes.Add(pair.Key, pair.Value);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2615,6 +2615,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < count; i++)
             {
                 var invokeParameter = invoke.Parameters[i];
+                // Parameter nullability is expected to match exactly. This corresponds to the behavior of initial binding.
+                //    Action<string> x = (object o) => { }; // error CS1661: Cannot convert lambda expression to delegate type 'Action<string>' because the parameter types do not match the delegate parameter types
+                //    Action<object> y = (object? o) => { }; // warning CS8622: Nullability of reference types in type of parameter 'o' of 'lambda expression' doesn't match the target delegate 'Action<object>'.
+                // PROTOTYPE(NullableReferenceTypes): Consider relaxing and allow implicit conversions of nullability.
+                // (Compare with method group conversions which pass `requireIdentity: false`.)
                 if (IsNullabilityMismatch(invokeParameter.Type, unboundLambda.ParameterType(i), requireIdentity: true))
                 {
                     ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, syntax,

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -5748,21 +5748,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundLambda : BoundExpression
     {
-        public BoundLambda(SyntaxNode syntax, LambdaSymbol symbol, BoundBlock body, ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics, Binder binder, TypeSymbol type, bool hasErrors = false)
-            : base(BoundKind.Lambda, syntax, type, hasErrors || body.HasErrors())
+        public BoundLambda(SyntaxNode syntax, UnboundLambda unboundLambda, LambdaSymbol symbol, BoundBlock body, ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics, Binder binder, TypeSymbol type, bool hasErrors = false)
+            : base(BoundKind.Lambda, syntax, type, hasErrors || unboundLambda.HasErrors() || body.HasErrors())
         {
 
+            Debug.Assert(unboundLambda != null, "Field 'unboundLambda' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(body != null, "Field 'body' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(!diagnostics.IsDefault, "Field 'diagnostics' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(binder != null, "Field 'binder' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
+            this.UnboundLambda = unboundLambda;
             this.Symbol = symbol;
             this.Body = body;
             this.Diagnostics = diagnostics;
             this.Binder = binder;
         }
 
+
+        public UnboundLambda UnboundLambda { get; }
 
         public LambdaSymbol Symbol { get; }
 
@@ -5777,11 +5781,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.VisitLambda(this);
         }
 
-        public BoundLambda Update(LambdaSymbol symbol, BoundBlock body, ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics, Binder binder, TypeSymbol type)
+        public BoundLambda Update(UnboundLambda unboundLambda, LambdaSymbol symbol, BoundBlock body, ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics, Binder binder, TypeSymbol type)
         {
-            if (symbol != this.Symbol || body != this.Body || diagnostics != this.Diagnostics || binder != this.Binder || type != this.Type)
+            if (unboundLambda != this.UnboundLambda || symbol != this.Symbol || body != this.Body || diagnostics != this.Diagnostics || binder != this.Binder || type != this.Type)
             {
-                var result = new BoundLambda(this.Syntax, symbol, body, diagnostics, binder, type, this.HasErrors);
+                var result = new BoundLambda(this.Syntax, unboundLambda, symbol, body, diagnostics, binder, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -9628,9 +9632,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitLambda(BoundLambda node)
         {
+            UnboundLambda unboundLambda = node.UnboundLambda;
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(node.Symbol, body, node.Diagnostics, node.Binder, type);
+            return node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, type);
         }
         public override BoundNode VisitUnboundLambda(UnboundLambda node)
         {
@@ -11199,6 +11204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return new TreeDumperNode("lambda", null, new TreeDumperNode[]
             {
+                new TreeDumperNode("unboundLambda", null, new TreeDumperNode[] { Visit(node.UnboundLambda, null) }),
                 new TreeDumperNode("symbol", node.Symbol, null),
                 new TreeDumperNode("body", null, new TreeDumperNode[] { Visit(node.Body, null) }),
                 new TreeDumperNode("diagnostics", node.Diagnostics, null),

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -773,7 +773,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ParameterSymbol replacementParameter;
             if (_parameterMap.TryGetValue(node.ParameterSymbol, out replacementParameter))
             {
-                return new BoundParameter(node.Syntax, replacementParameter, replacementParameter.Type.TypeSymbol, node.HasErrors);
+                return new BoundParameter(node.Syntax, replacementParameter, node.HasErrors);
             }
 
             return base.VisitUnhoistedParameter(node);
@@ -1513,7 +1513,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var newType = VisitType(node.Type);
                 var newBody = (BoundBlock)Visit(node.Body);
-                node = node.Update(node.Symbol, newBody, node.Diagnostics, node.Binder, newType);
+                node = node.Update(node.UnboundLambda, node.Symbol, newBody, node.Diagnostics, node.Binder, newType);
                 var result0 = wasInExpressionLambda ? node : ExpressionLambdaRewriter.RewriteLambda(node, CompilationState, TypeMap, RecursionDepth, Diagnostics);
                 _inExpressionLambda = wasInExpressionLambda;
                 return result0;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -174,6 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _refKind; }
         }
 
+        // Nullability reflects declared state not inferred state from flow analysis.
         public override TypeSymbolWithAnnotations ReturnType
         {
             get { return _returnType; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -174,7 +174,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _refKind; }
         }
 
-        // Nullability reflects declared state not inferred state from flow analysis.
         public override TypeSymbolWithAnnotations ReturnType
         {
             get { return _returnType; }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -941,8 +941,9 @@ class C
     }
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
-            // No missing attribute warning since the nullable state of the lambda
-            // return type was inferred in flow analysis, not from initial binding.
+            // The lambda signature is emitted without a [Nullable] attribute because
+            // the return type is inferred from flow analysis, not from initial binding.
+            // As a result, there is no missing attribute warning.
             comp.VerifyEmitDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -941,10 +941,9 @@ class C
     }
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
-            comp.VerifyEmitDiagnostics(
-                // (9,14): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
-                //         F(() =>
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "=>").WithArguments("System.Runtime.CompilerServices.NullableAttribute").WithLocation(9, 14));
+            // No missing attribute warning since the nullable state of the lambda
+            // return type was inferred in flow analysis, not from initial binding.
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -11939,8 +11939,9 @@ class C
         }
 
         /// <summary>
-        /// Inferred nullability of captured variables outside lambda
-        /// should be independent of inferred nullability inside lambda.
+        /// To track nullability of captured variables inside and outside a lambda,
+        /// the lambda should be considered executed at the location the lambda
+        /// is converted to a delegate.
         /// </summary>
         [Fact]
         public void Lambda_19()
@@ -11981,6 +11982,8 @@ class C
         z3.ToString();
     }
 }";
+            // PROTOTYPE(NullableReferenceTypes): For captured variables, the lambda should be
+            // considered executed at the location the lambda is converted to a delegate.
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (9,18): warning CS8600: Converting null literal or possible null value to non-nullable type.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -24038,6 +24038,21 @@ class C
         }
 
         [Fact]
+        public void PartialClassConstraintMismatch()
+        {
+            var source =
+@"class A { }
+partial class B<T> where T : A { }
+partial class B<T> where T : A? { }";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            // PROTOTYPE(NullableReferenceTypes): Should report ErrorCode.ERR_PartialWrongConstraints.
+            comp.VerifyDiagnostics(
+                // (3,30): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                // partial class B<T> where T : A? { }
+                Diagnostic(ErrorCode.ERR_BadConstraintType, "A?").WithLocation(3, 30));
+        }
+
+        [Fact]
         public void AssignmentNullability()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -10211,8 +10211,7 @@ class CL1
                 );
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Calculate lamba conversion.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void Lambda_12()
         {
             CSharpCompilation c = CreateCompilation(@"
@@ -10252,35 +10251,34 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (12,51): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //         System.Action<CL1?> x1 = (CL1 p1) => p1 = M1();
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(12, 51),
-                 // (12,34): warning CS8622: Nullability of reference types in type of parameter 'p1' of 'lambda expression' doesn't match the target delegate 'Action<CL1?>'.
-                 //         System.Action<CL1?> x1 = (CL1 p1) => p1 = M1();
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1 p1) => p1 = M1()").WithArguments("p1", "lambda expression", "System.Action<CL1?>").WithLocation(12, 34),
-                 // (17,59): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //         System.Action<CL1?> x2 = delegate (CL1 p2) { p2 = M1(); };
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(17, 59),
-                 // (17,34): warning CS8622: Nullability of reference types in type of parameter 'p2' of 'lambda expression' doesn't match the target delegate 'Action<CL1?>'.
-                 //         System.Action<CL1?> x2 = delegate (CL1 p2) { p2 = M1(); };
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1 p2) { p2 = M1(); }").WithArguments("p2", "lambda expression", "System.Action<CL1?>").WithLocation(17, 34),
-                 // (24,34): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //         D1 x3 = (CL1 p3) => p3 = M1();
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(24, 34),
-                 // (24,17): warning CS8622: Nullability of reference types in type of parameter 'p3' of 'lambda expression' doesn't match the target delegate 'C.D1'.
-                 //         D1 x3 = (CL1 p3) => p3 = M1();
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1 p3) => p3 = M1()").WithArguments("p3", "lambda expression", "C.D1").WithLocation(24, 17),
-                 // (29,42): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //         D1 x4 = delegate (CL1 p4) { p4 = M1(); };
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(29, 42),
-                 // (29,17): warning CS8622: Nullability of reference types in type of parameter 'p4' of 'lambda expression' doesn't match the target delegate 'C.D1'.
-                 //         D1 x4 = delegate (CL1 p4) { p4 = M1(); };
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1 p4) { p4 = M1(); }").WithArguments("p4", "lambda expression", "C.D1").WithLocation(29, 17)
+                // (12,51): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         System.Action<CL1?> x1 = (CL1 p1) => p1 = M1();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(12, 51),
+                // (12,34): warning CS8622: Nullability of reference types in type of parameter 'p1' of 'lambda expression' doesn't match the target delegate 'Action<CL1?>'.
+                //         System.Action<CL1?> x1 = (CL1 p1) => p1 = M1();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1 p1) => p1 = M1()").WithArguments("p1", "lambda expression", "System.Action<CL1?>").WithLocation(12, 34),
+                // (17,59): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         System.Action<CL1?> x2 = delegate (CL1 p2) { p2 = M1(); };
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(17, 59),
+                // (17,34): warning CS8622: Nullability of reference types in type of parameter 'p2' of 'anonymous method' doesn't match the target delegate 'Action<CL1?>'.
+                //         System.Action<CL1?> x2 = delegate (CL1 p2) { p2 = M1(); };
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1 p2) { p2 = M1(); }").WithArguments("p2", "anonymous method", "System.Action<CL1?>").WithLocation(17, 34),
+                // (24,34): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         D1 x3 = (CL1 p3) => p3 = M1();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(24, 34),
+                // (24,17): warning CS8622: Nullability of reference types in type of parameter 'p3' of 'lambda expression' doesn't match the target delegate 'C.D1'.
+                //         D1 x3 = (CL1 p3) => p3 = M1();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1 p3) => p3 = M1()").WithArguments("p3", "lambda expression", "C.D1").WithLocation(24, 17),
+                // (29,42): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         D1 x4 = delegate (CL1 p4) { p4 = M1(); };
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "M1()").WithLocation(29, 42),
+                // (29,17): warning CS8622: Nullability of reference types in type of parameter 'p4' of 'anonymous method' doesn't match the target delegate 'C.D1'.
+                //         D1 x4 = delegate (CL1 p4) { p4 = M1(); };
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1 p4) { p4 = M1(); }").WithArguments("p4", "anonymous method", "C.D1").WithLocation(29, 17)
                 );
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Calculate lamba conversion.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void Lambda_13()
         {
             CSharpCompilation c = CreateCompilation(@"
@@ -10320,18 +10318,18 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (12,33): warning CS8622: Nullability of reference types in type of parameter 'p1' of 'lambda expression' doesn't match the target delegate 'Action<CL1>'.
-                 //         System.Action<CL1> x1 = (CL1? p1) => p1 = M1();
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1? p1) => p1 = M1()").WithArguments("p1", "lambda expression", "System.Action<CL1>").WithLocation(12, 33),
-                 // (17,33): warning CS8622: Nullability of reference types in type of parameter 'p2' of 'lambda expression' doesn't match the target delegate 'Action<CL1>'.
-                 //         System.Action<CL1> x2 = delegate (CL1? p2) { p2 = M1(); };
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1? p2) { p2 = M1(); }").WithArguments("p2", "lambda expression", "System.Action<CL1>").WithLocation(17, 33),
-                 // (24,17): warning CS8622: Nullability of reference types in type of parameter 'p3' of 'lambda expression' doesn't match the target delegate 'C.D1'.
-                 //         D1 x3 = (CL1? p3) => p3 = M1();
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1? p3) => p3 = M1()").WithArguments("p3", "lambda expression", "C.D1").WithLocation(24, 17),
-                 // (29,17): warning CS8622: Nullability of reference types in type of parameter 'p4' of 'lambda expression' doesn't match the target delegate 'C.D1'.
-                 //         D1 x4 = delegate (CL1? p4) { p4 = M1(); };
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1? p4) { p4 = M1(); }").WithArguments("p4", "lambda expression", "C.D1").WithLocation(29, 17)
+                // (12,33): warning CS8622: Nullability of reference types in type of parameter 'p1' of 'lambda expression' doesn't match the target delegate 'Action<CL1>'.
+                //         System.Action<CL1> x1 = (CL1? p1) => p1 = M1();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1? p1) => p1 = M1()").WithArguments("p1", "lambda expression", "System.Action<CL1>").WithLocation(12, 33),
+                // (17,33): warning CS8622: Nullability of reference types in type of parameter 'p2' of 'anonymous method' doesn't match the target delegate 'Action<CL1>'.
+                //         System.Action<CL1> x2 = delegate (CL1? p2) { p2 = M1(); };
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1? p2) { p2 = M1(); }").WithArguments("p2", "anonymous method", "System.Action<CL1>").WithLocation(17, 33),
+                // (24,17): warning CS8622: Nullability of reference types in type of parameter 'p3' of 'lambda expression' doesn't match the target delegate 'C.D1'.
+                //         D1 x3 = (CL1? p3) => p3 = M1();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1? p3) => p3 = M1()").WithArguments("p3", "lambda expression", "C.D1").WithLocation(24, 17),
+                // (29,17): warning CS8622: Nullability of reference types in type of parameter 'p4' of 'anonymous method' doesn't match the target delegate 'C.D1'.
+                //         D1 x4 = delegate (CL1? p4) { p4 = M1(); };
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "delegate (CL1? p4) { p4 = M1(); }").WithArguments("p4", "anonymous method", "C.D1").WithLocation(29, 17)
                 );
         }
 
@@ -10438,8 +10436,7 @@ class C
                 );
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Calculate lamba conversion.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void Lambda_16()
         {
             CSharpCompilation c = CreateCompilation(@"
@@ -10474,8 +10471,7 @@ class CL1<T>
                 );
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Calculate lamba conversion.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void Lambda_17()
         {
             CSharpCompilation c = CreateCompilation(@"
@@ -10510,6 +10506,40 @@ class CL1<T>
                  //         Expression<System.Action<CL1<string>>> x2 = (CL1<string?> p2) => System.Console.WriteLine();
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(CL1<string?> p2) => System.Console.WriteLine()").WithArguments("p2", "lambda expression", "System.Action<CL1<string>>").WithLocation(17, 53)
                 );
+        }
+
+        [Fact]
+        public void Lambda_18()
+        {
+            var source =
+@"delegate T D<T>(T t) where T : class;
+class C
+{
+    static void F()
+    {
+        var d1 = (D<string?>)((string s1) =>
+            {
+                s1 = null;
+                return s1;
+            });
+        var d2 = (D<string>)((string? s2) =>
+            {
+                s2.ToString();
+                return s2;
+            });
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //                 s1 = null;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(8, 22),
+                // (13,17): warning CS8602: Possible dereference of a null reference.
+                //                 s2.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(13, 17),
+                // (14,24): warning CS8603: Possible null reference return.
+                //                 return s2;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "s2").WithLocation(14, 24));
         }
 
         [Fact]
@@ -12579,9 +12609,6 @@ class CL0<T>
                 // (12,37): warning CS8622: Nullability of reference types in type of parameter 'x' of 'void C.M1<string>(string x)' doesn't match the target delegate 'Action<string?>'.
                 //         System.Action<string?> u1 = M1<string>;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "M1<string>").WithArguments("x", "void C.M1<string>(string x)", "System.Action<string?>").WithLocation(12, 37),
-                // (17,36): warning CS8622: Nullability of reference types in type of parameter 'x' of 'void C.M1<string?>(string? x)' doesn't match the target delegate 'Action<string>'.
-                //         System.Action<string> u2 = M1<string?>;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "M1<string?>").WithArguments("x", "void C.M1<string?>(string? x)", "System.Action<string>").WithLocation(17, 36),
                 // (22,42): warning CS8622: Nullability of reference types in type of parameter 'x' of 'void C.M1<CL0<string>>(CL0<string> x)' doesn't match the target delegate 'Action<CL0<string?>>'.
                 //         System.Action<CL0<string?>> u3 = M1<CL0<string>>;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "M1<CL0<string>>").WithArguments("x", "void C.M1<CL0<string>>(CL0<string> x)", "System.Action<CL0<string?>>").WithLocation(22, 42),
@@ -12672,9 +12699,6 @@ class CL0<T>
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (12,35): warning CS8621: Nullability of reference types in return type of 'string C.M1<string>()' doesn't match the target delegate 'Func<string?>'.
-                //         System.Func<string?> u1 = M1<string>;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate, "M1<string>").WithArguments("string C.M1<string>()", "System.Func<string?>").WithLocation(12, 35),
                  // (17,34): warning CS8621: Nullability of reference types in return type of 'string? C.M1<string?>()' doesn't match the target delegate 'Func<string>'.
                  //         System.Func<string> u2 = M1<string?>;
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate, "M1<string?>").WithArguments("string? C.M1<string?>()", "System.Func<string>").WithLocation(17, 34),
@@ -17610,8 +17634,7 @@ class C
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "i").WithArguments("I<object>", "I<string?>").WithLocation(5, 42));
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Conversions: Other
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void Covariance_Delegate()
         {
             var source =
@@ -17647,8 +17670,7 @@ class C
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "F3").WithArguments("o", "void C.F3(object o)", "D<string?>").WithLocation(17, 20));
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Conversions: Other
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void Contravariance_Delegate()
         {
             var source =
@@ -22094,6 +22116,28 @@ class C
                 // (15,13): warning CS8602: Possible dereference of a null reference.
                 //             a2.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2.F").WithLocation(15, 13));
+        }
+
+        [Fact]
+        public void SelectAnonymousType()
+        {
+            var source =
+@"using System.Collections.Generic;
+using System.Linq;
+class C
+{
+    int? E;
+    static void F(IEnumerable<C> c)
+    {
+        const int F = 0;
+        c.Select(o => new { E = o.E ?? F });
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (5,10): warning CS0649: Field 'C.E' is never assigned to, and will always have its default value 
+                //     int? E;
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "E").WithArguments("C.E", "").WithLocation(5, 10));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Should report CS8600 for `T1 t = (T1)NullableObject();`

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -10730,6 +10730,68 @@ class CL1<T>
         public void AnonymousTypes_05()
         {
             var source =
+@"interface I<T> { }
+interface IIn<in T> { }
+interface IOut<out T> { }
+class C
+{
+    static void F0(string x0, string? y0)
+    {
+        var a0 = new { F = x0 };
+        var b0 = new { F = y0 };
+        a0 = b0;
+        b0 = a0;
+    }
+    static void F1(I<string> x1, I<string?> y1)
+    {
+        var a1 = new { F = x1 };
+        var b1 = new { F = y1 };
+        a1 = b1;
+        b1 = a1;
+    }
+    static void F2(IIn<string> x2, IIn<string?> y2)
+    {
+        var a2 = new { F = x2 };
+        var b2 = new { F = y2 };
+        a2 = b2;
+        b2 = a2;
+    }
+    static void F3(IOut<string> x3, IOut<string?> y3)
+    {
+        var a3 = new { F = x3 };
+        var b3 = new { F = y3 };
+        a3 = b3;
+        b3 = a3;
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            // PROTOTYPE(NullableReferenceTypes): Should report a warning for `a0 = b0`.
+            // PROTOTYPE(NullableReferenceTypes): Should not report a warning for `b3 = a3`.
+            comp.VerifyDiagnostics(
+                // (17,14): warning CS8619: Nullability of reference types in value of type '<anonymous type: I<string?> F>' doesn't match target type '<anonymous type: I<string> F>'.
+                //         a1 = b1;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b1").WithArguments("<anonymous type: I<string?> F>", "<anonymous type: I<string> F>").WithLocation(17, 14),
+                // (18,14): warning CS8619: Nullability of reference types in value of type '<anonymous type: I<string> F>' doesn't match target type '<anonymous type: I<string?> F>'.
+                //         b1 = a1;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "a1").WithArguments("<anonymous type: I<string> F>", "<anonymous type: I<string?> F>").WithLocation(18, 14),
+                // (24,14): warning CS8619: Nullability of reference types in value of type '<anonymous type: IIn<string?> F>' doesn't match target type '<anonymous type: IIn<string> F>'.
+                //         a2 = b2;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b2").WithArguments("<anonymous type: IIn<string?> F>", "<anonymous type: IIn<string> F>").WithLocation(24, 14),
+                // (25,14): warning CS8619: Nullability of reference types in value of type '<anonymous type: IIn<string> F>' doesn't match target type '<anonymous type: IIn<string?> F>'.
+                //         b2 = a2;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "a2").WithArguments("<anonymous type: IIn<string> F>", "<anonymous type: IIn<string?> F>").WithLocation(25, 14),
+                // (31,14): warning CS8619: Nullability of reference types in value of type '<anonymous type: IOut<string?> F>' doesn't match target type '<anonymous type: IOut<string> F>'.
+                //         a3 = b3;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b3").WithArguments("<anonymous type: IOut<string?> F>", "<anonymous type: IOut<string> F>").WithLocation(31, 14),
+                // (32,14): warning CS8619: Nullability of reference types in value of type '<anonymous type: IOut<string> F>' doesn't match target type '<anonymous type: IOut<string?> F>'.
+                //         b3 = a3;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "a3").WithArguments("<anonymous type: IOut<string> F>", "<anonymous type: IOut<string?> F>").WithLocation(32, 14));
+        }
+
+        [Fact]
+        public void AnonymousTypes_06()
+        {
+            var source =
 @"class C
 {
     static void F(string x, string y)
@@ -10738,9 +10800,7 @@ class CL1<T>
         y = new { x, y = y }.y ?? y;
     }
 }";
-            var comp = CreateCompilation(
-                source,
-                parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
             // PROTOTYPE(NullableReferenceTypes): Should report ErrorCode.HDN_ExpressionIsProbablyNeverNull.
             // See comment in DataFlowPass.VisitAnonymousObjectCreationExpression.
             comp.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -1647,6 +1647,8 @@ class C
         if (o != null) F(() => { return o; }).ToString();
     }
 }";
+            // PROTOTYPE(NullableReferenceTypes): For captured variables, the lambda should be
+            // considered executed at the location the lambda is converted to a delegate.
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (10,9): warning CS8602: Possible dereference of a null reference.
@@ -3334,6 +3336,8 @@ class C
         D<I<object>> b = () => y;
     }
 }";
+            // PROTOTYPE(NullableReferenceTypes): For captured variables, the lambda should be
+            // considered executed at the location the lambda is converted to a delegate.
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (8,29): warning CS8603: Possible null reference return.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -1620,6 +1620,7 @@ class C
     {
         F(() => x).ToString();
         F(() => y).ToString();
+        if (y != null) F(() => y).ToString();
     }
 }";
             var comp = CreateCompilation(
@@ -2290,6 +2291,8 @@ class C
         if (o == null) return;
         d = () => o;
         e = () => o;
+        d = (D<object?>)(() => o);
+        e = (D<object>)(() => o);
     }
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
@@ -2324,20 +2327,13 @@ class B
         var y = F(o);
         d = y.M;
         e = y.M;
+        d = (D<object?>)y.M;
+        e = (D<object>)y.M;
     }
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
-            // PROTOTYPE(NullableReferenceTypes): Should report WRN_NullabilityMismatchInReturnTypeOfTargetDelegate for `e = x.M` rather than  `d = x.M`.
-            comp.VerifyDiagnostics(
-                // (12,24): warning CS8621: Nullability of reference types in return type of 'object A<object>.M()' doesn't match the target delegate 'D<object?>'.
-                //         D<object?> d = x.M;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate, "x.M").WithArguments("object A<object>.M()", "D<object?>").WithLocation(12, 24),
-                //// (13,23): warning CS8621: Nullability of reference types in return type of 'object? A<object?>.M()' doesn't match the target delegate 'D<object>'.
-                ////         D<object> e = x.M;
-                //Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate, "x.M").WithArguments("object? A<object?>.M()", "D<object>").WithLocation(13, 23),
-                // (16,13): warning CS8621: Nullability of reference types in return type of 'object A<object>.M()' doesn't match the target delegate 'D<object?>'.
-                //         d = y.M;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate, "y.M").WithArguments("object A<object>.M()", "D<object?>").WithLocation(16, 13));
+            // PROTOTYPE(NullableReferenceTypes): Should report WRN_NullabilityMismatchInReturnTypeOfTargetDelegate for `e = x.M`.
+            comp.VerifyDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -1623,6 +1623,8 @@ class C
         if (y != null) F(() => y).ToString();
     }
 }";
+            // PROTOTYPE(NullableReferenceTypes): For captured variables, the lambda should be
+            // considered executed at the location the lambda is converted to a delegate.
             var comp = CreateCompilation(
                 source,
                 parseOptions: TestOptions.Regular8);

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     method,
                     block,
                     diagnostics,
-                    (BoundExpression expr, TypeSymbolWithAnnotations exprType) => dictionary[expr.Syntax] = exprType);
+                    callbackOpt: (BoundExpression expr, TypeSymbolWithAnnotations exprType) => dictionary[expr.Syntax] = exprType);
                 diagnostics.Free();
                 var expectedTypes = annotations.SelectAsArray(annotation => annotation.Text);
                 var actualTypes = annotations.SelectAsArray(annotation => toDisplayString(annotation.Expression));


### PR DESCRIPTION
- Report nullable warnings in lambda bodies
- Allow variance in method group conversions
- Report mismatch for anonymous method parameter types
- Use flow analysis to determine nullability of lambda return type in `MethodTypeInferrer`
