### PR TITLE
Remove duplicate references in tests

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -33,7 +33,7 @@
     <MicrosoftCodeAnalysisCSharpWorkspacesVersion>1.0.1</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftCodeAnalysisEditorFeaturesTextVersion>1.0.1</MicrosoftCodeAnalysisEditorFeaturesTextVersion>
     <MicrosoftCodeAnalysisElfieVersion>0.10.6</MicrosoftCodeAnalysisElfieVersion>
-    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.10</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
+    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.11</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftCodeAnalysisVisualBasicVersion>1.0.1</MicrosoftCodeAnalysisVisualBasicVersion>
     <MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>1.0.1</MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonVersion>1.0.1</MicrosoftCodeAnalysisWorkspacesCommonVersion>

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -1547,7 +1547,7 @@ public class Test
     public int P { get; set; }
 }
 ";
-            var comp = CreateCompilation(source, references: new[] { SystemCoreRef });
+            var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (4,13): error CS1970: Do not use 'System.Runtime.CompilerServices.DynamicAttribute'. Use the 'dynamic' keyword instead.
                 //     [field: System.Runtime.CompilerServices.DynamicAttribute()]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -1658,7 +1658,6 @@ public class C
 {
   static void Goo() {}
 }",
-                    new MetadataReference[] { MscorlibRef_v4_0_30316_17626 },
                     options: options);
 
                 using (var metadata = ModuleMetadata.CreateFromImage(other.EmitToArray()))

--- a/src/Compilers/CSharp/Test/Emit/BreakingChanges.cs
+++ b/src/Compilers/CSharp/Test/Emit/BreakingChanges.cs
@@ -1348,7 +1348,7 @@ static int Main()
 }
 ";
             // Native compiler throw
-            CompileAndVerify(source, references: new[] { SystemCoreRef }, expectedOutput: "3");
+            CompileAndVerify(source, expectedOutput: "3");
         }
 
         [Fact, WorkItem(530696, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530696")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -936,7 +936,7 @@ class Test
             var expected = @"
 2
 ";
-            var v = CompileAndVerifyWithMscorlib40(source, s_asyncRefs, options: TestOptions.DebugExe.WithMetadataImportOptions(MetadataImportOptions.All), expectedOutput: expected, symbolValidator: module =>
+            var v = CompileAndVerify(source, s_asyncRefs, targetFramework: TargetFramework.Empty, options: TestOptions.DebugExe.WithMetadataImportOptions(MetadataImportOptions.All), expectedOutput: expected, symbolValidator: module =>
             {
                 Assert.Equal(new[]
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null)
         {
             references = (references != null) ? references.Concat(s_asyncRefs) : s_asyncRefs;
-            return base.CompileAndVerifyWithMscorlib40(source, expectedOutput: expectedOutput, references: references, options: options);
+            return base.CompileAndVerify(source, targetFramework: TargetFramework.Empty, expectedOutput: expectedOutput, references: references, options: options);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null, Verification verify = Verification.Passes)
         {
             references = (references != null) ? references.Concat(s_asyncRefs) : s_asyncRefs;
-            return base.CompileAndVerifyWithMscorlib40(source, expectedOutput: expectedOutput, references: references, options: options, verify: verify);
+            return base.CompileAndVerify(source, targetFramework: TargetFramework.Empty, expectedOutput: expectedOutput, references: references, options: options, verify: verify);
         }
 
         private string GetFieldLoadsAndStores(CompilationVerifier c, string qualifiedMethodName)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -1239,7 +1239,7 @@ public class C
         var b8 = await Task.FromResult(default(Tuple<long, long, long>));
     }
 }";
-            CompileAndVerifyWithMscorlib40(source, references: s_asyncRefs, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All), symbolValidator: module =>
+            CompileAndVerify(source, targetFramework: TargetFramework.Empty, references: s_asyncRefs, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All), symbolValidator: module =>
             {
                 AssertEx.Equal(new[]
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -7383,7 +7383,7 @@ class C : EventInterface
 
             var comp2 = CompileAndVerify(source2, targetFramework: TargetFramework.Empty, expectedOutput:
 @"True
-Handler", references: WinRtRefs.Concat(new[] { SystemRuntimeFacadeRef, ValueTupleRef, comp1.ToMetadataReference() }));
+Handler", references: WinRtRefs.Concat(new[] { ValueTupleRef, comp1.ToMetadataReference() }));
             comp2.VerifyDiagnostics();
 
             Assert.True(comp2.Compilation.GetMember<EventSymbol>("C.E").IsWindowsRuntimeEvent);
@@ -7446,7 +7446,7 @@ struct S : EventInterface
 True
 GetC
 2
-Handler", references: WinRtRefs.Concat(new[] { SystemRuntimeFacadeRef, ValueTupleRef, comp1.ToMetadataReference() }));
+Handler", references: WinRtRefs.Concat(new[] { ValueTupleRef, comp1.ToMetadataReference() }));
             comp2.VerifyDiagnostics();
 
             Assert.True(comp2.Compilation.GetMember<EventSymbol>("S.E").IsWindowsRuntimeEvent);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -7381,7 +7381,7 @@ class C : EventInterface
 }
 ";
 
-            var comp2 = CompileAndVerifyWithMscorlib40(source2, expectedOutput:
+            var comp2 = CompileAndVerify(source2, targetFramework: TargetFramework.Empty, expectedOutput:
 @"True
 Handler", references: WinRtRefs.Concat(new[] { SystemRuntimeFacadeRef, ValueTupleRef, comp1.ToMetadataReference() }));
             comp2.VerifyDiagnostics();
@@ -7440,7 +7440,7 @@ struct S : EventInterface
 }
 ";
 
-            var comp2 = CompileAndVerifyWithMscorlib40(source2, expectedOutput:
+            var comp2 = CompileAndVerify(source2, targetFramework: TargetFramework.Empty, expectedOutput:
 @"GetC
 1
 True

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -15419,7 +15419,7 @@ class C
         public int Length = 123;
     }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "321 123", references: new[] { SystemCoreRef, CSharpRef });
+            var comp = CompileAndVerify(source, expectedOutput: "321 123", references: new[] { CSharpRef });
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         /// <summary>
         /// Reference to an assembly that defines Expression Trees.
         /// </summary>
-        protected new static MetadataReference ExpressionAssemblyRef => SystemCoreRef_v46;
+        protected static MetadataReference ExpressionAssemblyRef => SystemCoreRef_v46;
 
 
         #region A string containing expression-tree dumping utilities

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenImplicitlyTypeArraysTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenImplicitlyTypeArraysTests.cs
@@ -280,7 +280,7 @@ namespace Test
             // The version of mscorlib checked in to the test resources in v4_0_30316 does not have
             // the IReadOnlyList<T> and IReadOnlyCollection<T> interfaces. Use the one in v4_0_30316_17626.
 
-            var mscorlib17626 = MetadataReference.CreateFromImage(TestResources.NetFX.v4_0_30316_17626.mscorlib);
+            var mscorlib17626 = MetadataReference.CreateFromImage(TestResources.NetFX.v4_0_30319_17626.mscorlib);
             CompileAndVerify(testSrc, new MetadataReference[] { mscorlib17626 }, expectedOutput: "1", targetFramework: TargetFramework.Empty);
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -212,7 +212,7 @@ class Program
                 }
             });
     }
-}", references: new[] { LinqAssemblyRef });
+}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -2150,8 +2150,7 @@ class P
                 // using System.Linq;
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Linq;").WithLocation(3, 1)
                 );
-            CompileAndVerify(source, references: new[] { LinqAssemblyRef },
-                expectedOutput: "0");
+            CompileAndVerify(source, expectedOutput: "0");
         }
 
         [WorkItem(543109, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543109")]
@@ -2172,8 +2171,7 @@ class P
         return (errCount > 0) ? 1 : 0;
     }
 }";
-            CompileAndVerify(source, references: new[] { LinqAssemblyRef },
-                expectedOutput: "0");
+            CompileAndVerify(source, expectedOutput: "0");
         }
 
         [WorkItem(543377, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543377")]
@@ -4412,7 +4410,7 @@ using System.Security;
     }
 ";
 
-            var comp = CompileAndVerify(new string[] { source }, references: new[] { SystemCoreRef }, expectedOutput: @"");
+            var comp = CompileAndVerify(new string[] { source }, expectedOutput: @"");
             //            var comp = CompileAndVerify(source);
             comp.VerifyDiagnostics();
             comp.VerifyIL("Program.Main", @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
@@ -1169,7 +1169,7 @@ class Test
         int x = 5;
         x.M();
     }
-}", references: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
+}", verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -1198,7 +1198,7 @@ class Test
     {
         x.M();
     }
-}", references: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
+}", verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       13 (0xd)
   .maxstack  1
@@ -1225,7 +1225,7 @@ class Test
     {
         x.M().M().M();
     }
-}", references: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
+}", verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       23 (0x17)
   .maxstack  1
@@ -1253,7 +1253,7 @@ class Test
     {
         5.M();
     }
-}", references: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
+}", verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -1282,7 +1282,7 @@ class Test
         int x = 5;
         x.M();
     }
-}", references: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
+}", verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -1311,7 +1311,7 @@ class Test
     {
         x.M();
     }
-}", references: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
+}", verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       13 (0xd)
   .maxstack  1
@@ -1338,7 +1338,7 @@ class Test
     {
         x.M().M().M();
     }
-}", references: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
+}", verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       23 (0x17)
   .maxstack  1

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3086,7 +3086,7 @@ class C
                     model.GetDeclaredSymbol(x).ToTestDisplayString());
             };
 
-            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5", references: new[] { MscorlibRef }, sourceSymbolValidator: validator);
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5", sourceSymbolValidator: validator);
             verifier.VerifyDiagnostics();
         }
 
@@ -15261,7 +15261,7 @@ System.ValueTuple`2[System.Int32,System.ValueTuple`2[System.Int32,System.String]
 class Class { void Method() { tuple = (1, ""hello""); } }
 " + trivial2uple + tupleattributes_cs;
 
-            var comp = CreateCompilation(source, references: new[] { SystemRef });
+            var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (2,31): error CS0103: The name 'tuple' does not exist in the current context
                 // class Class { void Method() { tuple = (1, "hello"); } }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/ObjectAndCollectionInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/ObjectAndCollectionInitializerTests.cs
@@ -1347,7 +1347,7 @@ struct A
 2
 3";
 
-            var compVerifier = CompileAndVerify(source, references: new[] { SystemCoreRef, CSharpRef }, expectedOutput: expectedOutput);
+            var compVerifier = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("A.Main()", @"
 {
   // Code size      194 (0xc2)
@@ -1485,7 +1485,7 @@ get
 get
 3";
 
-            var compVerifier = CompileAndVerify(source, references: new[] { SystemCoreRef, CSharpRef }, expectedOutput: expectedOutput);
+            var compVerifier = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("A.Main()", @"
 {
   // Code size      222 (0xde)
@@ -1871,7 +1871,7 @@ class Program
 ";
             string expectedOutput = @"422";
 
-            var compVerifier = CompileAndVerify(source, references: new[] { SystemCoreRef, CSharpRef }, expectedOutput: expectedOutput);
+            var compVerifier = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: expectedOutput);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -303,7 +303,7 @@ class Program
         System.Console.WriteLine(null != (x as Derived));
     }
 }";
-            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, references: new[] { LinqAssemblyRef });
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics();
             var expectedOutput =
 @"True

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -4282,7 +4282,7 @@ public static class FixableExt
 
 ";
 
-            var compVerifier = CompileAndVerify(text, references: new[] { ExtensionAssemblyRef },options: TestOptions.UnsafeReleaseExe, expectedOutput: @"2", verify: Verification.Fails);
+            var compVerifier = CompileAndVerify(text,options: TestOptions.UnsafeReleaseExe, expectedOutput: @"2", verify: Verification.Fails);
 
             compVerifier.VerifyIL("C.Main", @"
 {
@@ -4513,7 +4513,7 @@ static class FixAllExt
 }
 ";
 
-            var compVerifier = CompileAndVerify(text, references: new[] { ExtensionAssemblyRef },  options: TestOptions.UnsafeReleaseExe, expectedOutput: @"20", verify: Verification.Fails);
+            var compVerifier = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"20", verify: Verification.Fails);
 
             compVerifier.VerifyIL("C.Test<T>(T)", @"
 {
@@ -4828,7 +4828,7 @@ static class FixAllExt
     }
 ";
 
-            var compVerifier = CompileAndVerify(text, references: new[] { ExtensionAssemblyRef }, options: TestOptions.UnsafeReleaseExe, verify: Verification.Fails, expectedOutput: @"5456");
+            var compVerifier = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, verify: Verification.Fails, expectedOutput: @"5456");
 
             compVerifier.VerifyIL("C.Test<T>(ref T)", @"
 {
@@ -4888,7 +4888,7 @@ public static class FixableExt
 
 ";
 
-            var compVerifier = CompileAndVerify(text, references: new[] { ExtensionAssemblyRef }, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"23", verify: Verification.Fails);
+            var compVerifier = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"23", verify: Verification.Fails);
 
             compVerifier.VerifyIL("C.Main", @"
 {
@@ -4966,7 +4966,7 @@ public static class FixableExt
 
 ";
 
-            var compVerifier = CompileAndVerify(text, references: new[] { ExtensionAssemblyRef }, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"3", verify: Verification.Fails);
+            var compVerifier = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"3", verify: Verification.Fails);
 
             compVerifier.VerifyIL("C.Main", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -4898,7 +4898,7 @@ class C4
         return d(ref o, 2);
     }
 }";
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll, references: new[] { SystemCoreRef, CSharpRef });
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll, references: new[] { CSharpRef });
             var bytes = compilation.EmitToArray();
             using (var metadata = ModuleMetadata.CreateFromImage(bytes))
             {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -5149,7 +5149,7 @@ class C
 }
 ");
 
-            var compilation0 = CreateEmptyCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.v4_0_30316_17626.mscorlib }, options: ComSafeDebugDll);
+            var compilation0 = CreateEmptyCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.v4_0_30319_17626.mscorlib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(source1.Tree);
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
@@ -5367,7 +5367,7 @@ class C
 }
 ");
 
-            var compilation0 = CreateEmptyCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.v4_0_30316_17626.mscorlib }, options: ComSafeDebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            var compilation0 = CreateEmptyCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.v4_0_30319_17626.mscorlib }, options: ComSafeDebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
             var compilation1 = compilation0.WithSource(source1.Tree);
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -1991,7 +1991,7 @@ class UsePia
 
             verifier.VerifyIL("UsePia.Test", expected);
 
-            compilation = CreateCompilation(consumer,
+            compilation = CreateEmptyCompilation(consumer,
                                                         new MetadataReference[] { MscorlibRef_v4_0_30316_17626, piaCompilation.EmitToImageReference(embedInteropTypes: true) },
                                                         options: TestOptions.DebugExe);
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/OptionalArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/OptionalArgumentsTests.cs
@@ -176,7 +176,7 @@ public delegate object D([DecimalConstant(0, 0, 0, 0, 3)]decimal o = 3);
 3");
             var comp2b = CreateCompilation(
                 source2,
-                references: new[] { SystemRef, MetadataReference.CreateFromStream(comp1.EmitToStream()) },
+                references: new[] { MetadataReference.CreateFromStream(comp1.EmitToStream()) },
                 options: TestOptions.DebugExe);
             comp2b.VerifyDiagnostics();
             CompileAndVerify(comp2b, expectedOutput:

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -2058,7 +2058,7 @@ class C
         }
     }
 }";
-            var v = CreateCompilationWithMscorlib40(src, LatestVbReferences, options: TestOptions.DebugDll);
+            var v = CreateEmptyCompilation(src, LatestVbReferences, options: TestOptions.DebugDll);
 
             v.VerifyPdb("C+<M>d__0.MoveNext", @"
 <symbols>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
@@ -2184,7 +2184,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef.WithAliases(new[] { "A" }), SystemDataRef });
+            var comp = CreateCompilationWithMscorlib40(source, new[] { SystemCoreRef.WithAliases(new[] { "A" }), SystemDataRef });
             var v = CompileAndVerify(comp, validator: (peAssembly) =>
             {
                 var reader = peAssembly.ManifestModule.MetadataReader;
@@ -2528,7 +2528,7 @@ using System;
 class C6 { void F() {} }
 " };
 
-            var c = CreateCompilation(sources, new[] { SystemCoreRef.WithAliases(ImmutableArray.Create("A")) });
+            var c = CreateCompilationWithMscorlib40(sources, new[] { SystemCoreRef.WithAliases(ImmutableArray.Create("A")) });
             var pdbStream = new MemoryStream();
             c.EmitToArray(EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.PortablePdb), pdbStream: pdbStream);
             var pdbImage = pdbStream.ToImmutable();

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTestBase.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTestBase.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         protected T CompileAndGetModelAndExpression<T>(string program, Func<SemanticModel, ExpressionSyntax, T> analysisDelegate)
         {
-            var comp = CreateCompilation(program, new[] { LinqAssemblyRef });
+            var comp = CreateCompilation(program);
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
             int start = program.IndexOf(StartString, StringComparison.Ordinal) + StartString.Length;
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         protected T CompileAndGetModelAndStatements<T>(string program, Func<SemanticModel, StatementSyntax, StatementSyntax, T> analysisDelegate)
         {
-            var comp = CreateCompilation(program, new[] { LinqAssemblyRef });
+            var comp = CreateCompilation(program);
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
             int start = program.IndexOf(StartString, StringComparison.Ordinal) + StartString.Length;
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         protected IEnumerable<T> CompileAndGetModelAndMultipleExpressions<T>(string program, Func<SemanticModel, ExpressionSyntax, T> analysisDelegate, int treeindex = 0, int which = -1)
         {
-            var comp = CreateCompilation(program, new[] { LinqAssemblyRef });
+            var comp = CreateCompilation(program);
             var tuple = GetBindingNodesAndModel<ExpressionSyntax>(comp, treeindex, which);
 
             foreach (var expr in tuple.Item1)
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         protected IEnumerable<T> CompileAndGetModelAndMultipleStatements<T>(string program, Func<SemanticModel, StatementSyntax, T> analysisDelegate, int treeindex = 0, int which = -1)
         {
-            var comp = CreateCompilation(program, new[] { LinqAssemblyRef });
+            var comp = CreateCompilation(program);
             var tuple = GetBindingNodesAndModel<StatementSyntax>(comp, treeindex, which);
 
             foreach (var stmt in tuple.Item1)

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
@@ -1620,7 +1620,7 @@ IPropertyReferenceOperation: System.Int32 Derived.this[[System.Int32 x = 8], [Sy
 
             VerifyOperationTreeAndDiagnosticsForTest<ElementAccessExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, additionalOperationTreeVerifier: IndexerAccessArgumentVerifier.Verify);
 
-            CompileAndVerify(new[] { source }, new[] { SystemRef }, expectedOutput: expectedOutput);
+            CompileAndVerify(new[] { source }, expectedOutput: expectedOutput);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1814,7 +1814,7 @@ IPropertyReferenceOperation: System.Int32 P.this[[System.Int32 i = 3], [System.I
 
             var ilReference = VerifyOperationTreeAndDiagnosticsForTestWithIL<ElementAccessExpressionSyntax>(csharp, il, expectedOperationTree, expectedDiagnostics, additionalOperationTreeVerifier: IndexerAccessArgumentVerifier.Verify);
 
-            CompileAndVerify(new[] { csharp }, new[] { SystemRef, ilReference }, expectedOutput: expectedOutput);
+            CompileAndVerify(new[] { csharp }, new[] { ilReference }, expectedOutput: expectedOutput);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1933,7 +1933,7 @@ IPropertyReferenceOperation: System.Int32 P.this[[System.Int32 i = 3], [System.I
 
             var ilReference = VerifyOperationTreeAndDiagnosticsForTestWithIL<ElementAccessExpressionSyntax>(csharp, il, expectedOperationTree, expectedDiagnostics, additionalOperationTreeVerifier: IndexerAccessArgumentVerifier.Verify);
 
-            CompileAndVerify(new[] { csharp }, new[] { SystemRef, ilReference }, expectedOutput: expectedOutput);
+            CompileAndVerify(new[] { csharp }, new[] { ilReference }, expectedOutput: expectedOutput);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -2053,7 +2053,7 @@ IPropertyReferenceOperation: System.Int32 P.this[[System.Int32 i = 3], [System.I
 
             var ilReference = VerifyOperationTreeAndDiagnosticsForTestWithIL<ElementAccessExpressionSyntax>(csharp, il, expectedOperationTree, expectedDiagnostics, additionalOperationTreeVerifier: IndexerAccessArgumentVerifier.Verify);
 
-            CompileAndVerify(new[] { csharp }, new[] { SystemRef, ilReference }, expectedOutput: expectedOutput);
+            CompileAndVerify(new[] { csharp }, new[] { ilReference }, expectedOutput: expectedOutput);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.cs
@@ -942,7 +942,7 @@ struct S
             var compilation0 = CreateCompilation(sources0);
             compilation0.VerifyDiagnostics();
 
-            var compilation1 = CreateCompilation(
+            var compilation1 = CreateEmptyCompilation(
                 sources1,
                 references: new[] { MscorlibRef, SystemRef, compilation0.EmitToImageReference(embedInteropTypes: true) });
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AccessCheckTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AccessCheckTests.cs
@@ -1063,7 +1063,7 @@ class C
     }
 }
 ";
-            var compilationC = CreateCompilation(sourceC, assemblyName: "C", references: new[] { referenceA, referenceB, SystemCoreRef });
+            var compilationC = CreateCompilation(sourceC, assemblyName: "C", references: new[] { referenceA, referenceB });
             compilationC.VerifyDiagnostics(
                 // (6,9): error CS0122: 'B.M(int)' is inaccessible due to its protection level
                 //         b.M(d);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeTests.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
@@ -186,7 +187,7 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
             }
             else
             {
-                CompileAndVerify(source, references: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "better");
+                CompileAndVerify(source, targetFramework: TargetFramework.Empty, references: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "better");
             }
             return true;
         }
@@ -508,7 +509,7 @@ class MyTaskBuilder<T>
 
 namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : System.Attribute { public AsyncMethodBuilderAttribute(System.Type t) { } } }
 ";
-            CompileAndVerify(source, references: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "1");
+            CompileAndVerify(source, targetFramework: TargetFramework.Empty, references: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "1");
         }
 
         [Fact]
@@ -559,7 +560,7 @@ public class ValueTaskBuilder<T>
 
 namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : System.Attribute { public AsyncMethodBuilderAttribute(System.Type t) { } } }
 ";
-            CompileAndVerify(source, references: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "bbbb");
+            CompileAndVerify(source, targetFramework: TargetFramework.Empty, references: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "bbbb");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2864,7 +2864,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef });
+            var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (7,40): error CS1001: Identifier expected
                 //         var x = new Action<int>(i => i.
@@ -2909,7 +2909,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef });
+            var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (7,32): error CS1001: Identifier expected
                 //         Action<int> x = i => i.
@@ -3136,7 +3136,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef });
+            var comp = CreateCompilation(source);
 
             comp.VerifyDiagnostics(
     // (41,38): error CS7036: There is no argument given that corresponds to the required formal parameter 'authenticationScheme' of 'AuthenticationManager.AuthenticateAsync(string)'

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
@@ -581,7 +581,7 @@ class F
             // Can't use CheckExpressionAndParent because we're using alias.
 
             var tree = Parse(text);
-            var comp = CreateCompilation(tree, new[] { TestReferences.NetFx.v4_0_30319.System_Core });
+            var comp = CreateCompilation(tree);
             var model = comp.GetSemanticModel(tree);
 
             var expr = (IdentifierNameSyntax)GetExprSyntaxForBinding(GetExprSyntaxList(tree));
@@ -1096,7 +1096,7 @@ class F
 ";
             var tree = Parse(text);
 
-            var comp = CreateCompilation(tree, new[] { TestReferences.NetFx.v4_0_30319.System_Core });
+            var comp = CreateCompilation(tree);
             comp.VerifyDiagnostics(
             // (14,32): error CS1061: 'E' does not contain a definition for 'Q' and no extension method 'Q' accepting a first argument of type 'E' could be found (are you missing a using directive or an assembly reference?)
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Q").WithArguments("E", "Q"));
@@ -1186,7 +1186,7 @@ class F
 ";
             var tree = Parse(text);
 
-            var comp = CreateCompilation(tree, new[] { TestReferences.NetFx.v4_0_30319.System_Core });
+            var comp = CreateCompilation(tree);
             comp.VerifyDiagnostics(
             // (14,58): error CS0123: No overload for 'M' matches delegate 'System.Action<string>'
                 Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "M").WithArguments("M", "System.Action<string>"));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConditionalOperatorTests.cs
@@ -673,7 +673,7 @@ class Program
 }
 ";
 
-            var verifier = CompileAndVerify(new string[] { source }, references: new[] { SystemCoreRef }, expectedOutput: "1");
+            var verifier = CompileAndVerify(new string[] { source }, expectedOutput: "1");
             verifier.VerifyIL("Program.Main", expectedIL);
         }
 
@@ -735,7 +735,7 @@ class Program
 }
 ";
 
-            var verifier = CompileAndVerify(new string[] { source }, references: new[] { SystemCoreRef }, expectedOutput: "1");
+            var verifier = CompileAndVerify(new string[] { source }, expectedOutput: "1");
             verifier.VerifyIL("Program.Main", expectedIL);
         }
 
@@ -800,7 +800,7 @@ class Program
 }
 ";
 
-            var verifier = CompileAndVerify(new string[] { source }, references: new[] { SystemCoreRef }, expectedOutput: "1");
+            var verifier = CompileAndVerify(new string[] { source }, expectedOutput: "1");
             verifier.VerifyIL("Program.Main", expectedIL);
         }
 
@@ -877,7 +877,7 @@ class Program
 }
 ";
 
-            var verifier = CompileAndVerify(new string[] { source }, references: new[] { SystemCoreRef }, expectedOutput: "1");
+            var verifier = CompileAndVerify(new string[] { source }, expectedOutput: "1");
             verifier.VerifyIL("Program.Main", expectedIL);
         }
 
@@ -955,7 +955,7 @@ class Program
 }
 ";
 
-            var verifier = CompileAndVerify(new string[] { source }, references: new[] { SystemCoreRef }, expectedOutput: "1");
+            var verifier = CompileAndVerify(new string[] { source }, expectedOutput: "1");
             verifier.VerifyIL("Program.Main", expectedIL);
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
@@ -40,7 +40,7 @@ public unsafe class C
         [Fact]
         public void ConversionClassification()
         {
-            var c = CreateCompilation("", new[] { CSharpRef, SystemCoreRef });
+            var c = CreateCompilation("", new[] { CSharpRef });
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             var dynamicToObject = c.Conversions.ClassifyConversionFromType(DynamicTypeSymbol.Instance, c.GetSpecialType(SpecialType.System_Object), ref useSiteDiagnostics);
             var objectToDynamic = c.Conversions.ClassifyConversionFromType(c.GetSpecialType(SpecialType.System_Object), DynamicTypeSymbol.Instance, ref useSiteDiagnostics);
@@ -235,7 +235,7 @@ class C : B
     public override event Action<object> E { add { } remove { } }
 }
 ";
-            CreateCompilation(source, new[] { CSharpRef, SystemCoreRef }).VerifyDiagnostics();
+            CreateCompilation(source, new[] { CSharpRef }).VerifyDiagnostics();
         }
 
         [Fact]
@@ -258,7 +258,7 @@ class B : A
     public void I(ref object a) { }
 }
 ";
-            CreateCompilation(source, new[] { CSharpRef, SystemCoreRef }).VerifyDiagnostics(
+            CreateCompilation(source, new[] { CSharpRef }).VerifyDiagnostics(
                 // (13,17): warning CS0108: 'B.G(object)' hides inherited member 'A.G(dynamic)'. Use the new keyword if hiding was intended.
                 Diagnostic(ErrorCode.WRN_NewRequired, "G").WithArguments("B.G(object)", "A.G(dynamic)"),
                 // (14,17): warning CS0108: 'B.H(dynamic[])' hides inherited member 'A.H(params object[])'. Use the new keyword if hiding was intended.
@@ -3522,7 +3522,7 @@ class Program
     static T Goo<T>(Func<T, T> x) { throw null; }
 }
 ";
-            var verifier = CompileAndVerify(source, new[] { CSharpRef, SystemCoreRef }, options: TestOptions.DebugDll).VerifyDiagnostics();
+            var verifier = CompileAndVerify(source, new[] { CSharpRef }, options: TestOptions.DebugDll).VerifyDiagnostics();
 
             var tree = verifier.Compilation.SyntaxTrees.Single();
             var model = verifier.Compilation.GetSemanticModel(tree);
@@ -3571,7 +3571,7 @@ class Test
 }
 ";
 
-            var compilation2 = CreateCompilation(source2, new[] { reference.WithEmbedInteropTypes(true), CSharpRef, SystemCoreRef }, options: TestOptions.ReleaseExe);
+            var compilation2 = CreateCompilation(source2, new[] { reference.WithEmbedInteropTypes(true), CSharpRef }, options: TestOptions.ReleaseExe);
 
             CompileAndVerify(compilation2, expectedOutput: @"4");
         }
@@ -3594,7 +3594,7 @@ class Program
     }
 }
 ";
-            var compilation = CreateCompilation(source, new[] { CSharpRef, SystemCoreRef }, options: TestOptions.DebugDll);
+            var compilation = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             // crash happens during emit if not detected, so VerifyDiagnostics (no Emit) doesn't catch the crash.
             compilation.VerifyEmitDiagnostics(
                 // (7,25): error CS0154: The property or indexer 'Program.I.d' cannot be used in this context because it lacks the get accessor
@@ -3621,7 +3621,7 @@ class Program
     }
 }
 ";
-            var compilation = CreateCompilation(source, new[] { CSharpRef, SystemCoreRef }, options: TestOptions.DebugDll);
+            var compilation = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             compilation.VerifyEmitDiagnostics(
                 // (7,25): error CS0154: The property or indexer 'Program.I.this[string]' cannot be used in this context because it lacks the get accessor
                 //         System.Type t = i[null].GetType();
@@ -3799,7 +3799,7 @@ class Test
 ";
 
             var compilation1 = CreateCompilation(consumer1, options: TestOptions.ReleaseExe,
-                references: new MetadataReference[] { reference, CSharpRef, SystemCoreRef });
+                references: new MetadataReference[] { reference, CSharpRef });
 
             compilation1.VerifyDiagnostics(
                 // (11,18): error CS0120: An object reference is required for the non-static field, method, or property '_Worksheet.MRange(object, object)'
@@ -3822,7 +3822,7 @@ class Test
 ";
 
             var compilation2 = CreateCompilation(consumer2, options: TestOptions.ReleaseExe,
-                references: new MetadataReference[] { reference, CSharpRef, SystemCoreRef });
+                references: new MetadataReference[] { reference, CSharpRef });
 
             compilation2.VerifyDiagnostics(
                 // (10,18): error CS0120: An object reference is required for the non-static field, method, or property '_Worksheet.Range[object, object]'
@@ -3923,7 +3923,7 @@ class Test
 }";
 
             var compilation1 = CreateCompilation(consumer1, options: TestOptions.ReleaseExe,
-                references: new MetadataReference[] { reference, CSharpRef, SystemCoreRef });
+                references: new MetadataReference[] { reference, CSharpRef });
 
             CompileAndVerify(compilation1, expectedOutput: "MIndexer").VerifyDiagnostics();
 
@@ -3939,7 +3939,7 @@ class Test
 }";
 
             var compilation2 = CreateCompilation(consumer2, options: TestOptions.ReleaseExe,
-                references: new MetadataReference[] { reference, CSharpRef, SystemCoreRef });
+                references: new MetadataReference[] { reference, CSharpRef });
 
             compilation2.VerifyDiagnostics(
                 // (8,30): error CS1545: Property, indexer, or event 'WithIndexer.Indexer[object, object]' is not supported by the language; try directly calling accessor methods 'WithIndexer.get_Indexer(object, object)' or 'WithIndexer.set_Indexer(object, object, object)'

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ImportsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ImportsTests.cs
@@ -98,7 +98,8 @@ using F = System.IO;
         {
             var comp = CreateCompilation(
                 "extern alias A; extern alias B;",
-                new[]
+                targetFramework: TargetFramework.Mscorlib40,
+                references: new[]
                 {
                     SystemCoreRef.WithAliases(new[] { "A" }),
                     SystemDataRef.WithAliases(new[] { "B" }),
@@ -140,7 +141,7 @@ using F = System.IO;
             var compilationUnits = trees.Select(tree => (CompilationUnitSyntax)tree.GetRoot());
             var externAliases = compilationUnits.SelectMany(cu => cu.Externs).Select(e => e.Identifier.ValueText).Distinct();
 
-            var comp = CreateCompilation(trees, new[] { SystemCoreRef.WithAliases(externAliases) });
+            var comp = CreateCompilation(trees, targetFramework: TargetFramework.Mscorlib40, references: new[] { SystemCoreRef.WithAliases(externAliases) });
             comp.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).Verify();
 
             var factories = trees.Select(tree => comp.GetBinderFactory(tree));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InteractiveSemanticModelTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InteractiveSemanticModelTests.cs
@@ -349,8 +349,7 @@ var x = from c in ""goo"" select /*<bind>*/c/*</bind>*/";
 
         private CompilationUtils.SemanticInfoSummary GetBindInfoForTest(string testSrc)
         {
-            var compilation = CreateCompilation(
-                testSrc, parseOptions: TestOptions.Script, references: new[] { SystemCoreRef });
+            var compilation = CreateCompilation(testSrc, parseOptions: TestOptions.Script);
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);
             var exprSyntaxToBind = GetExprSyntaxForBinding(GetExprSyntaxList(tree));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -270,7 +270,7 @@ class Program
 }";
             string expectedOutput = @"<>
 <System.String[]>";
-            var verifier = CompileAndVerify(source, new[] { SystemCoreRef, CSharpRef }, expectedOutput: expectedOutput).VerifyDiagnostics();
+            var verifier = CompileAndVerify(source, new[] { CSharpRef }, expectedOutput: expectedOutput).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -1567,7 +1567,7 @@ public static class Program
 
 public interface IColumn { }
 ";
-            var compilation = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: "Select<T, S>");
         }
 
@@ -1605,7 +1605,7 @@ public static class Program
 
 public interface IColumn { }
 ";
-            var compilation = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: "Select<T, S>");
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
@@ -1460,7 +1460,7 @@ label1:
 }
 ";
 
-            var compilation = CreateCompilation(source, references: new[] { LinqAssemblyRef });
+            var compilation = CreateCompilation(source);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = (Microsoft.CodeAnalysis.SemanticModel)(compilation.GetSemanticModel(tree));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MethodBodyModelTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MethodBodyModelTests.cs
@@ -789,8 +789,7 @@ class F
 }
 ";
             var tree = Parse(text);
-            var comp = CreateCompilation(tree,
-                references: new[] { TestReferences.NetFx.v4_0_30319.System });
+            var comp = CreateCompilation(tree);
             Assert.Equal(string.Empty, string.Join(Environment.NewLine, comp.GetDiagnostics()));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NameCollisionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NameCollisionTests.cs
@@ -686,7 +686,7 @@ class Base
 {
     public string name = null;
 }";
-            CompileAndVerify(source, new[] { LinqAssemblyRef }).VerifyDiagnostics();
+            CompileAndVerify(source).VerifyDiagnostics();
         }
 
         [Fact]
@@ -714,7 +714,7 @@ class Base
 {
     public string name = null;
 }";
-            CompileAndVerify(source, new[] { LinqAssemblyRef }).VerifyDiagnostics();
+            CompileAndVerify(source).VerifyDiagnostics();
         }
 
         [Fact]
@@ -1597,7 +1597,7 @@ partial class Class
         return null;
     }
 }";
-            CompileAndVerify(source, new[] { LinqAssemblyRef }).VerifyDiagnostics();
+            CompileAndVerify(source).VerifyDiagnostics();
         }
 
         [WorkItem(543045, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543045")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
@@ -523,7 +523,7 @@ class Program
     [Obsolete(""Please do not use this method: "" + nameof(Program.Old), true)]
     static void Old() { }
 }";
-            CompileAndVerify(source, new[] { LinqAssemblyRef }, expectedOutput: @"
+            CompileAndVerify(source, expectedOutput: @"
 EntryMethodName
 Correct
 Correct");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -956,7 +956,7 @@ class Test{
     }
 }
 ";
-            CreateCompilation(source, new[] { SystemRef }).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 // (9,21): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
                 //     public int Bar([DefaultParameterValue(1)]int i = 2) {
                 Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue").WithLocation(9, 21),
@@ -1004,7 +1004,7 @@ public class Parent
      }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemRef });
+            var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
  // (8,10): error CS7036: There is no argument given that corresponds to the required formal parameter 'x' of 'Parent.Goo(ref int)'
  //          Goo();
@@ -1023,7 +1023,7 @@ public interface IOptionalRef
     MyEnum MethodRef([In, Out, Optional, DefaultParameterValue(MyEnum.three)] ref MyEnum v);
 }
 ";
-            CompileAndVerify(source, new[] { SystemRef }).VerifyDiagnostics();
+            CompileAndVerify(source).VerifyDiagnostics();
         }
 
         [Fact]
@@ -1115,7 +1115,7 @@ public static class ErrorCases
 }
 ";
             // NOTE: anywhere dev10 reported CS1909, roslyn reports CS1910.
-            CreateCompilation(source, new[] { SystemRef }).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 // (27,20): error CS1908: The type of the argument to the DefaultParameterValue attribute must match the parameter type
                 //         [Optional][DefaultParameterValue(0)]         bool b1,
                 Diagnostic(ErrorCode.ERR_DefaultValueTypeMustMatch, "DefaultParameterValue"),
@@ -1337,12 +1337,12 @@ System.Runtime.InteropServices.UnknownWrapper
 17
 18";
             // definitions in source:
-            var verifier = CompileAndVerify(new[] { sourceDefinitions, sourceCalls }, new[] { SystemRef }, expectedOutput: expected);
+            var verifier = CompileAndVerify(new[] { sourceDefinitions, sourceCalls }, expectedOutput: expected);
 
             // definitions in metadata:
             using (var assembly = AssemblyMetadata.CreateFromImage(verifier.EmittedAssemblyData))
             {
-                CompileAndVerify(new[] { sourceCalls }, new[] { SystemRef, assembly.GetReference() }, expectedOutput: expected);
+                CompileAndVerify(new[] { sourceCalls }, new[] { assembly.GetReference() }, expectedOutput: expected);
             }
         }
 
@@ -2055,7 +2055,7 @@ public class C
                 Assert.Equal(isFromSource ? 2 : 0, parameters[7].GetAttributes().Length);
             };
 
-            CompileAndVerify(source, new[] { SystemRef }, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
+            CompileAndVerify(source, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
         }
 
         [Fact]
@@ -2106,7 +2106,7 @@ public struct S
             };
 
             // TODO: RefEmit doesn't emit the default value of M1's parameter.
-            CompileAndVerify(source, new[] { SystemRef }, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
+            CompileAndVerify(source, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
         }
 
         [Fact]
@@ -2188,7 +2188,7 @@ public class C
                 Assert.Equal(isFromSource ? 2 : 0, parameters[7].GetAttributes().Length);
             };
 
-            CompileAndVerify(source, new[] { SystemRef }, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
+            CompileAndVerify(source, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
         }
 
         [Fact]
@@ -2271,7 +2271,7 @@ public class C
                 Assert.Equal(isFromSource ? 2 : 0, parameters[7].GetAttributes().Length); // Optional+DecimalConstantAttribute / DecimalConstantAttribute
             };
 
-            CompileAndVerify(source, new[] { SystemRef }, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
+            CompileAndVerify(source, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
         }
 
         [Fact]
@@ -2348,7 +2348,7 @@ public class C
             };
 
             // TODO: Guess - RefEmit doesn't like DateTime constants.
-            CompileAndVerify(source, new[] { SystemRef }, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
+            CompileAndVerify(source, sourceSymbolValidator: validator(true), symbolValidator: validator(false));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -6644,7 +6644,7 @@ class Program
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.ReleaseExe);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: @"A
 A");
         }
@@ -6691,7 +6691,7 @@ class Program
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.ReleaseExe);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, TestOptions.ReleaseExe);
             CompileAndVerifyException<Microsoft.CSharp.RuntimeBinder.RuntimeBinderException>(comp,
                 "Operator '|' is ambiguous on operands of type 'InputParameter' and 'InputParameter'");
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -1699,7 +1699,7 @@ public class Cls
     }
 }";
             var compilation = CreateCompilation(text,
-                                                            references: new MetadataReference[] { CSharpRef, SystemCoreRef },
+                                                            references: new MetadataReference[] { CSharpRef },
                                                             options: TestOptions.ReleaseExe,
                                                             parseOptions: TestOptions.Regular);
 
@@ -19041,7 +19041,7 @@ public class Cls
     }
 }";
             var compilation = CreateCompilation(text,
-                                                            references: new MetadataReference[] { CSharpRef, SystemCoreRef },
+                                                            references: new MetadataReference[] { CSharpRef },
                                                             options: TestOptions.ReleaseExe,
                                                             parseOptions: TestOptions.Regular);
 
@@ -19817,7 +19817,7 @@ public class Cls
     }
 }";
             // the C# dynamic binder does not support ref or out indexers, so we don't run this
-            CompileAndVerify(text, references: new[] { SystemCoreRef, CSharpRef }).VerifyIL("Cls.Main()",
+            CompileAndVerify(text, references: new[] { CSharpRef }).VerifyIL("Cls.Main()",
 @"{
   // Code size       87 (0x57)
   .maxstack  7
@@ -19871,7 +19871,7 @@ public class Cls
     }
 }";
             // the C# dynamic binder does not support ref or out indexers, so we don't run this
-            CompileAndVerify(text, references: new[] { SystemCoreRef, CSharpRef }).VerifyIL("Cls.Main()",
+            CompileAndVerify(text, references: new[] { CSharpRef }).VerifyIL("Cls.Main()",
 @"
 {
   // Code size       87 (0x57)
@@ -19927,7 +19927,7 @@ public class Cls
     }
 }";
             // the C# dynamic binder does not support ref or out indexers, so we don't run this
-            var comp = CreateCompilation(text, options: TestOptions.DebugDll, references: new[] { SystemCoreRef, CSharpRef });
+            var comp = CreateCompilation(text, options: TestOptions.DebugDll, references: new[] { CSharpRef });
             comp.VerifyDiagnostics(
                 // (7,23): error CS8183: Cannot infer the type of implicitly-typed discard.
                 //         var x = d[out var _];
@@ -32165,7 +32165,7 @@ public class C
         // Note that the embedded statement is parsed as a missing identifier, followed by && with many spaces attached as leading trivia
     }
 }";
-            var comp = CreateCompilation(source, options: TestOptions.DebugDll, references: new[] { SystemCoreRef });
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTestBase.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTestBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // from it the nodes that describe the method symbols. We then compare the description of
             // the symbols given to the comment that follows the call.
 
-            var mscorlibRef = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30316_17626.mscorlib).GetReference(display: "mscorlib");
+            var mscorlibRef = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319_17626.mscorlib).GetReference(display: "mscorlib");
             var references = new[] { mscorlibRef }.Concat(additionalRefs ?? Array.Empty<MetadataReference>());
 
             var compilation = CreateEmptyCompilation(source, references, TestOptions.ReleaseDll);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -228,7 +228,7 @@ static class P
     }
 }";
 
-            CompileAndVerify(source3, references: new[] { SystemCoreRef }, expectedOutput: @"BB");
+            CompileAndVerify(source3, expectedOutput: @"BB");
         }
 
         [Fact]
@@ -2304,7 +2304,7 @@ class Test
         Console.WriteLine(M().First());
     }
 }";
-            CompileAndVerify(source, references: new[] { LinqAssemblyRef }, expectedOutput: @"12");
+            CompileAndVerify(source, expectedOutput: @"12");
         }
 
         [Fact]
@@ -3172,7 +3172,7 @@ class X
     }
 }
 ";
-            CompileAndVerify(source, references: new[] { SystemCoreRef });
+            CompileAndVerify(source);
         }
 
         [Fact]
@@ -8061,7 +8061,7 @@ namespace ConsoleApplication2
 }
 ";
 
-            var compilation = CreateCompilation(source1, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
+            var compilation = CreateCompilation(source1, options: TestOptions.DebugExe);
 
             CompileAndVerify(compilation, expectedOutput:
 @"IfNotNull<T, U>(this T? source, Func<T, U> selector)
@@ -8397,7 +8397,7 @@ namespace VS2015CompilerBug
 }
 ";
 
-            var compilation = CreateCompilation(source1, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
+            var compilation = CreateCompilation(source1, options: TestOptions.DebugExe);
 
             CompileAndVerify(compilation, expectedOutput:
 @"int Properties(this IFirstInterface source, params int[] x)
@@ -8445,7 +8445,7 @@ namespace VS2015CompilerBug
 }
 ";
 
-            var compilation = CreateCompilation(source1, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
+            var compilation = CreateCompilation(source1, options: TestOptions.DebugExe);
 
             CompileAndVerify(compilation, expectedOutput:
 @"void Test2(int x, params int[] y)
@@ -8492,7 +8492,7 @@ namespace VS2015CompilerBug
 }
 ";
 
-            var compilation = CreateCompilation(source1, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
+            var compilation = CreateCompilation(source1, options: TestOptions.DebugExe);
 
             CompileAndVerify(compilation, expectedOutput:
 @"void Test2(int x = 0, int y = 0)
@@ -8531,7 +8531,7 @@ namespace VS2015CompilerBug
 }
 ";
 
-            var compilation = CreateCompilation(source1, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
+            var compilation = CreateCompilation(source1, options: TestOptions.DebugExe);
 
             compilation.VerifyDiagnostics(
     // (9,39): error CS0121: The call is ambiguous between the following methods or properties: 'VS2015CompilerBug.Test2(int, int)' and 'VS2015CompilerBug.Test2(int, int, int)'
@@ -10529,7 +10529,6 @@ class Program
         instance.M(3);
     }
 }",
-                references: new[] { SystemCoreRef },
                 expectedOutput:
 @"val: 1
 in: 2
@@ -10558,7 +10557,6 @@ class Program
         Console.WriteLine(instance[3]);
     }
 }",
-                references: new[] { SystemCoreRef },
                 expectedOutput:
 @"val: 1
 in: 2

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -1626,7 +1626,7 @@ class Query
        Console.WriteLine(r1);
     }
 }";
-            var compilation = CreateCompilation(csSource, new[] { LinqAssemblyRef });
+            var compilation = CreateCompilation(csSource);
             foreach (var dd in compilation.GetDiagnostics()) Console.WriteLine(dd);
             compilation.VerifyDiagnostics();
             var tree = compilation.SyntaxTrees[0];
@@ -1902,7 +1902,7 @@ class Program
     }
 }";
 
-            CompileAndVerify(csSource, references: new[] { LinqAssemblyRef }, expectedOutput: "3 3 4 4");
+            CompileAndVerify(csSource, expectedOutput: "3 3 4 4");
         }
 
         [WorkItem(541782, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541782")]
@@ -1929,7 +1929,7 @@ class Program
         System.Console.Write(serializer.Trim());
     }
 }";
-            CompileAndVerify(csSource, references: new[] { LinqAssemblyRef }, expectedOutput: "3 4");
+            CompileAndVerify(csSource, expectedOutput: "3 4");
         }
 
 
@@ -1959,7 +1959,7 @@ class Program
     }
 }";
 
-            CompileAndVerify(csSource, references: new[] { LinqAssemblyRef }, expectedOutput: "1 2 3");
+            CompileAndVerify(csSource, expectedOutput: "1 2 3");
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -2093,7 +2093,7 @@ class Program
     }
 }";
 
-            CompileAndVerify(csSource, references: new[] { LinqAssemblyRef }, expectedOutput: "3 4");
+            CompileAndVerify(csSource, expectedOutput: "3 4");
         }
 
         [WorkItem(541942, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541942")]
@@ -2124,7 +2124,7 @@ class P
     }
 }";
 
-            CompileAndVerify(csSource, references: new[] { LinqAssemblyRef }, expectedOutput: "45");
+            CompileAndVerify(csSource, expectedOutput: "45");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
@@ -59,7 +59,7 @@ public static class Program
     }
 }";
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "67");
+            CompileAndVerify(code, expectedOutput: "67");
         }
 
         [Fact]
@@ -82,7 +82,7 @@ public static class Program
     }
 }";
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "55");
+            CompileAndVerify(code, expectedOutput: "55");
         }
 
         [Fact]
@@ -106,7 +106,7 @@ public static class Program
     }
 }";
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "55");
+            CompileAndVerify(code, expectedOutput: "55");
         }
 
         [Fact]
@@ -1693,7 +1693,7 @@ public class Test
     }
 }";
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "Instance,Extension,Static");
+            CompileAndVerify(code, expectedOutput: "Instance,Extension,Static");
         }
 
         [Fact]
@@ -1732,7 +1732,7 @@ public class Test
     }
 }";
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "Instance,Extension,Static");
+            CompileAndVerify(code, expectedOutput: "Instance,Extension,Static");
         }
 
         [Fact]
@@ -1768,7 +1768,7 @@ public class Program
     }
 }";
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "54321");
+            CompileAndVerify(code, expectedOutput: "54321");
         }
 
         [Fact]
@@ -1792,7 +1792,7 @@ public class Program
     }
 }";
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "7");
+            CompileAndVerify(code, expectedOutput: "7");
         }
 
         [Fact]
@@ -1833,7 +1833,7 @@ public class Program
     }
 }";
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "5554535251");
+            CompileAndVerify(code, expectedOutput: "5554535251");
         }
 
         [Fact]
@@ -2096,7 +2096,7 @@ public static class Program
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref extension methods", "7.2").WithLocation(14, 9)
             );
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "5");
+            CompileAndVerify(code, expectedOutput: "5");
         }
 
         [Fact]
@@ -2137,8 +2137,8 @@ public static class Program
                 //         p.Print();
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref extension methods", "7.2").WithLocation(7, 9));
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef, reference.ToMetadataReference() }, expectedOutput: "5");
-            CompileAndVerify(code, references: new[] { SystemCoreRef, reference.EmitToImageReference() }, expectedOutput: "5");
+            CompileAndVerify(code, references: new[] { reference.ToMetadataReference() }, expectedOutput: "5");
+            CompileAndVerify(code, references: new[] { reference.EmitToImageReference() }, expectedOutput: "5");
         }
 
         [Fact]
@@ -2173,7 +2173,7 @@ public static class Program
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref extension methods", "7.2").WithLocation(14, 9)
             );
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "5");
+            CompileAndVerify(code, expectedOutput: "5");
         }
 
         [Fact]
@@ -2214,8 +2214,8 @@ public static class Program
                 //         p.Print();
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref extension methods", "7.2").WithLocation(7, 9));
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef, reference.ToMetadataReference() }, expectedOutput: "5");
-            CompileAndVerify(code, references: new[] { SystemCoreRef, reference.EmitToImageReference() }, expectedOutput: "5");
+            CompileAndVerify(code, references: new[] { reference.ToMetadataReference() }, expectedOutput: "5");
+            CompileAndVerify(code, references: new[] { reference.EmitToImageReference() }, expectedOutput: "5");
         }
         
         private const string ExtraRefReadOnlyIL = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -685,7 +685,7 @@ class C
             c = ref x;
         });
     }
-}", references: new[] { LinqAssemblyRef });
+}");
             comp.VerifyDiagnostics(
                 // (12,22): error CS1939: Cannot pass the range variable 'c' as an out or ref parameter
                 //             rx = ref c;
@@ -1610,7 +1610,7 @@ public class Test
     }
 
 }";
-            var comp = CreateCompilation(text, references: new[] { MscorlibRef, SystemCoreRef, LinqAssemblyRef });
+            var comp = CreateCompilation(text, targetFramework: TargetFramework.Empty, references: new[] { MscorlibRef, SystemCoreRef });
             comp.VerifyDiagnostics(
                 // (16,34): error CS8159: Cannot return the range variable 'ch' by reference
                 //             select(D1)(() => ref ch);
@@ -1661,7 +1661,7 @@ public class Test
     }
 
 }";
-            var comp = CreateCompilation(text, references: new[] { MscorlibRef, SystemCoreRef });
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
     // (14,26): error CS1657: Cannot use 'M' as a ref or out value because it is a 'method group'
     //         ref char r = ref M;
@@ -2274,7 +2274,7 @@ class C
 ";
             CompileAndVerify(text,
                 expectedOutput: "frog",
-                references: new[] { SystemCoreRef, CSharpRef }).VerifyDiagnostics();
+                references: new[] { CSharpRef }).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticAnalyzerTests.cs
@@ -904,7 +904,7 @@ class Program
         d = (int)d;
     }
 }";
-            CreateCompilation(source, new[] { SystemCoreRef }).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -2979,7 +2979,7 @@ class F
   ProtectionLevel Prop { get { return 0; } }
 }
 ";
-            CreateCompilation(text, references: new[] { SystemRef }).VerifyDiagnostics(
+            CreateCompilation(text).VerifyDiagnostics(
                 // (9,17): error CS0120: An object reference is required for the non-static field, method, or property 'F.Prop'
                 //   [DefaultValue(Prop.Privacy)] // CS0120
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "Prop").WithArguments("F.Prop"),
@@ -9746,7 +9746,7 @@ namespace N
         }
     }
 }";
-            CreateCompilation(text, references: new[] { SystemCoreRef }).VerifyDiagnostics(
+            CreateCompilation(text).VerifyDiagnostics(
                 // (4,7): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
                 // using CB = N.C<N.B>;
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "CB").WithArguments("N.C<T>", "T", "N.B").WithLocation(4, 7),
@@ -9811,7 +9811,7 @@ class D<T> where T : new()
         D<C>.M();
     }
 }";
-            CreateCompilation(text, references: new[] { SystemCoreRef }).VerifyDiagnostics(
+            CreateCompilation(text).VerifyDiagnostics(
                 // (18,11): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'D<T>'
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "B").WithArguments("D<T>", "T", "B").WithLocation(18, 11),
                 // (19,11): error CS0310: 'C' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'D<T>'
@@ -15744,7 +15744,7 @@ class Errors
    }
 }
 ";
-            var compilation = CreateCompilation(text, references: new[] { SystemCoreRef });
+            var compilation = CreateCompilation(text);
             compilation.VerifyDiagnostics(
                 // (7,13): error CS1661: Cannot convert anonymous method to delegate type 'E' because the parameter types do not match the delegate parameter types
                 //       E e = delegate(out int i) { };   // CS1676
@@ -15772,7 +15772,7 @@ class Errors
     }
 }
 ";
-            var compilation = CreateCompilation(text, references: new[] { SystemCoreRef });
+            var compilation = CreateCompilation(text);
             compilation.VerifyDiagnostics(
                 // (7,15): error CS1661: Cannot convert anonymous method to delegate type 'D' because the parameter types do not match the delegate parameter types
                 //         D d = delegate(out int i) { };   // CS1677
@@ -16758,7 +16758,7 @@ class Test
     }
 }
 ";
-            CreateCompilation(text, new[] { LinqAssemblyRef }).VerifyDiagnostics(
+            CreateCompilation(text).VerifyDiagnostics(
                 // (13,35): error CS1939: Cannot pass the range variable 'x' as an out or ref parameter
                 //                 select Test.F(ref x); // CS1939
                 Diagnostic(ErrorCode.ERR_QueryOutRefRangeVariable, "x").WithArguments("x"));
@@ -16986,7 +16986,7 @@ class Test
     }
 }
 ";
-            CreateCompilation(program, new[] { LinqAssemblyRef }).VerifyDiagnostics(
+            CreateCompilation(program).VerifyDiagnostics(
                 Diagnostic(ErrorCode.ERR_QueryRangeVariableReadOnly, "i").WithArguments("i"));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -2175,7 +2175,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1, references: new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugExe);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1, references: new[] { CSharpRef }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "True");
         }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -766,7 +766,7 @@ class D { }
 
 
 
-            c = CreateCompilation(source, new[] { r1, r2 });
+            c = createCompilationCore(source, new[] { r1, r2 });
             Assert.Null(c.GetReferencedAssemblySymbol(r1));
             Assert.NotNull(c.GetReferencedAssemblySymbol(r2));
             c.VerifyDiagnostics();
@@ -775,19 +775,19 @@ class D { }
 class D : C { }
             ";
 
-            c = CreateCompilation(source, new[] { r1, r2 });
+            c = createCompilationCore(source, new[] { r1, r2 });
             Assert.Null(c.GetReferencedAssemblySymbol(r1));
             Assert.NotNull(c.GetReferencedAssemblySymbol(r2));
             c.VerifyDiagnostics();
 
-            c = CreateCompilation(source, new[] { rGoo, r2 });
+            c = createCompilationCore(source, new[] { rGoo, r2 });
             Assert.Null(c.GetReferencedAssemblySymbol(rGoo));
             Assert.NotNull(c.GetReferencedAssemblySymbol(r2));
             AssertEx.SetEqual(new[] { "goo", "global" }, c.ExternAliases);
             c.VerifyDiagnostics();
 
             // 2 aliases for the same path, aliases not used to qualify name
-            c = CreateCompilation(source, new[] { rGoo, rBar });
+            c = createCompilationCore(source, new[] { rGoo, rBar });
             Assert.Null(c.GetReferencedAssemblySymbol(rGoo));
             Assert.NotNull(c.GetReferencedAssemblySymbol(rBar));
             AssertEx.SetEqual(new[] { "goo", "bar" }, c.ExternAliases);
@@ -801,7 +801,7 @@ class D : C { }
             ";
 
             // /l and /r with the same path
-            c = CreateCompilation(source, new[] { rGoo, rEmbed });
+            c = createCompilationCore(source, new[] { rGoo, rEmbed });
             Assert.Null(c.GetReferencedAssemblySymbol(rGoo));
             Assert.NotNull(c.GetReferencedAssemblySymbol(rEmbed));
 
@@ -824,10 +824,16 @@ public class D : goo::C { }
 public class E : bar::C { }
 ";
             // 2 aliases for the same path, aliases used
-            c = CreateCompilation(source, new[] { rGoo, rBar });
+            c = createCompilationCore(source, new[] { rGoo, rBar });
             Assert.Null(c.GetReferencedAssemblySymbol(rGoo));
             Assert.NotNull(c.GetReferencedAssemblySymbol(rBar));
             c.VerifyDiagnostics();
+
+            CSharpCompilation createCompilationCore(string s, IEnumerable<MetadataReference> references)
+            {
+                references = TargetFrameworkUtil.StandardReferences.AddRange(references);
+                return CreateEmptyCompilation(s, references);
+            }
         }
 
         // "<path>\x\y.dll" -> "<path>\x\..\x\y.dll"
@@ -956,7 +962,7 @@ public class E : bar::C { }
             var ref1 = AssemblyMetadata.CreateFromImage(TestResources.General.C2).GetReference(embedInteropTypes: true, filePath: @"R:\A\MTTestLib1.dll");
             var ref2 = AssemblyMetadata.CreateFromImage(TestResources.General.C2).GetReference(embedInteropTypes: false, filePath: @"R:\B\MTTestLib1.dll");
 
-            var c = CreateCompilation("class C {}", new[] { ref1, ref2 });
+            var c = CreateEmptyCompilation("class C {}", TargetFrameworkUtil.StandardReferences.AddRange(new[] { ref1, ref2 }));
             c.VerifyDiagnostics(
                 // error CS1760: Assemblies 'R:\B\MTTestLib1.dll' and 'R:\A\MTTestLib1.dll' refer to the same metadata but only one is a linked reference (specified using /link option); consider removing one of the references.
                 Diagnostic(ErrorCode.ERR_AssemblySpecifiedForLinkAndRef).WithArguments(@"R:\B\MTTestLib1.dll", @"R:\A\MTTestLib1.dll"));
@@ -978,7 +984,7 @@ public interface I {}";
             var ref1 = lib1.ToMetadataReference(embedInteropTypes: true);
             var ref2 = lib2.ToMetadataReference(embedInteropTypes: false);
 
-            var c = CreateCompilation("class C {}", new[] { ref1, ref2 });
+            var c = CreateEmptyCompilation("class C {}", TargetFrameworkUtil.StandardReferences.AddRange(new[] { ref1, ref2 }));
             c.VerifyDiagnostics(
                 // error CS1760: Assemblies 'Lib' and 'Lib' refer to the same metadata but only one is a linked reference (specified using /link option); consider removing one of the references.
                 Diagnostic(ErrorCode.ERR_AssemblySpecifiedForLinkAndRef).WithArguments("Lib", "Lib"));
@@ -1051,7 +1057,7 @@ class C : A2::A { }
             // Dev12 reports CS1704. An assembly with the same simple name '...' has already been imported. 
             // We consider the second reference a duplicate and ignore it (merging the aliases).
 
-            CreateCompilation(source, new[] { ref1, ref2 }).VerifyDiagnostics();
+            CreateEmptyCompilation(source, TargetFrameworkUtil.StandardReferences.AddRange(new[] { ref1, ref2 })).VerifyDiagnostics();
         }
 
         [Fact]
@@ -1127,8 +1133,8 @@ public class Q
                 var mdRefLib1 = metadataLib1.GetReference(filePath: @"C:\W1.dll");
                 var mdRefLib2 = metadataLib2.GetReference(filePath: @"C:\W2.dll");
 
-                var main = CreateCompilation(sourceMain,
-                    new[] { mdRefLib1, mdRefLib2 });
+                var main = CreateEmptyCompilation(sourceMain,
+                    TargetFrameworkUtil.StandardReferences.AddRange(new[] { mdRefLib1, mdRefLib2 }));
 
                 // Dev12 reports CS1704. An assembly with the same simple name '...' has already been imported. 
                 // We consider the second reference a duplicate and ignore it.
@@ -1192,8 +1198,8 @@ public class Q
                 var mdRefLib1 = metadataLib1.GetReference(filePath: @"C:\WB.dll");
                 var mdRefLib2 = metadataLib2.GetReference(filePath: @"C:\WB_Version1.dll");
 
-                var main = CreateCompilation(sourceMain,
-                    new[] { mdRefLib1, mdRefLib2 });
+                var main = CreateEmptyCompilation(sourceMain,
+                    TargetFrameworkUtil.StandardReferences.AddRange(new[] { mdRefLib1, mdRefLib2 }));
 
                 main.VerifyDiagnostics(
                     // error CS1704: An assembly with the same simple name 'WB' has already been imported. Try removing one of the references (e.g. 'C:\WB.dll') or sign them to enable side-by-side.
@@ -1220,7 +1226,7 @@ public class A
 }
 ";
 
-            var compilation = CreateCompilation(source, references: new[] { arSA, enUS });
+            var compilation = CreateEmptyCompilation(source, TargetFrameworkUtil.StandardReferences.AddRange(new[] { arSA, enUS }));
             var arSA_sym = compilation.GetReferencedAssemblySymbol(arSA);
             var enUS_sym = compilation.GetReferencedAssemblySymbol(enUS);
 
@@ -2185,7 +2191,9 @@ public class Source
             var refVectors40 = vectors40.EmitToImageReference();
             var refVectors41 = vectors41.EmitToImageReference();
 
-            var c1 = CreateCompilation("", new[] { refVectors40, refVectors41 }, options: TestOptions.ReleaseDll.WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default));
+            var c1 = CreateEmptyCompilation("", 
+                TargetFrameworkUtil.StandardReferences.AddRange(new[] { refVectors40, refVectors41 }),
+                options: TestOptions.ReleaseDll.WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default));
             c1.VerifyDiagnostics();
 
             var a0 = c1.GetAssemblyOrModuleSymbol(refVectors40);
@@ -2193,7 +2201,9 @@ public class Source
             Assert.Equal("System.Numerics.Vectors, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", ((IAssemblySymbol)a0).Identity.GetDisplayName());
             Assert.Equal("System.Numerics.Vectors, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", ((IAssemblySymbol)a1).Identity.GetDisplayName());
 
-            var c2 = CreateCompilation("", new[] { refVectors41, refVectors40 }, options: TestOptions.ReleaseDll.WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default));
+            var c2 = CreateEmptyCompilation("", 
+                TargetFrameworkUtil.StandardReferences.AddRange(new[] { refVectors41, refVectors40 }),
+                options: TestOptions.ReleaseDll.WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default));
             c2.VerifyDiagnostics();
 
             a0 = c2.GetAssemblyOrModuleSymbol(refVectors40);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
 
             Assert.False(msCorLibRef.KeepLookingForDeclaredSpecialTypes);
 
-            assemblies = MetadataTestHelpers.GetSymbolsForReferences(mrefs: new[] { MetadataReference.CreateFromImage(TestResources.NetFX.v4_0_30316_17626.mscorlib.AsImmutableOrNull()) });
+            assemblies = MetadataTestHelpers.GetSymbolsForReferences(mrefs: new[] { MetadataReference.CreateFromImage(TestResources.NetFX.v4_0_30319_17626.mscorlib.AsImmutableOrNull()) });
 
             msCorLibRef = (MetadataOrSourceAssemblySymbol)assemblies[0];
             Assert.True(msCorLibRef.KeepLookingForDeclaredSpecialTypes);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -5730,7 +5730,7 @@ public static class Program
     }
 }";
 
-            CreateCompilationWithMscorlib40AndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
+            CreateCompilation(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
                // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                //     public static void Print(in this int p)
                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("readonly references", "7.2").WithLocation(4, 30),
@@ -5739,7 +5739,7 @@ public static class Program
                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("ref extension methods", "7.2").WithLocation(4, 30)
             );
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "5");
+            CompileAndVerify(code, expectedOutput: "5");
         }
 
         [Fact]
@@ -5762,13 +5762,13 @@ public static class Program
     }
 }";
 
-            CreateCompilationWithMscorlib40AndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
+            CreateCompilation(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
                // (4,30): error CS8302: Feature 'ref extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                //     public static void Print(ref this int p)
                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("ref extension methods", "7.2").WithLocation(4, 30)
             );
 
-            CompileAndVerify(code, references: new[] { SystemCoreRef }, expectedOutput: "5");
+            CompileAndVerify(code, expectedOutput: "5");
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/WinRT/CodeGen/WinRTCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/CodeGen/WinRTCollectionTests.cs
@@ -41,7 +41,7 @@ public sealed class BehaviorCollection : DependencyObjectCollection
      return this[i];
     }
 }";
-            var comp = CreateCompilationWithMscorlib45(source, references: WinRtRefs);
+            var comp = CreateEmptyCompilation(source, references: WinRtRefs);
             comp.VerifyDiagnostics();
         }
 
@@ -7405,7 +7405,7 @@ public class Class1
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib45(source, references: WinRtRefs);
+            var comp = CreateEmptyCompilation(source, references: WinRtRefs);
             comp.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees.Single();

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
@@ -324,9 +324,10 @@ class C
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "d2").WithArguments("A.d2")
             });
 
-            var verifier = this.CompileAndVerifyOnWin8Only(
+            var verifier = this.CompileAndVerify(
                 src,
-                additionalRefs: new[] {
+                targetFramework: TargetFramework.Empty,
+                references: new[] {
                     MscorlibRef_v4_0_30316_17626,
                     SystemCoreRef_v4_0_30319_17929,
                     CSharpRef,
@@ -3288,7 +3289,7 @@ class C
     }
 }
 ";
-            CreateCompilation(source, WinRtRefs, TestOptions.ReleaseWinMD).VerifyDiagnostics(
+            CreateEmptyCompilation(source, WinRtRefs, TestOptions.ReleaseWinMD).VerifyDiagnostics(
                 // (9,17): error CS7084: A Windows Runtime event may not be passed as an out or ref parameter.
                 //         Ref(ref Instance);
                 Diagnostic(ErrorCode.ERR_WinRtEventPassedByRef, "Instance").WithArguments("C.Instance"),
@@ -3408,7 +3409,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 }
 ";
 
-            var compilation = CreateCompilationWithILAndMscorlib40("", il, references: WinRtRefs);
+            var compilation = CreateCompilationWithIL("", il, targetFramework: TargetFramework.Empty, references: WinRtRefs);
 
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Events");
             var instanceEvent = type.GetMember<EventSymbol>("Instance");

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdMetadataTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                                 }
                              };";
 
-            CompileAndVerify(text, WinRtRefs, expectedOutput: "#FF000000");
+            CompileAndVerify(text, WinRtRefs, targetFramework: TargetFramework.Empty, expectedOutput: "#FF000000");
         }
 
         /// <summary>
@@ -231,6 +231,7 @@ public class MyAttribute : System.Attribute
             CompileAndVerify(
                 source,
                 WinRtRefs.Concat(new[] { AssemblyMetadata.CreateFromImage(TestResources.WinRt.W1).GetReference() }),
+                targetFramework: TargetFramework.Empty,
                 symbolValidator: m =>
             {
                 var module = (PEModuleSymbol)m;

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -314,9 +314,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static CSharpCompilation CreateCompilationWithIL(
             CSharpTestSource source,
             string ilSource,
+            TargetFramework targetFramework = TargetFramework.Standard,
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
-            bool appendDefaultHeader = true) => CreateCompilationWithILAndMscorlib40(source, ilSource, TargetFramework.Standard, references, options, appendDefaultHeader);
+            bool appendDefaultHeader = true) => CreateCompilationWithILAndMscorlib40(source, ilSource, targetFramework, references, options, appendDefaultHeader);
 
         public static CSharpCompilation CreateCompilationWithILAndMscorlib40(
             CSharpTestSource source,

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -799,12 +799,8 @@ Public MustInherit Class BasicTestBase
 
         Dim fileName = "a.vb"
         Dim syntaxTree = Parse(source, fileName, parseOptions)
-        Dim allReferences As IEnumerable(Of MetadataReference)
-        If useLatestFrameworkReferences Then
-            allReferences = TargetFrameworkUtil.Mscorlib45ExtendedReferences.Add(TestBase.MsvbRef_v4_0_30319_17929)
-        Else
-            allReferences = TargetFrameworkUtil.Mscorlib45ExtendedReferences.Add(TestBase.MsvbRef)
-        End If
+        Dim allReferences = TargetFrameworkUtil.Mscorlib45ExtendedReferences.Add(
+            If(useLatestFrameworkReferences, TestBase.MsvbRef_v4_0_30319_17929, TestBase.MsvbRef))
         Dim compilation = CreateEmptyCompilation({syntaxTree}, references:=allReferences, options:=If(compilationOptions, TestOptions.ReleaseDll))
         Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, which)
         Return (operationTree.tree, operationTree.syntax, operationTree.operation, compilation)
@@ -863,12 +859,8 @@ Public MustInherit Class BasicTestBase
 
         Dim fileName = "a.vb"
         Dim syntaxTree = Parse(source, fileName, parseOptions)
-        Dim allReferences As IEnumerable(Of MetadataReference) = Nothing
-        If useLatestFramework Then
-            allReferences = TargetFrameworkUtil.Mscorlib45ExtendedReferences.Add(TestBase.MsvbRef_v4_0_30319_17929)
-        Else
-            allReferences = TargetFrameworkUtil.Mscorlib45ExtendedReferences.Add(TestBase.MsvbRef)
-        End If
+        Dim allReferences As IEnumerable(Of MetadataReference) = TargetFrameworkUtil.Mscorlib45ExtendedReferences.Add(
+            If(useLatestFramework, TestBase.MsvbRef_v4_0_30319_17929, TestBase.MsvbRef))
 
         allReferences = If(references IsNot Nothing, allReferences.Concat(references), allReferences)
         Dim compilation = CreateEmptyCompilation({syntaxTree}, references:=allReferences, options:=If(compilationOptions, TestOptions.ReleaseDll))

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -4698,7 +4698,7 @@ Class C
     End Function
 End Class
 ")
-            Dim compilation0 = CompilationUtils.CreateEmptyCompilation({source0.Tree}, {TestReferences.NetFx.v4_0_30316_17626.mscorlib}, options:=ComSafeDebugDll)
+            Dim compilation0 = CompilationUtils.CreateEmptyCompilation({source0.Tree}, {TestReferences.NetFx.v4_0_30319_17626.mscorlib}, options:=ComSafeDebugDll)
             Dim compilation1 = compilation0.WithSource(source1.Tree)
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor))

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EntryPointTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EntryPointTests.vb
@@ -545,7 +545,7 @@ End Class
             Dim vbx = <text>
 System.Console.WriteLine(1)
 </text>
-            Dim compilation = CreateCompilationWithMscorlib40(
+            Dim compilation = CreateEmptyCompilation(
                 {VisualBasicSyntaxTree.ParseText(vbx.Value, options:=TestOptions.Script)}, options:=TestOptions.ReleaseExe, references:=LatestVbReferences)
 
             CompileAndVerify(compilation, expectedOutput:="1")
@@ -564,7 +564,7 @@ Public Class C
   End Sub
 End Class
 </text>
-            Dim compilation = CreateCompilationWithMscorlib40(
+            Dim compilation = CreateEmptyCompilation(
                 {VisualBasicSyntaxTree.ParseText(vbx.Value, options:=TestOptions.Script),
                  VisualBasicSyntaxTree.ParseText(vb.Value, options:=VisualBasicParseOptions.Default)}, options:=TestOptions.ReleaseExe, references:=LatestVbReferences)
 
@@ -591,7 +591,7 @@ Public Class D
     End Sub
 End Class
 </text>
-            Dim compilation = CreateCompilationWithMscorlib40(
+            Dim compilation = CreateEmptyCompilation(
                 {VisualBasicSyntaxTree.ParseText(vbx.Value, options:=TestOptions.Script),
                  VisualBasicSyntaxTree.ParseText(vb.Value, options:=VisualBasicParseOptions.Default)}, options:=TestOptions.ReleaseExe, references:=LatestVbReferences)
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -1908,7 +1908,8 @@ End Class
             Dim md2 = AssemblyMetadata.CreateFromImage(CreateCompilationWithMscorlib40({"Public Class D : End Class"}, options:=TestOptions.ReleaseDll).EmitToArray())
             Dim reference = New EvolvingTestReference({md1, md2})
 
-            Dim c1 = CreateCompilationWithMscorlib40({"Public Class Main : Public Shared C As C : End Class"}, {reference, reference}, options:=TestOptions.ReleaseDll)
+            Dim references = TargetFrameworkUtil.Mscorlib40References.AddRange({reference, reference})
+            Dim c1 = CreateEmptyCompilation({"Public Class Main : Public Shared C As C : End Class"}, references:=references, options:=TestOptions.ReleaseDll)
             Dim c2 = c1.WithAssemblyName("c2")
             Dim c3 = c2.AddSyntaxTrees(Parse("Public Class Main2 : Public Shared A As Integer : End Class"))
             Dim c4 = c3.WithOptions(New VisualBasicCompilationOptions(OutputKind.NetModule))

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
@@ -1969,8 +1969,9 @@ End Class
             Dim dRef = CreateCompilationWithMscorlib40({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface D : Inherits B : End Interface"}, {b2Ref}, options:=s_signedDll, assemblyName:="D").EmitToImageReference()
             Dim eRef = CreateCompilationWithMscorlib40({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface E : Inherits B : End Interface"}, {b1Ref}, options:=s_signedDll, assemblyName:="E").EmitToImageReference()
 
-            Dim aRef = CreateCompilationWithMscorlib40({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface A : Inherits D, E : End Interface"},
-                                                     {dRef, eRef, b1Ref, b2Ref},
+            Dim references = TargetFrameworkUtil.Mscorlib40References.AddRange({dRef, eRef, b1Ref, b2Ref})
+            Dim aRef = CreateEmptyCompilation({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface A : Inherits D, E : End Interface"},
+                                                     references,
                                                      s_signedDll,
                                                      assemblyName:="A").EmitToImageReference()
 
@@ -2016,7 +2017,11 @@ End Class
             Dim dRef = CreateCompilationWithMscorlib40({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")>: Public Interface D : Inherits B : End Interface"}, {b2Ref}, options:=s_signedDll, assemblyName:="D").EmitToImageReference()
             Dim eRef = CreateCompilationWithMscorlib40({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")>: Public Interface E : Inherits B : End Interface"}, {b1Ref}, options:=s_signedDll, assemblyName:="E").EmitToImageReference()
 
-            Dim aRef = CreateCompilationWithMscorlib40({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")>: Public Interface A : Inherits D, E : End Interface"}, {dRef, eRef, b1Ref, b2Ref}, s_signedDll, assemblyName:="A").EmitToImageReference()
+            Dim aRef = CreateEmptyCompilation(
+                {"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")>: Public Interface A : Inherits D, E : End Interface"},
+                TargetFrameworkUtil.Mscorlib40References.AddRange({dRef, eRef, b1Ref, b2Ref}),
+                s_signedDll,
+                assemblyName:="A").EmitToImageReference()
 
             Dim resolverC = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
             {

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
@@ -676,7 +676,10 @@ Class D
 End Class
 </text>.Value
 
-            c = CreateCompilationWithMscorlib40({source}, {r1, r2}, options:=TestOptions.ReleaseDll)
+            c = CreateEmptyCompilation(
+                {source},
+                TargetFrameworkUtil.Mscorlib40References.AddRange({r1, r2}),
+                options:=TestOptions.ReleaseDll)
             c.AssertTheseDiagnostics()
             Assert.Null(c.GetReferencedAssemblySymbol(r1))
             Assert.NotNull(c.GetReferencedAssemblySymbol(r2))
@@ -688,12 +691,18 @@ Class D
 End Class
 </text>.Value
 
-            c = CreateCompilationWithMscorlib40({source}, {r1, r2}, options:=TestOptions.ReleaseDll)
+            c = CreateEmptyCompilation(
+                {source},
+                TargetFrameworkUtil.Mscorlib40References.AddRange({r1, r2}),
+                options:=TestOptions.ReleaseDll)
             Assert.Null(c.GetReferencedAssemblySymbol(r1))
             Assert.NotNull(c.GetReferencedAssemblySymbol(r2))
             c.AssertTheseDiagnostics()
 
-            c = CreateCompilationWithMscorlib40({source}, {r1, rEmbed}, options:=TestOptions.ReleaseDll)
+            c = CreateEmptyCompilation(
+                {source},
+                TargetFrameworkUtil.Mscorlib40References.AddRange({r1, rEmbed}),
+                options:=TestOptions.ReleaseDll)
             c.AssertTheseDiagnostics(<errors>
 BC31549: Cannot embed interop types from assembly 'C, Version=1.0.0.0, Culture=neutral, PublicKeyToken=374d0c2befcd8cc9' because it is missing the 'System.Runtime.InteropServices.GuidAttribute' attribute.
 BC31553: Cannot embed interop types from assembly 'C, Version=1.0.0.0, Culture=neutral, PublicKeyToken=374d0c2befcd8cc9' because it is missing either the 'System.Runtime.InteropServices.ImportedFromTypeLibAttribute' attribute or the 'System.Runtime.InteropServices.PrimaryInteropAssemblyAttribute' attribute.
@@ -704,7 +713,10 @@ BC31541: Reference to class 'C' is not allowed when its assembly is configured t
             Assert.Null(c.GetReferencedAssemblySymbol(r1))
             Assert.NotNull(c.GetReferencedAssemblySymbol(rEmbed))
 
-            c = CreateCompilationWithMscorlib40({source}, {rEmbed, r1}, options:=TestOptions.ReleaseDll)
+            c = CreateEmptyCompilation(
+                {source},
+                TargetFrameworkUtil.Mscorlib40References.AddRange({rEmbed, r1}),
+                options:=TestOptions.ReleaseDll)
             c.AssertTheseDiagnostics()
             Assert.Null(c.GetReferencedAssemblySymbol(rEmbed))
             Assert.NotNull(c.GetReferencedAssemblySymbol(r1))

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
 
             Assert.False(msCorLibRef.KeepLookingForDeclaredSpecialTypes)
 
-            assemblies = MetadataTestHelpers.GetSymbolsForReferences({MetadataReference.CreateFromImage(TestResources.NetFX.v4_0_30316_17626.mscorlib)})
+            assemblies = MetadataTestHelpers.GetSymbolsForReferences({MetadataReference.CreateFromImage(TestResources.NetFX.v4_0_30319_17626.mscorlib)})
             msCorLibRef = DirectCast(assemblies(0), MetadataOrSourceAssemblySymbol)
             Assert.True(msCorLibRef.KeepLookingForDeclaredSpecialTypes)
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditAndContinue
         private readonly ImmutableArray<PortableExecutableReference> _fxReferences;
 
         internal static readonly CSharpEditAndContinueTestHelpers Instance = new CSharpEditAndContinueTestHelpers(
-            ImmutableArray.Create(TestReferences.NetFx.v4_0_30316_17626.mscorlib, TestReferences.NetFx.v4_0_30319.System_Core));
+            ImmutableArray.Create(TestReferences.NetFx.v4_0_30319_17626.mscorlib, TestReferences.NetFx.v4_0_30319.System_Core));
         
         internal static CSharpEditAndContinueTestHelpers Instance40 => new CSharpEditAndContinueTestHelpers(
             ImmutableArray.Create(TestReferences.NetFx.v4_0_30319.mscorlib, TestReferences.NetFx.v4_0_30319.System_Core));

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/VisualBasicEditAndContinueTestHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/VisualBasicEditAndContinueTestHelpers.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EditAndContinue
         Private ReadOnly _fxReferences As ImmutableArray(Of PortableExecutableReference)
 
         Friend Shared ReadOnly Instance As VisualBasicEditAndContinueTestHelpers = New VisualBasicEditAndContinueTestHelpers(
-            ImmutableArray.Create(TestReferences.NetFx.v4_0_30316_17626.mscorlib, TestReferences.NetFx.v4_0_30319.System, TestReferences.NetFx.v4_0_30319.System_Core))
+            ImmutableArray.Create(TestReferences.NetFx.v4_0_30319_17626.mscorlib, TestReferences.NetFx.v4_0_30319.System, TestReferences.NetFx.v4_0_30319.System_Core))
 
         Friend Shared ReadOnly Instance40 As VisualBasicEditAndContinueTestHelpers = New VisualBasicEditAndContinueTestHelpers(
             ImmutableArray.Create(TestReferences.NetFx.v4_0_30319.mscorlib, TestReferences.NetFx.v4_0_30319.System_Core))

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
@@ -399,7 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         d.F();
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(
                 comp,
                 references: null,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -753,7 +753,7 @@ class C
         return null;
     }
 }";
-            var compilation0 = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
+            var compilation0 = CreateCompilation(source, new[] { CSharpRef }, TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -247,7 +247,7 @@ class Generic<T>
 {
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -297,7 +297,7 @@ class Generic<T>
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
@@ -366,7 +366,7 @@ class Generic<T>
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
@@ -433,7 +433,7 @@ class Generic<T>
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
@@ -532,7 +532,7 @@ class Generic<T>
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
@@ -600,7 +600,7 @@ class Generic<T>
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, methodName: "C.M");
@@ -642,7 +642,7 @@ class Generic<T>
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -681,7 +681,7 @@ class Generic<T>
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -720,7 +720,7 @@ class Generic<T>
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -768,7 +768,7 @@ public class Outer<T, U>
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -855,7 +855,7 @@ public class Outer<T, U>
         return null;
     }
 }";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(
@@ -971,7 +971,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -1039,7 +1039,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
+            var comp = CreateCompilationWithCSharp(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -1262,7 +1262,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.Goo");
@@ -1374,7 +1374,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, new[] { CSharpRef }, TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -1450,7 +1450,7 @@ class C
             var compilation0 = CreateCompilation(
                 source,
                 options: TestOptions.DebugDll,
-                references: new[] { SystemCoreRef, CSharpRef });
+                references: new[] { CSharpRef });
 
             WithRuntimeInstance(compilation0, runtime =>
             {
@@ -1504,7 +1504,7 @@ class C
             var compilation0 = CreateCompilation(
                 source,
                 options: TestOptions.DebugDll,
-                references: new[] { SystemCoreRef, CSharpRef });
+                references: new[] { CSharpRef });
 
             WithRuntimeInstance(compilation0, runtime =>
             {
@@ -1555,7 +1555,7 @@ class C
             var compilation0 = CreateCompilation(
                 source,
                 options: TestOptions.DebugDll,
-                references: new[] { SystemCoreRef, CSharpRef });
+                references: new[] { CSharpRef });
 
             WithRuntimeInstance(compilation0, runtime =>
             {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -3423,7 +3423,7 @@ class C
 }
 ";
             var libRef = CreateCompilation(libSource).EmitToImageReference();
-            var comp = CreateCompilation(source, new[] { SystemRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
 
             WithRuntimeInstance(comp, new[] { MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef }, runtime =>
             {
@@ -3578,7 +3578,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilation(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 string typeName;
@@ -3674,7 +3674,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilation(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 string typeName;
@@ -3746,7 +3746,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilation(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 string typeName;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -122,7 +122,7 @@ public class C
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
 
             WithRuntimeInstance(comp, new[] { MscorlibRef }, runtime =>
             {
@@ -164,7 +164,7 @@ public class C
     }
 }
 ";
-            var comp = CreateCompilation(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, new[] { MscorlibRef }, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -554,7 +554,7 @@ class C
     {
     }
 }";
-            var comp = CreateCompilation(source, WinRtRefs, TestOptions.DebugDll);
+            var comp = CreateEmptyCompilation(source, WinRtRefs, TestOptions.DebugDll);
             var runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage");
             Assert.True(runtimeAssemblies.Any());
 
@@ -597,7 +597,7 @@ class C
     {
     }
 }";
-            var comp = CreateCompilation(source, WinRtRefs, TestOptions.DebugDll);
+            var comp = CreateEmptyCompilation(source, WinRtRefs, TestOptions.DebugDll);
             var runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.UI");
             Assert.True(runtimeAssemblies.Any());
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     {
     }
 }";
-            var compilation0 = CreateCompilation(
+            var compilation0 = CreateEmptyCompilation(
                 source,
                 options: TestOptions.DebugDll,
                 assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
@@ -79,7 +79,7 @@ class C
     {
     }
 }";
-            var compilation0 = CreateCompilation(
+            var compilation0 = CreateEmptyCompilation(
                 source,
                 options: TestOptions.DebugDll,
                 assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
@@ -173,7 +173,7 @@ class C
     {
     }
 }";
-            var compilation0 = CreateCompilation(source, compileReferences, TestOptions.DebugDll);
+            var compilation0 = CreateEmptyCompilation(source, compileReferences, TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtimeReferences, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -252,7 +252,7 @@ class C
     {
     }
 }";
-            var compilation = CreateCompilation(source, WinRtRefs, TestOptions.DebugDll);
+            var compilation = CreateEmptyCompilation(source, WinRtRefs, TestOptions.DebugDll);
             WithRuntimeInstance(compilation, new[] { MscorlibRef }.Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage", "Windows.Foundation.Collections")), runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -302,7 +302,7 @@ class C
     {
     }
 }";
-            var compilation = CreateCompilation(source, WinRtRefs, TestOptions.DebugDll);
+            var compilation = CreateEmptyCompilation(source, WinRtRefs, TestOptions.DebugDll);
             WithRuntimeInstance(compilation, new[] { MscorlibRef }.Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Foundation", "Windows.UI", "Windows.UI.Xaml")), runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
@@ -336,7 +336,7 @@ class C
     {
     }
 }";
-            var compilation = CreateCompilation(source, WinRtRefs, TestOptions.DebugDll);
+            var compilation = CreateEmptyCompilation(source, WinRtRefs, TestOptions.DebugDll);
             WithRuntimeInstance(compilation, new[] { MscorlibRef }.Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.UI", "Windows.UI.Xaml")), runtime =>
             {
                 string errorMessage;

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/CSharpFunctionResolverTests.cs
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/CSharpFunctionResolverTests.cs
@@ -1245,7 +1245,7 @@ class C
     static void F(dynamic d) { }
     static void F(C<dynamic[]> d) { }
 }";
-            var compilation = CreateCompilation(source, references: new[] { CSharpRef, SystemCoreRef });
+            var compilation = CreateCompilation(source, references: new[] { CSharpRef });
             using (var process = new Process(new Module(compilation.EmitToArray())))
             {
                 var resolver = Resolver.CSharpResolver;

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/WinMdTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/WinMdTests.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Shared Sub M(f As Windows.Storage.StorageFolder, p As Windows.Foundation.Collections.PropertySet)
     End Sub
 End Class"
-            Dim comp = CreateCompilationWithMscorlib40({source}, options:=TestOptions.DebugDll, references:=WinRtRefs)
+            Dim comp = CreateEmptyCompilation({source}, options:=TestOptions.DebugDll, references:=WinRtRefs)
             Dim runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage", "Windows.Foundation.Collections")
             Assert.True(runtimeAssemblies.Length >= 2)
 
@@ -194,7 +194,7 @@ End Class"
     End Sub
 End Class"
 
-            Dim comp = CreateCompilationWithMscorlib40({source}, WinRtRefs, TestOptions.DebugDll)
+            Dim comp = CreateEmptyCompilation({source}, WinRtRefs, TestOptions.DebugDll)
             Dim runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage", "Windows.Foundation.Collections")
             WithRuntimeInstance(comp, {MscorlibRef}.Concat(runtimeAssemblies),
                 Sub(runtime)

--- a/src/Test/Utilities/Portable/Mocks/TestReferences.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestReferences.cs
@@ -131,10 +131,13 @@ public static class TestReferences
             public static PortableExecutableReference SystemCore => s_systemCore.Value;
         }
 
+        /// <summary>
+        /// References here map to net40 RTM
+        /// </summary>
         public static class v4_0_30319
         {
             private static readonly Lazy<PortableExecutableReference> s_mscorlib = new Lazy<PortableExecutableReference>(
-        () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_21006.mscorlib).GetReference(filePath: @"R:\v4_0_30319\mscorlib.dll"),
+        () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.mscorlib).GetReference(filePath: @"R:\v4_0_30319\mscorlib.dll"),
         LazyThreadSafetyMode.PublicationOnly);
             public static PortableExecutableReference mscorlib => s_mscorlib.Value;
 
@@ -212,10 +215,13 @@ public static class TestReferences
             public static PortableExecutableReference System_Runtime_Serialization => s_system_Runtime_Serialization.Value;
         }
 
-        public static class v4_0_30316_17626
+        /// <summary>
+        /// References here map to net45 beta.
+        /// </summary>
+        public static class v4_0_30319_17626
         {
             private static readonly Lazy<PortableExecutableReference> s_mscorlib = new Lazy<PortableExecutableReference>(
-        () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30316_17626.mscorlib).GetReference(display: @"mscorlib.v4_0_30319_17626.dll", filePath: @"Z:\FxReferenceAssembliesUri"),
+        () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319_17626.mscorlib).GetReference(display: @"mscorlib.v4_0_30319_17626.dll", filePath: @"Z:\FxReferenceAssembliesUri"),
         LazyThreadSafetyMode.PublicationOnly);
             public static PortableExecutableReference mscorlib => s_mscorlib.Value;
         }

--- a/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
+++ b/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
@@ -79,7 +79,7 @@ namespace Roslyn.Test.Utilities
         public static ImmutableArray<MetadataReference> StandardAndVBRuntimeReferences => CoreClrShim.IsRunningOnCoreClr ? NetStandard20References.Add(NetStandard20.MicrosoftVisualBasicRef) : Mscorlib46ExtendedReferences.Add(TestBase.MsvbRef_v4_0_30319_17929);
         public static ImmutableArray<MetadataReference> StandardCompatReferences => CoreClrShim.IsRunningOnCoreClr ? NetStandard20References : Mscorlib40References;
         public static ImmutableArray<MetadataReference> DefaultVbReferencs => ImmutableArray.Create(TestBase.MscorlibRef, TestBase.SystemRef, TestBase.SystemCoreRef, TestBase.MsvbRef);
- 
+
         public static ImmutableArray<MetadataReference> GetReferences(TargetFramework tf)
         {
             switch (tf)
@@ -114,15 +114,58 @@ namespace Roslyn.Test.Utilities
                 return references;
             }
 
-            foreach (var r in additionalReferences)
+            checkForDuplicateReferences();
+            return references.AddRange(additionalReferences);
+
+            void checkForDuplicateReferences()
             {
-                if (references.Contains(r))
+                var nameSet = new HashSet<string>(getNames(references), StringComparer.OrdinalIgnoreCase);
+                foreach (var r in additionalReferences)
                 {
-                    throw new Exception($"Duplicate reference detected {r.Display}");
+                    if (references.Contains(r))
+                    {
+                        throw new Exception($"Duplicate reference detected {r.Display}");
+                    }
+
+                    var name = getName(r);
+                    if (name != null && !nameSet.Add(name))
+                    {
+                        throw new Exception($"Duplicate reference detected {r.Display} - {name}");
+                    }
                 }
             }
 
-            return references.AddRange(additionalReferences);
+            IEnumerable<string> getNames(IEnumerable<MetadataReference> e) 
+            {
+                foreach (var r in e)
+                {
+                    var name = getName(r);
+                    if (name != null)
+                    {
+                        yield return name;
+                    }
+                }
+            }
+
+            string getName(MetadataReference m)
+            {
+                if (m is PortableExecutableReference p &&
+                    p.GetMetadata() is AssemblyMetadata assemblyMetadata)
+                {
+                    try
+                    {
+                        var identity = assemblyMetadata.GetAssembly().Identity;
+                        return identity?.Name;
+                    }
+                    catch (BadImageFormatException)
+                    {
+                        // Happens when a native image is incorrectly passed as a PE.
+                        return null;
+                    }
+                }
+
+                return null;
+            }
         }
     }
 }

--- a/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
+++ b/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
@@ -117,6 +117,9 @@ namespace Roslyn.Test.Utilities
             checkForDuplicateReferences();
             return references.AddRange(additionalReferences);
 
+            // Check to see if there are any duplicate references. This guards against tests inadvertently passing multiple copies of 
+            // say System.Core to the tests and implicitly depending on the higher one to win. The few tests which actually mean to 
+            // pass multiple verisons of a DLL should manually construct the reference list and not use this helper.
             void checkForDuplicateReferences()
             {
                 var nameSet = new HashSet<string>(getNames(references), StringComparer.OrdinalIgnoreCase);

--- a/src/Test/Utilities/Portable/TestBase.cs
+++ b/src/Test/Utilities/Portable/TestBase.cs
@@ -109,7 +109,7 @@ namespace Roslyn.Test.Utilities
                 //Not mentioned in the adapter doc but pointed to from System.Runtime, so we'll put it here.
                 var system = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.System).GetReference(display: "System.dll");
 
-                var mscor = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30316_17626.mscorlib).GetReference(display: "mscorlib");
+                var mscor = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319_17626.mscorlib).GetReference(display: "mscorlib");
 
                 return new MetadataReference[] { winmd, windowsruntime, runtime, objectModel, uixaml, interop, system, mscor };
             },
@@ -208,7 +208,7 @@ namespace Roslyn.Test.Utilities
             LazyThreadSafetyMode.PublicationOnly);
         public static MetadataReference MscorlibRef_v20 => s_mscorlibRef_v20.Value;
 
-        public static MetadataReference MscorlibRef_v4_0_30316_17626 => TestReferences.NetFx.v4_0_30316_17626.mscorlib;
+        public static MetadataReference MscorlibRef_v4_0_30316_17626 => TestReferences.NetFx.v4_0_30319_17626.mscorlib;
 
         private static readonly Lazy<MetadataReference> s_mscorlibRef_v46 = new Lazy<MetadataReference>(
             () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_6_1038_0.mscorlib).GetReference(display: "mscorlib.v4_6_1038_0.dll", filePath: @"Z:\FxReferenceAssembliesUri"),

--- a/src/Test/Utilities/Portable/TestBase.cs
+++ b/src/Test/Utilities/Portable/TestBase.cs
@@ -125,11 +125,6 @@ namespace Roslyn.Test.Utilities
         public static MetadataReference[] PortableRefsMinimal => s_portableRefsMinimal.Value;
 
         /// <summary>
-        /// Reference to an assembly that defines Expression Trees.
-        /// </summary>
-        public static MetadataReference ExpressionAssemblyRef => SystemCoreRef_v46;
-
-        /// <summary>
         /// Reference to an assembly that defines LINQ operators.
         /// </summary>
         public static MetadataReference LinqAssemblyRef => SystemCoreRef;


### PR DESCRIPTION
This updates the compilation test helpers to detect when duplicate references are passed to it. For instance two versions of mscorlib, System.Core, etc ... Most of this change is fixing up the ~600 places where we incorrectly passed duplicate references. The handful of places where we deliberately passed duplicates were updated to use the correct helpers. 