### PR TITLE
Allow passing in a workspace for a ContainedLanguage

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
@@ -44,14 +44,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             uint itemid,
             TLanguageService languageService,
             SourceCodeKind sourceCodeKind,
-            IFormattingRule vbHelperFormattingRule = null)
+            IFormattingRule vbHelperFormattingRule = null,
+            Workspace workspace = null)
             : base(project)
         {
             this.BufferCoordinator = bufferCoordinator;
             this.ComponentModel = componentModel;
             _languageService = languageService;
 
-            this.Workspace = componentModel.GetService<VisualStudioWorkspace>();
+            this.Workspace = workspace ?? componentModel.GetService<VisualStudioWorkspace>();
 
             _editorAdaptersFactoryService = componentModel.GetService<IVsEditorAdaptersFactoryService>();
             _diagnosticAnalyzerService = componentModel.GetService<IDiagnosticAnalyzerService>();


### PR DESCRIPTION
### Customer scenario
When a Razor file is opened in a Live Share guest session, we currently don't populate the roslyn workspace and hence don't get language services. This change makes it so that we can pass in the remote workspace to make it possible to get language services in a cshtml file.

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

None

### Risk

Low
### Performance impact

Low - doesn't change code for mainline scenarios.

### Is this a regression from a previous update?
No

### How was the bug found?

Part of Live Share work.
