### PR TITLE
Csc/Vbc Tasks should log stderr as error

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -34,6 +34,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         public ManagedCompiler()
         {
             TaskResources = ErrorString.ResourceManager;
+
+            // If there is a crash, the runtime error is output to stderr and
+            // we want MSBuild to print it out regardless of verbosity.
             LogStandardErrorAsError = true;
         }
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         public ManagedCompiler()
         {
             TaskResources = ErrorString.ResourceManager;
+            LogStandardErrorAsError = true;
         }
 
         #region Properties


### PR DESCRIPTION
@nguerrera Would you have some tips for setting up a CLI with a custom-build version of Roslyn, so that I can validate the fix?

### Customer scenario
If you build a CLI project that causes the compiler to crash (for instance, stackoverflow on a very deep fluent expression, or any other crash), you get an error code, but not error message or stacktrace.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/27248
Fixes https://github.com/Microsoft/msbuild/issues/3054

### Workarounds, if any
It is possible to recover the details of the failure with the following steps;
1. run the problematic `build` command, but add the option for binary logging `/bl` (for example, `dotnet build /bl`)
2. assuming this reproduced the issue, open the `msbuild.binlog` file with the [binary log viewer](https://github.com/KirillOsenkov/MSBuildStructuredLog).
3. the log viewer should show the failed `Csc` task (as shown below)
4. you can view and copy the command-line arguments to a text file `repro.rsp`, removing the first two chunks (the first one for "dotnet.exe" and the second one for "csc.dll")
5. re-use those two chunks to run `dotnet.exe csc.dll @repro.rsp`
6. this should repro, but also print out the compiler diagnostics

![image](https://user-images.githubusercontent.com/12466233/36326802-42886daa-1311-11e8-87bd-14c52067fcb9.png)

### Risk
### Performance impact
Low. We're just setting an option for how the MSBuild ToolTask reports on outputs to `stderr`. The compiler doesn't normally output to `stderr`.

### Is this a regression from a previous update?
No.

### How was the bug found?
Reported by customers.

Tagging @rainersigwald  @jaredpar