### PR TITLE
Use ValueTask in DisposeAsync and WaitForNextAsync

### DIFF
--- a/build/Targets/Tools.props
+++ b/build/Targets/Tools.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <dotnetRuntimeVersion>2.0.0</dotnetRuntimeVersion>
+    <dotnetRuntimeVersion>2.0.7</dotnetRuntimeVersion>
 
     <!--
         When changing this value ensure that you do not exceed the LKG used by source build. This is necessary

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -504,7 +504,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool GetAwaitDisposeAsyncInfo(ref ForEachEnumeratorInfo.Builder builder, DiagnosticBag diagnostics)
         {
             bool hasErrors = false;
-            BoundExpression placeholder = new BoundAwaitableValuePlaceholder(_syntax.Expression, Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task));
+            BoundExpression placeholder = new BoundAwaitableValuePlaceholder(_syntax.Expression, Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_ValueTask));
             builder.DisposeAwaitableInfo = BindAwaitInfo(placeholder, _syntax.Expression, _syntax.AwaitKeyword.GetLocation(), diagnostics, ref hasErrors);
             return hasErrors;
         }

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -1155,9 +1155,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var returnType = waitForNextAsyncMethodCandidate.OriginalDefinition.ReturnType;
-            if (!returnType.OriginalDefinition.Equals(Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T)))
+            if (!returnType.IsGenericTaskType(Compilation))
             {
-                // PROTOTYPE(async-streams) What about a task-like type?
+                // PROTOTYPE(async-streams): Add tests for other task-like return types for WaitForNextAsync
                 return false;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (hasAwait)
             {
-                TypeSymbol taskType = this.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
+                TypeSymbol taskType = this.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_ValueTask);
                 hasErrors |= ReportUseSiteDiagnostics(taskType, diagnostics, _syntax.AwaitKeyword);
 
                 var resource = (SyntaxNode)expressionSyntax ?? declarationSyntax;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncDisposableTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncDisposableTests.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -11,12 +14,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     [CompilerTrait(CompilerFeature.AsyncStreams)]
     public class CodeGenAsyncDisposableTests : CSharpTestBase
     {
+        public static CSharpCompilation CreateCompilationWithTasksExtensions(
+            CSharpTestSource source,
+            IEnumerable<MetadataReference> references = null,
+            CSharpCompilationOptions options = null,
+            CSharpParseOptions parseOptions = null,
+            TargetFramework targetFramework = TargetFramework.Standard,
+            string assemblyName = "",
+            string sourceFileName = "")
+            => CreateCompilation(source,
+                (references ?? ImmutableArray<MetadataReference>.Empty).Concat( new[] { TestReferences.NetStandard20.TasksExtensionsRef, TestReferences.NetStandard20.UnsafeRef }),
+                options, parseOptions, targetFramework, assemblyName, sourceFileName);
+
         private static readonly string s_interfaces = @"
 namespace System
 {
     public interface IAsyncDisposable
     {
-        System.Threading.Tasks.Task DisposeAsync();
+        System.Threading.Tasks.ValueTask DisposeAsync();
     }
 }
 ";
@@ -33,13 +48,13 @@ class C : System.IAsyncDisposable
         {
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         throw null;
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, parseOptions: TestOptions.Regular7_1);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, parseOptions: TestOptions.Regular7_1);
             comp.VerifyDiagnostics(
                 // (6,15): error CS8302: Feature 'async streams' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         using await (var x = new C())
@@ -61,13 +76,13 @@ class C : System.IAsyncDisposable
             return;
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         throw null;
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics(
                 // (6,15): error CS4033: The 'await' operator can only be used within an async method. Consider marking this method with the 'async' modifier and changing its return type to 'Task'.
                 //         using await (var x = new C())
@@ -88,13 +103,13 @@ class C : System.IAsyncDisposable
             return 1;
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         throw null;
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics(
                 // (6,15): error CS4032: The 'await' operator can only be used within an async method. Consider marking this method with the 'async' modifier and changing its return type to 'Task<int>'.
                 //         using await (var x = new C())
@@ -118,17 +133,43 @@ class C : System.IAsyncDisposable
             }
         };
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         throw null;
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics(
                 // (8,19): error CS4034: The 'await' operator can only be used within an async lambda expression. Consider marking this lambda expression with the 'async' modifier.
                 //             using await (var y = new C())
                 Diagnostic(ErrorCode.ERR_BadAwaitWithoutAsyncLambda, "await").WithArguments("lambda expression").WithLocation(8, 19)
+                );
+        }
+
+        [Fact]
+        public void TestWithTaskReturningDisposeAsync()
+        {
+            string source = @"
+using System.Threading.Tasks;
+class C : System.IAsyncDisposable
+{
+    public static async Task Main()
+    {
+        using await (var y = new C()) { }
+    }
+    public async Task DisposeAsync() { }
+}
+";
+            // PROTOTYPE(async-streams): The second diagnostic is unexpected
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (3,11): error CS0738: 'C' does not implement interface member 'IAsyncDisposable.DisposeAsync()'. 'C.DisposeAsync()' cannot implement 'IAsyncDisposable.DisposeAsync()' because it does not have the matching return type of 'ValueTask'.
+                // class C : System.IAsyncDisposable
+                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberWrongReturnType, "System.IAsyncDisposable").WithArguments("C", "System.IAsyncDisposable.DisposeAsync()", "C.DisposeAsync()", "System.Threading.Tasks.ValueTask").WithLocation(3, 11),
+                // (9,23): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     public async Task DisposeAsync() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "DisposeAsync").WithLocation(9, 23)
                 );
         }
 
@@ -155,7 +196,7 @@ class C : System.IAsyncDisposable
         };
         await x();
     }
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         System.Console.Write(""DisposeAsync1 "");
         await Task.Delay(10);
@@ -163,9 +204,9 @@ class C : System.IAsyncDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "C body DisposeAsync1 DisposeAsync2 end");
+            CompileAndVerify(comp, expectedOutput: "C body DisposeAsync1 DisposeAsync2 end", verify: Verification.Fails);
         }
 
         [Fact]
@@ -184,13 +225,13 @@ class C : System.IAsyncDisposable
             }
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         throw null;
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (8,19): error CS4004: Cannot await in an unsafe context
                 //             using await (var x = new C())
@@ -214,13 +255,13 @@ class C : System.IAsyncDisposable
             }
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         throw null;
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics(
                 // (8,19): error CS1996: Cannot await in the body of a lock statement
                 //             using await (var x = new C())
@@ -241,13 +282,13 @@ class C : System.IAsyncDisposable
         }
     }
     [System.Obsolete]
-    public async System.Threading.Tasks.Task DisposeAsync()
+    public async System.Threading.Tasks.ValueTask DisposeAsync()
     {
         await System.Threading.Tasks.Task.Delay(10);
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             // PROTOTYPE(async-streams) Confirm whether this behavior is ok (currently matching behavior of obsolete Dispose in non-async using)
         }
@@ -270,7 +311,7 @@ class C : System.IDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics();
         }
 
@@ -296,7 +337,7 @@ class C : System.IAsyncDisposable
             System.Console.Write(""end"");
         }
     }
-    public async System.Threading.Tasks.Task DisposeAsync()
+    public async System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write($""dispose_start "");
         await System.Threading.Tasks.Task.Delay(10);
@@ -304,9 +345,9 @@ class C : System.IAsyncDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "try using dispose_start dispose_end end");
+            CompileAndVerify(comp, expectedOutput: "try using dispose_start dispose_end end", verify: Verification.Fails);
         }
 
         [Fact]
@@ -335,7 +376,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics(
                 // (4,53): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     public static async System.Threading.Tasks.Task Main()
@@ -378,7 +419,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics(
                 // (17,43): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //         async System.Threading.Tasks.Task local()
@@ -411,7 +452,7 @@ class C : System.IAsyncDisposable
         System.Console.Write(""return"");
         return 1;
     }
-    public async System.Threading.Tasks.Task DisposeAsync()
+    public async System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write($""dispose_start "");
         await System.Threading.Tasks.Task.Delay(10);
@@ -419,9 +460,9 @@ class C : System.IAsyncDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
+            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return", verify: Verification.Fails);
         }
 
         [Fact]
@@ -446,9 +487,9 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "before after");
+            CompileAndVerify(comp, expectedOutput: "before after", verify: Verification.Fails);
         }
 
         [Fact]
@@ -469,7 +510,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source);
+            var comp = CreateCompilationWithTasksExtensions(source);
             comp.VerifyDiagnostics(
                 // (6,15): error CS0518: Predefined type 'System.IAsyncDisposable' is not defined or imported
                 //         using await (new C())
@@ -487,7 +528,7 @@ class C
         }
 
         [Fact]
-        public void TestMissingIAsyncDisposableAndMissingTaskAndMissingAsync()
+        public void TestMissingIAsyncDisposableAndMissingValueTaskAndMissingAsync()
         {
             string source = @"
 class C
@@ -505,7 +546,7 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib46(source);
-            comp.MakeTypeMissing(WellKnownType.System_Threading_Tasks_Task);
+            comp.MakeTypeMissing(WellKnownType.System_Threading_Tasks_ValueTask);
             comp.VerifyDiagnostics(
                 // (6,15): error CS0518: Predefined type 'System.IAsyncDisposable' is not defined or imported
                 //         using await (new C())
@@ -513,9 +554,9 @@ class C
                 // (6,22): error CS9000: 'C': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'
                 //         using await (new C())
                 Diagnostic(ErrorCode.ERR_NoConvToIAsyncDisp, "new C()").WithArguments("C").WithLocation(6, 22),
-                // (6,15): error CS0518: Predefined type 'System.Threading.Tasks.Task' is not defined or imported
+                // (6,15): error CS0518: Predefined type 'System.Threading.Tasks.ValueTask' is not defined or imported
                 //         using await (new C())
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.Threading.Tasks.Task").WithLocation(6, 15),
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.Threading.Tasks.ValueTask").WithLocation(6, 15),
                 // (6,15): error CS4032: The 'await' operator can only be used within an async method. Consider marking this method with the 'async' modifier and changing its return type to 'Task<Task<int>>'.
                 //         using await (new C())
                 Diagnostic(ErrorCode.ERR_BadAwaitWithoutAsyncMethod, "await").WithArguments("System.Threading.Tasks.Task<int>").WithLocation(6, 15),
@@ -525,9 +566,9 @@ class C
                 // (9,22): error CS9000: 'C': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'
                 //         using await (var x = new C())
                 Diagnostic(ErrorCode.ERR_NoConvToIAsyncDisp, "var x = new C()").WithArguments("C").WithLocation(9, 22),
-                // (9,15): error CS0518: Predefined type 'System.Threading.Tasks.Task' is not defined or imported
+                // (9,15): error CS0518: Predefined type 'System.Threading.Tasks.ValueTask' is not defined or imported
                 //         using await (var x = new C())
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.Threading.Tasks.Task").WithLocation(9, 15),
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.Threading.Tasks.ValueTask").WithLocation(9, 15),
                 // (9,15): error CS4032: The 'await' operator can only be used within an async method. Consider marking this method with the 'async' modifier and changing its return type to 'Task<Task<int>>'.
                 //         using await (var x = new C())
                 Diagnostic(ErrorCode.ERR_BadAwaitWithoutAsyncMethod, "await").WithArguments("System.Threading.Tasks.Task<int>").WithLocation(9, 15),
@@ -593,7 +634,7 @@ class C : System.IAsyncDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source);
+            var comp = CreateCompilationWithTasksExtensions(source);
             comp.VerifyDiagnostics();
             comp.VerifyEmitDiagnostics(
                 // (13,15): error CS0656: Missing compiler required member 'System.IAsyncDisposable.DisposeAsync'
@@ -622,7 +663,7 @@ class C : System.IDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source);
+            var comp = CreateCompilationWithTasksExtensions(source);
             comp.MakeMemberMissing(SpecialMember.System_IDisposable__Dispose);
             comp.VerifyEmitDiagnostics(
                 // (6,9): error CS0656: Missing compiler required member 'System.IDisposable.Dispose'
@@ -658,7 +699,7 @@ class C : System.IAsyncDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source);
+            var comp = CreateCompilationWithTasksExtensions(source);
             comp.VerifyDiagnostics();
             comp.VerifyEmitDiagnostics(
                 // (13,15): error CS0656: Missing compiler required member 'System.IAsyncDisposable.DisposeAsync'
@@ -676,10 +717,10 @@ class C : System.IAsyncDisposable
             string lib_cs = @"
 public class Base : System.IAsyncDisposable
 {
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write(""DisposeAsync"");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
 }
 ";
@@ -697,13 +738,13 @@ public class C : Base
     }
 }
 ";
-            var libComp = CreateCompilationWithMscorlib46(lib_cs + s_interfaces);
-            var comp = CreateCompilationWithMscorlib46(comp_cs, references: new[] { libComp.EmitToImageReference() }, options: TestOptions.DebugExe);
-            comp.MakeTypeMissing(WellKnownType.System_Threading_Tasks_Task);
+            var libComp = CreateCompilationWithTasksExtensions(lib_cs + s_interfaces);
+            var comp = CreateCompilationWithTasksExtensions(comp_cs, references: new[] { libComp.EmitToImageReference() }, options: TestOptions.DebugExe);
+            comp.MakeTypeMissing(WellKnownType.System_Threading_Tasks_ValueTask);
             comp.VerifyDiagnostics(
-                // (6,15): error CS0518: Predefined type 'System.Threading.Tasks.Task' is not defined or imported
+                // (6,15): error CS0518: Predefined type 'System.Threading.Tasks.ValueTask' is not defined or imported
                 //         using await (var x = new C())
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.Threading.Tasks.Task").WithLocation(6, 15)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.Threading.Tasks.ValueTask").WithLocation(6, 15)
                 );
         }
 
@@ -721,10 +762,10 @@ class C : System.IAsyncDisposable, System.IDisposable
             return 1;
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write(""DisposeAsync"");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
     public void Dispose()
     {
@@ -732,9 +773,9 @@ class C : System.IAsyncDisposable, System.IDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
+            CompileAndVerify(comp, expectedOutput: "body DisposeAsync", verify: Verification.Fails);
         }
 
         [Fact]
@@ -751,10 +792,10 @@ class C : System.IAsyncDisposable, System.IDisposable
             return 1;
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write(""IGNORED"");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
     public void Dispose()
     {
@@ -762,9 +803,9 @@ class C : System.IAsyncDisposable, System.IDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "body Dispose");
+            CompileAndVerify(comp, expectedOutput: "body Dispose", verify: Verification.Fails);
         }
 
         [Fact]
@@ -782,16 +823,16 @@ class C : System.IAsyncDisposable
         System.Console.Write(""end "");
         return 1;
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write(""DisposeAsync "");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe, references: new[] { SystemCoreRef, CSharpRef });
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe, references: new[] { CSharpRef });
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "body DisposeAsync end");
+            CompileAndVerify(comp, expectedOutput: "body DisposeAsync end", verify: Verification.Fails);
         }
 
         [Fact]
@@ -808,26 +849,27 @@ class C : System.IAsyncDisposable
             return;
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write(""DisposeAsync"");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
+            var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync", verify: Verification.Fails);
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      302 (0x12e)
+  // Code size      306 (0x132)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
-                System.Runtime.CompilerServices.TaskAwaiter V_2,
-                C.<Main>d__0 V_3,
-                System.Exception V_4,
-                int V_5)
+                System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
+                System.Threading.Tasks.ValueTask V_3,
+                C.<Main>d__0 V_4,
+                System.Exception V_5,
+                int V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<Main>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -836,7 +878,7 @@ class C : System.IAsyncDisposable
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_0011
-    IL_000c:  br         IL_0095
+    IL_000c:  br         IL_0099
     IL_0011:  nop
     IL_0012:  ldarg.0
     IL_0013:  newobj     ""C..ctor()""
@@ -869,99 +911,101 @@ class C : System.IAsyncDisposable
     }
     IL_004c:  ldarg.0
     IL_004d:  ldfld      ""C C.<Main>d__0.<>s__1""
-    IL_0052:  brfalse.s  IL_00b9
+    IL_0052:  brfalse.s  IL_00bd
     IL_0054:  ldarg.0
     IL_0055:  ldfld      ""C C.<Main>d__0.<>s__1""
-    IL_005a:  callvirt   ""System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()""
-    IL_005f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-    IL_0064:  stloc.2
-    IL_0065:  ldloca.s   V_2
-    IL_0067:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-    IL_006c:  brtrue.s   IL_00b1
-    IL_006e:  ldarg.0
-    IL_006f:  ldc.i4.0
-    IL_0070:  dup
-    IL_0071:  stloc.0
-    IL_0072:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_0077:  ldarg.0
-    IL_0078:  ldloc.2
-    IL_0079:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<Main>d__0.<>u__1""
-    IL_007e:  ldarg.0
-    IL_007f:  stloc.3
-    IL_0080:  ldarg.0
-    IL_0081:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0086:  ldloca.s   V_2
-    IL_0088:  ldloca.s   V_3
-    IL_008a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<Main>d__0)""
-    IL_008f:  nop
-    IL_0090:  leave      IL_012d
-    IL_0095:  ldarg.0
-    IL_0096:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<Main>d__0.<>u__1""
-    IL_009b:  stloc.2
-    IL_009c:  ldarg.0
-    IL_009d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<Main>d__0.<>u__1""
-    IL_00a2:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_00a8:  ldarg.0
-    IL_00a9:  ldc.i4.m1
-    IL_00aa:  dup
-    IL_00ab:  stloc.0
-    IL_00ac:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00b1:  ldloca.s   V_2
-    IL_00b3:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_00b8:  nop
-    IL_00b9:  ldarg.0
-    IL_00ba:  ldfld      ""object C.<Main>d__0.<>s__2""
-    IL_00bf:  stloc.1
-    IL_00c0:  ldloc.1
-    IL_00c1:  brfalse.s  IL_00de
-    IL_00c3:  ldloc.1
-    IL_00c4:  isinst     ""System.Exception""
-    IL_00c9:  stloc.s    V_4
-    IL_00cb:  ldloc.s    V_4
-    IL_00cd:  brtrue.s   IL_00d1
-    IL_00cf:  ldloc.1
-    IL_00d0:  throw
-    IL_00d1:  ldloc.s    V_4
-    IL_00d3:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_00d8:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_00dd:  nop
-    IL_00de:  ldarg.0
-    IL_00df:  ldfld      ""int C.<Main>d__0.<>s__3""
-    IL_00e4:  stloc.s    V_5
-    IL_00e6:  ldloc.s    V_5
-    IL_00e8:  ldc.i4.1
-    IL_00e9:  beq.s      IL_00ed
-    IL_00eb:  br.s       IL_00ef
-    IL_00ed:  leave.s    IL_0119
-    IL_00ef:  ldarg.0
-    IL_00f0:  ldnull
-    IL_00f1:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_00f6:  ldarg.0
-    IL_00f7:  ldnull
-    IL_00f8:  stfld      ""C C.<Main>d__0.<>s__1""
-    IL_00fd:  leave.s    IL_0119
+    IL_005a:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
+    IL_005f:  stloc.3
+    IL_0060:  ldloca.s   V_3
+    IL_0062:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_0067:  stloc.2
+    IL_0068:  ldloca.s   V_2
+    IL_006a:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_006f:  brtrue.s   IL_00b5
+    IL_0071:  ldarg.0
+    IL_0072:  ldc.i4.0
+    IL_0073:  dup
+    IL_0074:  stloc.0
+    IL_0075:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_007a:  ldarg.0
+    IL_007b:  ldloc.2
+    IL_007c:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
+    IL_0081:  ldarg.0
+    IL_0082:  stloc.s    V_4
+    IL_0084:  ldarg.0
+    IL_0085:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_008a:  ldloca.s   V_2
+    IL_008c:  ldloca.s   V_4
+    IL_008e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
+    IL_0093:  nop
+    IL_0094:  leave      IL_0131
+    IL_0099:  ldarg.0
+    IL_009a:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
+    IL_009f:  stloc.2
+    IL_00a0:  ldarg.0
+    IL_00a1:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
+    IL_00a6:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_00ac:  ldarg.0
+    IL_00ad:  ldc.i4.m1
+    IL_00ae:  dup
+    IL_00af:  stloc.0
+    IL_00b0:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00b5:  ldloca.s   V_2
+    IL_00b7:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_00bc:  nop
+    IL_00bd:  ldarg.0
+    IL_00be:  ldfld      ""object C.<Main>d__0.<>s__2""
+    IL_00c3:  stloc.1
+    IL_00c4:  ldloc.1
+    IL_00c5:  brfalse.s  IL_00e2
+    IL_00c7:  ldloc.1
+    IL_00c8:  isinst     ""System.Exception""
+    IL_00cd:  stloc.s    V_5
+    IL_00cf:  ldloc.s    V_5
+    IL_00d1:  brtrue.s   IL_00d5
+    IL_00d3:  ldloc.1
+    IL_00d4:  throw
+    IL_00d5:  ldloc.s    V_5
+    IL_00d7:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_00dc:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_00e1:  nop
+    IL_00e2:  ldarg.0
+    IL_00e3:  ldfld      ""int C.<Main>d__0.<>s__3""
+    IL_00e8:  stloc.s    V_6
+    IL_00ea:  ldloc.s    V_6
+    IL_00ec:  ldc.i4.1
+    IL_00ed:  beq.s      IL_00f1
+    IL_00ef:  br.s       IL_00f3
+    IL_00f1:  leave.s    IL_011d
+    IL_00f3:  ldarg.0
+    IL_00f4:  ldnull
+    IL_00f5:  stfld      ""object C.<Main>d__0.<>s__2""
+    IL_00fa:  ldarg.0
+    IL_00fb:  ldnull
+    IL_00fc:  stfld      ""C C.<Main>d__0.<>s__1""
+    IL_0101:  leave.s    IL_011d
   }
   catch System.Exception
   {
-    IL_00ff:  stloc.s    V_4
-    IL_0101:  ldarg.0
-    IL_0102:  ldc.i4.s   -2
-    IL_0104:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_0109:  ldarg.0
-    IL_010a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_010f:  ldloc.s    V_4
-    IL_0111:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0116:  nop
-    IL_0117:  leave.s    IL_012d
+    IL_0103:  stloc.s    V_5
+    IL_0105:  ldarg.0
+    IL_0106:  ldc.i4.s   -2
+    IL_0108:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_010d:  ldarg.0
+    IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_0113:  ldloc.s    V_5
+    IL_0115:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_011a:  nop
+    IL_011b:  leave.s    IL_0131
   }
-  IL_0119:  ldarg.0
-  IL_011a:  ldc.i4.s   -2
-  IL_011c:  stfld      ""int C.<Main>d__0.<>1__state""
-  IL_0121:  ldarg.0
-  IL_0122:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_0127:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_012c:  nop
-  IL_012d:  ret
+  IL_011d:  ldarg.0
+  IL_011e:  ldc.i4.s   -2
+  IL_0120:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_0125:  ldarg.0
+  IL_0126:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_012b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0130:  nop
+  IL_0131:  ret
 }");
         }
 
@@ -981,9 +1025,9 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "body");
+            var verifier = CompileAndVerify(comp, expectedOutput: "body", verify: Verification.Fails);
         }
 
         [Fact]
@@ -1000,7 +1044,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics(
                 // (6,22): error CS9000: 'method group': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'
                 //         using await (Main)
@@ -1023,16 +1067,16 @@ class C : System.IAsyncDisposable
             return;
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write(""DisposeAsync"");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe, references: new[] { SystemCoreRef, CSharpRef });
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe, references: new[] { CSharpRef });
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
+            CompileAndVerify(comp, expectedOutput: "body DisposeAsync", verify: Verification.Fails);
         }
 
         [Fact]
@@ -1049,26 +1093,27 @@ struct S : System.IAsyncDisposable
             return;
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write(""DisposeAsync"");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
+            var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync", verify: Verification.Fails);
             verifier.VerifyIL("S.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      294 (0x126)
+  // Code size      298 (0x12a)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
-                System.Runtime.CompilerServices.TaskAwaiter V_2,
-                S.<Main>d__0 V_3,
-                System.Exception V_4,
-                int V_5)
+                System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
+                System.Threading.Tasks.ValueTask V_3,
+                S.<Main>d__0 V_4,
+                System.Exception V_5,
+                int V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int S.<Main>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1077,7 +1122,7 @@ struct S : System.IAsyncDisposable
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_0011
-    IL_000c:  br         IL_0094
+    IL_000c:  br         IL_0098
     IL_0011:  nop
     IL_0012:  ldarg.0
     IL_0013:  ldflda     ""S S.<Main>d__0.<>s__1""
@@ -1111,93 +1156,95 @@ struct S : System.IAsyncDisposable
     IL_004d:  ldarg.0
     IL_004e:  ldflda     ""S S.<Main>d__0.<>s__1""
     IL_0053:  constrained. ""S""
-    IL_0059:  callvirt   ""System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()""
-    IL_005e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-    IL_0063:  stloc.2
-    IL_0064:  ldloca.s   V_2
-    IL_0066:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-    IL_006b:  brtrue.s   IL_00b0
-    IL_006d:  ldarg.0
-    IL_006e:  ldc.i4.0
-    IL_006f:  dup
-    IL_0070:  stloc.0
-    IL_0071:  stfld      ""int S.<Main>d__0.<>1__state""
-    IL_0076:  ldarg.0
-    IL_0077:  ldloc.2
-    IL_0078:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter S.<Main>d__0.<>u__1""
-    IL_007d:  ldarg.0
-    IL_007e:  stloc.3
-    IL_007f:  ldarg.0
-    IL_0080:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-    IL_0085:  ldloca.s   V_2
-    IL_0087:  ldloca.s   V_3
-    IL_0089:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, S.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref S.<Main>d__0)""
-    IL_008e:  nop
-    IL_008f:  leave      IL_0125
-    IL_0094:  ldarg.0
-    IL_0095:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter S.<Main>d__0.<>u__1""
-    IL_009a:  stloc.2
-    IL_009b:  ldarg.0
-    IL_009c:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter S.<Main>d__0.<>u__1""
-    IL_00a1:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_00a7:  ldarg.0
-    IL_00a8:  ldc.i4.m1
-    IL_00a9:  dup
-    IL_00aa:  stloc.0
-    IL_00ab:  stfld      ""int S.<Main>d__0.<>1__state""
-    IL_00b0:  ldloca.s   V_2
-    IL_00b2:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_00b7:  nop
-    IL_00b8:  ldarg.0
-    IL_00b9:  ldfld      ""object S.<Main>d__0.<>s__2""
-    IL_00be:  stloc.1
-    IL_00bf:  ldloc.1
-    IL_00c0:  brfalse.s  IL_00dd
-    IL_00c2:  ldloc.1
-    IL_00c3:  isinst     ""System.Exception""
-    IL_00c8:  stloc.s    V_4
-    IL_00ca:  ldloc.s    V_4
-    IL_00cc:  brtrue.s   IL_00d0
-    IL_00ce:  ldloc.1
-    IL_00cf:  throw
-    IL_00d0:  ldloc.s    V_4
-    IL_00d2:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_00d7:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_00dc:  nop
-    IL_00dd:  ldarg.0
-    IL_00de:  ldfld      ""int S.<Main>d__0.<>s__3""
-    IL_00e3:  stloc.s    V_5
-    IL_00e5:  ldloc.s    V_5
-    IL_00e7:  ldc.i4.1
-    IL_00e8:  beq.s      IL_00ec
-    IL_00ea:  br.s       IL_00ee
-    IL_00ec:  leave.s    IL_0111
-    IL_00ee:  ldarg.0
-    IL_00ef:  ldnull
-    IL_00f0:  stfld      ""object S.<Main>d__0.<>s__2""
-    IL_00f5:  leave.s    IL_0111
+    IL_0059:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
+    IL_005e:  stloc.3
+    IL_005f:  ldloca.s   V_3
+    IL_0061:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_0066:  stloc.2
+    IL_0067:  ldloca.s   V_2
+    IL_0069:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_006e:  brtrue.s   IL_00b4
+    IL_0070:  ldarg.0
+    IL_0071:  ldc.i4.0
+    IL_0072:  dup
+    IL_0073:  stloc.0
+    IL_0074:  stfld      ""int S.<Main>d__0.<>1__state""
+    IL_0079:  ldarg.0
+    IL_007a:  ldloc.2
+    IL_007b:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
+    IL_0080:  ldarg.0
+    IL_0081:  stloc.s    V_4
+    IL_0083:  ldarg.0
+    IL_0084:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+    IL_0089:  ldloca.s   V_2
+    IL_008b:  ldloca.s   V_4
+    IL_008d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, S.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref S.<Main>d__0)""
+    IL_0092:  nop
+    IL_0093:  leave      IL_0129
+    IL_0098:  ldarg.0
+    IL_0099:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
+    IL_009e:  stloc.2
+    IL_009f:  ldarg.0
+    IL_00a0:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
+    IL_00a5:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_00ab:  ldarg.0
+    IL_00ac:  ldc.i4.m1
+    IL_00ad:  dup
+    IL_00ae:  stloc.0
+    IL_00af:  stfld      ""int S.<Main>d__0.<>1__state""
+    IL_00b4:  ldloca.s   V_2
+    IL_00b6:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_00bb:  nop
+    IL_00bc:  ldarg.0
+    IL_00bd:  ldfld      ""object S.<Main>d__0.<>s__2""
+    IL_00c2:  stloc.1
+    IL_00c3:  ldloc.1
+    IL_00c4:  brfalse.s  IL_00e1
+    IL_00c6:  ldloc.1
+    IL_00c7:  isinst     ""System.Exception""
+    IL_00cc:  stloc.s    V_5
+    IL_00ce:  ldloc.s    V_5
+    IL_00d0:  brtrue.s   IL_00d4
+    IL_00d2:  ldloc.1
+    IL_00d3:  throw
+    IL_00d4:  ldloc.s    V_5
+    IL_00d6:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_00db:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_00e0:  nop
+    IL_00e1:  ldarg.0
+    IL_00e2:  ldfld      ""int S.<Main>d__0.<>s__3""
+    IL_00e7:  stloc.s    V_6
+    IL_00e9:  ldloc.s    V_6
+    IL_00eb:  ldc.i4.1
+    IL_00ec:  beq.s      IL_00f0
+    IL_00ee:  br.s       IL_00f2
+    IL_00f0:  leave.s    IL_0115
+    IL_00f2:  ldarg.0
+    IL_00f3:  ldnull
+    IL_00f4:  stfld      ""object S.<Main>d__0.<>s__2""
+    IL_00f9:  leave.s    IL_0115
   }
   catch System.Exception
   {
-    IL_00f7:  stloc.s    V_4
-    IL_00f9:  ldarg.0
-    IL_00fa:  ldc.i4.s   -2
-    IL_00fc:  stfld      ""int S.<Main>d__0.<>1__state""
-    IL_0101:  ldarg.0
-    IL_0102:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-    IL_0107:  ldloc.s    V_4
-    IL_0109:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_010e:  nop
-    IL_010f:  leave.s    IL_0125
+    IL_00fb:  stloc.s    V_5
+    IL_00fd:  ldarg.0
+    IL_00fe:  ldc.i4.s   -2
+    IL_0100:  stfld      ""int S.<Main>d__0.<>1__state""
+    IL_0105:  ldarg.0
+    IL_0106:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+    IL_010b:  ldloc.s    V_5
+    IL_010d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0112:  nop
+    IL_0113:  leave.s    IL_0129
   }
-  IL_0111:  ldarg.0
-  IL_0112:  ldc.i4.s   -2
-  IL_0114:  stfld      ""int S.<Main>d__0.<>1__state""
-  IL_0119:  ldarg.0
-  IL_011a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-  IL_011f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0124:  nop
-  IL_0125:  ret
+  IL_0115:  ldarg.0
+  IL_0116:  ldc.i4.s   -2
+  IL_0118:  stfld      ""int S.<Main>d__0.<>1__state""
+  IL_011d:  ldarg.0
+  IL_011e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+  IL_0123:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0128:  nop
+  IL_0129:  ret
 }");
         }
 
@@ -1216,16 +1263,16 @@ struct S : System.IAsyncDisposable
             return;
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write(""DisposeAsync"");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
+            CompileAndVerify(comp, expectedOutput: "body DisposeAsync", verify: Verification.Fails);
         }
 
         [Fact]
@@ -1243,23 +1290,23 @@ struct S : System.IAsyncDisposable
             return;
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write(""NOT RELEVANT"");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "body");
+            var verifier = CompileAndVerify(comp, expectedOutput: "body", verify: Verification.Fails);
         }
 
         [Fact]
         [WorkItem(24267, "https://github.com/dotnet/roslyn/issues/24267")]
         public void AssignsInAsyncWithAsyncUsing()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilationWithTasksExtensions(@"
 class C
 {
     public static void M2()
@@ -1311,7 +1358,7 @@ class S : System.IAsyncDisposable
             return;
         }
     }
-    public async System.Threading.Tasks.Task DisposeAsync()
+    public async System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write($""dispose{_i}_start "");
         await System.Threading.Tasks.Task.Delay(10);
@@ -1319,9 +1366,9 @@ class S : System.IAsyncDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "ctor1 ctor2 body dispose2_start dispose2_end dispose1_start dispose1_end");
+            CompileAndVerify(comp, expectedOutput: "ctor1 ctor2 body dispose2_start dispose2_end dispose1_start dispose1_end", verify: Verification.Fails);
         }
 
         [Fact]
@@ -1351,16 +1398,16 @@ class S : System.IAsyncDisposable
             System.Console.Write(""caught"");
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write($""dispose{_i} "");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "ctor1 ctor2 body dispose2 dispose1 caught");
+            CompileAndVerify(comp, expectedOutput: "ctor1 ctor2 body dispose2 dispose1 caught", verify: Verification.Fails);
         }
 
         [Fact]
@@ -1396,16 +1443,16 @@ class S : System.IAsyncDisposable
             System.Console.Write(""caught"");
         }
     }
-    public System.Threading.Tasks.Task DisposeAsync()
+    public System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write($""dispose{_i} "");
-        return System.Threading.Tasks.Task.CompletedTask;
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source + s_interfaces, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "ctor1 ctor2 dispose1 caught");
+            CompileAndVerify(comp, expectedOutput: "ctor1 ctor2 dispose1 caught", verify: Verification.Fails);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncDisposableTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncDisposableTests.cs
@@ -14,35 +14,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     [CompilerTrait(CompilerFeature.AsyncStreams)]
     public class CodeGenAsyncDisposableTests : CSharpTestBase
     {
-        public static CSharpCompilation CreateCompilationWithTasksExtensions(
-            CSharpTestSource source,
-            IEnumerable<MetadataReference> references = null,
-            CSharpCompilationOptions options = null,
-            CSharpParseOptions parseOptions = null,
-            string assemblyName = "",
-            string sourceFileName = "")
-        {
-            IEnumerable<MetadataReference> allReferences = CoreClrShim.IsRunningOnCoreClr
-                ? TargetFrameworkUtil.NetStandard20References
-                : TargetFrameworkUtil.Mscorlib461ExtendedReferences.Add(TestReferences.Net461.netstandardRef);
-
-            allReferences = allReferences.Concat(new[] { TestReferences.NetStandard20.TasksExtensionsRef, TestReferences.NetStandard20.UnsafeRef });
-
-            if (references != null)
-            {
-                allReferences = allReferences.Concat(references);
-            }
-
-            return CreateCompilation(
-                source,
-                allReferences,
-                options,
-                parseOptions,
-                TargetFramework.Empty,
-                assemblyName,
-                sourceFileName);
-        }
-
         private static readonly string s_interfaces = @"
 namespace System
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncDisposableTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncDisposableTests.cs
@@ -149,7 +149,6 @@ class C : System.IAsyncDisposable
     public async Task DisposeAsync() { }
 }
 ";
-            // PROTOTYPE(async-streams): The second diagnostic is unexpected
             var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (3,11): error CS0738: 'C' does not implement interface member 'IAsyncDisposable.DisposeAsync()'. 'C.DisposeAsync()' cannot implement 'IAsyncDisposable.DisposeAsync()' because it does not have the matching return type of 'ValueTask'.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
@@ -18,18 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         {
         }
 
-        public static CSharpCompilation CreateCompilationWithTasksExtensions(
-            CSharpTestSource source,
-            IEnumerable<MetadataReference> references = null,
-            CSharpCompilationOptions options = null,
-            CSharpParseOptions parseOptions = null,
-            TargetFramework targetFramework = TargetFramework.Standard,
-            string assemblyName = "",
-            string sourceFileName = "")
-            => CreateCompilation(source,
-                (references ?? ImmutableArray<MetadataReference>.Empty).Concat( new[] { TestReferences.NetStandard20.TasksExtensionsRef, TestReferences.NetStandard20.UnsafeRef }),
-                options, parseOptions, targetFramework, assemblyName, sourceFileName);
-
         private static readonly string s_interfaces = @"
 namespace System.Collections.Generic
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
-            TargetFramework targetFramework = TargetFramework.NetStandard20,
+            TargetFramework targetFramework = TargetFramework.Standard,
             string assemblyName = "",
             string sourceFileName = "")
             => CreateCompilation(source,
@@ -48,13 +48,13 @@ namespace System
 {
     public interface IAsyncDisposable
     {
-        System.Threading.Tasks.Task DisposeAsync();
+        System.Threading.Tasks.ValueTask DisposeAsync();
     }
 }
 ";
 
         [Fact]
-        void TestWithMissingPattern()
+        public void TestWithMissingPattern()
         {
             string source = @"
 class C
@@ -76,7 +76,7 @@ class C
 
         // PROTOTYPE(async-streams): Regressed in merge
         [Fact(Skip = "Interaction with improved candidate resolution")]
-        void TestWithStaticGetEnumerator()
+        public void TestWithStaticGetEnumerator()
         {
             string source = @"
 class C
@@ -107,7 +107,7 @@ class C
         }
 
         [Fact]
-        void TestWithInaccessibleGetEnumerator()
+        public void TestWithInaccessibleGetEnumerator()
         {
             string source = @"
 class C
@@ -138,7 +138,7 @@ class C
         }
 
         [Fact]
-        void TestWithObsoletePatternMethods()
+        public void TestWithObsoletePatternMethods()
         {
             string source = @"
 class C
@@ -183,7 +183,7 @@ class C
         }
 
         [Fact]
-        void TestWithStaticWaitForNextAsync()
+        public void TestWithStaticWaitForNextAsync()
         {
             string source = @"
 class C
@@ -219,7 +219,7 @@ class C
         }
 
         [Fact]
-        void TestWithStaticTryGetNext()
+        public void TestWithStaticTryGetNext()
         {
             string source = @"
 class C
@@ -255,7 +255,7 @@ class C
         }
 
         [Fact]
-        void TestWithNonPublicWaitForNextAsync()
+        public void TestWithNonPublicWaitForNextAsync()
         {
             string source = @"
 class C
@@ -291,7 +291,7 @@ class C
         }
 
         [Fact]
-        void TestWithNonPublicTryGetNext()
+        public void TestWithNonPublicTryGetNext()
         {
             string source = @"
 class C
@@ -330,7 +330,7 @@ class C
         }
 
         [Fact]
-        void TestWaitForNextAsync_ReturnsTask()
+        public void TestWaitForNextAsync_ReturnsTask()
         {
             string source = @"
 class C
@@ -366,7 +366,7 @@ class C
         }
 
         [Fact]
-        void TestWaitForNextAsync_ReturnsTaskOfInt()
+        public void TestWaitForNextAsync_ReturnsTaskOfInt()
         {
             string source = @"
 class C
@@ -402,7 +402,7 @@ class C
         }
 
         [Fact]
-        void TestWaitForNextAsync_WithOptionalParameter()
+        public void TestWaitForNextAsync_WithOptionalParameter()
         {
             string source = @"
 class C
@@ -438,7 +438,7 @@ class C
         }
 
         [Fact]
-        void TestTryGetNext_WithOptionalParameter()
+        public void TestTryGetNext_WithOptionalParameter()
         {
             string source = @"
 class C
@@ -474,7 +474,7 @@ class C
         }
 
         [Fact]
-        void TestTryGetNext_WithByValParameter()
+        public void TestTryGetNext_WithByValParameter()
         {
             string source = @"
 class C
@@ -510,7 +510,7 @@ class C
         }
 
         [Fact]
-        void TestTryGetNext_WithIntParameter()
+        public void TestTryGetNext_WithIntParameter()
         {
             string source = @"
 class C
@@ -546,7 +546,7 @@ class C
         }
 
         [Fact]
-        void TestTryGetNext_WithVoidReturn()
+        public void TestTryGetNext_WithVoidReturn()
         {
             string source = @"
 class C
@@ -582,7 +582,7 @@ class C
         }
 
         [Fact]
-        void TestWithNonConvertibleElementType()
+        public void TestWithNonConvertibleElementType()
         {
             string source = @"
 class C
@@ -627,7 +627,7 @@ class C
         }
 
         [Fact]
-        void TestWithNonConvertibleElementType2()
+        public void TestWithNonConvertibleElementType2()
         {
             string source = @"
 using System.Threading.Tasks;
@@ -647,14 +647,14 @@ class C
             => throw null;
         public Task<bool> WaitForNextAsync()
             => throw null;
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
             => throw null;
     }
 }
 class Element
 {
 }";
-            var comp = CreateCompilationWithMscorlib46(source);
+            var comp = CreateCompilationWithTasksExtensions(source);
             comp.VerifyDiagnostics(
                 // (7,9): error CS0030: Cannot convert type 'int' to 'Element'
                 //         foreach await (Element i in new C())
@@ -663,7 +663,7 @@ class Element
         }
 
         [Fact]
-        void TestWithExplicitlyConvertibleElementType()
+        public void TestWithExplicitlyConvertibleElementType()
         {
             string source = @"
 using static System.Console;
@@ -697,7 +697,7 @@ class C
             bool more = await Task.FromResult(i < 30);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
             await Task.Delay(10);
@@ -714,13 +714,13 @@ class Element
             var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics( );
             // PROTOTYPE(async-streams) Convert(0) is here because we're converting the result even if TryGetNext returned false
-            CompileAndVerify(comp, expectedOutput: "NextAsync(0) Next(11) Convert(11) Got(11) Next(12) Convert(12) Got(12) "+
-                "Next(13) Convert(0) NextAsync(13) Next(24) Convert(24) Got(24) Next(25) Convert(25) Got(25) "+
+            CompileAndVerify(comp, expectedOutput: "NextAsync(0) Next(11) Convert(11) Got(11) Next(12) Convert(12) Got(12) " +
+                "Next(13) Convert(0) NextAsync(13) Next(24) Convert(24) Got(24) Next(25) Convert(25) Got(25) " +
                 "Next(26) Convert(0) NextAsync(26) Dispose(37)", verify: Verification.Skipped);
         }
 
         [Fact]
-        void TestWithIncompleteInterface()
+        public void TestWithIncompleteInterface()
         {
             string source = @"
 namespace System.Collections.Generic
@@ -747,7 +747,7 @@ class C
         }
 
         [Fact]
-        void TestWithIncompleteInterface2()
+        public void TestWithIncompleteInterface2()
         {
             string source = @"
 namespace System.Collections.Generic
@@ -783,7 +783,7 @@ class C
         }
 
         [Fact]
-        void TestWithIncompleteInterface3()
+        public void TestWithIncompleteInterface3()
         {
             string source = @"
 namespace System.Collections.Generic
@@ -819,7 +819,7 @@ class C
         }
 
         [Fact]
-        void TestGetAsyncEnumeratorPatternViaExtensions()
+        public void TestGetAsyncEnumeratorPatternViaExtensions()
         {
             string source = @"
 public class C
@@ -850,7 +850,7 @@ public static class Extensions
         }
 
         [Fact]
-        void TestGetEnumeratorPatternViaExtensions()
+        public void TestGetEnumeratorPatternViaExtensions()
         {
             string source = @"
 public class C
@@ -880,7 +880,7 @@ public static class Extensions
         }
 
         [Fact]
-        void TestWaitForNextAsyncPatternViaExtensions()
+        public void TestWaitForNextAsyncPatternViaExtensions()
         {
             string source = @"
 public class C
@@ -922,7 +922,7 @@ public static class Extensions
         }
 
         [Fact]
-        void TestTryGetNextPatternViaExtensions()
+        public void TestTryGetNextPatternViaExtensions()
         {
             string source = @"
 public class C
@@ -964,7 +964,7 @@ public static class Extensions
         }
 
         [Fact]
-        void TestMoveNextPatternViaExtensions()
+        public void TestMoveNextPatternViaExtensions()
         {
             string source = @"
 public class C
@@ -1003,7 +1003,7 @@ public static class Extensions
         }
 
         [Fact]
-        void TestWithSyncPattern()
+        public void TestWithSyncPattern()
         {
             string source = @"
 class C
@@ -1033,7 +1033,7 @@ class C
         }
 
         [Fact]
-        void TestRegularForeachWithAsyncPattern()
+        public void TestRegularForeachWithAsyncPattern()
         {
             string source = @"
 class C
@@ -1060,7 +1060,7 @@ class C
         }
 
         [Fact]
-        void TestRegularForeachWithAsyncInterface()
+        public void TestRegularForeachWithAsyncInterface()
         {
             string source = @"
 using System.Collections.Generic;
@@ -1082,7 +1082,7 @@ class C
         }
 
         [Fact]
-        void TestWithSyncInterfaceInRegularMethod()
+        public void TestWithSyncInterfaceInRegularMethod()
         {
             string source = @"
 using System.Collections.Generic;
@@ -1107,7 +1107,7 @@ class C
         }
 
         [Fact]
-        void TestWithPattern()
+        public void TestWithPattern()
         {
             string source = @"
 class C
@@ -1159,7 +1159,7 @@ class C
         }
 
         [Fact]
-        void TestWithPattern_WithStruct_SimpleImplementation()
+        public void TestWithPattern_WithStruct_SimpleImplementation()
         {
             string source = @"
 using static System.Console;
@@ -1196,10 +1196,10 @@ class C
             bool more = await Task.FromResult(i < 20);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await Task.Delay(10);
+            await new ValueTask(Task.Delay(10));
         }
     }
 }";
@@ -1212,7 +1212,7 @@ class C
         }
 
         [Fact]
-        void TestWithPattern_WithUnsealed()
+        public void TestWithPattern_WithUnsealed()
         {
             string source = @"
 using static System.Console;
@@ -1246,7 +1246,7 @@ public class C
             bool more = await Task.FromResult(i < 30);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -1271,7 +1271,7 @@ public class C
         }
 
         [Fact]
-        void TestWithPattern_WithUnsealed_WithIAsyncDisposable()
+        public void TestWithPattern_WithUnsealed_WithIAsyncDisposable()
         {
             string source = @"
 using static System.Console;
@@ -1308,7 +1308,7 @@ public class C
     }
     public class DerivedEnumerator : Enumerator, System.IAsyncDisposable
     {
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -1333,7 +1333,7 @@ public class C
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      480 (0x1e0)
+  // Code size      484 (0x1e4)
   .maxstack  3
   .locals init (int V_0,
                 bool V_1,
@@ -1341,8 +1341,9 @@ public class C
                 C.<Main>d__0 V_3,
                 object V_4,
                 System.IAsyncDisposable V_5,
-                System.Runtime.CompilerServices.TaskAwaiter V_6,
-                System.Exception V_7)
+                System.Runtime.CompilerServices.ValueTaskAwaiter V_6,
+                System.Threading.Tasks.ValueTask V_7,
+                System.Exception V_8)
   // sequence point: <hidden>
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<Main>d__0.<>1__state""
@@ -1358,7 +1359,7 @@ public class C
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
     IL_0012:  br.s       IL_0038
-    IL_0014:  br         IL_014c
+    IL_0014:  br         IL_0150
     // sequence point: {
     IL_0019:  nop
     IL_001a:  ldarg.0
@@ -1433,7 +1434,7 @@ public class C
       IL_00ad:  ldloca.s   V_3
       IL_00af:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
       IL_00b4:  nop
-      IL_00b5:  leave      IL_01df
+      IL_00b5:  leave      IL_01e3
       // async: resume
       IL_00ba:  ldarg.0
       IL_00bb:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
@@ -1471,106 +1472,108 @@ public class C
     IL_0102:  isinst     ""System.IAsyncDisposable""
     IL_0107:  stloc.s    V_5
     IL_0109:  ldloc.s    V_5
-    IL_010b:  brfalse.s  IL_0171
+    IL_010b:  brfalse.s  IL_0175
     IL_010d:  ldloc.s    V_5
-    IL_010f:  callvirt   ""System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()""
-    IL_0114:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-    IL_0119:  stloc.s    V_6
+    IL_010f:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
+    IL_0114:  stloc.s    V_7
+    IL_0116:  ldloca.s   V_7
+    IL_0118:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_011d:  stloc.s    V_6
     // sequence point: <hidden>
-    IL_011b:  ldloca.s   V_6
-    IL_011d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-    IL_0122:  brtrue.s   IL_0169
-    IL_0124:  ldarg.0
-    IL_0125:  ldc.i4.1
-    IL_0126:  dup
-    IL_0127:  stloc.0
-    IL_0128:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_011f:  ldloca.s   V_6
+    IL_0121:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_0126:  brtrue.s   IL_016d
+    IL_0128:  ldarg.0
+    IL_0129:  ldc.i4.1
+    IL_012a:  dup
+    IL_012b:  stloc.0
+    IL_012c:  stfld      ""int C.<Main>d__0.<>1__state""
     // async: yield
-    IL_012d:  ldarg.0
-    IL_012e:  ldloc.s    V_6
-    IL_0130:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0135:  ldarg.0
-    IL_0136:  stloc.3
-    IL_0137:  ldarg.0
-    IL_0138:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_013d:  ldloca.s   V_6
-    IL_013f:  ldloca.s   V_3
-    IL_0141:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<Main>d__0)""
-    IL_0146:  nop
-    IL_0147:  leave      IL_01df
+    IL_0131:  ldarg.0
+    IL_0132:  ldloc.s    V_6
+    IL_0134:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
+    IL_0139:  ldarg.0
+    IL_013a:  stloc.3
+    IL_013b:  ldarg.0
+    IL_013c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_0141:  ldloca.s   V_6
+    IL_0143:  ldloca.s   V_3
+    IL_0145:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
+    IL_014a:  nop
+    IL_014b:  leave      IL_01e3
     // async: resume
-    IL_014c:  ldarg.0
-    IL_014d:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0152:  stloc.s    V_6
-    IL_0154:  ldarg.0
-    IL_0155:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<Main>d__0.<>u__2""
-    IL_015a:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0160:  ldarg.0
-    IL_0161:  ldc.i4.m1
-    IL_0162:  dup
-    IL_0163:  stloc.0
-    IL_0164:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_0169:  ldloca.s   V_6
-    IL_016b:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_0170:  nop
+    IL_0150:  ldarg.0
+    IL_0151:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
+    IL_0156:  stloc.s    V_6
+    IL_0158:  ldarg.0
+    IL_0159:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
+    IL_015e:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_0164:  ldarg.0
+    IL_0165:  ldc.i4.m1
+    IL_0166:  dup
+    IL_0167:  stloc.0
+    IL_0168:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_016d:  ldloca.s   V_6
+    IL_016f:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_0174:  nop
     // sequence point: <hidden>
-    IL_0171:  ldarg.0
-    IL_0172:  ldfld      ""object C.<Main>d__0.<>s__2""
-    IL_0177:  stloc.s    V_4
-    IL_0179:  ldloc.s    V_4
-    IL_017b:  brfalse.s  IL_019a
+    IL_0175:  ldarg.0
+    IL_0176:  ldfld      ""object C.<Main>d__0.<>s__2""
+    IL_017b:  stloc.s    V_4
     IL_017d:  ldloc.s    V_4
-    IL_017f:  isinst     ""System.Exception""
-    IL_0184:  stloc.s    V_7
-    IL_0186:  ldloc.s    V_7
-    IL_0188:  brtrue.s   IL_018d
-    IL_018a:  ldloc.s    V_4
-    IL_018c:  throw
-    IL_018d:  ldloc.s    V_7
-    IL_018f:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_0194:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_0199:  nop
-    IL_019a:  ldarg.0
-    IL_019b:  ldfld      ""int C.<Main>d__0.<>s__3""
-    IL_01a0:  pop
-    IL_01a1:  ldarg.0
-    IL_01a2:  ldnull
-    IL_01a3:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_01a8:  ldarg.0
-    IL_01a9:  ldnull
-    IL_01aa:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-    IL_01af:  leave.s    IL_01cb
+    IL_017f:  brfalse.s  IL_019e
+    IL_0181:  ldloc.s    V_4
+    IL_0183:  isinst     ""System.Exception""
+    IL_0188:  stloc.s    V_8
+    IL_018a:  ldloc.s    V_8
+    IL_018c:  brtrue.s   IL_0191
+    IL_018e:  ldloc.s    V_4
+    IL_0190:  throw
+    IL_0191:  ldloc.s    V_8
+    IL_0193:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_0198:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_019d:  nop
+    IL_019e:  ldarg.0
+    IL_019f:  ldfld      ""int C.<Main>d__0.<>s__3""
+    IL_01a4:  pop
+    IL_01a5:  ldarg.0
+    IL_01a6:  ldnull
+    IL_01a7:  stfld      ""object C.<Main>d__0.<>s__2""
+    IL_01ac:  ldarg.0
+    IL_01ad:  ldnull
+    IL_01ae:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_01b3:  leave.s    IL_01cf
   }
   catch System.Exception
   {
     // sequence point: <hidden>
-    IL_01b1:  stloc.s    V_7
-    IL_01b3:  ldarg.0
-    IL_01b4:  ldc.i4.s   -2
-    IL_01b6:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_01bb:  ldarg.0
-    IL_01bc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_01c1:  ldloc.s    V_7
-    IL_01c3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_01c8:  nop
-    IL_01c9:  leave.s    IL_01df
+    IL_01b5:  stloc.s    V_8
+    IL_01b7:  ldarg.0
+    IL_01b8:  ldc.i4.s   -2
+    IL_01ba:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_01bf:  ldarg.0
+    IL_01c0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_01c5:  ldloc.s    V_8
+    IL_01c7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_01cc:  nop
+    IL_01cd:  leave.s    IL_01e3
   }
   // sequence point: }
-  IL_01cb:  ldarg.0
-  IL_01cc:  ldc.i4.s   -2
-  IL_01ce:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_01cf:  ldarg.0
+  IL_01d0:  ldc.i4.s   -2
+  IL_01d2:  stfld      ""int C.<Main>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_01d3:  ldarg.0
-  IL_01d4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_01d9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_01de:  nop
-  IL_01df:  ret
+  IL_01d7:  ldarg.0
+  IL_01d8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_01dd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_01e2:  nop
+  IL_01e3:  ret
 }
 ", sequencePoints: "C+<Main>d__0.MoveNext", source: source);
         }
 
         [Fact]
-        void TestWithPattern_WithIAsyncDisposable()
+        public void TestWithPattern_WithIAsyncDisposable()
         {
             string source = @"
 using static System.Console;
@@ -1604,7 +1607,7 @@ class C
             bool more = await Task.FromResult(i < 30);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -1628,7 +1631,7 @@ class C
         }
 
         [Fact]
-        void TestWithPattern_WithIAsyncDisposableUseSiteError()
+        public void TestWithPattern_WithIAsyncDisposableUseSiteError()
         {
             string enumerator = @"
 using System.Threading.Tasks;
@@ -1648,9 +1651,9 @@ public class C
         {
             throw null;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
-            await Task.Delay(10);
+            await new ValueTask(Task.Delay(10));
         }
     }
 }";
@@ -1693,7 +1696,7 @@ class Client
         }
 
         [Fact]
-        void TestWithMultipleInterface()
+        public void TestWithMultipleInterface()
         {
             string source = @"
 using System.Collections.Generic;
@@ -1723,7 +1726,7 @@ class C : IAsyncEnumerable<int>, IAsyncEnumerable<string>
         }
 
         [Fact]
-        void TestWithMultipleImplementations()
+        public void TestWithMultipleImplementations()
         {
             string source = @"
 using System.Collections.Generic;
@@ -1753,7 +1756,7 @@ class C : Base, IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithInterface()
+        public void TestWithInterface()
         {
             string source = @"
 using static System.Console;
@@ -1788,7 +1791,7 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 30);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -1814,7 +1817,7 @@ class C : IAsyncEnumerable<int>
                 info.TryGetNextMethod.ToTestDisplayString());
             Assert.Null(info.CurrentProperty);
             Assert.Null(info.MoveNextMethod);
-            Assert.Equal("System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
             Assert.Equal("System.Int32", info.ElementType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, info.ElementConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
@@ -1826,7 +1829,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithInterface_WithEarlyCompletion1()
+        public void TestWithInterface_WithEarlyCompletion1()
         {
             string source = @"
 using static System.Console;
@@ -1862,10 +1865,10 @@ class C : IAsyncEnumerable<int>
             i = i + 11;
             return new ValueTask<bool>(i < 30); // return a completed task
         }
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            return Task.CompletedTask; // return a completed task
+            return new ValueTask(Task.CompletedTask); // return a completed task
         }
     }
 }";
@@ -1876,7 +1879,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithInterface_WithBreakAndContinue()
+        public void TestWithInterface_WithBreakAndContinue()
         {
             string source = @"
 using static System.Console;
@@ -1914,7 +1917,7 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 30);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -1929,7 +1932,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithInterface_WithGoto()
+        public void TestWithInterface_WithGoto()
         {
             string source = @"
 using static System.Console;
@@ -1968,7 +1971,7 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 30);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -1983,7 +1986,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithInterface_WithStruct()
+        public void TestWithInterface_WithStruct()
         {
             string source = @"
 using static System.Console;
@@ -2021,7 +2024,7 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 20);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
             await Task.Delay(10);
@@ -2037,7 +2040,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithInterface_WithStruct_ManualIteration()
+        public void TestWithInterface_WithStruct_ManualIteration()
         {
             string source = @"
 using static System.Console;
@@ -2086,7 +2089,7 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 20);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -2103,7 +2106,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithInterface_WithStruct2()
+        public void TestWithInterface_WithStruct2()
         {
             string source = @"
 using static System.Console;
@@ -2148,7 +2151,7 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 13);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -2163,7 +2166,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithNullLiteralCollection()
+        public void TestWithNullLiteralCollection()
         {
             string source = @"
 using System.Collections.Generic;
@@ -2190,7 +2193,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithNullCollection()
+        public void TestWithNullCollection()
         {
             string source = @"
 using System.Collections.Generic;
@@ -2227,7 +2230,7 @@ class C : IAsyncEnumerable<int>
         {
             throw new System.Exception();
         }
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
         {
             throw new System.Exception();
         }
@@ -2239,7 +2242,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestInCatch()
+        public void TestInCatch()
         {
             string source = @"
 using System.Collections.Generic;
@@ -2285,7 +2288,7 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 20);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -2299,7 +2302,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestInFinally()
+        public void TestInFinally()
         {
             string source = @"
 using System.Collections.Generic;
@@ -2332,7 +2335,7 @@ class C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithConversionToElement()
+        public void TestWithConversionToElement()
         {
             string source = @"
 using System.Collections.Generic;
@@ -2370,7 +2373,7 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 20);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -2402,7 +2405,7 @@ class Element
                 info.TryGetNextMethod.ToTestDisplayString());
             Assert.Null(info.CurrentProperty);
             Assert.Null(info.MoveNextMethod);
-            Assert.Equal("System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
             Assert.Equal("System.Int32", info.ElementType.ToTestDisplayString());
             Assert.Equal(ConversionKind.ExplicitUserDefined, info.ElementConversion.Kind);
             Assert.Equal("Element Element.op_Implicit(System.Int32 value)", info.ElementConversion.MethodSymbol.ToTestDisplayString());
@@ -2415,7 +2418,7 @@ class Element
         }
 
         [Fact]
-        void TestWithNullableCollection()
+        public void TestWithNullableCollection()
         {
             string source = @"
 using static System.Console;
@@ -2451,7 +2454,7 @@ struct C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 30);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -2477,7 +2480,7 @@ struct C : IAsyncEnumerable<int>
                 info.TryGetNextMethod.ToTestDisplayString());
             Assert.Null(info.CurrentProperty);
             Assert.Null(info.MoveNextMethod);
-            Assert.Equal("System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
             Assert.Equal("System.Int32", info.ElementType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, info.ElementConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
@@ -2489,7 +2492,7 @@ struct C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithNullableCollection2()
+        public void TestWithNullableCollection2()
         {
             string source = @"
 using static System.Console;
@@ -2523,7 +2526,7 @@ struct C : IAsyncEnumerable<int>
         }
 
         [Fact]
-        void TestWithInterfaceAndDeconstruction()
+        public void TestWithInterfaceAndDeconstruction()
         {
             string source = @"
 using static System.Console;
@@ -2559,10 +2562,10 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 20);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await Task.Delay(10);
+            await new ValueTask(Task.Delay(10));
         }
     }
 }
@@ -2589,7 +2592,7 @@ public static class Extensions
                 info.TryGetNextMethod.ToTestDisplayString());
             Assert.Null(info.CurrentProperty);
             Assert.Null(info.MoveNextMethod);
-            Assert.Equal("System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
             Assert.Equal("System.Int32", info.ElementType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, info.ElementConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
@@ -2601,7 +2604,7 @@ public static class Extensions
         }
 
         [Fact]
-        void TestWithDeconstructionInNonAsyncMethod()
+        public void TestWithDeconstructionInNonAsyncMethod()
         {
             string source = @"
 using System.Collections.Generic;
@@ -2629,7 +2632,7 @@ public static class Extensions
         }
 
         [Fact]
-        void TestWithPatternAndDeconstructionOfTuple()
+        public void TestWithPatternAndDeconstructionOfTuple()
         {
             string source = @"
 using static System.Console;
@@ -2666,10 +2669,10 @@ class C : IAsyncEnumerable<(string, int)>
             bool more = await Task.FromResult(i < 20);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await Task.Delay(10);
+            await new ValueTask(Task.Delay(10));
         }
     }
 }";
@@ -2690,14 +2693,14 @@ class C : IAsyncEnumerable<(string, int)>
                 info.TryGetNextMethod.ToTestDisplayString());
             Assert.Null(info.CurrentProperty);
             Assert.Null(info.MoveNextMethod);
-            Assert.Equal("System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
             Assert.Equal("(System.String, System.Int32)", info.ElementType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, info.ElementConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
         }
 
         [Fact]
-        void TestWithInterfaceAndDeconstruction_ManualIteration()
+        public void TestWithInterfaceAndDeconstruction_ManualIteration()
         {
             string source = @"
 using static System.Console;
@@ -2746,7 +2749,7 @@ class C : IAsyncEnumerable<int>
             bool more = await Task.FromResult(i < 20);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
             await Task.Delay(10);
@@ -2765,7 +2768,7 @@ public static class Extensions
         }
 
         [Fact]
-        void TestWithPatternAndObsolete()
+        public void TestWithPatternAndObsolete()
         {
             string source = @"
 using System.Threading.Tasks;
@@ -2796,14 +2799,12 @@ class C
             throw null;
         }
         [System.Obsolete]
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
         {
             throw null;
         }
     }
 }";
-            // PROTOTYPE(async-streams): Update pattern-based case to recognize task-like WaitForNextAsync
-
             var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (7,9): warning CS0612: 'C.GetAsyncEnumerator()' is obsolete
@@ -2820,7 +2821,7 @@ class C
         }
 
         [Fact]
-        void TestWithUnassignedCollection()
+        public void TestWithUnassignedCollection()
         {
             string source = @"
 using System.Collections.Generic;
@@ -2847,7 +2848,7 @@ class C
         }
 
         [Fact]
-        void TestInRegularForeach()
+        public void TestInRegularForeach()
         {
             string source = @"
 using System.Collections.Generic;
@@ -2874,7 +2875,7 @@ class C
         }
 
         [Fact]
-        void TestWithGenericCollection()
+        public void TestWithGenericCollection()
         {
             string source = @"
 using static System.Console;
@@ -2903,10 +2904,10 @@ class Collection<T> : IAsyncEnumerable<T>
             bool more = await Task.FromResult(i < 30);
             return more;
         }
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await Task.Delay(10);
+            await new ValueTask(Task.Delay(10));
         }
     }
 }
@@ -2938,7 +2939,7 @@ class C
                 info.TryGetNextMethod.ToTestDisplayString());
             Assert.Null(info.CurrentProperty);
             Assert.Null(info.MoveNextMethod);
-            Assert.Equal("System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
             Assert.Equal("System.Int32", info.ElementType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, info.ElementConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
@@ -2950,7 +2951,7 @@ class C
         }
 
         [Fact]
-        void TestWithInterfaceImplementingPattern()
+        public void TestWithInterfaceImplementingPattern()
         {
             string source = @"
 using static System.Console;
@@ -3021,7 +3022,7 @@ class C
                 info.TryGetNextMethod.ToTestDisplayString());
             Assert.Null(info.CurrentProperty);
             Assert.Null(info.MoveNextMethod);
-            Assert.Equal("System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
             Assert.Equal("System.Int32", info.ElementType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, info.ElementConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
@@ -3033,7 +3034,7 @@ class C
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      476 (0x1dc)
+  // Code size      480 (0x1e0)
   .maxstack  3
   .locals init (int V_0,
                 bool V_1,
@@ -3041,8 +3042,9 @@ class C
                 C.<Main>d__0 V_3,
                 object V_4,
                 System.IAsyncDisposable V_5,
-                System.Runtime.CompilerServices.TaskAwaiter V_6,
-                System.Exception V_7)
+                System.Runtime.CompilerServices.ValueTaskAwaiter V_6,
+                System.Threading.Tasks.ValueTask V_7,
+                System.Exception V_8)
   // sequence point: <hidden>
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<Main>d__0.<>1__state""
@@ -3058,7 +3060,7 @@ class C
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
     IL_0012:  br.s       IL_0044
-    IL_0014:  br         IL_0148
+    IL_0014:  br         IL_014c
     // sequence point: {
     IL_0019:  nop
     // sequence point: ICollection<int> c = new Collection<int>();
@@ -3134,7 +3136,7 @@ class C
       IL_00a9:  ldloca.s   V_3
       IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
       IL_00b0:  nop
-      IL_00b1:  leave      IL_01db
+      IL_00b1:  leave      IL_01df
       // async: resume
       IL_00b6:  ldarg.0
       IL_00b7:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
@@ -3172,100 +3174,102 @@ class C
     IL_00fe:  isinst     ""System.IAsyncDisposable""
     IL_0103:  stloc.s    V_5
     IL_0105:  ldloc.s    V_5
-    IL_0107:  brfalse.s  IL_016d
+    IL_0107:  brfalse.s  IL_0171
     IL_0109:  ldloc.s    V_5
-    IL_010b:  callvirt   ""System.Threading.Tasks.Task System.IAsyncDisposable.DisposeAsync()""
-    IL_0110:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-    IL_0115:  stloc.s    V_6
+    IL_010b:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
+    IL_0110:  stloc.s    V_7
+    IL_0112:  ldloca.s   V_7
+    IL_0114:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_0119:  stloc.s    V_6
     // sequence point: <hidden>
-    IL_0117:  ldloca.s   V_6
-    IL_0119:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-    IL_011e:  brtrue.s   IL_0165
-    IL_0120:  ldarg.0
-    IL_0121:  ldc.i4.1
-    IL_0122:  dup
-    IL_0123:  stloc.0
-    IL_0124:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_011b:  ldloca.s   V_6
+    IL_011d:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_0122:  brtrue.s   IL_0169
+    IL_0124:  ldarg.0
+    IL_0125:  ldc.i4.1
+    IL_0126:  dup
+    IL_0127:  stloc.0
+    IL_0128:  stfld      ""int C.<Main>d__0.<>1__state""
     // async: yield
-    IL_0129:  ldarg.0
-    IL_012a:  ldloc.s    V_6
-    IL_012c:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0131:  ldarg.0
-    IL_0132:  stloc.3
-    IL_0133:  ldarg.0
-    IL_0134:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0139:  ldloca.s   V_6
-    IL_013b:  ldloca.s   V_3
-    IL_013d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<Main>d__0)""
-    IL_0142:  nop
-    IL_0143:  leave      IL_01db
+    IL_012d:  ldarg.0
+    IL_012e:  ldloc.s    V_6
+    IL_0130:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
+    IL_0135:  ldarg.0
+    IL_0136:  stloc.3
+    IL_0137:  ldarg.0
+    IL_0138:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_013d:  ldloca.s   V_6
+    IL_013f:  ldloca.s   V_3
+    IL_0141:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
+    IL_0146:  nop
+    IL_0147:  leave      IL_01df
     // async: resume
-    IL_0148:  ldarg.0
-    IL_0149:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<Main>d__0.<>u__2""
-    IL_014e:  stloc.s    V_6
-    IL_0150:  ldarg.0
-    IL_0151:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0156:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_015c:  ldarg.0
-    IL_015d:  ldc.i4.m1
-    IL_015e:  dup
-    IL_015f:  stloc.0
-    IL_0160:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_0165:  ldloca.s   V_6
-    IL_0167:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_016c:  nop
+    IL_014c:  ldarg.0
+    IL_014d:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
+    IL_0152:  stloc.s    V_6
+    IL_0154:  ldarg.0
+    IL_0155:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
+    IL_015a:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_0160:  ldarg.0
+    IL_0161:  ldc.i4.m1
+    IL_0162:  dup
+    IL_0163:  stloc.0
+    IL_0164:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_0169:  ldloca.s   V_6
+    IL_016b:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_0170:  nop
     // sequence point: <hidden>
-    IL_016d:  ldarg.0
-    IL_016e:  ldfld      ""object C.<Main>d__0.<>s__3""
-    IL_0173:  stloc.s    V_4
-    IL_0175:  ldloc.s    V_4
-    IL_0177:  brfalse.s  IL_0196
+    IL_0171:  ldarg.0
+    IL_0172:  ldfld      ""object C.<Main>d__0.<>s__3""
+    IL_0177:  stloc.s    V_4
     IL_0179:  ldloc.s    V_4
-    IL_017b:  isinst     ""System.Exception""
-    IL_0180:  stloc.s    V_7
-    IL_0182:  ldloc.s    V_7
-    IL_0184:  brtrue.s   IL_0189
-    IL_0186:  ldloc.s    V_4
-    IL_0188:  throw
-    IL_0189:  ldloc.s    V_7
-    IL_018b:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_0190:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_0195:  nop
-    IL_0196:  ldarg.0
-    IL_0197:  ldfld      ""int C.<Main>d__0.<>s__4""
-    IL_019c:  pop
-    IL_019d:  ldarg.0
-    IL_019e:  ldnull
-    IL_019f:  stfld      ""object C.<Main>d__0.<>s__3""
-    IL_01a4:  ldarg.0
-    IL_01a5:  ldnull
-    IL_01a6:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_01ab:  leave.s    IL_01c7
+    IL_017b:  brfalse.s  IL_019a
+    IL_017d:  ldloc.s    V_4
+    IL_017f:  isinst     ""System.Exception""
+    IL_0184:  stloc.s    V_8
+    IL_0186:  ldloc.s    V_8
+    IL_0188:  brtrue.s   IL_018d
+    IL_018a:  ldloc.s    V_4
+    IL_018c:  throw
+    IL_018d:  ldloc.s    V_8
+    IL_018f:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_0194:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_0199:  nop
+    IL_019a:  ldarg.0
+    IL_019b:  ldfld      ""int C.<Main>d__0.<>s__4""
+    IL_01a0:  pop
+    IL_01a1:  ldarg.0
+    IL_01a2:  ldnull
+    IL_01a3:  stfld      ""object C.<Main>d__0.<>s__3""
+    IL_01a8:  ldarg.0
+    IL_01a9:  ldnull
+    IL_01aa:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_01af:  leave.s    IL_01cb
   }
   catch System.Exception
   {
     // sequence point: <hidden>
-    IL_01ad:  stloc.s    V_7
-    IL_01af:  ldarg.0
-    IL_01b0:  ldc.i4.s   -2
-    IL_01b2:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_01b7:  ldarg.0
-    IL_01b8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_01bd:  ldloc.s    V_7
-    IL_01bf:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_01c4:  nop
-    IL_01c5:  leave.s    IL_01db
+    IL_01b1:  stloc.s    V_8
+    IL_01b3:  ldarg.0
+    IL_01b4:  ldc.i4.s   -2
+    IL_01b6:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_01bb:  ldarg.0
+    IL_01bc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_01c1:  ldloc.s    V_8
+    IL_01c3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_01c8:  nop
+    IL_01c9:  leave.s    IL_01df
   }
   // sequence point: }
-  IL_01c7:  ldarg.0
-  IL_01c8:  ldc.i4.s   -2
-  IL_01ca:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_01cb:  ldarg.0
+  IL_01cc:  ldc.i4.s   -2
+  IL_01ce:  stfld      ""int C.<Main>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_01cf:  ldarg.0
-  IL_01d0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_01d5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_01da:  nop
-  IL_01db:  ret
+  IL_01d3:  ldarg.0
+  IL_01d4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_01d9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_01de:  nop
+  IL_01df:  ret
 }
 ", sequencePoints: "C+<Main>d__0.MoveNext", source: source);
         }
@@ -3309,7 +3313,6 @@ class C
 
         // Misc other test ideas:
         // WaitForMoveNext with task-like type (see IsCustomTaskType). Would that provide any benefits?
-        // DisposeAsync with task-like return
         // Verify that async-dispose doesn't have a similar bug with struct resource
         // cleanup: use statement lists for async-using, instead of blocks
         // IAsyncEnumerable has an 'out' type parameter, any tests I need to do related to that?

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -572,6 +572,7 @@ namespace System
                     case WellKnownType.System_Threading_Tasks_Sources_ValueTaskSourceOnCompletedFlags:
                     case WellKnownType.System_Threading_Tasks_Sources_IValueTaskSource_T:
                     case WellKnownType.System_Threading_Tasks_ValueTask_T:
+                    case WellKnownType.System_Threading_Tasks_ValueTask:
                     // Not yet in the platform.
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
                         // Not always available.

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3053,8 +3053,8 @@ namespace Microsoft.CodeAnalysis
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_IAsyncEnumerator_T - WellKnownType.ExtSentinel),               // DeclaringTypeId
                 0,                                                                                                                                              // Arity
                     0,                                                                                                                                          // Method Signature
-                    (byte)SignatureTypeCode.GenericTypeInstance, // Return Type: Task<bool>
-                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Threading_Tasks_Task_T,
+                    (byte)SignatureTypeCode.GenericTypeInstance, // Return Type: ValueTask<bool>
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_Tasks_ValueTask_T - WellKnownType.ExtSentinel),
                     1,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3036,7 +3036,7 @@ namespace Microsoft.CodeAnalysis
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_IAsyncDisposable - WellKnownType.ExtSentinel),                                    // DeclaringTypeId
                 0,                                                                                                                                             // Arity
                     0,                                                                                                                                         // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Threading_Tasks_Task, // Return Type: Task
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_Tasks_ValueTask - WellKnownType.ExtSentinel), // Return Type: ValueTask
 
                 // System_Collections_Generic_IAsyncEnumerable_T__GetAsyncEnumerator
                 (byte)(MemberFlags.Method | MemberFlags.Virtual),                                                                                               // Flags

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -285,6 +285,7 @@ namespace Microsoft.CodeAnalysis
         System_Threading_Tasks_Sources_ValueTaskSourceOnCompletedFlags,
         System_Threading_Tasks_Sources_IValueTaskSource_T,
         System_Threading_Tasks_ValueTask_T,
+        System_Threading_Tasks_ValueTask,
 
         NextAvailable,
     }
@@ -565,6 +566,7 @@ namespace Microsoft.CodeAnalysis
             "System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags",
             "System.Threading.Tasks.Sources.IValueTaskSource`1",
             "System.Threading.Tasks.ValueTask`1",
+            "System.Threading.Tasks.ValueTask",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -403,6 +403,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             return CreateCompilation(source, references, options, parseOptions, TargetFramework.Mscorlib40, assemblyName, sourceFileName);
         }
 
+        public static CSharpCompilation CreateCompilationWithTasksExtensions(
+                CSharpTestSource source,
+                IEnumerable<MetadataReference> references = null,
+                CSharpCompilationOptions options = null,
+                CSharpParseOptions parseOptions = null,
+                string assemblyName = "",
+                string sourceFileName = "")
+        {
+            IEnumerable<MetadataReference> allReferences = CoreClrShim.IsRunningOnCoreClr
+                ? TargetFrameworkUtil.NetStandard20References
+                : TargetFrameworkUtil.Mscorlib461ExtendedReferences.Add(TestReferences.Net461.netstandardRef);
+
+            allReferences = allReferences.Concat(new[] { TestReferences.NetStandard20.TasksExtensionsRef, TestReferences.NetStandard20.UnsafeRef });
+
+            if (references != null)
+            {
+                allReferences = allReferences.Concat(references);
+            }
+
+            return CreateCompilation(source, allReferences, options, parseOptions, TargetFramework.Empty, assemblyName, sourceFileName);
+        }
+
         public static CSharpCompilation CreateCompilation(
             CSharpTestSource source,
             IEnumerable<MetadataReference> references = null,

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -512,7 +512,8 @@ End Namespace
                          WellKnownType.System_Threading_Tasks_Sources_ValueTaskSourceStatus,
                          WellKnownType.System_Threading_Tasks_Sources_ValueTaskSourceOnCompletedFlags,
                          WellKnownType.System_Threading_Tasks_Sources_IValueTaskSource_T,
-                         WellKnownType.System_Threading_Tasks_ValueTask_T
+                         WellKnownType.System_Threading_Tasks_ValueTask_T,
+                         WellKnownType.System_Threading_Tasks_ValueTask
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -562,7 +563,8 @@ End Namespace
                          WellKnownType.System_Threading_Tasks_Sources_ValueTaskSourceStatus,
                          WellKnownType.System_Threading_Tasks_Sources_ValueTaskSourceOnCompletedFlags,
                          WellKnownType.System_Threading_Tasks_Sources_IValueTaskSource_T,
-                         WellKnownType.System_Threading_Tasks_ValueTask_T
+                         WellKnownType.System_Threading_Tasks_ValueTask_T,
+                         WellKnownType.System_Threading_Tasks_ValueTask
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel

--- a/src/Test/Utilities/Portable/CompilationVerifier.cs
+++ b/src/Test/Utilities/Portable/CompilationVerifier.cs
@@ -85,10 +85,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             {
                 string mainModuleFullName = Emit(testEnvironment, manifestResources: null, EmitOptions.Default);
                 IList<ModuleData> moduleDatas = testEnvironment.GetAllModuleData();
-                string mainModuleSimpleName = moduleDatas.Single(md => md.FullName == mainModuleFullName).SimpleName;
+                var mainModule = moduleDatas.Single(md => md.FullName == mainModuleFullName);
                 RuntimeEnvironmentUtilities.DumpAssemblyData(moduleDatas, out var dumpDir);
 
-                string modulePath = Path.Combine(dumpDir, mainModuleSimpleName + ".dll");
+                string extension = mainModule.Kind == OutputKind.ConsoleApplication ? ".exe" : ".dll";
+                string modulePath = Path.Combine(dumpDir, mainModule.SimpleName + extension);
                 var decompiler = new ICSharpCode.Decompiler.CSharp.CSharpDecompiler(modulePath, new ICSharpCode.Decompiler.DecompilerSettings());
                 var syntaxTree = decompiler.DecompileWholeModuleAsSingleFile();
                 return syntaxTree.ToString();

--- a/src/Test/Utilities/Portable/Mocks/TestReferences.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestReferences.cs
@@ -272,6 +272,11 @@ public static class TestReferences
         LazyThreadSafetyMode.PublicationOnly);
         public static PortableExecutableReference TasksExtensionsRef => s_system_Threading_Tasks_Extensions.Value;
 
+        private static readonly Lazy<PortableExecutableReference> s_system_Runtime_CompilerServices_Unsafe = new Lazy<PortableExecutableReference>(
+        () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.netstandard20.System_Runtime_CompilerServices_Unsafe).GetReference(display: "System.Runtime.CompilerServices.Unsafe.dll (netstandard 2.0)"),
+        LazyThreadSafetyMode.PublicationOnly);
+        public static PortableExecutableReference UnsafeRef => s_system_Runtime_CompilerServices_Unsafe.Value;
+
         private static readonly Lazy<PortableExecutableReference> s_microsoftVisualBasic = new Lazy<PortableExecutableReference>(
         () => AssemblyMetadata.CreateFromImage(TestResources.NetFX.netstandard20.Microsoft_VisualBasic).GetReference(display: "Microsoft.VisualBasic.dll (netstandard 2.0 ref)"),
         LazyThreadSafetyMode.PublicationOnly);


### PR DESCRIPTION
This change does a couple of small things:
- `IAsyncDisposable` returns a `ValueTask`
- `IAsyncEnumerator.WaitForNextAsync` returns a `ValueTask`
- async foreach recognizes `WaitForNextAsync` methods that return a task-like (left a PROTOTYPE comment to test more thoroughly)
- pulling a new version of the test resource package as `Tasks.Extensions.dll` has a dependency on `CompilerServices.Unsafe.dll`
- fixing a tiny bug in `CompilationVerifier.Dump()` which I had recently added (it didn't work if the output was an exe)

Most of the change is updating tests accordingly.

Note to self: follow-up branch is `async-streams4`.