### PR TITLE
[Razor FAR]: PROTOTYPE: connect generated documents to editor

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             this.RunningDocumentTable = (IVsRunningDocumentTable4)serviceProvider.GetService(typeof(SVsRunningDocumentTable));
 
-            var displayName = hierarchy != null && hierarchy.TryGetName(out var name) ? name : projectSystemName;
+            var displayName = projectSystemName;
             this.DisplayName = displayName;
 
             this.ProjectTracker = projectTracker;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
@@ -238,6 +238,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         sourceCodeKind,
                         id,
                         updatedHandler,
+                        openedHandler,
+                        closingHandler,
                         documentServiceFactory);
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -86,6 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             Workspace workspace,
             IVsHierarchy hierarchy,
             uint itemId,
+            string filePath,
             IComponentModel componentModel,
             IDocumentServiceFactory documentServiceFactory,
             IFormattingRule vbHelperFormattingRule)
@@ -97,16 +98,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             _componentModel = componentModel;
             _workspace = workspace;
             _hostType = GetHostType();
-            if (!ErrorHandler.Succeeded(((IVsProject)hierarchy).GetMkDocument(itemId, out var filePath)))
-            {
-                // we couldn't look up the document moniker from an hierarchy for an itemid.
-                // Since we only use this moniker as a key, we could fall back to something else, like the document name.
-                Debug.Assert(false, "Could not get the document moniker for an item from its hierarchy.");
-                if (!hierarchy.TryGetItemName(itemId, out filePath))
-                {
-                    Environment.FailFast("Failed to get document moniker for a contained document");
-                }
-            }
 
             if (Project.Hierarchy != null)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.IVsContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.IVsContainedLanguageCodeSupport.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             TextSpan[] pSpanInsertionPoint)
         {
             var thisDocument = GetThisDocument();
-            var targetDocumentId = this.ContainedDocument.FindProjectDocumentIdWithItemId(itemidInsertionPoint);
+            var targetDocumentId = this.FindProjectDocumentIdWithItemId(itemidInsertionPoint);
             var targetDocument = thisDocument.Project.Solution.GetDocument(targetDocumentId);
             if (targetDocument == null)
             {
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                     if (ContainedLanguageCodeSupport.TryGetMemberNavigationPoint(GetThisDocument(), pszClassName, pszUniqueMemberID, out textSpan, out var targetDocument, c.CancellationToken))
                     {
                         succeeded = true;
-                        itemId = this.ContainedDocument.FindItemIdOfDocument(targetDocument);
+                        itemId = this.FindItemIdOfDocument(targetDocument);
                     }
                 });
 
@@ -208,6 +208,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             }
 
             return document;
+        }
+
+        protected DocumentId FindProjectDocumentIdWithItemId(uint itemidInsertionPoint)
+        {
+            return Project.GetCurrentDocuments().SingleOrDefault(d => d.GetItemId() == itemidInsertionPoint).Id;
+        }
+
+        protected uint FindItemIdOfDocument(Document document)
+        {
+            return Project.GetDocumentOrAdditionalDocument(document.Id).GetItemId();
         }
 
         private static readonly int s_CONTAINEDLANGUAGE_CANNOTFINDITEM = MakeHResult(1, FACILITY_ITF, 0x8003);

--- a/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
                                                  pSpanInsertionPoint() As VsTextSpan) As Integer Implements IVsContainedLanguageStaticEventBinding.EnsureStaticEventHandler
 
             Dim thisDocument = GetThisDocument()
-            Dim targetDocumentId = Me.ContainedDocument.FindProjectDocumentIdWithItemId(itemidInsertionPoint)
+            Dim targetDocumentId = FindProjectDocumentIdWithItemId(itemidInsertionPoint)
             Dim targetDocument = thisDocument.Project.Solution.GetDocument(targetDocumentId)
             If targetDocument Is Nothing Then
                 Throw New InvalidOperationException("Can't generate into that itemid")


### PR DESCRIPTION
/cc @jasonmalinowski @heejaechang 

This is a prototype of how the contained language support could open and
attach to one of the new generated Razor documents.

There are surely many features that aren't working in this example, my
goal here is just to share an idea and continue the discussion. I think if we end up doing FAR for Razor in 15.8 we will not need this change, but here's an idea of a direction that seems promising to me looking forward at features like refactoring.

-----

**Summary**
The big idea here is that the contained language implementation in Roslyn can bind to an existing document rather than creating an ephemeral one.

We can use an existing project system API to inform the contained language implementation to use the project context created by Razor.

There are a few big issues with this approach that I haven't tried to solve in a prototype... I thought I got far enough with it to trigger a fruitful discussion 😆 

**Timing**
There are timing issues with initialization. The contained language code path is synchronous, and WTE calls it in a loop, waiting for the buffer to be successfully created. This works OK today because if the workspace/project hasn't been initialized yet from Roslyn's point of view, you can just say NO, and WTE will try again.

These changes introduce an inherent race between the current (old) code path, and the new one that gets taken only when the document is already known because there are two different success paths. I don't think anything in the contained language subsystem today has the ability to migrate to a new context if a document is registered for something open in the editor.

**Feature Divergence**

I didn't attempt to unify the `ContainedDocument` and `SimpleContainedDocument` into a single class. There are lots of places where code does a downcast to `ContainedDocument` to implement some kind of feature. I think a real implementation would need to extract an interface, or unify these types. I'll bet some features are currently broken in the features/razorFar branch due to this and we will probably need to address that independent of this idea.

I spot fixed a few of these places that were trivial, before looking a bit deeper and deciding that I didn't want to try and solve these in a prototype.

**Editing Support**

Most of the support for Roslyn editing the underlying C# buffer lives in `ContainedDocument`. Introducing another document implementation like `SimpleContainedDocument` means that we don't reuse this code, so if we don't unify these types, we need to solve that somehow.
