### PR TITLE
Fix unnecessary cast

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -4491,6 +4491,7 @@ class C
 }", parameters: new TestParameters(new CSharpParseOptions(LanguageVersion.CSharp7_1)));
         }
 
+        [WorkItem(27239, "https://github.com/dotnet/roslyn/issues/27239")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DontOfferToRemoveCastWhereNoConversionExists()
         {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -4490,5 +4490,22 @@ class C
     }
 }", parameters: new TestParameters(new CSharpParseOptions(LanguageVersion.CSharp7_1)));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontOfferToRemoveCastFormObjectToStruct()
+        {
+            await TestMissingInRegularAndScriptAsync(
+                @"
+using System;
+
+class C
+{
+    void M()
+    {
+        object o = null;
+        TypedReference r2 = [|(TypedReference)o|];
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -4492,7 +4492,7 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontOfferToRemoveCastFormObjectToStruct()
+        public async Task DontOfferToRemoveCastWhereNoConversionExists()
         {
             await TestMissingInRegularAndScriptAsync(
                 @"

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -393,6 +393,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var expressionToCastType = semanticModel.ClassifyConversion(cast.SpanStart, cast.Expression, castType, isExplicitInSource: true);
             var outerType = GetOuterCastType(cast, semanticModel, out var parentIsOrAsExpression) ?? castTypeInfo.ConvertedType;
 
+            // If there is no conversion then there will be a compiler error, but offering the code fix before that is confusing, so jump out.
+            if (!expressionToCastType.Exists)
+            {
+                return false;
+            }
+            
             // Simple case: If the conversion from the inner expression to the cast type is identity,
             // the cast can be removed.
             if (expressionToCastType.IsIdentity)


### PR DESCRIPTION
Don't offer unnecessary cast fixer on invalid code

### Customer scenario

When trying to cast to a TypedReference (or presumably any other ref-like struct) from object, the RemoveUnnecessaryCast diagnostic pops up which is confusing, since its incorrect, and can hide the underlying compilation error. Allowing the error to bubble up in this case is a better user experience.

### Bugs this fixes

Fixes: #27239 

### Workarounds, if any

None really.

### Risk

There is a small chance that there could be scenarios where the diagnostic is desired even though no conversion is valid, but I couldn't think of one. An alternate approach if necessary could be to make the diagnostic use similar logic to the compiler in determining specifically that the unboxing conversion will be going to something stack only, and not show in those circumstances.

### Performance impact

Low, because the analyzer had already done the work

### Is this a regression from a previous update?

Not as far as I know

### Root cause analysis

I added a test for this case. Presumably missed because most (all?) other invalid conversions meet one of the other conditions, ie explicit, implicit, unboxing etc.

### How was the bug found?

Not much detail on the issue. I just picked something off the "Help Wanted" label 🙂

### Test documentation updated?

N/A
