### PR TITLE
Offer generate variable fixer when inside a lock statement in C#

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -8019,5 +8019,83 @@ class Program
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TestIdentifierInsideLock1()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        lock ([|goo|])
+        {
+        }
+    }
+}",
+@"class Class
+{
+    private object goo;
+
+    void Method()
+    {
+        lock (goo)
+        {
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TestIdentifierInsideLock2()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        lock ([|goo|])
+        {
+        }
+    }
+}",
+@"class Class
+{
+    private readonly object goo;
+
+    void Method()
+    {
+        lock (goo)
+        {
+        }
+    }
+}", index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TestIdentifierInsideLock3()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        lock ([|goo|])
+        {
+        }
+    }
+}",
+@"class Class
+{
+    public object goo { get; private set; }
+
+    void Method()
+    {
+        lock (goo)
+        {
+        }
+    }
+}", index: 2);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -8020,6 +8020,7 @@ class Program
 }");
         }
 
+        [WorkItem(26406, "https://github.com/dotnet/roslyn/issues/26406")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public async Task TestIdentifierInsideLock1()
         {
@@ -8046,6 +8047,7 @@ class Program
 }");
         }
 
+        [WorkItem(26406, "https://github.com/dotnet/roslyn/issues/26406")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public async Task TestIdentifierInsideLock2()
         {
@@ -8072,6 +8074,7 @@ class Program
 }", index: 1);
         }
 
+        [WorkItem(26406, "https://github.com/dotnet/roslyn/issues/26406")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public async Task TestIdentifierInsideLock3()
         {

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
@@ -2771,5 +2771,65 @@ class C
     end sub
 end class", index:=1)
         End Function
+
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        Public Async Function TestGenerateSimplePropertyInSyncLock() As Threading.Tasks.Task
+            Await TestInRegularAndScriptAsync(
+"Module Program
+    Sub Main(args As String())
+        SyncLock [|Bar|]
+        End SyncLock
+    End Sub
+End Module",
+"Module Program
+    Public Property Bar As Object
+
+    Sub Main(args As String())
+        SyncLock Bar
+        End SyncLock
+    End Sub
+End Module")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        Public Async Function TestGenerateSimpleFieldInSyncLock() As Threading.Tasks.Task
+            Await TestInRegularAndScriptAsync(
+"Module Program
+    Sub Main(args As String())
+        SyncLock [|Bar|]
+        End SyncLock
+    End Sub
+End Module",
+"Module Program
+    Private Bar As Object
+
+    Sub Main(args As String())
+        SyncLock Bar
+        End SyncLock
+    End Sub
+End Module",
+index:=1)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        Public Async Function TestGenerateReadOnlyFieldInSyncLock() As Threading.Tasks.Task
+            Await TestInRegularAndScriptAsync(
+"Module Program
+    Sub Main(args As String())
+        SyncLock [|Bar|]
+        End SyncLock
+    End Sub
+End Module",
+"Module Program
+    Private ReadOnly Bar As Object
+
+    Sub Main(args As String())
+        SyncLock Bar
+        End SyncLock
+    End Sub
+End Module",
+index:=2)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -646,6 +646,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 case SyntaxKind.ComplexElementInitializerExpression:
                 case SyntaxKind.Interpolation:
                 case SyntaxKind.RefExpression:
+                case SyntaxKind.LockStatement:
                     // Direct parent kind checks.
                     return true;
             }


### PR DESCRIPTION
<details><summary>Show generate variable fix inside lock</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

When typing a new identifier inside a lock statement none of the Generate Variable fixers are offered as suggestions.

### Bugs this fixes

Fixes #26406 

### Workarounds, if any

None

### Risk

Low, the fix is one more item in a switch statement, and Visual Basic already had that option. I've added tests for C# and VB to prevent regression.

### Performance impact

Low, no extra allocations etc.

### Is this a regression from a previous update?

I don't know

### Root cause analysis

There is a large switch statement that has a whitelist of places where the generate variable refactoring is offered, and it was missing from there. There is a reasonable chance there are other things listed.

### How was the bug found?

I was just browsing Help Wanted issues, guessing the original requester found it in the course of using VS.

### Test documentation updated?

N/A?

</details>
