### PR TITLE
bug fix: don't optimize interpolations when in an expression lambda

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression result;
 
-            if (CanLowerToStringConcatenation(node))
+            if (!_inExpressionLambda && CanLowerToStringConcatenation(node))
             {
                 // All fill-ins, if any, are strings, and none of them have alignment or format specifiers.
                 // We can lower to a more efficient string concatenation

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -32,14 +32,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private static bool CanLowerToStringConcatenation(BoundInterpolatedString node)
+        private bool CanLowerToStringConcatenation(BoundInterpolatedString node)
         {
             foreach (var part in node.Parts)
             {
                 if (part is BoundStringInsert fillin)
                 {
                     // this is one of the expression holes
-                    if (fillin.HasErrors ||
+                    if (_inExpressionLambda ||
+                        fillin.HasErrors ||
                         fillin.Value.Type?.SpecialType != SpecialType.System_String ||
                         fillin.Alignment != null ||
                         fillin.Format != null)
@@ -119,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression result;
 
-            if (!_inExpressionLambda && CanLowerToStringConcatenation(node))
+            if (CanLowerToStringConcatenation(node))
             {
                 // All fill-ins, if any, are strings, and none of them have alignment or format specifiers.
                 // We can lower to a more efficient string concatenation

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInterpolatedString.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInterpolatedString.cs
@@ -218,5 +218,27 @@ a: a
 }
 ");
         }
+
+        [Fact]
+        public void ExpressionsAreNotOptimized()
+        {
+            var source = @"
+using System;
+using System.Linq.Expressions;
+
+public class Test
+{
+    static void Main()
+    {
+        Expression<Func<string, string>> f = a => $""a: {a}"";
+
+        Console.Write(f);
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: @"a => Format(""a: {0}"", a)");
+
+            comp.VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Interpolated strings should not be optimized to string concatenations when in an expression lambda.

This PR fixes this bug, which was introduced by #26612 (an optimization implemented in 15.8).

