### PR TITLE
Don't offer to qualify property from inside an attribute on a class

### DIFF
--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1201,6 +1201,34 @@ class Program
 CodeStyleOptions.QualifyPropertyAccess);
         }
 
+        [WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInStaticContext8()
+        {
+            await TestMissingAsyncWithOption(
+@"class Program
+{
+    [Obsolete(nameof([|Foo|]))]
+    public int Foo { get; set; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInStaticContext9()
+        {
+            await TestMissingAsyncWithOption(
+@"class Program
+{
+    [Obsolete(nameof([|Foo|]))]
+    public int Bar = 0 ;
+
+    public int Foo { get; set; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
         [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
         public async Task QualifyPropertyAccess_InAccessorExpressionBody()

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1188,6 +1188,19 @@ CodeStyleOptions.QualifyPropertyAccess);
 CodeStyleOptions.QualifyEventAccess);
         }
 
+        [WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInStaticContext7()
+        {
+            await TestMissingAsyncWithOption(
+@"[Obsolete(nameof([|Foo|]))]
+class Program
+{
+    public int Foo { get; set; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
         [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
         public async Task QualifyPropertyAccess_InAccessorExpressionBody()

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -625,10 +625,36 @@ CodeStyleOptions.QualifyFieldAccess)
             Await TestMissingAsyncWithOption("
 <Obsolete(NameOf([|Foo|]))>
 class C
-    Private Foo As String
+    Private Property Foo As String
 End Class
 ",
-CodeStyleOptions.QualifyFieldAccess)
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
+
+        <WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_InAttribute2() As Task
+            Await TestMissingAsyncWithOption("
+class C
+    <Obsolete(NameOf([|Foo|]))>
+    Private Property Foo As String
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
+
+        <WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_InAttribute3() As Task
+            Await TestMissingAsyncWithOption("
+class C
+    Private Property Foo As String
+
+    <Obsolete(NameOf([|Foo|]))>
+    Private Bar As String
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -618,5 +618,17 @@ End Class
 ",
 CodeStyleOptions.QualifyFieldAccess)
         End Function
+
+        <WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_InAttribute1() As Task
+            Await TestMissingAsyncWithOption("
+<Obsolete(NameOf([|Foo|]))>
+class C
+    Private Foo As String
+End Class
+",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -103,6 +103,12 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                 return;
             }
 
+            // if the containing symbol is a class, as for attributes, then we can't do anything
+            if (context.ContainingSymbol.Kind == SymbolKind.NamedType)
+            {
+                return;
+            }
+
             var simpleName = instanceOperation.Syntax as TSimpleNameSyntax;
             if (simpleName == null)
             {


### PR DESCRIPTION
### Customer scenario

When using `nameof` in an attribute on a class the fixer for qualifying with `this.` appears, which results in broken code.

### Bugs this fixes

FIxes #26893 and #23803

### Workarounds, if any

None

### Risk

Low

### Performance impact

Low, just checking existing property

### Root cause analysis

Added tests to prevent regression in VB and C#

### How was the bug found?

Customer reported

### Test documentation updated?

N/A

</details>
