### PR TITLE
Add support for VSMac unit test synchronization context

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
@@ -29,9 +29,9 @@ namespace Microsoft.CodeAnalysis.Utilities
 
         internal static ForegroundThreadDataKind CreateDefault(ForegroundThreadDataKind defaultKind)
         {
-            var syncConextTypeName = SynchronizationContext.Current?.GetType().FullName;
+            var syncContextTypeName = SynchronizationContext.Current?.GetType().FullName;
 
-            switch (syncConextTypeName)
+            switch (syncContextTypeName)
             {
                 case "System.Windows.Threading.DispatcherSynchronizationContext":
 

--- a/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.Utilities
         JoinableTask,
         ForcedByPackageInitialize,
         MonoDevelopGtk,
+        MonoDevelopXwt,
         Unknown
     }
 
@@ -47,6 +48,10 @@ namespace Microsoft.CodeAnalysis.Utilities
                 case "MonoDevelop.Ide.DispatchService+GtkSynchronizationContext":
 
                     return MonoDevelopGtk;
+
+                case "Xwt.XwtSynchronizationContext":
+
+                    return MonoDevelopXwt;
 
                 default:
 


### PR DESCRIPTION
<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Customer not affected.

### Bugs this fixes

-

### Workarounds, if any

A lot of refactoring in VSMac test suites to get this done. This is a workaround to move us forward until we properly layer the integration test suites.

### Risk

Just adds new enum values that allow Xwt-based synchronization context to function with default data.

### Performance impact

None

### Is this a regression from a previous update?

No

### Root cause analysis

We weren't hitting into ForegroundThreadData needed to be initialized in parts of VSMac test suite

### How was the bug found?

-

### Test documentation updated?

None needed.

</details>
