### PR TITLE
Add scripts for checking loc status

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -37,8 +37,13 @@
 
   <!-- Settings for localization -->
   <ItemGroup>
-    <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="All" Condition="'$(NonShipping)' != 'true'" />
+    <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Disable localization for non-shipping projects -->
+    <EnableXlfLocalization Condition="'$(NonShipping)' == 'true'">false</EnableXlfLocalization>
+  </PropertyGroup>
 
   <Choose>
     <When Condition="'$(SignAssembly)' == 'true'">
@@ -497,12 +502,4 @@
            Condition="$(PathMap.Contains(' '))" />
   </Target>
 
-  <!--
-    Delegates to XliffTasks to validate that all localizable resources have been translated.
-    We can't use EnsureAllResoucesTranslated directly because the XliffTasks package is only pulled in by projects that
-    produce shipping binaries.
-  -->
-  <Target Name="CheckLocStatus"
-          DependsOnTargets="EnsureAllResourcesTranslated"
-          Condition="'$(NonShipping)' != 'true'" />
 </Project>

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -496,4 +496,13 @@
     <Error Text="PathMap, DeterministicSourceRoot and RepoRoot shall not contain spaces (https://github.com/dotnet/roslyn/issues/22835)" 
            Condition="$(PathMap.Contains(' '))" />
   </Target>
+
+  <!--
+    Delegates to XliffTasks to validate that all localizable resources have been translated.
+    We can't use EnsureAllResoucesTranslated directly because the XliffTasks package is only pulled in by projects that
+    produce shipping binaries.
+  -->
+  <Target Name="CheckLocStatus"
+          DependsOnTargets="EnsureAllResourcesTranslated"
+          Condition="'$(NonShipping)' != 'true'" />
 </Project>

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -34,6 +34,7 @@ param (
     [string]$signType = "",
     [switch]$skipBuildExtras = $false,
     [switch]$skipAnalyzers = $false,
+    [switch]$checkLoc = $false,
 
     # Test options
     [switch]$test32 = $false,
@@ -67,6 +68,7 @@ function Print-Usage() {
     Write-Host "  -procdump                 Monitor test runs with procdump"
     Write-Host "  -skipAnalyzers            Do not run analyzers during build operations"
     Write-Host "  -skipBuildExtras          Do not build insertion items"
+    Write-Host "  -checkLoc                 Check that all resources are localized"
     Write-Host ""
     Write-Host "Test options"
     Write-Host "  -test32                   Run unit tests in the 32-bit runner"
@@ -481,6 +483,10 @@ function Build-DeployToSymStore() {
     Run-MSBuild "Roslyn.sln" "/t:DeployToSymStore" -logFileName "RoslynDeployToSymStore"
 }
 
+function Build-CheckLocStatus() {
+    Run-MSBuild "Roslyn.sln" "/t:CheckLocStatus" -logFileName "RoslynCheckLocStatus"
+}
+
 # These are tests that don't follow our standard restore, build, test pattern. They customize
 # the processes in order to test specific elements of our build and hence are handled
 # separately from our other tests
@@ -799,6 +805,10 @@ try {
 
     if ($build -or $pack) {
         Build-Artifacts
+    }
+
+    if ($checkLoc) {
+        Build-CheckLocStatus
     }
 
     if ($testDesktop -or $testCoreClr -or $testVsi -or $testVsiNetCore -or $testIOperation) {

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -484,7 +484,7 @@ function Build-DeployToSymStore() {
 }
 
 function Build-CheckLocStatus() {
-    Run-MSBuild "Roslyn.sln" "/t:CheckLocStatus" -logFileName "RoslynCheckLocStatus"
+    Run-MSBuild "Roslyn.sln" "/t:EnsureAllResourcesTranslated" -logFileName "RoslynCheckLocStatus"
 }
 
 # These are tests that don't follow our standard restore, build, test pattern. They customize

--- a/build/scripts/check-loc-status.cmd
+++ b/build/scripts/check-loc-status.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\build.ps1" -cibuild -restore -checkLoc -release -binaryLog %*

--- a/netci.groovy
+++ b/netci.groovy
@@ -236,6 +236,22 @@ commitPullList.each { isPr ->
   }
 }
 
+// Loc status check
+commitPullList.each { isPr ->
+  def jobName = Utilities.getFullJobName(projectName, "windows_loc_status", isPr)
+  def myJob = job(jobName) {
+    description('Check for untranslated resources')
+    steps {
+      batchFile(""".\\build\\scripts\\check-loc-status.cmd""")
+    }
+  }
+
+  def triggerPhraseOnly = true
+  def triggerPhraseExtra = "loc"
+  Utilities.setMachineAffinity(myJob, 'Windows_NT', windowsUnitTestMachine)
+  addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
+}
+
 JobReport.Report.generateJobReport(out)
 
 // Make the call to generate the help job


### PR DESCRIPTION
1. Add a new `CheckLocStatus` target. When run this target validates that all localizable resources have been translated, and produced MSBuild errors for those that have not. This simply delegates to the `EnsureAllResourcesTranslated` in the XliffTasks package, but it is conditioned to only run for projects producing shipping binaries (non-shipping projects don't pull in the XliffTasks package).
2. Update build.ps1 to include a `-checkLoc` switch. When the switch it set, build.ps1 will run the above target in MSBuild.
3. Add a check-loc-status.cmd script for use in the CI build. This executes build.ps1 with the minimum set of switches for checking the loc status. For example, we need to restore to ensure we have XliffTasks installed, but we don't need to actually run the `build` target. By skipping that we can greatly speed up the associated leg in CI builds.
4. Update netci.groovy to include a build leg that runs the check-loc-status.cmd script. Currently it will only be run on-demand via a `test loc` comment, but I can imagine turning it on for release branches to ensure loc changes don't find their way in late in the cycle.