### PR TITLE
Exclude nested captures from quick-info

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -5337,6 +5337,82 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(26101, "https://github.com/dotnet/roslyn/issues/26101")]
+        public async Task QuickInfoCapturesOnLocalFunction5()
+        {
+            await TestAsync(@"
+class C
+{
+    int field;
+    void M()
+    {
+        void OuterLocalFunction()
+        {
+            int local = 0;
+            int InnerLocalFunction$$() 
+            {
+                field++;
+                return local;
+            }
+        }
+    }
+}",
+                Captures($"\r\n{WorkspacesResources.Variables_captured_colon} this, local"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(26101, "https://github.com/dotnet/roslyn/issues/26101")]
+        public async Task QuickInfoCapturesOnLocalFunction6()
+        {
+            await TestAsync(@"
+class C
+{
+    int field;
+    void M()
+    {
+        int local1 = 0;
+        int local2 = 0;
+
+        void OuterLocalFunction$$()
+        {
+            _ = local1;
+            void InnerLocalFunction() 
+            {
+                _ = local2;
+            }
+        }
+    }
+}",
+                Captures($"\r\n{WorkspacesResources.Variables_captured_colon} local1, local2"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(26101, "https://github.com/dotnet/roslyn/issues/26101")]
+        public async Task QuickInfoCapturesOnLocalFunction7()
+        {
+            await TestAsync(@"
+class C
+{
+    int field;
+    void M()
+    {
+        int local1 = 0;
+        int local2 = 0;
+
+        void OuterLocalFunction()
+        {
+            _ = local1;
+            void InnerLocalFunction$$() 
+            {
+                _ = local2;
+            }
+        }
+    }
+}",
+                Captures($"\r\n{WorkspacesResources.Variables_captured_colon} local2"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         [WorkItem(23307, "https://github.com/dotnet/roslyn/issues/23307")]
         public async Task QuickInfoCapturesOnLambda()
         {
@@ -5441,6 +5517,82 @@ class C
     }
 }",
                 Captures($"\r\n{WorkspacesResources.Variables_captured_colon} this"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(26101, "https://github.com/dotnet/roslyn/issues/26101")]
+        public async Task QuickInfoCapturesOnLambda6()
+        {
+            await TestAsync(@"
+class C
+{
+    int field;
+    void M()
+    {
+        System.Action a = () =>
+        {
+            int local = 0;
+            System.Func<int> b = () =$$>
+            {
+                field++;
+                return local;
+            };
+        };
+    }
+}",
+                Captures($"\r\n{WorkspacesResources.Variables_captured_colon} this, local"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(26101, "https://github.com/dotnet/roslyn/issues/26101")]
+        public async Task QuickInfoCapturesOnLambda7()
+        {
+            await TestAsync(@"
+class C
+{
+    int field;
+    void M()
+    {
+        int local1 = 0;
+        int local2 = 0;
+
+        System.Action a = () =$$>
+        {
+            _ = local1;
+            System.Action b = () =>
+            {
+                _ = local2;
+            };
+        };
+    }
+}",
+                Captures($"\r\n{WorkspacesResources.Variables_captured_colon} local1, local2"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(26101, "https://github.com/dotnet/roslyn/issues/26101")]
+        public async Task QuickInfoCapturesOnLambda8()
+        {
+            await TestAsync(@"
+class C
+{
+    int field;
+    void M()
+    {
+        int local1 = 0;
+        int local2 = 0;
+
+        System.Action a = () =>
+        {
+            _ = local1;
+            System.Action b = () =$$>
+            {
+                _ = local2;
+            };
+        };
+    }
+}",
+                Captures($"\r\n{WorkspacesResources.Variables_captured_colon} local2"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -5313,6 +5313,30 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(26101, "https://github.com/dotnet/roslyn/issues/26101")]
+        public async Task QuickInfoCapturesOnLocalFunction4()
+        {
+            await TestAsync(@"
+class C
+{
+    int field;
+    void M()
+    {
+        void OuterLocalFunction$$()
+        {
+            int local = 0;
+            int InnerLocalFunction() 
+            {
+                field++;
+                return local;
+            }
+        }
+    }
+}",
+                Captures($"\r\n{WorkspacesResources.Variables_captured_colon} this"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         [WorkItem(23307, "https://github.com/dotnet/roslyn/issues/23307")]
         public async Task QuickInfoCapturesOnLambda()
         {
@@ -5393,6 +5417,30 @@ class C
     void N(System.Action x, System.Action y) { }
 }",
                 Captures($"\r\n{WorkspacesResources.Variables_captured_colon} i"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(26101, "https://github.com/dotnet/roslyn/issues/26101")]
+        public async Task QuickInfoCapturesOnLambda5()
+        {
+            await TestAsync(@"
+class C
+{
+    int field;
+    void M()
+    {
+        System.Action a = () =$$>
+        {
+            int local = 0;
+            System.Func<int> b = () =>
+            {
+                field++;
+                return local;
+            };
+        };
+    }
+}",
+                Captures($"\r\n{WorkspacesResources.Variables_captured_colon} this"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                 }
 
                 var analysis = semanticModel.AnalyzeDataFlow(syntax);
-                var captures = analysis.CapturedInside;
+                var captures = analysis.CapturedInside.Except(analysis.VariablesDeclared).ToImmutableArray();
                 if (!captures.IsEmpty)
                 {
                     var parts = new List<SymbolDisplayPart>();


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/26101

<details><summary>Ask Mode template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Customer hovers over a lambda or inner function that has a further lambda or inner function. The "captures" information isn't always correct in this case.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/26101

### Workarounds, if any

No workarounds, just could recognize this is being reported wrong.

### Risk

Low.

### Performance impact

None.

### Is this a regression from a previous update?

No, new feature that was added missed this edge case.

### Root cause analysis

More complicated edge case; tests were added.

### How was the bug found?

Customer reported -- and fixed!

</details>
