### PR TITLE
Disabling integration tests due to Jenkins failure

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -227,7 +227,7 @@ commitPullList.each { isPr ->
         }
       }
 
-      def triggerPhraseOnly = false
+      def triggerPhraseOnly = true
       def triggerPhraseExtra = ""
       Utilities.setMachineAffinity(myJob, 'Windows.10.Amd64.ClientRS4.DevEx.Open')
       Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')


### PR DESCRIPTION
Jenkins is currently failing on most integration tests very often with either java.nio.channels.ClosedChannelException or java.lang.NullPointerException.

They should probably be disabled while this is being investigated. 