### PR TITLE
Stop NGENing System.Net.Http and dependencies

### DIFF
--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -41,7 +41,6 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Vsix\CompilerExtension\Microsoft.Win32.Primitives.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.AppContext.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Console.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.DiagnosticSource.dll
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.FileVersionInfo.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.StackTrace.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Globalization.Calendars.dll vs.file.ngenArchitecture=all
@@ -49,7 +48,6 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.Compression.ZipFile.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.Primitives.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Net.Http.dll
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Net.Sockets.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Cryptography.Algorithms.dll vs.file.ngenArchitecture=all
@@ -62,6 +60,10 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Xml.XmlDocument.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Xml.XPath.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Xml.XPath.XDocument.dll vs.file.ngenArchitecture=all
+# We never load these binaries, and it does not generate the correct binding redirects, so do not NGEN them
+# https://github.com/dotnet/roslyn/pull/27537
+    file source=$(OutputPath)\Vsix\CompilerExtension\System.Net.Http.dll
+    file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.DiagnosticSource.dll
 
 folder InstallDir:\Common7\Tools\vsdevcmd\ext
     file source=$(RepoRoot)\src\Setup\MSBuildScripts\roslyn.bat

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -41,7 +41,7 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Vsix\CompilerExtension\Microsoft.Win32.Primitives.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.AppContext.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Console.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.DiagnosticSource.dll vs.file.ngenArchitecture=all
+    file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.DiagnosticSource.dll
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.FileVersionInfo.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.StackTrace.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Globalization.Calendars.dll vs.file.ngenArchitecture=all
@@ -49,7 +49,7 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.Compression.ZipFile.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.Primitives.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Net.Http.dll vs.file.ngenArchitecture=all
+    file source=$(OutputPath)\Vsix\CompilerExtension\System.Net.Http.dll
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Net.Sockets.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Cryptography.Algorithms.dll vs.file.ngenArchitecture=all

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -302,9 +302,16 @@ namespace BuildBoss
         /// </summary>
         private bool VerifySwrFile(TextWriter textWriter, List<string> dllFileNames)
         {
-            var nativeDlls = new[] { "Microsoft.DiaSymReader.Native.amd64.dll", "Microsoft.DiaSymReader.Native.x86.dll" };
+            var excludedDlls = new[]
+            {
+                "Microsoft.DiaSymReader.Native.amd64.dll",      // native
+                "Microsoft.DiaSymReader.Native.x86.dll",        // native
+                "System.Net.Http.dll",                          // not loaded: https://github.com/dotnet/roslyn/pull/27537
+                "System.Diagnostics.DiagnosticSource.dll",      // not loaded: https://github.com/dotnet/roslyn/pull/27537
+            };
+
             var map = dllFileNames
-                .Where(x => !nativeDlls.Contains(x, PathComparer))
+                .Where(x => !excludedDlls.Contains(x, PathComparer))
                 .ToDictionary(
                     keySelector: x => x,
                     elementSelector: _ => false,


### PR DESCRIPTION
This is failing NGEN in official builds, as binding redirects to dependencies are not generated correctly.
We don't actually use/load that assembly in any way, so let's stop NGENing it.

cc @jaredpar @tannergooding @jasonmalinowski 