### PR TITLE
Only call EnsureSubcription for text loaders when we are actually reading

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -82,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 // The project system does not tell us the CodePage specified in the proj file, so
                 // we use null to auto-detect.
-                _doNotAccessDirectlyLoader = new FileTextLoader(documentKey.Moniker, defaultEncoding: null);
+                _doNotAccessDirectlyLoader = new FileChangeTrackingTextLoader(_fileChangeTracker, new FileTextLoader(documentKey.Moniker, defaultEncoding: null));
 
                 // If we aren't already open in the editor, then we should create a file change notification
                 if (openTextBuffer == null)
@@ -135,7 +137,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 get
                 {
-                    _fileChangeTracker.EnsureSubscription();
                     return _doNotAccessDirectlyLoader;
                 }
             }
@@ -236,6 +237,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
 
                 return Project.Hierarchy.TryGetItemId(_itemMoniker);
+            }
+
+            /// <summary>
+            /// A wrapper for a <see cref="TextLoader"/> that ensures we are watching file contents prior to reading the file.
+            /// </summary>
+            private sealed class FileChangeTrackingTextLoader : TextLoader
+            {
+                private readonly FileChangeTracker _fileChangeTracker;
+                private readonly TextLoader _innerTextLoader;
+
+                public FileChangeTrackingTextLoader(FileChangeTracker fileChangeTracker, TextLoader innerTextLoader)
+                {
+                    _fileChangeTracker = fileChangeTracker;
+                    _innerTextLoader = innerTextLoader;
+                }
+
+                public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+                {
+                    _fileChangeTracker.EnsureSubscription();
+                    return _innerTextLoader.LoadTextAndVersionAsync(workspace, documentId, cancellationToken);
+                }
+
+                internal override TextAndVersion LoadTextAndVersionSynchronously(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+                {
+                    _fileChangeTracker.EnsureSubscription();
+                    return _innerTextLoader.LoadTextAndVersionSynchronously(workspace, documentId, cancellationToken);
+                }
             }
         }
     }


### PR DESCRIPTION
We were calling .EnsureSubscription() right away when we add the documents to the workspace, which was never the intent of this API; this can (and should) be deferred until when we read the file. This should remove a lot of overhead during solution load.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
