### PR TITLE
Fix memory leak in EditorConfigDocumentOptionsProvider

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProvider.cs
@@ -87,31 +87,20 @@ namespace Microsoft.CodeAnalysis.Editor.Options
         {
             lock (_gate)
             {
-                var itemReleased = false;
+                var itemsToRemove = new List<DocumentId>();
                 foreach (var (documentId, contextTask) in _openDocumentContexts)
                 {
                     if (projectId is null || documentId.ProjectId == projectId)
                     {
-                        itemReleased = true;
+                        itemsToRemove.Add(documentId);
                         ReleaseContext_NoLock(contextTask);
                     }
                 }
 
                 // If any items were released due to the Clear operation, we need to remove them from the map.
-                if (itemReleased)
+                foreach (var documentId in itemsToRemove)
                 {
-                    if (projectId is null)
-                    {
-                        _openDocumentContexts.Clear();
-                    }
-                    else
-                    {
-                        var itemsToRemove = _openDocumentContexts.Keys.Where(key => key.ProjectId == projectId).ToList();
-                        foreach (var documentId in itemsToRemove)
-                        {
-                            _openDocumentContexts.Remove(documentId);
-                        }
-                    }
+                    _openDocumentContexts.Remove(documentId);
                 }
             }
         }


### PR DESCRIPTION
This pull request implements the memory leak fix from #26386.

### Customer scenario

A memory leak occurs if a solution is closed while documents are open.

### Bugs this fixes

This is an interim solution for #26377.

### Workarounds, if any

Either of the following:

* Close all documents before closing a solution
* Restart the IDE when opening a different solution or reopening the same solution

### Risk

Low. The code only impacts cases where a project or solution is getting closed, and takes the same actions that occur if we received the expected events for closing documents.

### Performance impact

Minor performance improvement in the impacted scenario.

### Is this a regression from a previous update?

No.

### Root cause analysis

The leak is minor (a few small object graphs) so it didn't show up in profiling reports.

### How was the bug found?

Found by @heejaechang the investigation for #15003.

### Test documentation updated?

N/A
