### PR TITLE
Revert BuildBoss fix for non-NGENed compiler binaries

### DIFF
--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -302,16 +302,9 @@ namespace BuildBoss
         /// </summary>
         private bool VerifySwrFile(TextWriter textWriter, List<string> dllFileNames)
         {
-            var excludedDlls = new[]
-            {
-                "Microsoft.DiaSymReader.Native.amd64.dll",      // native
-                "Microsoft.DiaSymReader.Native.x86.dll",        // native
-                "System.Net.Http.dll",                          // not loaded: https://github.com/dotnet/roslyn/pull/27537
-                "System.Diagnostics.DiagnosticSource.dll",      // not loaded: https://github.com/dotnet/roslyn/pull/27537
-            };
-
+            var nativeDlls = new[] { "Microsoft.DiaSymReader.Native.amd64.dll", "Microsoft.DiaSymReader.Native.x86.dll" };
             var map = dllFileNames
-                .Where(x => !excludedDlls.Contains(x, PathComparer))
+                .Where(x => !nativeDlls.Contains(x, PathComparer))
                 .ToDictionary(
                     keySelector: x => x,
                     elementSelector: _ => false,


### PR DESCRIPTION
Related failure: https://ci.dot.net/job/dotnet_roslyn/job/master/job/windows_build_correctness_prtest/14275/
