### PR TITLE
Fix crash in GetDeconstructionInfo

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -854,7 +854,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var boundConversion = boundDeconstruction.Right;
-            Debug.Assert(boundConversion != null || boundDeconstruction.HasAnyErrors);
+            Debug.Assert(boundConversion != null);
+            if (boundConversion is null)
+            {
+                return default;
+            }
 
             return new DeconstructionInfo(boundConversion.Conversion);
         }
@@ -869,6 +873,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var boundDeconstruction = boundForEach.DeconstructionOpt;
             Debug.Assert(boundDeconstruction != null || boundForEach.HasAnyErrors);
+            if (boundDeconstruction is null)
+            {
+                return default;
+            }
 
             return new DeconstructionInfo(boundDeconstruction.DeconstructionAssignment.Right.Conversion);
         }


### PR DESCRIPTION
### Customer scenario
Type an incomplete `foreach (char in s) { }` and hover your mouse over the `in`. The IDE will pop-up an exception dialog or crash.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/27520
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/628435

### Risk
### Performance impact
Low. This fix is just adding a null check.

### Is this a regression from a previous update?
Yes, this is a regression from 15.7.

### Root cause analysis
Although the API (including this underlying bug) was introduced in 15.6, it was only used for Find All References. But [in 15.8](https://github.com/dotnet/roslyn/pull/25984), I made a change to use this API in QuickInfo, which is much more common, especially on incomplete code.

### How was the bug found?
Watson and bug report from a team member