### PR TITLE
Fix building EditorFeatures on non-Windows machine

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -422,7 +422,7 @@
        
        https://github.com/dotnet/core-setup/issues/3805
        -->
-  <Target Name="BeforeBuild" Condition="'$(MSBuildRuntimeType)' != 'Core'">
+  <Target Name="BeforeBuild" Condition="'$(MSBuildRuntimeType)' != 'Core' AND '$(OS)' == 'Windows_NT'">
     <ValidateBuildEnvironment
       MSBuildBinPath="$(MSBuildBinPath)"
       MSBuildMinimumFileVersion="15.3.409"


### PR DESCRIPTION
Problem is that `ValidateBuildEnvironment` task is conditionally imported only in case of `'$(OS)' == 'Windows_NT'` see https://github.com/dotnet/roslyn/blob/1c67c5ee/build/Targets/Settings.props#L193-L195
