### PR TITLE
Fix #26358: AbstractDocumentationCommentCommandHandler has hardcoded Windows line ending

### DIFF
--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -36,6 +36,22 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void TypingCharacter_Class_NewLine()
+        {
+            var code = "//$$\nclass C\n{\n}";
+
+            var expected = "/// <summary>\n/// $$\n/// </summary>\nclass C\n{\n}";
+
+            VerifyTypingCharacter(code, expected, newLine: "\n");
+
+            code = "//$$\r\nclass C\r\n{\r\n}";
+
+            expected = "/// <summary>\r\n/// $$\r\n/// </summary>\r\nclass C\r\n{\r\n}";
+
+            VerifyTypingCharacter(code, expected, newLine: "\r\n");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void TypingCharacter_Class_AutoGenerateXmlDocCommentsOff()
         {
             var code =

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -38,9 +38,9 @@ class C
         [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void TypingCharacter_Class_NewLine()
         {
-            var code = "//$$\nclass C\n{\n}";
+            var code = "//$$\r\nclass C\r\n{\r\n}";
 
-            var expected = "/// <summary>\n/// $$\n/// </summary>\nclass C\n{\n}";
+            var expected = "/// <summary>\n/// $$\n/// </summary>\r\nclass C\r\n{\r\n}";
 
             VerifyTypingCharacter(code, expected, newLine: "\n");
 

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -76,12 +76,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
 
         public string DisplayName => EditorFeaturesResources.Documentation_Comment;
 
-        private string GetNewLine(SourceText text)
-        {
-            // return editorOptionsFactoryService.GetEditorOptions(text).GetNewLineCharacter();
-            return "\r\n";
-        }
-
         private TMemberNode GetTargetMember(SyntaxTree syntaxTree, SourceText text, int position, CancellationToken cancellationToken)
         {
             var member = GetContainingMember(syntaxTree, position, cancellationToken);
@@ -127,11 +121,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             return targetMember;
         }
 
-        private void AddLineBreaks(SourceText text, IList<string> lines)
+        private void AddLineBreaks(SourceText text, IList<string> lines, string newLine)
         {
             for (int i = 0; i < lines.Count; i++)
             {
-                lines[i] = lines[i] + GetNewLine(text);
+                lines[i] = lines[i] + newLine;
             }
         }
 
@@ -186,7 +180,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             var lines = GetDocumentationCommentStubLines(targetMember);
             Contract.Assume(lines.Count > 2);
 
-            AddLineBreaks(text, lines);
+            var newLine = options.GetOption(FormattingOptions.NewLine);
+            AddLineBreaks(text, lines, newLine);
 
             // Shave off initial three slashes
             lines[0] = lines[0].Substring(3);
@@ -200,11 +195,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             }
 
             var lastLine = lines[lines.Count - 1];
-            lastLine = indentText + lastLine.Substring(0, lastLine.Length - GetNewLine(text).Length);
+            lastLine = indentText + lastLine.Substring(0, lastLine.Length - newLine.Length);
             lines[lines.Count - 1] = lastLine;
 
             var newText = string.Join(string.Empty, lines);
-            var offset = lines[0].Length + lines[1].Length - GetNewLine(text).Length;
+            var offset = lines[0].Length + lines[1].Length - newLine.Length;
 
             subjectBuffer.Insert(position, newText);
             textView.TryMoveCaretToAndEnsureVisible(subjectBuffer.CurrentSnapshot.GetPoint(position + offset));
@@ -286,7 +281,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             var lines = GetDocumentationCommentStubLines(targetMember);
             Contract.Assume(lines.Count > 2);
 
-            AddLineBreaks(text, lines);
+            var newLine = options.GetOption(FormattingOptions.NewLine);
+            AddLineBreaks(text, lines, newLine);
 
             // Shave off initial exterior trivia
             lines[0] = lines[0].Substring(3);
@@ -300,13 +296,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             }
 
             var newText = string.Join(string.Empty, lines);
-            var offset = lines[0].Length + lines[1].Length - GetNewLine(text).Length;
+            var offset = lines[0].Length + lines[1].Length - newLine.Length;
 
             // Shave off final line break or add trailing indent if necessary
             var trivia = syntaxTree.GetRoot(cancellationToken).FindTrivia(position, findInsideTrivia: false);
             if (IsEndOfLineTrivia(trivia))
             {
-                newText = newText.Substring(0, newText.Length - GetNewLine(text).Length);
+                newText = newText.Substring(0, newText.Length - newLine.Length);
             }
             else
             {
@@ -420,7 +416,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             var lines = GetDocumentationCommentStubLines(targetMember);
             Contract.Assume(lines.Count > 2);
 
-            AddLineBreaks(text, lines);
+            var newLine = options.GetOption(FormattingOptions.NewLine);
+            AddLineBreaks(text, lines, newLine);
 
             // Add indents
             var lineOffset = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(options.GetOption(FormattingOptions.TabSize));
@@ -435,7 +432,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             lines[lines.Count - 1] = lines[lines.Count - 1] + indentText;
 
             var newText = string.Join(string.Empty, lines);
-            var offset = lines[0].Length + lines[1].Length - GetNewLine(text).Length;
+            var offset = lines[0].Length + lines[1].Length - newLine.Length;
 
             subjectBuffer.Insert(startPosition, newText);
 

--- a/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
+++ b/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
@@ -29,9 +29,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
 
         protected abstract TestWorkspace CreateTestWorkspace(string code);
 
-        protected void VerifyTypingCharacter(string initialMarkup, string expectedMarkup, bool useTabs = false, bool autoGenerateXmlDocComments = true)
+        protected void VerifyTypingCharacter(string initialMarkup, string expectedMarkup, bool useTabs = false, bool autoGenerateXmlDocComments = true, string newLine = "\r\n")
         {
-            Verify(initialMarkup, expectedMarkup, useTabs, autoGenerateXmlDocComments,
+            Verify(initialMarkup, expectedMarkup, useTabs, autoGenerateXmlDocComments, newLine: newLine,
                 execute: (view, undoHistoryRegistry, editorOperationsFactoryService, completionService) =>
                 {
                     var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService);
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
 
         private void Verify(string initialMarkup, string expectedMarkup, bool useTabs, bool autoGenerateXmlDocComments,
             Action<IWpfTextView, ITextUndoHistoryRegistry, IEditorOperationsFactoryService, IAsyncCompletionService> execute,
-            Action<TestWorkspace> setOptionsOpt = null)
+            Action<TestWorkspace> setOptionsOpt = null, string newLine = "\r\n")
         {
             using (var workspace = CreateTestWorkspace(initialMarkup))
             {
@@ -148,6 +148,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
 
                 options = options.WithChangedOption(FormattingOptions.UseTabs, testDocument.Project.Language, useTabs);
                 options = options.WithChangedOption(FeatureOnOffOptions.AutoXmlDocCommentGeneration, testDocument.Project.Language, autoGenerateXmlDocComments);
+                options = options.WithChangedOption(FormattingOptions.NewLine, testDocument.Project.Language, newLine);
 
                 workspace.Options = options;
 


### PR DESCRIPTION
I used `\n` and `\r\n` in string instead `@""` because as far as I understand on Windows/CI code is checked out with `git config core.autocrlf` which means it modifies line endings...

### Customer scenario

If customer uses `\n` for line endings and has appropriate formatting setting set, every time documentation after `///` is inserted it inserted `\r\n` wrongly.

### Bugs this fixes

#26358

### Workarounds, if any

None.

### Risk

Fix is pretty small, so I would say it's unlikely to cause regressions.

### Performance impact

I don't expect changes

### Is this a regression from a previous update?

No.

### Root cause analysis

There was commented code that would support thiis, so I would assume reason was just not caring about `\n` scenario. Unit test is added.

### How was the bug found?

While integrating this command with VSfM.

### Test documentation updated?

Unit tests should be sufficient.