### PR TITLE
Make ShadowCopyAnalyzerAssemblyLoader threadsafe

### DIFF
--- a/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis
             return base.LoadImpl(shadowCopyPath);
         }
 
-        private string CopyFileAndResources(string fullPath, string assemblyDirectory)
+        private static string CopyFileAndResources(string fullPath, string assemblyDirectory)
         {
             string fileNameWithExtension = Path.GetFileName(fullPath);
             string shadowCopyPath = Path.Combine(assemblyDirectory, fileNameWithExtension);
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis
             return shadowCopyPath;
         }
 
-        private void CopyFile(string originalPath, string shadowCopyPath)
+        private static void CopyFile(string originalPath, string shadowCopyPath)
         {
             var directory = Path.GetDirectoryName(shadowCopyPath);
             Directory.CreateDirectory(directory);
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis
             ClearReadOnlyFlagOnFile(new FileInfo(shadowCopyPath));
         }
 
-        private void ClearReadOnlyFlagOnFiles(string directoryPath)
+        private static void ClearReadOnlyFlagOnFiles(string directoryPath)
         {
             DirectoryInfo directory = new DirectoryInfo(directoryPath);
 
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private void ClearReadOnlyFlagOnFile(FileInfo fileInfo)
+        private static void ClearReadOnlyFlagOnFile(FileInfo fileInfo)
         {
             try
             {

--- a/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -28,13 +28,12 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// The directory where this instance of <see cref="ShadowCopyAnalyzerAssemblyLoader"/>
-        /// will shadow-copy assemblies.
+        /// will shadow-copy assemblies, and the mutex created to mark that the owner of it is still active.
         /// </summary>
-        private string _shadowCopyDirectory;
-        private Mutex _shadowCopyDirectoryMutex;
+        private readonly Lazy<(string directory, Mutex)> _shadowCopyDirectoryAndMutex;
 
         /// <summary>
-        /// Used to generate unique names for per-assembly directories.
+        /// Used to generate unique names for per-assembly directories. Should be updated with <see cref="Interlocked.Increment(ref int)"/>.
         /// </summary>
         private int _assemblyDirectoryId;
 
@@ -48,6 +47,9 @@ namespace Microsoft.CodeAnalysis
             {
                 _baseDirectory = Path.Combine(Path.GetTempPath(), "CodeAnalysis", "AnalyzerShadowCopies");
             }
+
+            _shadowCopyDirectoryAndMutex = new Lazy<(string directory, Mutex)>(
+                () => CreateUniqueDirectoryForProcess(), LazyThreadSafetyMode.ExecutionAndPublication);
 
             DeleteLeftoverDirectoriesTask = Task.Run((Action)DeleteLeftoverDirectories);
         }
@@ -95,11 +97,6 @@ namespace Microsoft.CodeAnalysis
 
         protected override Assembly LoadImpl(string fullPath)
         {
-            if (_shadowCopyDirectory == null)
-            {
-                _shadowCopyDirectory = CreateUniqueDirectoryForProcess();
-            }
-
             string assemblyDirectory = CreateUniqueDirectoryForAssembly();
             string shadowCopyPath = CopyFileAndResources(fullPath, assemblyDirectory);
 
@@ -177,24 +174,24 @@ namespace Microsoft.CodeAnalysis
 
         private string CreateUniqueDirectoryForAssembly()
         {
-            int directoryId = _assemblyDirectoryId++;
+            int directoryId = Interlocked.Increment(ref _assemblyDirectoryId);
 
-            string directory = Path.Combine(_shadowCopyDirectory, directoryId.ToString());
+            string directory = Path.Combine(_shadowCopyDirectoryAndMutex.Value.directory, directoryId.ToString());
 
             Directory.CreateDirectory(directory);
             return directory;
         }
 
-        private string CreateUniqueDirectoryForProcess()
+        private (string directory, Mutex mutex) CreateUniqueDirectoryForProcess()
         {
             string guid = Guid.NewGuid().ToString("N").ToLowerInvariant();
             string directory = Path.Combine(_baseDirectory, guid);
 
-            _shadowCopyDirectoryMutex = new Mutex(initiallyOwned: false, name: guid);
+            var mutex = new Mutex(initiallyOwned: false, name: guid);
 
             Directory.CreateDirectory(directory);
 
-            return directory;
+            return (directory, mutex);
         }
     }
 }


### PR DESCRIPTION
Multiple callers on multiple threads risked potentially overwriting the same files or having a mismatched Mutex which could have resulted in things being deleted underneath us. This is now properly safe.

There are two consumers of this type today: Visual Studio, which was currently calling this on the same thread the whole time (but that's changing) and VBCSCompiler, where it's a singleton and thus this might have been broken all along.

<details><summary>Ask Mode template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Using analyzers might have done bad things in VBCSCompiler, and will eventually do bad things once we land the free-threaded language service initialization work.

### Bugs this fixes

No bug, noticed as a part of other investigations.

### Workarounds, if any

None.

### Risk

Very low; just using standard patterns.

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

Code was just never written to be thread-safe before.

### How was the bug found?

Feature work.

</details>
