### PR TITLE
Recommend 'this' inside local functions

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
@@ -270,6 +270,79 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27028, "https://github.com/dotnet/roslyn/issues/27028")]
+        public async Task TestInLocalFunction()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    int Method()
+    {
+        void local()
+        {
+            $$
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27028, "https://github.com/dotnet/roslyn/issues/27028")]
+        public async Task TestInNestedLocalFunction()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    int Method()
+    {
+        void local()
+        {
+            void nested()
+            {
+                $$
+            }
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27028, "https://github.com/dotnet/roslyn/issues/27028")]
+        public async Task TestInLocalFunctionInStaticMethod()
+        {
+            await VerifyAbsenceAsync(
+@"class C {
+    static int Method()
+    {
+        void local()
+        {
+            $$
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27028, "https://github.com/dotnet/roslyn/issues/27028")]
+        public async Task TestInNestedLocalFunctionInStaticMethod()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static int Method()
+    {
+        void local()
+        {
+            void nested()
+            {
+                $$
+            }
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAttribute()
         {
             await VerifyKeywordAsync(

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1771,6 +1771,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 #endif
 
             var enclosingSymbol = semanticModel.GetEnclosingSymbol(targetToken.SpanStart, cancellationToken);
+
+            while (enclosingSymbol is IMethodSymbol method && method.MethodKind == MethodKind.LocalFunction)
+            {
+                // It is allowed to reference the instance (`this`) within a local function, as long as the containing method allows it
+                enclosingSymbol = method.ContainingSymbol;
+            }
+
             return !enclosingSymbol.IsStatic;
         }
 


### PR DESCRIPTION
### Customer scenario
Try to type `this` inside a local function that is inside an instance method. `this` should be offered as a completion.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/27028

### Workarounds, if any
Type `this` in full.

### Risk
### Performance impact
Low. The change only impacts the case of typing inside a local function.

### Is this a regression from a previous update?
No.

### Root cause analysis
The semantic model shows local functions as static (since that is how they are emitted).

### How was the bug found?
Internally.