### PR TITLE
do not cancel pending incremental parsing request

### DIFF
--- a/src/Features/Core/Portable/Workspace/BackgroundParser.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundParser.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Host
             //
             // we are alraedy running in BG, you no need to run async version
             var task = _taskScheduler.ScheduleTask(
-                () => document.GetSyntaxTreeSynchronously(CancellationToken.None),
+                () => document.GetSyntaxTreeAsync(CancellationToken.None),
                 "BackgroundParser.ParseDocumentAsync",
                 cancellationToken);
 

--- a/src/Features/Core/Portable/Workspace/BackgroundParser.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundParser.cs
@@ -178,8 +178,12 @@ namespace Microsoft.CodeAnalysis.Host
 
             var cancellationToken = cancellationTokenSource.Token;
 
+            // once task runs, we never cancel running parsing request. this will make sure 
+            // chained incremental parsing request will always get shorten by BG
+            //
+            // we are alraedy running in BG, you no need to run async version
             var task = _taskScheduler.ScheduleTask(
-                () => document.GetSyntaxTreeAsync(cancellationToken),
+                () => document.GetSyntaxTreeSynchronously(CancellationToken.None),
                 "BackgroundParser.ParseDocumentAsync",
                 cancellationToken);
 

--- a/src/Features/Core/Portable/Workspace/BackgroundParser.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundParser.cs
@@ -8,6 +8,15 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Host
 {
+    /// <summary>
+    /// when users type, we chain all those changes as incremental parsing requests 
+    /// but doesn't actually realize those changes. it is saved as a pending request. 
+    /// so if nobody asks for final parse tree, those chain can keep grow. 
+    /// we do this since Roslyn is lazy at the core (don't do work if nobody asks for it)
+    /// 
+    /// but certain host such as VS, we have this (BackgroundParser) which preemptively 
+    /// trying to realize such trees for open/active files expecting users will use them soonish.
+    /// </summary>
     internal class BackgroundParser
     {
         private readonly Workspace _workspace;


### PR DESCRIPTION
### Customer scenario

user is typing in a big C#/VB file and after "enter" it takes long time to get to next line

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/605655 

### Workarounds, if any

type slower

### Risk

Low, theoretically, background parser can have longer pending requests, but that should be just 1 more pending request if running parsing request takes long time. or parsing still going even if it is no longer needed (file removed/closed)

### Performance impact

it should keep moving forward pending incremental parsing chain. reducing risk of the chain getting too big (here more than 50 chained requests)

### Is this a regression from a previous update?

No

### Root cause analysis

when users type, we chain all those changes as incremental parsing requests but doesn't actually realize those changes. it is saved as a pending request. so if nobody asks for final parse tree, those chain can keep grow. we do this since Roslyn is lazy at the core (don't do work if nobody asks for it)

but certain host such as VS, we have something called background parser which preemptively trying to realize such trees for open/active files expecting users will use them soonish.

here, issue was that BG parser cancelled if users types again before parsing is done. making it to do same work repeatedly but never move forward in the chain.

this change makes running parsing work to be never cancelled. making the chain to always move forward.

this still doesn't address the root cause though which might require design change (more risky) where we chain incremental parsing request that has strong dependency to previous result. having a way to break that dependency will let us to not having this long chain issue.

### How was the bug found?

customer reporting

