### PR TITLE
Pattern Using

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3176,7 +3176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// The overload resolution portion of FindForEachPatternMethod.
+        /// The overload resolution portion of FindPatternMethod.
         /// </summary>
         private MethodSymbol PerformPatternOverloadResolution(
             TypeSymbol patternType, ArrayBuilder<MethodSymbol> candidateMethods,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3121,7 +3121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MessageID messageID;
             switch (methodName)
             {
-                case WellKnownMemberNames.GetDisposeMethodName:
+                case WellKnownMemberNames.DisposeMethodName:
                     messageID = MessageID.IDS_Disposable;
                     break;
                 case WellKnownMemberNames.GetEnumeratorMethodName:
@@ -3289,8 +3289,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     lookupResult.Clear();
 
-                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                this.LookupMembersInType(
+                    HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                    this.LookupMembersInType(
                         lookupResult,
                         patternType,
                         memberName,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3101,5 +3101,195 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return ImmutableArray<LabelSymbol>.Empty;
             }
         }
+
+        /// <summary>
+        /// Perform a lookup for the specified method on the specified type.  Perform overload resolution
+        /// on the lookup results.
+        /// </summary>
+        /// <param name="patternType">Type to search.</param>
+        /// <param name="methodName">Method to search for.</param>
+        /// <param name="lookupResult">Passed in for reusability.</param>
+        /// <param name="warningsOnly">True if failures should result in warnings; false if they should result in errors.</param>
+        /// <param name="diagnostics">Populated with binding diagnostics.</param>
+        /// <returns>The desired method or null.</returns>
+        internal MethodSymbol FindPatternMethod(TypeSymbol patternType, string methodName, LookupResult lookupResult,
+                                                SyntaxNode syntaxExpr, bool warningsOnly, DiagnosticBag diagnostics,
+                                                SyntaxTree syntaxTree)
+        {
+            Debug.Assert(lookupResult.IsClear);
+
+            // Not using LookupOptions.MustBeInvocableMember because we don't want the corresponding lookup error.
+            // We filter out non-methods below.
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+            this.LookupMembersInType(
+                lookupResult,
+                patternType,
+                methodName,
+                arity: 0,
+                basesBeingResolved: null,
+                options: LookupOptions.Default,
+                originalBinder: this,
+                diagnose: false,
+                useSiteDiagnostics: ref useSiteDiagnostics);
+
+            diagnostics.Add(syntaxExpr, useSiteDiagnostics);
+
+            if (!lookupResult.IsMultiViable)
+            {
+                ReportPatternMemberLookupDiagnostics(lookupResult, patternType, methodName, syntaxExpr, warningsOnly, diagnostics);
+                return null;
+            }
+
+            ArrayBuilder<MethodSymbol> candidateMethods = ArrayBuilder<MethodSymbol>.GetInstance();
+
+            foreach (Symbol member in lookupResult.Symbols)
+            {
+                if (member.Kind != SymbolKind.Method)
+                {
+                    candidateMethods.Free();
+
+                    if (warningsOnly)
+                    {
+                        ReportPatternWarning(diagnostics, patternType, member, syntaxExpr);
+                    }
+                    return null;
+                }
+
+                MethodSymbol method = (MethodSymbol)member;
+
+                // SPEC VIOLATION: The spec says we should apply overload resolution, but Dev10 uses
+                // some custom logic in ExpressionBinder.BindGrpToParams.  The biggest difference
+                // we've found (so far) is that it only considers methods with zero parameters
+                // (i.e. doesn't work with "params" or optional parameters).
+                if (!method.Parameters.Any())
+                {
+                    candidateMethods.Add((MethodSymbol)member);
+                }
+            }
+
+            MethodSymbol patternMethod = PerformPatternOverloadResolution(patternType, candidateMethods, syntaxExpr, warningsOnly, diagnostics, syntaxTree);
+
+            candidateMethods.Free();
+
+            return patternMethod;
+        }
+
+        /// <summary>
+        /// The overload resolution portion of FindForEachPatternMethod.
+        /// </summary>
+        private MethodSymbol PerformPatternOverloadResolution
+            (TypeSymbol patternType, ArrayBuilder<MethodSymbol> candidateMethods,
+            SyntaxNode syntaxExpression, bool warningsOnly, DiagnosticBag diagnostics,
+            SyntaxTree syntaxTree)
+        {
+            ArrayBuilder<TypeSymbol> typeArguments = ArrayBuilder<TypeSymbol>.GetInstance();
+            AnalyzedArguments arguments = AnalyzedArguments.GetInstance();
+            OverloadResolutionResult<MethodSymbol> overloadResolutionResult = OverloadResolutionResult<MethodSymbol>.GetInstance();
+
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+            // We create a dummy receiver of the invocation so MethodInvocationOverloadResolution knows it was invoked from an instance, not a type
+            var dummyReceiver = new BoundImplicitReceiver(syntaxExpression, patternType);
+            this.OverloadResolution.MethodInvocationOverloadResolution(
+                methods: candidateMethods,
+                typeArguments: typeArguments,
+                receiver: dummyReceiver,
+                arguments: arguments,
+                result: overloadResolutionResult,
+                useSiteDiagnostics: ref useSiteDiagnostics);
+            diagnostics.Add(syntaxExpression, useSiteDiagnostics);
+
+            MethodSymbol result = null;
+
+            if (overloadResolutionResult.Succeeded)
+            {
+                result = overloadResolutionResult.ValidResult.Member;
+
+                if (result.IsStatic || result.DeclaredAccessibility != Accessibility.Public)
+                {
+                    if (warningsOnly)
+                    {
+                        diagnostics.Add(ErrorCode.WRN_PatternStaticOrInaccessible, syntaxExpression.Location, patternType, MessageID.IDS_Collection.Localize(), result);
+                    }
+                    result = null;
+                }
+                else if (result.CallsAreOmitted(syntaxTree))
+                {
+                    // Calls to this method are omitted in the current syntax tree, i.e it is either a partial method with no implementation part OR a conditional method whose condition is not true in this source file.
+                    // We don't want to want to allow this case, see StatementBinder::bindPatternToMethod.
+                    result = null;
+                }
+            }
+            else if (overloadResolutionResult.Results.Length > 1)
+            {
+                if (warningsOnly)
+                {
+                    diagnostics.Add(ErrorCode.WRN_PatternIsAmbiguous, syntaxExpression.Location, patternType, MessageID.IDS_Collection.Localize(),
+                        overloadResolutionResult.Results[0].Member, overloadResolutionResult.Results[1].Member);
+                }
+            }
+
+            overloadResolutionResult.Free();
+            arguments.Free();
+            typeArguments.Free();
+
+            return result;
+        }
+
+        private void ReportPatternWarning(DiagnosticBag diagnostics, TypeSymbol patternType, Symbol patternMemberCandidate, SyntaxNode expression)
+        {
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+            if (this.IsAccessible(patternMemberCandidate, ref useSiteDiagnostics))
+            {
+                diagnostics.Add(ErrorCode.WRN_PatternBadSignature, expression.Location, patternType, MessageID.IDS_Collection.Localize(), patternMemberCandidate);
+            }
+
+            diagnostics.Add(expression, useSiteDiagnostics);
+        }
+
+        /// <summary>
+        /// Report appropriate diagnostics when lookup of a pattern member (i.e. GetEnumerator, Current, or MoveNext) fails.
+        /// </summary>
+        /// <param name="lookupResult">Failed lookup result.</param>
+        /// <param name="patternType">Type in which member was looked up.</param>
+        /// <param name="memberName">Name of looked up member.</param>
+        /// <param name="warningsOnly">True if failures should result in warnings; false if they should result in errors.</param>
+        /// <param name="diagnostics">Populated appropriately.</param>
+        internal void ReportPatternMemberLookupDiagnostics(LookupResult lookupResult, TypeSymbol patternType, string memberName, SyntaxNode expression, bool warningsOnly, DiagnosticBag diagnostics)
+        { 
+            if (lookupResult.Symbols.Any())
+            {
+                if (warningsOnly)
+                {
+                    ReportPatternWarning(diagnostics, patternType, lookupResult.Symbols.First(), expression);
+                }
+                else
+                {
+                    lookupResult.Clear();
+
+                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                this.LookupMembersInType(
+                        lookupResult,
+                        patternType,
+                        memberName,
+                        arity: 0,
+                        basesBeingResolved: null,
+                        options: LookupOptions.Default,
+                        originalBinder: this,
+                        diagnose: true,
+                        useSiteDiagnostics: ref useSiteDiagnostics);
+
+                    diagnostics.Add(expression, useSiteDiagnostics);
+
+                    if (lookupResult.Error != null)
+                    {
+                        diagnostics.Add(lookupResult.Error, expression.Location);
+                    }
+                }
+            }
+            else if (!warningsOnly)
+            {
+                diagnostics.Add(ErrorCode.ERR_NoSuchMember, expression.Location, patternType, memberName);
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3226,11 +3226,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     result = null;
                 }
-                else if (messageID == MessageID.IDS_Disposable && !result.ReturnsVoid && warningsOnly)
-                {
-                    ReportPatternWarning(diagnostics, patternType, result, syntaxExpression, messageID);
-                    result = null;
-                }
                 else if (result.CallsAreOmitted(syntaxTree))
                 {
                     // Calls to this method are omitted in the current syntax tree, i.e it is either a partial method with no implementation part OR a conditional method whose condition is not true in this source file.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3167,6 +3167,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         ReportPatternWarning(diagnostics, patternType, member, syntaxExpr, messageID);
                     }
+
                     return null;
                 }
 
@@ -3181,6 +3182,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     candidateMethods.Add((MethodSymbol)member);
                 }
             }
+
             MethodSymbol patternMethod = PerformPatternOverloadResolution(patternType, candidateMethods, syntaxExpr, warningsOnly, diagnostics, syntaxTree, messageID);
 
             candidateMethods.Free();
@@ -3191,8 +3193,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// The overload resolution portion of FindForEachPatternMethod.
         /// </summary>
-        private MethodSymbol PerformPatternOverloadResolution
-            (TypeSymbol patternType, ArrayBuilder<MethodSymbol> candidateMethods,
+        private MethodSymbol PerformPatternOverloadResolution(
+            TypeSymbol patternType, ArrayBuilder<MethodSymbol> candidateMethods,
             SyntaxNode syntaxExpression, bool warningsOnly, DiagnosticBag diagnostics,
             SyntaxTree syntaxTree, MessageID messageID)
         {
@@ -3224,12 +3226,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         diagnostics.Add(ErrorCode.WRN_PatternStaticOrInaccessible, syntaxExpression.Location, patternType, messageID.Localize(), result);
                     }
+
                     result = null;
                 }
                 else if (result.CallsAreOmitted(syntaxTree))
                 {
                     // Calls to this method are omitted in the current syntax tree, i.e it is either a partial method with no implementation part OR a conditional method whose condition is not true in this source file.
-                    // We don't want to want to allow this case, see StatementBinder::bindPatternToMethod.
+                    // We don't want to allow this case, see StatementBinder::bindPatternToMethod.
                     result = null;
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3114,25 +3114,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns>The desired method or null.</returns>
         internal MethodSymbol FindPatternMethod(TypeSymbol patternType, string methodName, LookupResult lookupResult,
                                                 SyntaxNode syntaxExpr, bool warningsOnly, DiagnosticBag diagnostics,
-                                                SyntaxTree syntaxTree)
+                                                SyntaxTree syntaxTree, MessageID messageID)
         {
             Debug.Assert(lookupResult.IsClear);
-
-            MessageID messageID;
-            switch (methodName)
-            {
-                case WellKnownMemberNames.DisposeMethodName:
-                    messageID = MessageID.IDS_Disposable;
-                    break;
-                case WellKnownMemberNames.GetEnumeratorMethodName:
-                case WellKnownMemberNames.MoveNextMethodName:
-                case WellKnownMemberNames.CurrentPropertyName:
-                    messageID = MessageID.IDS_Collection;
-                    break;
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(methodName);
-            }
-
+            
             // Not using LookupOptions.MustBeInvocableMember because we don't want the corresponding lookup error.
             // We filter out non-methods below.
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -8,8 +9,6 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
-using System.Collections.Generic;
-
 
 namespace Microsoft.CodeAnalysis.CSharp
 {

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -834,7 +834,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!lookupResult.IsSingleViable)
                 {
-                    ReportPatternMemberLookupDiagnostics(lookupResult, enumeratorType, CurrentPropertyName, _syntax.Expression, warningsOnly: false, diagnostics: diagnostics);
+                    ReportPatternMemberLookupDiagnostics(lookupResult, enumeratorType, CurrentPropertyName, _syntax.Expression, warningsOnly: false, diagnostics: diagnostics, MessageID.IDS_Collection);
                     return false;
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -768,8 +768,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             LookupResult lookupResult = LookupResult.GetInstance();
             MethodSymbol getEnumeratorMethod = FindPatternMethod(collectionExprType, GetEnumeratorMethodName, lookupResult,
-                                                                _syntax.Expression, warningsOnly: true, diagnostics: diagnostics,
-                                                                _syntax.SyntaxTree, MessageID.IDS_Collection);
+                                                                 _syntax.Expression, warningsOnly: true, diagnostics: diagnostics,
+                                                                 _syntax.SyntaxTree, MessageID.IDS_Collection);
             lookupResult.Free();
 
             builder.GetEnumeratorMethod = getEnumeratorMethod;

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -767,7 +767,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool SatisfiesGetEnumeratorPattern(ref ForEachEnumeratorInfo.Builder builder, TypeSymbol collectionExprType, DiagnosticBag diagnostics)
         {
             LookupResult lookupResult = LookupResult.GetInstance();
-            MethodSymbol getEnumeratorMethod = FindPatternMethod(collectionExprType, GetEnumeratorMethodName, lookupResult, _syntax.Expression, warningsOnly: true, diagnostics: diagnostics, _syntax.SyntaxTree);
+            MethodSymbol getEnumeratorMethod = FindPatternMethod(collectionExprType, GetEnumeratorMethodName, lookupResult,
+                                                                _syntax.Expression, warningsOnly: true, diagnostics: diagnostics,
+                                                                _syntax.SyntaxTree, MessageID.IDS_Collection);
             lookupResult.Free();
 
             builder.GetEnumeratorMethod = getEnumeratorMethod;
@@ -869,7 +871,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 lookupResult.Clear(); // Reuse the same LookupResult
 
-                MethodSymbol moveNextMethodCandidate = FindPatternMethod(enumeratorType, MoveNextMethodName, lookupResult, _syntax.Expression, warningsOnly: false, diagnostics: diagnostics, _syntax.SyntaxTree);
+                MethodSymbol moveNextMethodCandidate = FindPatternMethod(enumeratorType, MoveNextMethodName, lookupResult, _syntax.Expression,
+                                                                        warningsOnly: false, diagnostics, _syntax.SyntaxTree, MessageID.IDS_Collection);
 
                 // SPEC VIOLATION: Dev10 checks the return type of the original definition, rather than the return type of the actual method.
 

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -3,11 +3,13 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using System.Collections.Generic;
+
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -766,141 +768,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool SatisfiesGetEnumeratorPattern(ref ForEachEnumeratorInfo.Builder builder, TypeSymbol collectionExprType, DiagnosticBag diagnostics)
         {
             LookupResult lookupResult = LookupResult.GetInstance();
-            MethodSymbol getEnumeratorMethod = FindForEachPatternMethod(collectionExprType, GetEnumeratorMethodName, lookupResult, warningsOnly: true, diagnostics: diagnostics);
+            MethodSymbol getEnumeratorMethod = FindPatternMethod(collectionExprType, GetEnumeratorMethodName, lookupResult, _syntax.Expression, warningsOnly: true, diagnostics: diagnostics, _syntax.SyntaxTree);
             lookupResult.Free();
 
             builder.GetEnumeratorMethod = getEnumeratorMethod;
             return (object)getEnumeratorMethod != null;
         }
-
-        /// <summary>
-        /// Perform a lookup for the specified method on the specified type.  Perform overload resolution
-        /// on the lookup results.
-        /// </summary>
-        /// <param name="patternType">Type to search.</param>
-        /// <param name="methodName">Method to search for.</param>
-        /// <param name="lookupResult">Passed in for reusability.</param>
-        /// <param name="warningsOnly">True if failures should result in warnings; false if they should result in errors.</param>
-        /// <param name="diagnostics">Populated with binding diagnostics.</param>
-        /// <returns>The desired method or null.</returns>
-        private MethodSymbol FindForEachPatternMethod(TypeSymbol patternType, string methodName, LookupResult lookupResult, bool warningsOnly, DiagnosticBag diagnostics)
-        {
-            Debug.Assert(lookupResult.IsClear);
-
-            // Not using LookupOptions.MustBeInvocableMember because we don't want the corresponding lookup error.
-            // We filter out non-methods below.
-            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            this.LookupMembersInType(
-                lookupResult,
-                patternType,
-                methodName,
-                arity: 0,
-                basesBeingResolved: null,
-                options: LookupOptions.Default,
-                originalBinder: this,
-                diagnose: false,
-                useSiteDiagnostics: ref useSiteDiagnostics);
-
-            diagnostics.Add(_syntax.Expression, useSiteDiagnostics);
-
-            if (!lookupResult.IsMultiViable)
-            {
-                ReportPatternMemberLookupDiagnostics(lookupResult, patternType, methodName, warningsOnly, diagnostics);
-                return null;
-            }
-
-            ArrayBuilder<MethodSymbol> candidateMethods = ArrayBuilder<MethodSymbol>.GetInstance();
-
-            foreach (Symbol member in lookupResult.Symbols)
-            {
-                if (member.Kind != SymbolKind.Method)
-                {
-                    candidateMethods.Free();
-
-                    if (warningsOnly)
-                    {
-                        ReportEnumerableWarning(diagnostics, patternType, member);
-                    }
-                    return null;
-                }
-
-                MethodSymbol method = (MethodSymbol)member;
-
-                // SPEC VIOLATION: The spec says we should apply overload resolution, but Dev10 uses
-                // some custom logic in ExpressionBinder.BindGrpToParams.  The biggest difference
-                // we've found (so far) is that it only considers methods with zero parameters
-                // (i.e. doesn't work with "params" or optional parameters).
-                if (!method.Parameters.Any())
-                {
-                    candidateMethods.Add((MethodSymbol)member);
-                }
-            }
-
-            MethodSymbol patternMethod = PerformForEachPatternOverloadResolution(patternType, candidateMethods, warningsOnly, diagnostics);
-
-            candidateMethods.Free();
-
-            return patternMethod;
-        }
-
-        /// <summary>
-        /// The overload resolution portion of FindForEachPatternMethod.
-        /// </summary>
-        private MethodSymbol PerformForEachPatternOverloadResolution(TypeSymbol patternType, ArrayBuilder<MethodSymbol> candidateMethods, bool warningsOnly, DiagnosticBag diagnostics)
-        {
-            ArrayBuilder<TypeSymbol> typeArguments = ArrayBuilder<TypeSymbol>.GetInstance();
-            AnalyzedArguments arguments = AnalyzedArguments.GetInstance();
-            OverloadResolutionResult<MethodSymbol> overloadResolutionResult = OverloadResolutionResult<MethodSymbol>.GetInstance();
-
-            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            // We create a dummy receiver of the invocation so MethodInvocationOverloadResolution knows it was invoked from an instance, not a type
-            var dummyReceiver = new BoundImplicitReceiver(_syntax.Expression, patternType);
-            this.OverloadResolution.MethodInvocationOverloadResolution(
-                methods: candidateMethods,
-                typeArguments: typeArguments,
-                receiver: dummyReceiver,
-                arguments: arguments,
-                result: overloadResolutionResult,
-                useSiteDiagnostics: ref useSiteDiagnostics);
-            diagnostics.Add(_syntax.Expression, useSiteDiagnostics);
-
-            MethodSymbol result = null;
-
-            if (overloadResolutionResult.Succeeded)
-            {
-                result = overloadResolutionResult.ValidResult.Member;
-
-                if (result.IsStatic || result.DeclaredAccessibility != Accessibility.Public)
-                {
-                    if (warningsOnly)
-                    {
-                        diagnostics.Add(ErrorCode.WRN_PatternStaticOrInaccessible, _syntax.Expression.Location, patternType, MessageID.IDS_Collection.Localize(), result);
-                    }
-                    result = null;
-                }
-                else if (result.CallsAreOmitted(_syntax.SyntaxTree))
-                {
-                    // Calls to this method are omitted in the current syntax tree, i.e it is either a partial method with no implementation part OR a conditional method whose condition is not true in this source file.
-                    // We don't want to want to allow this case, see StatementBinder::bindPatternToMethod.
-                    result = null;
-                }
-            }
-            else if (overloadResolutionResult.Results.Length > 1)
-            {
-                if (warningsOnly)
-                {
-                    diagnostics.Add(ErrorCode.WRN_PatternIsAmbiguous, _syntax.Expression.Location, patternType, MessageID.IDS_Collection.Localize(),
-                        overloadResolutionResult.Results[0].Member, overloadResolutionResult.Results[1].Member);
-                }
-            }
-
-            overloadResolutionResult.Free();
-            arguments.Free();
-            typeArguments.Free();
-
-            return result;
-        }
-
         /// <summary>
         /// Called after it is determined that the expression being enumerated is of a type that
         /// has a GetEnumerator method.  Checks to see if the return type of the GetEnumerator
@@ -961,7 +834,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!lookupResult.IsSingleViable)
                 {
-                    ReportPatternMemberLookupDiagnostics(lookupResult, enumeratorType, CurrentPropertyName, warningsOnly: false, diagnostics: diagnostics);
+                    ReportPatternMemberLookupDiagnostics(lookupResult, enumeratorType, CurrentPropertyName, _syntax.Expression, warningsOnly: false, diagnostics: diagnostics);
                     return false;
                 }
 
@@ -997,7 +870,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 lookupResult.Clear(); // Reuse the same LookupResult
 
-                MethodSymbol moveNextMethodCandidate = FindForEachPatternMethod(enumeratorType, MoveNextMethodName, lookupResult, warningsOnly: false, diagnostics: diagnostics);
+                MethodSymbol moveNextMethodCandidate = FindPatternMethod(enumeratorType, MoveNextMethodName, lookupResult, _syntax.Expression, warningsOnly: false, diagnostics: diagnostics, _syntax.SyntaxTree);
 
                 // SPEC VIOLATION: Dev10 checks the return type of the original definition, rather than the return type of the actual method.
 
@@ -1016,17 +889,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 lookupResult.Free();
             }
-        }
-
-        private void ReportEnumerableWarning(DiagnosticBag diagnostics, TypeSymbol enumeratorType, Symbol patternMemberCandidate)
-        {
-            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            if (this.IsAccessible(patternMemberCandidate, ref useSiteDiagnostics))
-            {
-                diagnostics.Add(ErrorCode.WRN_PatternBadSignature, _syntax.Expression.Location, enumeratorType, MessageID.IDS_Collection.Localize(), patternMemberCandidate);
-            }
-
-            diagnostics.Add(_syntax.Expression, useSiteDiagnostics);
         }
 
         private static bool IsIEnumerable(TypeSymbol type)
@@ -1118,53 +980,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
         }
-
-        /// <summary>
-        /// Report appropriate diagnostics when lookup of a pattern member (i.e. GetEnumerator, Current, or MoveNext) fails.
-        /// </summary>
-        /// <param name="lookupResult">Failed lookup result.</param>
-        /// <param name="patternType">Type in which member was looked up.</param>
-        /// <param name="memberName">Name of looked up member.</param>
-        /// <param name="warningsOnly">True if failures should result in warnings; false if they should result in errors.</param>
-        /// <param name="diagnostics">Populated appropriately.</param>
-        private void ReportPatternMemberLookupDiagnostics(LookupResult lookupResult, TypeSymbol patternType, string memberName, bool warningsOnly, DiagnosticBag diagnostics)
-        {
-            if (lookupResult.Symbols.Any())
-            {
-                if (warningsOnly)
-                {
-                    ReportEnumerableWarning(diagnostics, patternType, lookupResult.Symbols.First());
-                }
-                else
-                {
-                    lookupResult.Clear();
-
-                    HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                    this.LookupMembersInType(
-                        lookupResult,
-                        patternType,
-                        memberName,
-                        arity: 0,
-                        basesBeingResolved: null,
-                        options: LookupOptions.Default,
-                        originalBinder: this,
-                        diagnose: true,
-                        useSiteDiagnostics: ref useSiteDiagnostics);
-
-                    diagnostics.Add(_syntax.Expression, useSiteDiagnostics);
-
-                    if (lookupResult.Error != null)
-                    {
-                        diagnostics.Add(lookupResult.Error, _syntax.Expression.Location);
-                    }
-                }
-            }
-            else if (!warningsOnly)
-            {
-                diagnostics.Add(ErrorCode.ERR_NoSuchMember, _syntax.Expression.Location, patternType, memberName);
-            }
-        }
-
         internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(SyntaxNode scopeDesignator)
         {
             if (_syntax == scopeDesignator)

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 TypeSymbol expressionType = expressionOpt.Type;
                 
-                if (!iDisposableConversion.IsImplicit && disposeMethod is null)
+                if (!iDisposableConversion.IsImplicit)
                 {
                     if (!(expressionType is null))
                     {
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     iDisposableConversion = originalBinder.Conversions.ClassifyImplicitConversionFromType(declType, iDisposable, ref useSiteDiagnostics);
                     diagnostics.Add(declarationSyntax, useSiteDiagnostics);
 
-                    if (!iDisposableConversion.IsImplicit && disposeMethod is null)
+                    if (!iDisposableConversion.IsImplicit)
                     {
                         disposeMethod = TryFindDisposePatternMethod(declType, diagnostics);
                         if (disposeMethod is null)
@@ -149,12 +149,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Checks for a Dispose method on exprType. Failing to satisfy the pattern is not an error -
-        /// it just means we have to check for an interface instead.
+        /// Checks for a Dispose method on exprType in the case that there is no explicit
+        /// IDisposable conversion.
         /// </summary>
         /// <param name="exprType">Type of the expression over which to iterate</param>
         /// <param name="diagnostics">Populated with warnings if there are near misses</param>
-        /// <returns>True if a matching method is found (still need to verify return type).</returns>
+        /// <returns>True if a matching method is found with correct return type.</returns>
         private MethodSymbol TryFindDisposePatternMethod(TypeSymbol exprType, DiagnosticBag diagnostics)
         {
             LookupResult lookupResult = LookupResult.GetInstance();

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -153,11 +153,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         private MethodSymbol TryFindDisposePatternMethod(TypeSymbol exprType, DiagnosticBag diagnostics)
         {
             LookupResult lookupResult = LookupResult.GetInstance();
-            SyntaxNode exp = _syntax.Expression != null ? (SyntaxNode) _syntax.Expression : (SyntaxNode) _syntax.Declaration;
+            SyntaxNode exp = _syntax.Expression != null ? (SyntaxNode)_syntax.Expression : (SyntaxNode)_syntax.Declaration;
             MethodSymbol disposeMethod = FindPatternMethod(exprType, WellKnownMemberNames.DisposeMethodName, lookupResult, exp, warningsOnly: true, diagnostics: diagnostics, _syntax.SyntaxTree);
             lookupResult.Free();
 
-            if (!((object)disposeMethod is null) && !disposeMethod.ReturnsVoid)
+            if (disposeMethod?.ReturnsVoid == false)
             {
                 diagnostics.Add(ErrorCode.WRN_PatternBadSignature, exp.Location, exprType, MessageID.IDS_Disposable.Localize(), disposeMethod);
                 disposeMethod = null;

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -196,7 +196,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return disposeMethod;
         }
         
-
         internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(SyntaxNode scopeDesignator)
         {
             if (_syntax == scopeDesignator)

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -80,18 +80,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics.Add(expressionSyntax, useSiteDiagnostics);
 
                 TypeSymbol expressionType = expressionOpt.Type;
-                if (!(expressionType is null))
-                {
-                    disposeMethod = TryFindDisposePatternMethod(expressionType, diagnostics);
-                }
                 
                 if (!iDisposableConversion.IsImplicit && (object)disposeMethod is null)
                 {
-                    if ((object)expressionType == null || !expressionType.IsErrorType())
+                    if (!(expressionType is null))
                     {
-                        Error(diagnostics, ErrorCode.ERR_NoConvToIDisp, expressionSyntax, expressionOpt.Display);
+                        disposeMethod = TryFindDisposePatternMethod(expressionType, diagnostics);
                     }
-                    hasErrors = true;
+                    if (disposeMethod is null)
+                    {
+                        if ((object)expressionType == null || !expressionType.IsErrorType())
+                        {
+                            Error(diagnostics, ErrorCode.ERR_NoConvToIDisp, expressionSyntax, expressionOpt.Display);
+                        } else
+                        {
+                            hasErrors = true;
+                        }
+                    }       
                 }
             }
             else
@@ -105,7 +110,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 declarationsOpt = new BoundMultipleLocalDeclarations(declarationSyntax, declarations);
 
                 TypeSymbol declType = declarations[0].DeclaredType.Type;
-                disposeMethod = TryFindDisposePatternMethod(declType, diagnostics);
 
                 if (declType.IsDynamic())
                 {
@@ -119,12 +123,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (!iDisposableConversion.IsImplicit && (object)disposeMethod is null)
                     {
-                        if (!declType.IsErrorType())
+                        disposeMethod = TryFindDisposePatternMethod(declType, diagnostics);
+                        if (disposeMethod is null)
                         {
-                            Error(diagnostics, ErrorCode.ERR_NoConvToIDisp, declarationSyntax, declType);
+                            if (!declType.IsErrorType())
+                            {
+                                Error(diagnostics, ErrorCode.ERR_NoConvToIDisp, declarationSyntax, declType);
+                            }
+                            else
+                            {
+                                hasErrors = true;
+                            }
                         }
-
-                        hasErrors = true;
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 expressionOpt,
                 iDisposableConversion,
                 boundBody,
-                methodOpt: null, // This ensures that a pattern-matched Dispose statement is not used.
+                disposeMethodOpt: null, // This ensures that a pattern-matched Dispose statement is not used.
                 hasErrors);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -153,13 +153,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         private MethodSymbol TryFindDisposePatternMethod(TypeSymbol exprType, DiagnosticBag diagnostics)
         {
             LookupResult lookupResult = LookupResult.GetInstance();
-            SyntaxNode exp = _syntax.Expression != null ? (SyntaxNode)_syntax.Expression : (SyntaxNode)_syntax.Declaration;
-            MethodSymbol disposeMethod = FindPatternMethod(exprType, WellKnownMemberNames.DisposeMethodName, lookupResult, exp, warningsOnly: true, diagnostics: diagnostics, _syntax.SyntaxTree);
+            SyntaxNode syntax = _syntax.Expression != null ? (SyntaxNode)_syntax.Expression : (SyntaxNode)_syntax.Declaration;
+            MethodSymbol disposeMethod = FindPatternMethod(exprType, WellKnownMemberNames.DisposeMethodName, lookupResult, syntax, warningsOnly: true, diagnostics, _syntax.SyntaxTree, MessageID.IDS_Disposable);
             lookupResult.Free();
 
             if (disposeMethod?.ReturnsVoid == false)
             {
-                diagnostics.Add(ErrorCode.WRN_PatternBadSignature, exp.Location, exprType, MessageID.IDS_Disposable.Localize(), disposeMethod);
+                diagnostics.Add(ErrorCode.WRN_PatternBadSignature, syntax.Location, exprType, MessageID.IDS_Disposable.Localize(), disposeMethod);
                 disposeMethod = null;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!((object)disposeMethod is null) && !disposeMethod.ReturnsVoid)
             {
-                Error(diagnostics, ErrorCode.WRN_PatternBadSignature, _syntax);
+                diagnostics.Add(ErrorCode.WRN_PatternBadSignature, exp.Location, exprType, MessageID.IDS_Disposable.Localize(), disposeMethod);
                 disposeMethod = null;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 TypeSymbol expressionType = expressionOpt.Type;
-                MethodSymbol disposeMethod = expressionType == null ? null : SatisfiesDisposePattern(expressionOpt.Type, diagnostics);
+                MethodSymbol disposeMethod = expressionType == null ? null : TryFindDisposePattern(expressionOpt.Type, diagnostics);
                 iDisposableConversion = originalBinder.Conversions.ClassifyImplicitConversionFromExpression(expressionOpt, iDisposable, ref useSiteDiagnostics);
                 diagnostics.Add(expressionSyntax, useSiteDiagnostics);
 
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 TypeSymbol declType = declarations[0].DeclaredType.Type;
 
-                MethodSymbol disposeMethod = SatisfiesDisposePattern(declType, diagnostics);
+                MethodSymbol disposeMethod = TryFindDisposePattern(declType, diagnostics);
 
                 if (declType.IsDynamic())
                 {
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="exprType">Type of the expression over which to iterate</param>
         /// <param name="diagnostics">Populated with warnings if there are near misses</param>
         /// <returns>True if a matching method is found (still need to verify return type).</returns>
-        private MethodSymbol SatisfiesDisposePattern(TypeSymbol exprType, DiagnosticBag diagnostics)
+        private MethodSymbol TryFindDisposePattern(TypeSymbol exprType, DiagnosticBag diagnostics)
         {
             LookupResult lookupResult = LookupResult.GetInstance();
             SyntaxNode exp = _syntax.Expression != null ? (SyntaxNode) _syntax.Expression : (SyntaxNode) _syntax.Declaration;

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 TypeSymbol expressionType = expressionOpt.Type;
                 
-                if (!iDisposableConversion.IsImplicit && (object)disposeMethod is null)
+                if (!iDisposableConversion.IsImplicit && disposeMethod is null)
                 {
                     if (!(expressionType is null))
                     {
@@ -89,13 +89,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     if (disposeMethod is null)
                     {
-                        if ((object)expressionType == null || !expressionType.IsErrorType())
+                        if (expressionType is null || !expressionType.IsErrorType())
                         {
                             Error(diagnostics, ErrorCode.ERR_NoConvToIDisp, expressionSyntax, expressionOpt.Display);
-                        } else
-                        {
-                            hasErrors = true;
-                        }
+                        } 
+                        hasErrors = true;
                     }       
                 }
             }
@@ -121,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     iDisposableConversion = originalBinder.Conversions.ClassifyImplicitConversionFromType(declType, iDisposable, ref useSiteDiagnostics);
                     diagnostics.Add(declarationSyntax, useSiteDiagnostics);
 
-                    if (!iDisposableConversion.IsImplicit && (object)disposeMethod is null)
+                    if (!iDisposableConversion.IsImplicit && disposeMethod is null)
                     {
                         disposeMethod = TryFindDisposePatternMethod(declType, diagnostics);
                         if (disposeMethod is null)
@@ -130,10 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 Error(diagnostics, ErrorCode.ERR_NoConvToIDisp, declarationSyntax, declType);
                             }
-                            else
-                            {
-                                hasErrors = true;
-                            }
+                            hasErrors = true;
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -75,13 +75,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 expressionOpt = this.BindTargetExpression(diagnostics, originalBinder);
 
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                TypeSymbol expressionType = expressionOpt.Type;
+                MethodSymbol disposeMethod = expressionType == null ? null : SatisfiesDisposePattern(expressionOpt.Type, diagnostics);
                 iDisposableConversion = originalBinder.Conversions.ClassifyImplicitConversionFromExpression(expressionOpt, iDisposable, ref useSiteDiagnostics);
                 diagnostics.Add(expressionSyntax, useSiteDiagnostics);
 
                 if (!iDisposableConversion.IsImplicit)
                 {
-                    TypeSymbol expressionType = expressionOpt.Type;
-                    MethodSymbol disposeMethod = expressionType == null ? null : SatisfiesDisposePattern(expressionOpt.Type, diagnostics);
                     if ((object)disposeMethod != null)
                     {
                         if (!disposeMethod.ReturnsVoid)
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 expressionOpt,
                 iDisposableConversion,
                 boundBody,
-                null, // This ensures that a pattern-matched Dispose statement is not used.
+                methodOpt: null, // This ensures that a pattern-matched Dispose statement is not used.
                 hasErrors);
         }
 
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             LookupResult lookupResult = LookupResult.GetInstance();
             SyntaxNode exp = _syntax.Expression != null ? (SyntaxNode) _syntax.Expression : (SyntaxNode) _syntax.Declaration;
-            MethodSymbol disposeMethod = FindPatternMethod(exprType, WellKnownMemberNames.GetDisposeMethodName, lookupResult, exp, warningsOnly: true, diagnostics: diagnostics, _syntax.SyntaxTree);
+            MethodSymbol disposeMethod = FindPatternMethod(exprType, WellKnownMemberNames.DisposeMethodName, lookupResult, exp, warningsOnly: true, diagnostics: diagnostics, _syntax.SyntaxTree);
             lookupResult.Free();
 
             return disposeMethod;

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -128,11 +128,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if ((object)disposeMethod != null)
                 {
-                    if (!disposeMethod.ReturnsVoid)
-                    {
-                        Error(diagnostics, ErrorCode.WRN_PatternBadSignature, declarationSyntax);
-                        hasErrors = true;
-                    }
                     BoundStatement boundBody2 = originalBinder.BindPossibleEmbeddedStatement(_syntax.Statement, diagnostics);
 
                     Debug.Assert(GetDeclaredLocalsForScope(_syntax) == this.Locals);
@@ -192,6 +187,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxNode exp = _syntax.Expression != null ? (SyntaxNode) _syntax.Expression : (SyntaxNode) _syntax.Declaration;
             MethodSymbol disposeMethod = FindPatternMethod(exprType, WellKnownMemberNames.DisposeMethodName, lookupResult, exp, warningsOnly: true, diagnostics: diagnostics, _syntax.SyntaxTree);
             lookupResult.Free();
+
+            if (!((object)disposeMethod is null) && !disposeMethod.ReturnsVoid)
+            {
+                Error(diagnostics, ErrorCode.WRN_PatternBadSignature, _syntax);
+                disposeMethod = null;
+            }
 
             return disposeMethod;
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -934,6 +934,7 @@
     <Field Name="ExpressionOpt" Type="BoundExpression" Null="allow"/>
     <Field Name="IDisposableConversion" Type="Conversion" />
     <Field Name="Body" Type="BoundStatement"/>
+    <Field Name="MethodOpt" Type="MethodSymbol" Null="allow"/>
   </Node>
 
   <Node Name="BoundFixedStatement" Base="BoundStatement">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -934,7 +934,7 @@
     <Field Name="ExpressionOpt" Type="BoundExpression" Null="allow"/>
     <Field Name="IDisposableConversion" Type="Conversion" />
     <Field Name="Body" Type="BoundStatement"/>
-    <Field Name="MethodOpt" Type="MethodSymbol" Null="allow"/>
+    <Field Name="DisposeMethodOpt" Type="MethodSymbol" Null="allow"/>
   </Node>
 
   <Node Name="BoundFixedStatement" Base="BoundStatement">

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6983,7 +6983,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must have a public void-returning Dispose() function..
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must have a public void-returning Dispose() instance method..
         /// </summary>
         internal static string ERR_NoConvToIDisp {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6983,7 +6983,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must have a public void-returning Dispose() instance method..
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos; or have a public void-returning Dispose() instance method..
         /// </summary>
         internal static string ERR_NoConvToIDisp {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6983,7 +6983,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos;.
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must have a public void-returning Dispose() function..
         /// </summary>
         internal static string ERR_NoConvToIDisp {
             get {
@@ -10391,6 +10391,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_DirectoryHasInvalidPath {
             get {
                 return ResourceManager.GetString("IDS_DirectoryHasInvalidPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to disposable.
+        /// </summary>
+        internal static string IDS_Disposable {
+            get {
+                return ResourceManager.GetString("IDS_Disposable", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2942,7 +2942,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</value>
   </data>
   <data name="ERR_NoConvToIDisp" xml:space="preserve">
-    <value>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</value>
+    <value>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</value>
   </data>
   <data name="ERR_BadParamRef" xml:space="preserve">
     <value>Parameter {0} must be declared with the '{1}' keyword</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2942,7 +2942,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</value>
   </data>
   <data name="ERR_NoConvToIDisp" xml:space="preserve">
-    <value>'{0}': type used in a using statement must have a public void-returning Dispose() function.</value>
+    <value>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</value>
   </data>
   <data name="ERR_BadParamRef" xml:space="preserve">
     <value>Parameter {0} must be declared with the '{1}' keyword</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -198,6 +198,9 @@
   <data name="IDS_Collection" xml:space="preserve">
     <value>collection</value>
   </data>
+  <data name="IDS_Disposable" xml:space="preserve">
+    <value>disposable</value>
+  </data>
   <data name="IDS_FeaturePropertyAccessorMods" xml:space="preserve">
     <value>access modifiers on properties</value>
   </data>
@@ -2939,7 +2942,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</value>
   </data>
   <data name="ERR_NoConvToIDisp" xml:space="preserve">
-    <value>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</value>
+    <value>'{0}': type used in a using statement must have a public void-returning Dispose() function.</value>
   </data>
   <data name="ERR_BadParamRef" xml:space="preserve">
     <value>Parameter {0} must be declared with the '{1}' keyword</value>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -160,6 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureExpressionVariablesInQueriesAndInitializers = MessageBase + 12742,
         IDS_FeatureExtensibleFixedStatement = MessageBase + 12743,
         IDS_FeatureIndexingMovableFixedBuffers = MessageBase + 12744,
+        IDS_Disposable = MessageBase + 12745,
     }
 
     // Message IDs may refer to strings that need to be localized.

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3344,7 +3344,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundUsingStatement : BoundStatement
     {
-        public BoundUsingStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations declarationsOpt, BoundExpression expressionOpt, Conversion iDisposableConversion, BoundStatement body, bool hasErrors = false)
+        public BoundUsingStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations declarationsOpt, BoundExpression expressionOpt, Conversion iDisposableConversion, BoundStatement body, MethodSymbol methodOpt, bool hasErrors = false)
             : base(BoundKind.UsingStatement, syntax, hasErrors || declarationsOpt.HasErrors() || expressionOpt.HasErrors() || body.HasErrors())
         {
 
@@ -3356,6 +3356,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ExpressionOpt = expressionOpt;
             this.IDisposableConversion = iDisposableConversion;
             this.Body = body;
+            this.MethodOpt = methodOpt;
         }
 
 
@@ -3369,16 +3370,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundStatement Body { get; }
 
+        public MethodSymbol MethodOpt { get; }
+
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitUsingStatement(this);
         }
 
-        public BoundUsingStatement Update(ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations declarationsOpt, BoundExpression expressionOpt, Conversion iDisposableConversion, BoundStatement body)
+        public BoundUsingStatement Update(ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations declarationsOpt, BoundExpression expressionOpt, Conversion iDisposableConversion, BoundStatement body, MethodSymbol methodOpt)
         {
-            if (locals != this.Locals || declarationsOpt != this.DeclarationsOpt || expressionOpt != this.ExpressionOpt || iDisposableConversion != this.IDisposableConversion || body != this.Body)
+            if (locals != this.Locals || declarationsOpt != this.DeclarationsOpt || expressionOpt != this.ExpressionOpt || iDisposableConversion != this.IDisposableConversion || body != this.Body || methodOpt != this.MethodOpt)
             {
-                var result = new BoundUsingStatement(this.Syntax, locals, declarationsOpt, expressionOpt, iDisposableConversion, body, this.HasErrors);
+                var result = new BoundUsingStatement(this.Syntax, locals, declarationsOpt, expressionOpt, iDisposableConversion, body, methodOpt, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -9166,7 +9169,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundMultipleLocalDeclarations declarationsOpt = (BoundMultipleLocalDeclarations)this.Visit(node.DeclarationsOpt);
             BoundExpression expressionOpt = (BoundExpression)this.Visit(node.ExpressionOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.Locals, declarationsOpt, expressionOpt, node.IDisposableConversion, body);
+            return node.Update(node.Locals, declarationsOpt, expressionOpt, node.IDisposableConversion, body, node.MethodOpt);
         }
         public override BoundNode VisitFixedStatement(BoundFixedStatement node)
         {
@@ -10442,7 +10445,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new TreeDumperNode("declarationsOpt", null, new TreeDumperNode[] { Visit(node.DeclarationsOpt, null) }),
                 new TreeDumperNode("expressionOpt", null, new TreeDumperNode[] { Visit(node.ExpressionOpt, null) }),
                 new TreeDumperNode("iDisposableConversion", node.IDisposableConversion, null),
-                new TreeDumperNode("body", null, new TreeDumperNode[] { Visit(node.Body, null) })
+                new TreeDumperNode("body", null, new TreeDumperNode[] { Visit(node.Body, null) }),
+                new TreeDumperNode("methodOpt", node.MethodOpt, null)
             }
             );
         }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3344,7 +3344,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundUsingStatement : BoundStatement
     {
-        public BoundUsingStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations declarationsOpt, BoundExpression expressionOpt, Conversion iDisposableConversion, BoundStatement body, MethodSymbol methodOpt, bool hasErrors = false)
+        public BoundUsingStatement(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations declarationsOpt, BoundExpression expressionOpt, Conversion iDisposableConversion, BoundStatement body, MethodSymbol disposeMethodOpt, bool hasErrors = false)
             : base(BoundKind.UsingStatement, syntax, hasErrors || declarationsOpt.HasErrors() || expressionOpt.HasErrors() || body.HasErrors())
         {
 
@@ -3356,7 +3356,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ExpressionOpt = expressionOpt;
             this.IDisposableConversion = iDisposableConversion;
             this.Body = body;
-            this.MethodOpt = methodOpt;
+            this.DisposeMethodOpt = disposeMethodOpt;
         }
 
 
@@ -3370,18 +3370,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundStatement Body { get; }
 
-        public MethodSymbol MethodOpt { get; }
+        public MethodSymbol DisposeMethodOpt { get; }
 
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitUsingStatement(this);
         }
 
-        public BoundUsingStatement Update(ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations declarationsOpt, BoundExpression expressionOpt, Conversion iDisposableConversion, BoundStatement body, MethodSymbol methodOpt)
+        public BoundUsingStatement Update(ImmutableArray<LocalSymbol> locals, BoundMultipleLocalDeclarations declarationsOpt, BoundExpression expressionOpt, Conversion iDisposableConversion, BoundStatement body, MethodSymbol disposeMethodOpt)
         {
-            if (locals != this.Locals || declarationsOpt != this.DeclarationsOpt || expressionOpt != this.ExpressionOpt || iDisposableConversion != this.IDisposableConversion || body != this.Body || methodOpt != this.MethodOpt)
+            if (locals != this.Locals || declarationsOpt != this.DeclarationsOpt || expressionOpt != this.ExpressionOpt || iDisposableConversion != this.IDisposableConversion || body != this.Body || disposeMethodOpt != this.DisposeMethodOpt)
             {
-                var result = new BoundUsingStatement(this.Syntax, locals, declarationsOpt, expressionOpt, iDisposableConversion, body, methodOpt, this.HasErrors);
+                var result = new BoundUsingStatement(this.Syntax, locals, declarationsOpt, expressionOpt, iDisposableConversion, body, disposeMethodOpt, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -9169,7 +9169,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundMultipleLocalDeclarations declarationsOpt = (BoundMultipleLocalDeclarations)this.Visit(node.DeclarationsOpt);
             BoundExpression expressionOpt = (BoundExpression)this.Visit(node.ExpressionOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.Locals, declarationsOpt, expressionOpt, node.IDisposableConversion, body, node.MethodOpt);
+            return node.Update(node.Locals, declarationsOpt, expressionOpt, node.IDisposableConversion, body, node.DisposeMethodOpt);
         }
         public override BoundNode VisitFixedStatement(BoundFixedStatement node)
         {
@@ -10446,7 +10446,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new TreeDumperNode("expressionOpt", null, new TreeDumperNode[] { Visit(node.ExpressionOpt, null) }),
                 new TreeDumperNode("iDisposableConversion", node.IDisposableConversion, null),
                 new TreeDumperNode("body", null, new TreeDumperNode[] { Visit(node.Body, null) }),
-                new TreeDumperNode("methodOpt", node.MethodOpt, null)
+                new TreeDumperNode("disposeMethodOpt", node.DisposeMethodOpt, null)
             }
             );
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -290,15 +290,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // local.Dispose()
             BoundExpression disposeCall;
-
-            MethodSymbol disposeMethodSymbol;
-            if (!(methodOpt is null))
+            
+            if ((!(methodOpt is null)) || Binder.TryGetSpecialTypeMember(_compilation, SpecialMember.System_IDisposable__Dispose, syntax, _diagnostics, out methodOpt))
             {
                 disposeCall = BoundCall.Synthesized(syntax, disposedExpression, methodOpt);
-            }
-            else if (Binder.TryGetSpecialTypeMember(_compilation, SpecialMember.System_IDisposable__Dispose, syntax, _diagnostics, out disposeMethodSymbol))
-            {
-                disposeCall = BoundCall.Synthesized(syntax, disposedExpression, disposeMethodSymbol);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int numDeclarations = declarations.Length;
                 for (int i = numDeclarations - 1; i >= 0; i--) //NB: inner-to-outer = right-to-left
                 {
-                    result = RewriteDeclarationUsingStatement(usingSyntax, declarations[i], result, idisposableConversion);
+                    result = RewriteDeclarationUsingStatement(usingSyntax, declarations[i], result, idisposableConversion, node.MethodOpt);
                 }
 
                 // Declare all locals in a single, top-level block so that the scope is correct in the debugger
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 expressionStatement = _instrumenter.InstrumentUsingTargetCapture(node, expressionStatement);
             }
 
-            BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundTemp);
+            BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundTemp, node.MethodOpt);
 
             // { ResourceType temp = expr; try { ... } finally { ... } }
             return new BoundBlock(
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Assumes that the local symbol will be declared (i.e. in the LocalsOpt array) of an enclosing block.
         /// Assumes that using statements with multiple locals have already been split up into multiple using statements.
         /// </remarks>
-        private BoundBlock RewriteDeclarationUsingStatement(SyntaxNode usingSyntax, BoundLocalDeclaration localDeclaration, BoundBlock tryBlock, Conversion idisposableConversion)
+        private BoundBlock RewriteDeclarationUsingStatement(SyntaxNode usingSyntax, BoundLocalDeclaration localDeclaration, BoundBlock tryBlock, Conversion idisposableConversion, MethodSymbol methodSymbol)
         {
             SyntaxNode declarationSyntax = localDeclaration.Syntax;
 
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundAssignmentOperator tempAssignment;
                 BoundLocal boundTemp = _factory.StoreToTemp(tempInit, out tempAssignment, kind: SynthesizedLocalKind.Using);
 
-                BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundTemp);
+                BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundTemp, methodSymbol);
 
                 return new BoundBlock(
                     syntax: usingSyntax,
@@ -197,14 +197,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundLocal);
+                BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundLocal, methodSymbol);
 
                 // localSymbol will be declared by an enclosing block
                 return BoundBlock.SynthesizedNoLocals(usingSyntax, rewrittenDeclaration, tryFinally);
             }
         }
 
-        private BoundStatement RewriteUsingStatementTryFinally(SyntaxNode syntax, BoundBlock tryBlock, BoundLocal local)
+        private BoundStatement RewriteUsingStatementTryFinally(SyntaxNode syntax, BoundBlock tryBlock, BoundLocal local, MethodSymbol methodOpt)
         {
             // SPEC: When ResourceType is a non-nullable value type, the expansion is:
             // SPEC: 
@@ -292,7 +292,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression disposeCall;
 
             MethodSymbol disposeMethodSymbol;
-            if (Binder.TryGetSpecialTypeMember(_compilation, SpecialMember.System_IDisposable__Dispose, syntax, _diagnostics, out disposeMethodSymbol))
+            if (methodOpt != null)
+            {
+                disposeCall = BoundCall.Synthesized(syntax, disposedExpression, methodOpt);
+            }
+            else if (Binder.TryGetSpecialTypeMember(_compilation, SpecialMember.System_IDisposable__Dispose, syntax, _diagnostics, out disposeMethodSymbol))
             {
                 disposeCall = BoundCall.Synthesized(syntax, disposedExpression, disposeMethodSymbol);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int numDeclarations = declarations.Length;
                 for (int i = numDeclarations - 1; i >= 0; i--) //NB: inner-to-outer = right-to-left
                 {
-                    result = RewriteDeclarationUsingStatement(usingSyntax, declarations[i], result, idisposableConversion, node.MethodOpt);
+                    result = RewriteDeclarationUsingStatement(usingSyntax, declarations[i], result, idisposableConversion, node.DisposeMethodOpt);
                 }
 
                 // Declare all locals in a single, top-level block so that the scope is correct in the debugger
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 expressionStatement = _instrumenter.InstrumentUsingTargetCapture(node, expressionStatement);
             }
 
-            BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundTemp, node.MethodOpt);
+            BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundTemp, node.DisposeMethodOpt);
 
             // { ResourceType temp = expr; try { ... } finally { ... } }
             return new BoundBlock(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression disposeCall;
 
             MethodSymbol disposeMethodSymbol;
-            if (methodOpt != null)
+            if (!(methodOpt is null))
             {
                 disposeCall = BoundCall.Synthesized(syntax, disposedExpression, methodOpt);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             BoundExpression expressionOpt = (BoundExpression)this.Visit(node.ExpressionOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
             Conversion disposableConversion = RewriteConversion(node.IDisposableConversion);
-            return node.Update(newLocals, declarationsOpt, expressionOpt, disposableConversion, body, node.MethodOpt);
+            return node.Update(newLocals, declarationsOpt, expressionOpt, disposableConversion, body, node.DisposeMethodOpt);
         }
 
         private Conversion RewriteConversion(Conversion conversion)

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             BoundExpression expressionOpt = (BoundExpression)this.Visit(node.ExpressionOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
             Conversion disposableConversion = RewriteConversion(node.IDisposableConversion);
-            return node.Update(newLocals, declarationsOpt, expressionOpt, disposableConversion, body);
+            return node.Update(newLocals, declarationsOpt, expressionOpt, disposableConversion, body, node.MethodOpt);
         }
 
         private Conversion RewriteConversion(Conversion conversion)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -4696,7 +4696,7 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}: Typ použitý v příkazu using musí být implicitně převeditelný na System.IDisposable.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
@@ -4691,8 +4696,8 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'{0}: Typ použitý v příkazu using musí být implicitně převeditelný na System.IDisposable.</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'{0}: Typ použitý v příkazu using musí být implicitně převeditelný na System.IDisposable.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -4696,7 +4696,7 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}: Typ použitý v příkazu using musí být implicitně převeditelný na System.IDisposable.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;NULL&gt;</target>
@@ -4691,8 +4696,8 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'"{0}": Der in einer using-Anweisung verwendete Typ muss implizit in System.IDisposable konvertiert werden können.</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'"{0}": Der in einer using-Anweisung verwendete Typ muss implizit in System.IDisposable konvertiert werden können.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -4696,7 +4696,7 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'"{0}": Der in einer using-Anweisung verwendete Typ muss implizit in System.IDisposable konvertiert werden können.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -4696,7 +4696,7 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'"{0}": Der in einer using-Anweisung verwendete Typ muss implizit in System.IDisposable konvertiert werden können.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -4696,7 +4696,7 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': el tipo usado en una instrucción using debe poder convertirse implícitamente en 'System.IDisposable'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -4696,7 +4696,7 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': el tipo usado en una instrucción using debe poder convertirse implícitamente en 'System.IDisposable'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;NULL&gt;</target>
@@ -4691,8 +4696,8 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'{0}': el tipo usado en una instrucción using debe poder convertirse implícitamente en 'System.IDisposable'</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'{0}': el tipo usado en una instrucción using debe poder convertirse implícitamente en 'System.IDisposable'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -4696,7 +4696,7 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}' : le type utilisé dans une instruction using doit être implicitement convertible en 'System.IDisposable'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;Null&gt;</target>
@@ -4691,8 +4696,8 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'{0}' : le type utilisé dans une instruction using doit être implicitement convertible en 'System.IDisposable'</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'{0}' : le type utilisé dans une instruction using doit être implicitement convertible en 'System.IDisposable'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -4696,7 +4696,7 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}' : le type utilisé dans une instruction using doit être implicitement convertible en 'System.IDisposable'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -4696,7 +4696,7 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': il tipo usato in un'istruzione using deve essere convertibile in modo implicito in 'System.IDisposable'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;Null&gt;</target>
@@ -4691,8 +4696,8 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'{0}': il tipo usato in un'istruzione using deve essere convertibile in modo implicito in 'System.IDisposable'</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'{0}': il tipo usato in un'istruzione using deve essere convertibile in modo implicito in 'System.IDisposable'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -4696,7 +4696,7 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': il tipo usato in un'istruzione using deve essere convertibile in modo implicito in 'System.IDisposable'</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -4696,7 +4696,7 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': using ステートメントで使用される型は、暗黙的に 'System.IDisposable' への変換が可能でなければなりません。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -4696,7 +4696,7 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': using ステートメントで使用される型は、暗黙的に 'System.IDisposable' への変換が可能でなければなりません。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
@@ -4691,8 +4696,8 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'{0}': using ステートメントで使用される型は、暗黙的に 'System.IDisposable' への変換が可能でなければなりません。</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'{0}': using ステートメントで使用される型は、暗黙的に 'System.IDisposable' への変換が可能でなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -4696,7 +4696,7 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': using 문에 사용된 형식은 암시적으로 'System.IDisposable'로 변환할 수 있어야 합니다.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
@@ -4691,8 +4696,8 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'{0}': using 문에 사용된 형식은 암시적으로 'System.IDisposable'로 변환할 수 있어야 합니다.</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'{0}': using 문에 사용된 형식은 암시적으로 'System.IDisposable'로 변환할 수 있어야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -4696,7 +4696,7 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': using 문에 사용된 형식은 암시적으로 'System.IDisposable'로 변환할 수 있어야 합니다.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
@@ -4691,8 +4696,8 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'„{0}”: musi istnieć możliwość niejawnego przekonwertowania typu użytego w instrukcji using na interfejs „System.IDisposable”</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'„{0}”: musi istnieć możliwość niejawnego przekonwertowania typu użytego w instrukcji using na interfejs „System.IDisposable”</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -4696,7 +4696,7 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'„{0}”: musi istnieć możliwość niejawnego przekonwertowania typu użytego w instrukcji using na interfejs „System.IDisposable”</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -4696,7 +4696,7 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'„{0}”: musi istnieć możliwość niejawnego przekonwertowania typu użytego w instrukcji using na interfejs „System.IDisposable”</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;nulo&gt;</target>
@@ -4691,8 +4696,8 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'"{0}": tipo usado em uma instrução using deve ser implicitamente conversível para "System. IDisposable"</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'"{0}": tipo usado em uma instrução using deve ser implicitamente conversível para "System. IDisposable"</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -4696,7 +4696,7 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'"{0}": tipo usado em uma instrução using deve ser implicitamente conversível para "System. IDisposable"</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -4696,7 +4696,7 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'"{0}": tipo usado em uma instrução using deve ser implicitamente conversível para "System. IDisposable"</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -4696,7 +4696,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}": тип, использованный в операторе using, должен иметь неявное преобразование в System.IDisposable.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -4696,7 +4696,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}": тип, использованный в операторе using, должен иметь неявное преобразование в System.IDisposable.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;NULL&gt;</target>
@@ -4691,8 +4696,8 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'{0}": тип, использованный в операторе using, должен иметь неявное преобразование в System.IDisposable.</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'{0}": тип, использованный в операторе using, должен иметь неявное преобразование в System.IDisposable.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
@@ -4691,8 +4696,8 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'{0}': bir using deyiminde kullanılan tür açıkça 'System.IDisposable' öğesine dönüştürülebilir olmalıdır</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'{0}': bir using deyiminde kullanılan tür açıkça 'System.IDisposable' öğesine dönüştürülebilir olmalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -4696,7 +4696,7 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': bir using deyiminde kullanılan tür açıkça 'System.IDisposable' öğesine dönüştürülebilir olmalıdır</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -4696,7 +4696,7 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': bir using deyiminde kullanılan tür açıkça 'System.IDisposable' öğesine dönüştürülebilir olmalıdır</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -4696,7 +4696,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'“{0}”: using 语句中使用的类型必须可隐式转换为“System.IDisposable”</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -4696,7 +4696,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'“{0}”: using 语句中使用的类型必须可隐式转换为“System.IDisposable”</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
@@ -4691,8 +4696,8 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'“{0}”: using 语句中使用的类型必须可隐式转换为“System.IDisposable”</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'“{0}”: using 语句中使用的类型必须可隐式转换为“System.IDisposable”</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_Disposable">
+        <source>disposable</source>
+        <target state="new">disposable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
@@ -4691,8 +4696,8 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'</source>
-        <target state="translated">'{0}': 在 using 陳述式中所用的類型，必須可以隱含轉換成 'System.IDisposable'。</target>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <target state="needs-review-translation">'{0}': 在 using 陳述式中所用的類型，必須可以隱含轉換成 'System.IDisposable'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadParamRef">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -4696,7 +4696,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() function.</source>
+        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': 在 using 陳述式中所用的類型，必須可以隱含轉換成 'System.IDisposable'。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -4696,7 +4696,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must have a public void-returning Dispose() instance method.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.</source>
         <target state="needs-review-translation">'{0}': 在 using 陳述式中所用的類型，必須可以隱含轉換成 'System.IDisposable'。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -1066,6 +1066,97 @@ class C2
 }");
         }
 
+        [Fact]
+        public void UsingPatternDiffParameterOverloadTest()
+        {
+            var source = @"
+class C1
+{
+    public C1() { }
+    public void Dispose() { }
+    public void Dispose(int x) { }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (C1 c = new C1())
+        {
+        }
+    }
+}";
+            CompileAndVerify(source).VerifyIL("C2.Main()", @"
+{
+  // Code size       19 (0x13)
+  .maxstack  1
+  .locals init (C1 V_0) //c
+  IL_0000:  newobj     ""C1..ctor()""
+  IL_0005:  stloc.0
+  .try
+  {
+    IL_0006:  leave.s    IL_0012
+  }
+  finally
+  {
+    IL_0008:  ldloc.0
+    IL_0009:  brfalse.s  IL_0011
+    IL_000b:  ldloc.0
+    IL_000c:  callvirt   ""void C1.Dispose()""
+    IL_0011:  endfinally
+  }
+  IL_0012:  ret
+}"
+            );
+        }
+
+        [Fact]
+        public void UsingPatternInheritedTest()
+        {
+            var source = @"
+class C1
+{
+    public C1() { }
+    public void Dispose() { }
+}
+
+class C2 : C1
+{
+    internal void Dispose(int x) { } 
+}
+
+class C3
+{
+    static void Main()
+    {
+        using (C2 c = new C2())
+        {
+        }
+    }
+}";
+            CompileAndVerify(source).VerifyIL("C3.Main()", @"
+{
+  // Code size       19 (0x13)
+  .maxstack  1
+  .locals init (C2 V_0) //c
+  IL_0000:  newobj     ""C2..ctor()""
+  IL_0005:  stloc.0
+  .try
+  {
+    IL_0006:  leave.s    IL_0012
+  }
+  finally
+  {
+    IL_0008:  ldloc.0
+    IL_0009:  brfalse.s  IL_0011
+    IL_000b:  ldloc.0
+    IL_000c:  callvirt   ""void C1.Dispose()""
+    IL_0011:  endfinally
+  }
+  IL_0012:  ret
+}");
+        }
+
         // The object could be created outside the "using" statement 
         [Fact]
         public void ObjectCreateOutsideUsing()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -477,7 +477,7 @@ After");
     IL_0021:  ldloc.0
     IL_0022:  brfalse.s  IL_002a
     IL_0024:  ldloc.0
-    IL_0025:  callvirt   ""void DisposableClass.Dispose()""
+    IL_0025:  callvirt   ""void System.IDisposable.Dispose()""
     IL_002a:  endfinally
   }
   IL_002b:  ldstr      ""After""
@@ -512,7 +512,7 @@ Disposing A
 After");
             verifier.VerifyIL("Test.Main", @"
 {
-  // Code size       53 (0x35)
+  // Code size       59 (0x3b)
   .maxstack  2
   .locals init (DisposableStruct V_0) //d
   IL_0000:  ldstr      ""Before""
@@ -524,17 +524,18 @@ After");
   {
     IL_0016:  ldstr      ""In""
     IL_001b:  call       ""void System.Console.WriteLine(string)""
-    IL_0020:  leave.s    IL_002a
+    IL_0020:  leave.s    IL_0030
   }
   finally
   {
     IL_0022:  ldloca.s   V_0
-    IL_0024:  call       ""void DisposableStruct.Dispose()""
-    IL_0029:  endfinally
+    IL_0024:  constrained. ""DisposableStruct""
+    IL_002a:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_002f:  endfinally
   }
-  IL_002a:  ldstr      ""After""
-  IL_002f:  call       ""void System.Console.WriteLine(string)""
-  IL_0034:  ret
+  IL_0030:  ldstr      ""After""
+  IL_0035:  call       ""void System.Console.WriteLine(string)""
+  IL_003a:  ret
 }");
         }
 
@@ -730,7 +731,7 @@ After");
         IL_0037:  ldloc.2
         IL_0038:  brfalse.s  IL_0040
         IL_003a:  ldloc.2
-        IL_003b:  callvirt   ""void DisposableClass.Dispose()""
+        IL_003b:  callvirt   ""void System.IDisposable.Dispose()""
         IL_0040:  endfinally
       }
     }
@@ -739,7 +740,7 @@ After");
       IL_0041:  ldloc.1
       IL_0042:  brfalse.s  IL_004a
       IL_0044:  ldloc.1
-      IL_0045:  callvirt   ""void DisposableClass.Dispose()""
+      IL_0045:  callvirt   ""void System.IDisposable.Dispose()""
       IL_004a:  endfinally
     }
   }
@@ -748,7 +749,7 @@ After");
     IL_004b:  ldloc.0
     IL_004c:  brfalse.s  IL_0054
     IL_004e:  ldloc.0
-    IL_004f:  callvirt   ""void DisposableClass.Dispose()""
+    IL_004f:  callvirt   ""void System.IDisposable.Dispose()""
     IL_0054:  endfinally
   }
   IL_0055:  ldstr      ""After""
@@ -787,7 +788,7 @@ Disposing A
 After");
             verifier.VerifyIL("Test.Main", @"
 {
-  // Code size       91 (0x5b)
+  // Code size      109 (0x6d)
   .maxstack  2
   .locals init (DisposableStruct V_0, //d1
                 DisposableStruct V_1, //d2
@@ -811,31 +812,34 @@ After");
       {
         IL_002c:  ldstr      ""In""
         IL_0031:  call       ""void System.Console.WriteLine(string)""
-        IL_0036:  leave.s    IL_0050
+        IL_0036:  leave.s    IL_0062
       }
       finally
       {
         IL_0038:  ldloca.s   V_2
-        IL_003a:  call       ""void DisposableStruct.Dispose()""
-        IL_003f:  endfinally
+        IL_003a:  constrained. ""DisposableStruct""
+        IL_0040:  callvirt   ""void System.IDisposable.Dispose()""
+        IL_0045:  endfinally
       }
     }
     finally
     {
-      IL_0040:  ldloca.s   V_1
-      IL_0042:  call       ""void DisposableStruct.Dispose()""
-      IL_0047:  endfinally
+      IL_0046:  ldloca.s   V_1
+      IL_0048:  constrained. ""DisposableStruct""
+      IL_004e:  callvirt   ""void System.IDisposable.Dispose()""
+      IL_0053:  endfinally
     }
   }
   finally
   {
-    IL_0048:  ldloca.s   V_0
-    IL_004a:  call       ""void DisposableStruct.Dispose()""
-    IL_004f:  endfinally
+    IL_0054:  ldloca.s   V_0
+    IL_0056:  constrained. ""DisposableStruct""
+    IL_005c:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_0061:  endfinally
   }
-  IL_0050:  ldstr      ""After""
-  IL_0055:  call       ""void System.Console.WriteLine(string)""
-  IL_005a:  ret
+  IL_0062:  ldstr      ""After""
+  IL_0067:  call       ""void System.Console.WriteLine(string)""
+  IL_006c:  ret
 }");
         }
 
@@ -893,7 +897,7 @@ After");
       IL_002c:  ldloc.1
       IL_002d:  brfalse.s  IL_0035
       IL_002f:  ldloc.1
-      IL_0030:  callvirt   ""void DisposableClass.Dispose()""
+      IL_0030:  callvirt   ""void System.IDisposable.Dispose()""
       IL_0035:  endfinally
     }
   }
@@ -902,7 +906,7 @@ After");
     IL_0036:  ldloc.0
     IL_0037:  brfalse.s  IL_003f
     IL_0039:  ldloc.0
-    IL_003a:  callvirt   ""void DisposableClass.Dispose()""
+    IL_003a:  callvirt   ""void System.IDisposable.Dispose()""
     IL_003f:  endfinally
   }
   IL_0040:  ldstr      ""After""
@@ -1017,7 +1021,7 @@ class Program
     IL_000e:  ldloc.0
     IL_000f:  brfalse.s  IL_0017
     IL_0011:  ldloc.0
-    IL_0012:  callvirt   ""void Program.MyManagedClass.Dispose()""
+    IL_0012:  callvirt   ""void System.IDisposable.Dispose()""
     IL_0017:  endfinally
   }
   IL_0018:  ret

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -1028,6 +1028,48 @@ class Program
 }");
         }
 
+        [Fact]
+        public void UsingPatternTest()
+        {
+            var source = @"
+class C1
+{
+    public C1() { }
+    public void Dispose() { }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (C1 c = new C1())
+        {
+        }
+    }
+}";
+            CompileAndVerify(source).VerifyIL("C2.Main()", @"
+{
+  // Code size       19 (0x13)
+  .maxstack  1
+  .locals init (C1 V_0) //c
+  IL_0000:  newobj     ""C1..ctor()""
+  IL_0005:  stloc.0
+  .try
+  {
+    IL_0006:  leave.s    IL_0012
+  }
+  finally
+  {
+    IL_0008:  ldloc.0
+    IL_0009:  brfalse.s  IL_0011
+    IL_000b:  ldloc.0
+    IL_000c:  callvirt   ""void C1.Dispose()""
+    IL_0011:  endfinally
+  }
+  IL_0012:  ret
+}");
+        }
+
         // The object could be created outside the "using" statement 
         [Fact]
         public void ObjectCreateOutsideUsing()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -1278,7 +1278,7 @@ class Program
     }
 }
 ";
-            CreateCompilation(source).VerifyDiagnostics(Diagnostic(ErrorCode.ERR_NoConvToIDisp, "res").WithArguments("Program.MyManagedClass"));
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]
@@ -1301,7 +1301,7 @@ class Program
     }
 }
 ";
-            CreateCompilation(source).VerifyDiagnostics(Diagnostic(ErrorCode.ERR_NoConvToIDisp, "res").WithArguments("Program.MyManagedClass"));
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         // Implicit implement IDisposable

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -477,7 +477,7 @@ After");
     IL_0021:  ldloc.0
     IL_0022:  brfalse.s  IL_002a
     IL_0024:  ldloc.0
-    IL_0025:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_0025:  callvirt   ""void DisposableClass.Dispose()""
     IL_002a:  endfinally
   }
   IL_002b:  ldstr      ""After""
@@ -512,7 +512,7 @@ Disposing A
 After");
             verifier.VerifyIL("Test.Main", @"
 {
-  // Code size       59 (0x3b)
+  // Code size       53 (0x35)
   .maxstack  2
   .locals init (DisposableStruct V_0) //d
   IL_0000:  ldstr      ""Before""
@@ -521,21 +521,20 @@ After");
   IL_000c:  ldstr      ""A""
   IL_0011:  call       ""DisposableStruct..ctor(string)""
   .try
-{
-  IL_0016:  ldstr      ""In""
-  IL_001b:  call       ""void System.Console.WriteLine(string)""
-  IL_0020:  leave.s    IL_0030
-}
+  {
+    IL_0016:  ldstr      ""In""
+    IL_001b:  call       ""void System.Console.WriteLine(string)""
+    IL_0020:  leave.s    IL_002a
+  }
   finally
-{
-  IL_0022:  ldloca.s   V_0
-  IL_0024:  constrained. ""DisposableStruct""
-  IL_002a:  callvirt   ""void System.IDisposable.Dispose()""
-  IL_002f:  endfinally
-}
-  IL_0030:  ldstr      ""After""
-  IL_0035:  call       ""void System.Console.WriteLine(string)""
-  IL_003a:  ret
+  {
+    IL_0022:  ldloca.s   V_0
+    IL_0024:  call       ""void DisposableStruct.Dispose()""
+    IL_0029:  endfinally
+  }
+  IL_002a:  ldstr      ""After""
+  IL_002f:  call       ""void System.Console.WriteLine(string)""
+  IL_0034:  ret
 }");
         }
 
@@ -703,8 +702,8 @@ After");
   // Code size       96 (0x60)
   .maxstack  1
   .locals init (DisposableClass V_0, //d1
-  DisposableClass V_1, //d2
-  DisposableClass V_2) //d3
+                DisposableClass V_1, //d2
+                DisposableClass V_2) //d3
   IL_0000:  ldstr      ""Before""
   IL_0005:  call       ""void System.Console.WriteLine(string)""
   IL_000a:  ldstr      ""A""
@@ -731,7 +730,7 @@ After");
         IL_0037:  ldloc.2
         IL_0038:  brfalse.s  IL_0040
         IL_003a:  ldloc.2
-        IL_003b:  callvirt   ""void System.IDisposable.Dispose()""
+        IL_003b:  callvirt   ""void DisposableClass.Dispose()""
         IL_0040:  endfinally
       }
     }
@@ -740,7 +739,7 @@ After");
       IL_0041:  ldloc.1
       IL_0042:  brfalse.s  IL_004a
       IL_0044:  ldloc.1
-      IL_0045:  callvirt   ""void System.IDisposable.Dispose()""
+      IL_0045:  callvirt   ""void DisposableClass.Dispose()""
       IL_004a:  endfinally
     }
   }
@@ -749,7 +748,7 @@ After");
     IL_004b:  ldloc.0
     IL_004c:  brfalse.s  IL_0054
     IL_004e:  ldloc.0
-    IL_004f:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_004f:  callvirt   ""void DisposableClass.Dispose()""
     IL_0054:  endfinally
   }
   IL_0055:  ldstr      ""After""
@@ -788,58 +787,55 @@ Disposing A
 After");
             verifier.VerifyIL("Test.Main", @"
 {
-  // Code size      109 (0x6d)
+  // Code size       91 (0x5b)
   .maxstack  2
   .locals init (DisposableStruct V_0, //d1
-  DisposableStruct V_1, //d2
-  DisposableStruct V_2) //d3
+                DisposableStruct V_1, //d2
+                DisposableStruct V_2) //d3
   IL_0000:  ldstr      ""Before""
   IL_0005:  call       ""void System.Console.WriteLine(string)""
   IL_000a:  ldloca.s   V_0
   IL_000c:  ldstr      ""A""
   IL_0011:  call       ""DisposableStruct..ctor(string)""
   .try
-{
-  IL_0016:  ldstr      ""B""
-  IL_001b:  newobj     ""DisposableStruct..ctor(string)""
-  IL_0020:  stloc.1
-  .try
-{
-  IL_0021:  ldstr      ""C""
-  IL_0026:  newobj     ""DisposableStruct..ctor(string)""
-  IL_002b:  stloc.2
-  .try
-{
-  IL_002c:  ldstr      ""In""
-  IL_0031:  call       ""void System.Console.WriteLine(string)""
-  IL_0036:  leave.s    IL_0062
-}
+  {
+    IL_0016:  ldstr      ""B""
+    IL_001b:  newobj     ""DisposableStruct..ctor(string)""
+    IL_0020:  stloc.1
+    .try
+    {
+      IL_0021:  ldstr      ""C""
+      IL_0026:  newobj     ""DisposableStruct..ctor(string)""
+      IL_002b:  stloc.2
+      .try
+      {
+        IL_002c:  ldstr      ""In""
+        IL_0031:  call       ""void System.Console.WriteLine(string)""
+        IL_0036:  leave.s    IL_0050
+      }
+      finally
+      {
+        IL_0038:  ldloca.s   V_2
+        IL_003a:  call       ""void DisposableStruct.Dispose()""
+        IL_003f:  endfinally
+      }
+    }
+    finally
+    {
+      IL_0040:  ldloca.s   V_1
+      IL_0042:  call       ""void DisposableStruct.Dispose()""
+      IL_0047:  endfinally
+    }
+  }
   finally
-{
-  IL_0038:  ldloca.s   V_2
-  IL_003a:  constrained. ""DisposableStruct""
-  IL_0040:  callvirt   ""void System.IDisposable.Dispose()""
-  IL_0045:  endfinally
-}
-}
-  finally
-{
-  IL_0046:  ldloca.s   V_1
-  IL_0048:  constrained. ""DisposableStruct""
-  IL_004e:  callvirt   ""void System.IDisposable.Dispose()""
-  IL_0053:  endfinally
-}
-}
-  finally
-{
-  IL_0054:  ldloca.s   V_0
-  IL_0056:  constrained. ""DisposableStruct""
-  IL_005c:  callvirt   ""void System.IDisposable.Dispose()""
-  IL_0061:  endfinally
-}
-  IL_0062:  ldstr      ""After""
-  IL_0067:  call       ""void System.Console.WriteLine(string)""
-  IL_006c:  ret
+  {
+    IL_0048:  ldloca.s   V_0
+    IL_004a:  call       ""void DisposableStruct.Dispose()""
+    IL_004f:  endfinally
+  }
+  IL_0050:  ldstr      ""After""
+  IL_0055:  call       ""void System.Console.WriteLine(string)""
+  IL_005a:  ret
 }");
         }
 
@@ -875,7 +871,7 @@ After");
   // Code size       75 (0x4b)
   .maxstack  1
   .locals init (DisposableClass V_0, //d1
-  DisposableClass V_1) //d3
+                DisposableClass V_1) //d3
   IL_0000:  ldstr      ""Before""
   IL_0005:  call       ""void System.Console.WriteLine(string)""
   IL_000a:  ldstr      ""A""
@@ -897,7 +893,7 @@ After");
       IL_002c:  ldloc.1
       IL_002d:  brfalse.s  IL_0035
       IL_002f:  ldloc.1
-      IL_0030:  callvirt   ""void System.IDisposable.Dispose()""
+      IL_0030:  callvirt   ""void DisposableClass.Dispose()""
       IL_0035:  endfinally
     }
   }
@@ -906,7 +902,7 @@ After");
     IL_0036:  ldloc.0
     IL_0037:  brfalse.s  IL_003f
     IL_0039:  ldloc.0
-    IL_003a:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_003a:  callvirt   ""void DisposableClass.Dispose()""
     IL_003f:  endfinally
   }
   IL_0040:  ldstr      ""After""
@@ -1011,19 +1007,19 @@ class Program
   IL_0000:  newobj     ""Program.MyManagedClass..ctor()""
   IL_0005:  stloc.0
   .try
-{
-  IL_0006:  ldloc.0
-  IL_0007:  callvirt   ""void Program.MyManagedClass.Use()""
-  IL_000c:  leave.s    IL_0018
-}
+  {
+    IL_0006:  ldloc.0
+    IL_0007:  callvirt   ""void Program.MyManagedClass.Use()""
+    IL_000c:  leave.s    IL_0018
+  }
   finally
-{
-  IL_000e:  ldloc.0
-  IL_000f:  brfalse.s  IL_0017
-  IL_0011:  ldloc.0
-  IL_0012:  callvirt   ""void System.IDisposable.Dispose()""
-  IL_0017:  endfinally
-}
+  {
+    IL_000e:  ldloc.0
+    IL_000f:  brfalse.s  IL_0017
+    IL_0011:  ldloc.0
+    IL_0012:  callvirt   ""void Program.MyManagedClass.Dispose()""
+    IL_0017:  endfinally
+  }
   IL_0018:  ret
 }");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -1312,10 +1312,10 @@ class Gen<T> where T : new()
 }
 ";
             CreateCompilation(source).VerifyDiagnostics(
-                // (13,16): error CS1674: 'T': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (13,16): error CS1674: 'T': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (val)
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "val").WithArguments("T"),
-                // (24,16): error CS1674: 'T': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (24,16): error CS1674: 'T': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (T disp = new T()) // Invalid
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "T disp = new T()").WithArguments("T"));
         }
@@ -2611,13 +2611,13 @@ class Program
 }
 ";
             CreateCompilation(source).VerifyDiagnostics(
-                // (6,16): error CS1674: 'lambda expression': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'lambda expression': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (x => x)     // err
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "x => x").WithArguments("lambda expression"),
-                // (9,16): error CS1674: 'lambda expression': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (9,16): error CS1674: 'lambda expression': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (() => { })     // err
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "() => { }").WithArguments("lambda expression"),
-                // (12,16): error CS1674: 'lambda expression': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (12,16): error CS1674: 'lambda expression': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using ((int @int) => { return @int; })     // err
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "(int @int) => { return @int; }").WithArguments("lambda expression"));
         }
@@ -2651,19 +2651,19 @@ class Program
 }
 ";
             CreateCompilation(source).VerifyDiagnostics(
-    // (6,16): error CS1674: '<empty anonymous type>': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+    // (6,16): error CS1674: '<empty anonymous type>': type used in a using statement must have a public void-returning Dispose() instance method.
     //         using (var a = new { })
     Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var a = new { }").WithArguments("<empty anonymous type>"),
-    // (9,16): error CS1674: '<anonymous type: int p1>': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+    // (9,16): error CS1674: '<anonymous type: int p1>': type used in a using statement must have a public void-returning Dispose() instance method.
     //         using (var b = new { p1 = 10 })
     Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var b = new { p1 = 10 }").WithArguments("<anonymous type: int p1>"),
-    // (12,16): error CS1674: '<anonymous type: double p1, char p2>': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+    // (12,16): error CS1674: '<anonymous type: double p1, char p2>': type used in a using statement must have a public void-returning Dispose() instance method.
     //         using (var c = new { p1 = 10.0, p2 = 'a' })
     Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var c = new { p1 = 10.0, p2 = 'a' }").WithArguments("<anonymous type: double p1, char p2>"),
-    // (15,16): error CS1674: '<empty anonymous type>': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+    // (15,16): error CS1674: '<empty anonymous type>': type used in a using statement must have a public void-returning Dispose() instance method.
     //         using (new { })
     Diagnostic(ErrorCode.ERR_NoConvToIDisp, "new { }").WithArguments("<empty anonymous type>"),
-    // (19,16): error CS1674: '<anonymous type: string f1, char f2>': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+    // (19,16): error CS1674: '<anonymous type: string f1, char f2>': type used in a using statement must have a public void-returning Dispose() instance method.
     //         using (new { f1 = "12345", f2 = 'S' })
     Diagnostic(ErrorCode.ERR_NoConvToIDisp, @"new { f1 = ""12345"", f2 = 'S' }").WithArguments("<anonymous type: string f1, char f2>")
     );

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -5309,7 +5309,7 @@ class C
     IL_001a:  ldloc.2
     IL_001b:  brfalse.s  IL_0024
     IL_001d:  ldloc.2
-    IL_001e:  callvirt   ""void System.IO.Stream.Dispose()""
+    IL_001e:  callvirt   ""void System.IDisposable.Dispose()""
     IL_0023:  nop
     // sequence point: <hidden>
     IL_0024:  endfinally
@@ -5404,7 +5404,7 @@ class C
     IL_001c:  ldloc.2
     IL_001d:  brfalse.s  IL_0026
     IL_001f:  ldloc.2
-    IL_0020:  callvirt   ""void System.IO.Stream.Dispose()""
+    IL_0020:  callvirt   ""void System.IDisposable.Dispose()""
     IL_0025:  nop
     // sequence point: <hidden>
     IL_0026:  endfinally
@@ -5469,7 +5469,7 @@ class C
     IL_0013:  ldloc.0
     IL_0014:  brfalse.s  IL_001d
     IL_0016:  ldloc.0
-    IL_0017:  callvirt   ""void System.IO.Stream.Dispose()""
+    IL_0017:  callvirt   ""void System.IDisposable.Dispose()""
     IL_001c:  nop
     // sequence point: <hidden>
     IL_001d:  endfinally
@@ -5529,7 +5529,7 @@ class C
     IL_0013:  ldloc.0
     IL_0014:  brfalse.s  IL_001d
     IL_0016:  ldloc.0
-    IL_0017:  callvirt   ""void System.IO.Stream.Dispose()""
+    IL_0017:  callvirt   ""void System.IDisposable.Dispose()""
     IL_001c:  nop
     // sequence point: <hidden>
     IL_001d:  endfinally

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -5309,7 +5309,7 @@ class C
     IL_001a:  ldloc.2
     IL_001b:  brfalse.s  IL_0024
     IL_001d:  ldloc.2
-    IL_001e:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_001e:  callvirt   ""void System.IO.Stream.Dispose()""
     IL_0023:  nop
     // sequence point: <hidden>
     IL_0024:  endfinally
@@ -5404,7 +5404,7 @@ class C
     IL_001c:  ldloc.2
     IL_001d:  brfalse.s  IL_0026
     IL_001f:  ldloc.2
-    IL_0020:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_0020:  callvirt   ""void System.IO.Stream.Dispose()""
     IL_0025:  nop
     // sequence point: <hidden>
     IL_0026:  endfinally
@@ -5469,7 +5469,7 @@ class C
     IL_0013:  ldloc.0
     IL_0014:  brfalse.s  IL_001d
     IL_0016:  ldloc.0
-    IL_0017:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_0017:  callvirt   ""void System.IO.Stream.Dispose()""
     IL_001c:  nop
     // sequence point: <hidden>
     IL_001d:  endfinally
@@ -5529,7 +5529,7 @@ class C
     IL_0013:  ldloc.0
     IL_0014:  brfalse.s  IL_001d
     IL_0016:  ldloc.0
-    IL_0017:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_0017:  callvirt   ""void System.IO.Stream.Dispose()""
     IL_001c:  nop
     // sequence point: <hidden>
     IL_001d:  endfinally

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IUsingStatement.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IUsingStatement.cs
@@ -560,7 +560,7 @@ IUsingOperation (OperationKind.Using, Type: null, IsInvalid) (Syntax: 'using (va
                   OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS1674: 'C': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // CS1674: 'C': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         /*<bind>*/using (var c1 = new C())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var c1 = new C()").WithArguments("C").WithLocation(9, 26)
             };
@@ -609,7 +609,7 @@ IUsingOperation (OperationKind.Using, Type: null, IsInvalid) (Syntax: 'using (c1
                   OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS1674: 'C': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // CS1674: 'C': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         /*<bind>*/using (c1)
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1").WithArguments("C").WithLocation(10, 26)
             };

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -30,7 +30,7 @@ class C
     }
 }");
             comp.VerifyDiagnostics(
-                // (6,16): error CS1674: 'C.S2': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'C.S2': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (var x = GetRefStruct())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var x = GetRefStruct()").WithArguments("C.S2").WithLocation(6, 16));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -15725,9 +15725,9 @@ class C
             CreateCompilation(text).VerifyDiagnostics(
                 // (7,22): warning CS0642: Possible mistaken empty statement
                 Diagnostic(ErrorCode.WRN_PossibleMistakenNullStatement, ";"),
-                // (6,16): error CS1674: 'int': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'int': type used in a using statement must have a public void-returning Dispose() instance method.
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "int a = 0").WithArguments("int"),
-                // (7,20): error CS1674: 'int': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (7,20): error CS1674: 'int': type used in a using statement must have a public void-returning Dispose() instance method.
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "a").WithArguments("int"));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -723,6 +723,33 @@ public class Program
             );
         }
 
+        [Fact]
+        public void NoInterfaceImp()
+        {
+            var text = @"
+public class Program
+{
+    static void Main(string[] args)
+    {
+        using (new S1())
+        {
+
+        }
+    }
+
+    public ref struct S1
+    {
+        public void Dispose() { }
+    }
+}
+";
+
+            CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text);
+
+            comp.VerifyDiagnostics(
+            );
+        }
+
         [WorkItem(20226, "https://github.com/dotnet/roslyn/issues/20226")]
         [Fact]
         public void RefIteratorInAsync()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -719,10 +719,7 @@ public class Program
             comp.VerifyDiagnostics(
                 // (14,28): error CS8343: 'Program.S1': ref structs cannot implement interfaces
                 //     public ref struct S1 : IDisposable
-                Diagnostic(ErrorCode.ERR_RefStructInterfaceImpl, "IDisposable").WithArguments("Program.S1", "System.IDisposable").WithLocation(14, 28),
-                // (8,16): error CS1674: 'Program.S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'
-                //         using (new S1())
-                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "new S1()").WithArguments("Program.S1").WithLocation(8, 16)
+                Diagnostic(ErrorCode.ERR_RefStructInterfaceImpl, "IDisposable").WithArguments("Program.S1", "System.IDisposable").WithLocation(14, 28)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
@@ -1396,13 +1396,13 @@ public class Test
 }
 ";
             CreateCompilationWithMscorlibAndSpan(test, options: TestOptions.ReleaseDll.WithAllowUnsafe(true)).VerifyDiagnostics(
-                // (6,16): error CS1674: 'int*': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'int*': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (var v1 = stackalloc int [3] { 1, 2, 3 })
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var v1 = stackalloc int [3] { 1, 2, 3 }").WithArguments("int*").WithLocation(6, 16),
-                // (7,16): error CS1674: 'int*': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (7,16): error CS1674: 'int*': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (var v2 = stackalloc int [ ] { 1, 2, 3 })
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var v2 = stackalloc int [ ] { 1, 2, 3 }").WithArguments("int*").WithLocation(7, 16),
-                // (8,16): error CS1674: 'int*': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (8,16): error CS1674: 'int*': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (var v3 = stackalloc     [ ] { 1, 2, 3 })
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var v3 = stackalloc     [ ] { 1, 2, 3 }").WithArguments("int*").WithLocation(8, 16)
                 );

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocSpanExpressionsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocSpanExpressionsTests.cs
@@ -419,7 +419,7 @@ public class Test
 }
 ";
             CreateCompilationWithMscorlibAndSpan(test, options: TestOptions.ReleaseDll.WithAllowUnsafe(true)).VerifyDiagnostics(
-                // (6,16): error CS1674: 'int*': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'int*': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (var v = stackalloc int[1])
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var v = stackalloc int[1]").WithArguments("int*").WithLocation(6, 16));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -162,6 +162,8 @@ class C2
         using (C1 c = new C1())
         {
         }
+        C1 c1b = new C1();
+        using (c1b) { }
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
@@ -171,9 +173,15 @@ class C2
                 // (13,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(13, 16),
-                // (13,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() function.
+                // (13,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(13, 16)
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(13, 16),
+                // (17,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
+                //         using (c1b) { }
+                Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "c1b").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(17, 16),
+                // (17,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                //         using (c1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1b").WithArguments("C1").WithLocation(17, 16)
                 );
         }
 
@@ -195,6 +203,8 @@ class C2
         using (C1 c = new C1())
         {
         }
+        C1 c1b = new C1();
+        using (c1b) { }
     }
 }";
             // Shouldn't throw an error as the method signatures are different.
@@ -219,6 +229,8 @@ class C2
         using (C1 c = new C1())
         {
         }
+        C1 c1b = new C1();
+        using (c1b) { }
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
@@ -228,9 +240,15 @@ class C2
                 // (13,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(13, 16),
-                // (13,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() function.
+                // (13,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(13, 16)
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(13, 16),
+                // (17,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
+                //         using (c1b) { }
+                Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "c1b").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(17, 16),
+                // (17,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                //         using (c1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1b").WithArguments("C1").WithLocation(17, 16)
                 );
         }
 
@@ -256,6 +274,8 @@ class C3
         using (C2 c = new C2())
         {
         }
+        C2 c2b = new C2();
+        using (c2b) { }
     }
 }";
             CreateCompilation(source).VerifyDiagnostics();
@@ -282,13 +302,17 @@ class C3
         using (C1 c = new C1())
         {
         }
+        C1 c1b = new C1();
+        using (c1b) { }
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-
                 // (16,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(16, 16)
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(16, 16),
+                // (20,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                //         using (c1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1b").WithArguments("C1").WithLocation(20, 16)
                 );
         }
 
@@ -309,6 +333,8 @@ class C2
         using (C1 c = new C1())
         {
         }
+        C1 c1b = new C1();
+        using (c1b) { }
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
@@ -317,7 +343,13 @@ class C2
                 Diagnostic(ErrorCode.WRN_PatternBadSignature, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()").WithLocation(12, 16),
                 // (12,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(12, 16)
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(12, 16),
+                // (16,16): warning CS0280: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' has the wrong signature.
+                //         using (c1b) { }
+                Diagnostic(ErrorCode.WRN_PatternBadSignature, "c1b").WithArguments("C1", "disposable", "C1.Dispose()").WithLocation(16, 16),
+                // (16,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                //         using (c1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1b").WithArguments("C1").WithLocation(16, 16)
                 );
         }
 
@@ -338,6 +370,8 @@ class C2
         using (C1 c = new C1())
         {
         }
+        C1 c1b = new C1();
+        using (c1b) { }
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
@@ -346,7 +380,13 @@ class C2
                 Diagnostic(ErrorCode.WRN_PatternStaticOrInaccessible, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()").WithLocation(12, 16),
                 // (12,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(12, 16)
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(12, 16),
+                // (16,16): warning CS0279: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is either static or not public.
+                //         using (c1b) { }
+                Diagnostic(ErrorCode.WRN_PatternStaticOrInaccessible, "c1b").WithArguments("C1", "disposable", "C1.Dispose()").WithLocation(16, 16),
+                // (16,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                //         using (c1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1b").WithArguments("C1").WithLocation(16, 16)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -89,6 +87,28 @@ class C
             CreateCompilation(source).VerifyDiagnostics(
                 // (6,16): error CS1674: 'method group': type used in a using statement must be implicitly convertible to 'System.IDisposable'
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "Main").WithArguments("method group"));
+        }
+
+        [Fact]
+        public void UsingPatternTest()
+        {
+            var source = @"
+class C1
+{
+    public C1() { }
+    public void Dispose() { }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (C1 c = new C1())
+        {
+        }
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -85,7 +85,7 @@ class C
 ";
 
             CreateCompilation(source).VerifyDiagnostics(
-                // (6,16): error CS1674: 'method group': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'method group': type used in a using statement must have a public void-returning Dispose() instance method.
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "Main").WithArguments("method group"));
         }
 
@@ -138,7 +138,7 @@ class C2
                 // (13,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(13, 16),
-                // (13,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() function.
+                // (13,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(13, 16)
                 );
@@ -268,7 +268,6 @@ class C3
 class C1
 {
     public C1() { }
-    public void Dispose() { }
 }
 
 static class C2 
@@ -285,7 +284,12 @@ class C3
         }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics(
+
+                // (16,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                //         using (C1 c = new C1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(16, 16)
+                );
         }
 
         [Fact]
@@ -311,7 +315,7 @@ class C2
                 // (12,16): warning CS0280: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' has the wrong signature.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.WRN_PatternBadSignature, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()").WithLocation(12, 16),
-                // (12,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() function.
+                // (12,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(12, 16)
                 );
@@ -340,7 +344,7 @@ class C2
                 // (12,16): warning CS0279: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is either static or not public.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.WRN_PatternStaticOrInaccessible, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()").WithLocation(12, 16),
-                // (12,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() function.
+                // (12,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(12, 16)
             );
@@ -362,7 +366,7 @@ class C
 ";
 
             CreateCompilation(source).VerifyDiagnostics(
-                // (6,16): error CS1674: 'lambda expression': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'lambda expression': type used in a using statement must have a public void-returning Dispose() instance method.
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "x => x").WithArguments("lambda expression"));
         }
 
@@ -836,7 +840,7 @@ class C
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (16,16): error CS1674: 'T0': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (16,16): error CS1674: 'T0': type used in a using statement must have a public void-returning Dispose() instance method.
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "t0").WithArguments("T0").WithLocation(16, 16));
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
@@ -1245,7 +1245,7 @@ public class ClassA
     }
 }";
             var data = Compile(source, 1,
-                // (6,16): error CS1674: '<empty anonymous type>': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: '<empty anonymous type>': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (var v1 =    new { }   )
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var v1 =    new { }").WithArguments("<empty anonymous type>")
             );
@@ -1282,7 +1282,7 @@ IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration
   Initializer: 
     null";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS1674: '<empty anonymous type>': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // CS1674: '<empty anonymous type>': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (/*<bind>*/var v1 = new { }/*</bind>*/)
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var v1 = new { }").WithArguments("<empty anonymous type>").WithLocation(6, 26)
             };

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -1197,7 +1197,7 @@ class C
     }
 }";
             CreateCompilationWithILAndMscorlib40(csharp, il).VerifyDiagnostics(
-                // (6,16): error CS1674: 'ConvertibleToIDisposable': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'ConvertibleToIDisposable': type used in a using statement must have a public void-returning Dispose() instance method.
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var d = new ConvertibleToIDisposable()").WithArguments("ConvertibleToIDisposable"));
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -4812,7 +4812,7 @@ public class Test
 }
 ";
             CreateCompilation(test, options: TestOptions.ReleaseDll.WithAllowUnsafe(true)).VerifyDiagnostics(
-                // (6,16): error CS1674: 'int*': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'int*': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (var v = stackalloc int[1])
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var v = stackalloc int[1]").WithArguments("int*").WithLocation(6, 16));
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.Concurrent.get -> bool
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.Concurrent.set -> void
-const Microsoft.CodeAnalysis.WellKnownMemberNames.GetDisposeMethodName = "Dispose" -> string
+const Microsoft.CodeAnalysis.WellKnownMemberNames.DisposeMethodName = "Dispose" -> string

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.Concurrent.get -> bool
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.Concurrent.set -> void
+const Microsoft.CodeAnalysis.WellKnownMemberNames.GetDisposeMethodName = "Dispose" -> string

--- a/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
@@ -307,6 +307,6 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The required name for the <c>Dispose</c> method used in a Using statement.
         /// </summary>
-        public const string GetDisposeMethodName = "Dispose";
+        public const string DisposeMethodName = "Dispose";
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
@@ -303,5 +303,10 @@ namespace Microsoft.CodeAnalysis
         /// (see C# Specification, §7.7.7.1 Awaitable expressions).
         /// </summary>
         public const string OnCompleted = nameof(OnCompleted);
+
+        /// <summary>
+        /// The required name for the <c>Dispose</c> method used in a Using statement.
+        /// </summary>
+        public const string GetDisposeMethodName = "Dispose";
     }
 }


### PR DESCRIPTION
### Description

A user has a class method Dispose() but has not or does not want to implement the IDisposable interface. This allows the user to simply implement a public void-returning instance method called Dispose that bypasses the official interface check and thus allows this type to be utilized in a using statement.

An outline of a spec is in https://github.com/dotnet/csharplang/issues/1623