### PR TITLE
move some GetServices from constructor into CreateEditorInstance()

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
     //         Wrapping
     //       Naming
     //     IntelliSense
-    
+
     [ProvideLanguageEditorOptionPage(typeof(Options.AdvancedOptionPage), "CSharp", null, "Advanced", pageNameResourceId: "#102", keywordListResourceId: 306)]
     [ProvideLanguageEditorToolsOptionCategory("CSharp", "Code Style", "#114")]
     [ProvideLanguageEditorOptionPage(typeof(Options.Formatting.CodeStylePage), "CSharp", @"Code Style", "General", pageNameResourceId: "#108", keywordListResourceId: 313)]
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
         protected override IEnumerable<IVsEditorFactory> CreateEditorFactories()
         {
-            var editorFactory = new CSharpEditorFactory(this);
+            var editorFactory = new CSharpEditorFactory(this, this.ComponentModel);
             var codePageEditorFactory = new CSharpCodePageEditorFactory(editorFactory);
 
             return new IVsEditorFactory[] { editorFactory, codePageEditorFactory };

--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
         protected override IEnumerable<IVsEditorFactory> CreateEditorFactories()
         {
-            var editorFactory = new CSharpEditorFactory(this, this.ComponentModel);
+            var editorFactory = new CSharpEditorFactory(this.ComponentModel);
             var codePageEditorFactory = new CSharpCodePageEditorFactory(editorFactory);
 
             return new IVsEditorFactory[] { editorFactory, codePageEditorFactory };

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
@@ -13,8 +14,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
     [Guid(Guids.CSharpEditorFactoryIdString)]
     internal class CSharpEditorFactory : AbstractEditorFactory
     {
-        public CSharpEditorFactory(CSharpPackage package)
-            : base(package)
+        public CSharpEditorFactory(CSharpPackage package, IComponentModel componentModel)
+            : base(package, componentModel)
         {
         }
 

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
     [Guid(Guids.CSharpEditorFactoryIdString)]
     internal class CSharpEditorFactory : AbstractEditorFactory
     {
-        public CSharpEditorFactory(CSharpPackage package, IComponentModel componentModel)
-            : base(package, componentModel)
+        public CSharpEditorFactory(IComponentModel componentModel)
+            : base(componentModel)
         {
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -25,23 +25,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     /// </summary>
     internal abstract partial class AbstractEditorFactory : IVsEditorFactory, IVsEditorFactoryNotify
     {
-        private readonly Package _package;
         private readonly IComponentModel _componentModel;
         private Microsoft.VisualStudio.OLE.Interop.IServiceProvider _oleServiceProvider;
         private bool _encoding;
 
-        protected AbstractEditorFactory(Package package, IComponentModel componentModel)
+        protected AbstractEditorFactory(IComponentModel componentModel)
         {
-            _package = package ?? throw new ArgumentNullException(nameof(package));
             _componentModel = componentModel;
-        }
-
-        protected IServiceProvider ServiceProvider
-        {
-            get
-            {
-                return _package;
-            }
         }
 
         protected abstract string ContentTypeName { get; }
@@ -138,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                     // We must create the WinForms designer here
                     const string LoaderName = "Microsoft.VisualStudio.Design.Serialization.CodeDom.VSCodeDomDesignerLoader";
-                    var designerService = (IVSMDDesignerService)ServiceProvider.GetService(typeof(SVSMDDesignerService));
+                    var designerService = (IVSMDDesignerService)_oleServiceProvider.QueryService<SVSMDDesignerService>();
                     var designerLoader = (IVSMDDesignerLoader)designerService.CreateDesignerLoader(LoaderName);
 
                     try

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -28,14 +28,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         private readonly Package _package;
         private readonly IComponentModel _componentModel;
         private Microsoft.VisualStudio.OLE.Interop.IServiceProvider _oleServiceProvider;
-        private readonly IWaitIndicator _waitIndicator;
         private bool _encoding;
 
-        protected AbstractEditorFactory(Package package)
+        protected AbstractEditorFactory(Package package, IComponentModel componentModel)
         {
             _package = package ?? throw new ArgumentNullException(nameof(package));
-            _componentModel = (IComponentModel)ServiceProvider.GetService(typeof(SComponentModel));
-            _waitIndicator = _componentModel.GetService<IWaitIndicator>();
+            _componentModel = componentModel;
         }
 
         protected IServiceProvider ServiceProvider
@@ -220,8 +218,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             // Is this being added from a template?
             if (((__EFNFLAGS)grfEFN & __EFNFLAGS.EFN_ClonedFromTemplate) != 0)
             {
+                var waitIndicator = _componentModel.GetService<IWaitIndicator>();
                 // TODO(cyrusn): Can this be cancellable?
-                _waitIndicator.Wait(
+                waitIndicator.Wait(
                     "Intellisense",
                     allowCancel: false,
                     action: c => FormatDocumentCreatedFromTemplate(pHier, itemid, pszMkDocument, c.CancellationToken));

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
@@ -11,8 +11,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
     Friend Class VisualBasicEditorFactory
         Inherits AbstractEditorFactory
 
-        Public Sub New(package As VisualBasicPackage, componentModel As IComponentModel)
-            MyBase.New(package, componentModel)
+        Public Sub New(componentModel As IComponentModel)
+            MyBase.New(componentModel)
         End Sub
 
         Protected Overrides ReadOnly Property ContentTypeName As String

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
@@ -3,6 +3,7 @@
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor
+Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
@@ -10,8 +11,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
     Friend Class VisualBasicEditorFactory
         Inherits AbstractEditorFactory
 
-        Public Sub New(package As VisualBasicPackage)
-            MyBase.New(package)
+        Public Sub New(package As VisualBasicPackage, componentModel As IComponentModel)
+            MyBase.New(package, componentModel)
         End Sub
 
         Protected Overrides ReadOnly Property ContentTypeName As String

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -144,7 +144,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         End Function
 
         Protected Overrides Function CreateEditorFactories() As IEnumerable(Of IVsEditorFactory)
-            Dim editorFactory = New VisualBasicEditorFactory(Me)
+            Dim editorFactory = New VisualBasicEditorFactory(Me, Me.ComponentModel)
             Dim codePageEditorFactory = New VisualBasicCodePageEditorFactory(editorFactory)
 
             Return {editorFactory, codePageEditorFactory}

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -64,7 +64,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         Implements IVsUserSettingsQuery
 
         ' The property page for WinForms project has a special interface that it uses to get
-        ' entry points that are Forms: IVbEntryPointProvider. The semantics for this 
+        ' entry points that are Forms: IVbEntryPointProvider. The semantics for this
         ' interface are the same as VisualBasicProject::GetFormEntryPoints, but callers get
         ' the VB Package and cast it to IVbEntryPointProvider. The property page is managed
         ' and we've redefined the interface, so we have to register a COM aggregate of the
@@ -144,7 +144,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         End Function
 
         Protected Overrides Function CreateEditorFactories() As IEnumerable(Of IVsEditorFactory)
-            Dim editorFactory = New VisualBasicEditorFactory(Me, Me.ComponentModel)
+            Dim editorFactory = New VisualBasicEditorFactory(Me.ComponentModel)
             Dim codePageEditorFactory = New VisualBasicCodePageEditorFactory(editorFactory)
 
             Return {editorFactory, codePageEditorFactory}


### PR DESCRIPTION
Fixes #27741 

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes
https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/487203

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
