### PR TITLE
Add exception handling for erasing XML stream

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             var src = dir.CreateFile("temp.cs").WriteAllText("class C {}");
             const string docName = "doc.xml";
 
-            var cmd = new MockCSharpCompiler(null, dir.Path, new[] { "/nologo", "/t:library", $"/doc:{docName}", src.Path });
+            var cmd = new MockCSharpCompiler(null, dir.Path, new[] { "/nologo", "/t:library", "/preferreduilang:en", $"/doc:{docName}", src.Path });
 
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             var exitCode = cmd.Run(outWriter);

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -99,6 +100,31 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             sdkDirectory = sdkDirectory ?? s_defaultSdkDirectory;
             var args = CommandLineParser.SplitCommandLineIntoArguments(commandLine, removeHashComments: true);
             return CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
+        }
+
+        [Fact]
+        public void XmlMemoryMapped()
+        {
+            var dir = Temp.CreateDirectory();
+            var src = dir.CreateFile("temp.cs").WriteAllText("class C {}");
+            const string docName = "doc.xml";
+
+            var cmd = new MockCSharpCompiler(null, dir.Path, new[] { "/nologo", "/t:library", $"/doc:{docName}", src.Path });
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var exitCode = cmd.Run(outWriter);
+            Assert.Equal(0, exitCode);
+            Assert.Equal("", outWriter.ToString());
+
+            var xmlPath = Path.Combine(dir.Path, docName);
+            using (var fileStream = new FileStream(xmlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var mmf = MemoryMappedFile.CreateFromFile(fileStream, "xmlMap", 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: true))
+            {
+                exitCode = cmd.Run(outWriter);
+                Assert.Equal(1, exitCode);
+                Assert.Equal($"error CS0016: Could not write to output file '{xmlPath}' -- 'The requested operation cannot be performed on a file with a user-mapped section open.'",
+                    outWriter.ToString().Replace(Environment.NewLine, ""));
+            }
         }
 
         // This test should only run when the machine's default encoding is shift-JIS

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -766,7 +766,15 @@ namespace Microsoft.CodeAnalysis
                                     return;
                                 }
 
-                                xmlStreamOpt.SetLength(0);
+                                try
+                                {
+                                    xmlStreamOpt.SetLength(0);
+                                }
+                                catch (Exception e)
+                                {
+                                    MessageProvider.ReportStreamWriteException(e, finalXmlFilePath, diagnostics);
+                                    return;
+                                }
                                 xmlStreamDisposerOpt = new NoThrowStreamDisposer(
                                     xmlStreamOpt,
                                     finalXmlFilePath,

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -76,7 +76,7 @@ End Class")
                 Using mmf = MemoryMappedFile.CreateFromFile(fileStream, "xmlMap", 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen:=True)
                     exitCode = cmd.Run(outWriter)
                     Assert.Equal(1, exitCode)
-                    Assert.Equal($"vbc : error BC2012: can't open '{xmlPath}' for writing:'The requested operation cannot be performed on a file with a user-mapped section open.'",
+                    Assert.Equal($"vbc : error BC2012: can't open '{xmlPath}' for writing: The requested operation cannot be performed on a file with a user-mapped section open.",
             outWriter.ToString().Replace(Environment.NewLine, ""))
                 End Using
             End Using

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -4,6 +4,7 @@ Imports System.Collections.Immutable
 Imports System.ComponentModel
 Imports System.Globalization
 Imports System.IO
+Imports System.IO.MemoryMappedFiles
 Imports System.Reflection
 Imports System.Reflection.Metadata
 Imports System.Reflection.PortableExecutable
@@ -54,6 +55,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
             sdkDirectory = If(sdkDirectory, s_defaultSdkDirectory)
             Return VisualBasicCommandLineParser.Script.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
         End Function
+
+        <Fact>
+        Public Sub XmlMemoryMapped()
+            Dim dir = Temp.CreateDirectory()
+            Dim src = dir.CreateFile("temp.cs").WriteAllText("
+Class C
+End Class")
+            Dim docName As String = "doc.xml"
+
+            Dim cmd = New MockVisualBasicCompiler(Nothing, dir.Path, {"/nologo", "/t:library", "/preferreduilang:en", $"/doc:{docName}", src.Path})
+
+            Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
+            Dim exitCode = cmd.Run(outWriter)
+            Assert.Equal(0, exitCode)
+            Assert.Equal("", outWriter.ToString())
+
+            Dim xmlPath = Path.Combine(dir.Path, docName)
+            Using fileStream = New FileStream(xmlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)
+                Using mmf = MemoryMappedFile.CreateFromFile(fileStream, "xmlMap", 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen:=True)
+                    exitCode = cmd.Run(outWriter)
+                    Assert.Equal(1, exitCode)
+                    Assert.Equal($"vbc : error BC2012: can't open '{xmlPath}' for writing:'The requested operation cannot be performed on a file with a user-mapped section open.'",
+            outWriter.ToString().Replace(Environment.NewLine, ""))
+                End Using
+            End Using
+        End Sub
 
         <Fact>
         <WorkItem(946954, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/946954")>


### PR DESCRIPTION
This showed up as a common crash path in Watsons. The exception
is usually that another process is holding onto the file.