### PR TITLE
Make AnalyzerDependencyCheckingService thread safe

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 IgnorableAssemblyIdentityList loadedAssembliesList = new IgnorableAssemblyIdentityList(loadedAssemblies);
 
                 IIgnorableAssemblyList[] ignorableAssemblyLists = new[] { s_systemPrefixList, s_codeAnalysisPrefixList, s_explicitlyIgnoredAssemblyList, s_assembliesIgnoredByNameList, loadedAssembliesList };
-                return new AnalyzerDependencyChecker(currentAnalyzerPaths, ignorableAssemblyLists, _bindingRedirectionService).Run(_cancellationTokenSource.Token);
+                return AnalyzerDependencyChecker.ComputeDependencyConflicts(currentAnalyzerPaths, ignorableAssemblyLists, _bindingRedirectionService, _cancellationTokenSource.Token);
             },
             TaskScheduler.Default);
 

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Roslyn.Utilities;
 
@@ -19,21 +18,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     [Export(typeof(AnalyzerDependencyCheckingService))]
     internal sealed class AnalyzerDependencyCheckingService
     {
+        /// <summary>
+        /// Object given as key for <see cref="HostDiagnosticUpdateSource.UpdateDiagnosticsForProject(ProjectId, object, IEnumerable{DiagnosticData})"/>.
+        /// </summary>
         private static readonly object s_dependencyConflictErrorId = new object();
         private static readonly IIgnorableAssemblyList s_systemPrefixList = new IgnorableAssemblyNamePrefixList("System");
         private static readonly IIgnorableAssemblyList s_codeAnalysisPrefixList = new IgnorableAssemblyNamePrefixList("Microsoft.CodeAnalysis");
         private static readonly IIgnorableAssemblyList s_explicitlyIgnoredAssemblyList = new IgnorableAssemblyIdentityList(GetExplicitlyIgnoredAssemblyIdentities());
         private static readonly IIgnorableAssemblyList s_assembliesIgnoredByNameList = new IgnorableAssemblyNameList(ImmutableHashSet.Create("mscorlib"));
+        private static readonly IBindingRedirectionService s_bindingRedirectionService = new BindingRedirectionService();
 
-        private readonly VisualStudioWorkspaceImpl _workspace;
-        private readonly HostDiagnosticUpdateSource _updateSource;
-        private readonly BindingRedirectionService _bindingRedirectionService;
+        private readonly VisualStudioWorkspace _workspace;
+        private readonly HostDiagnosticUpdateSource _hostDiagnosticUpdateSource;
 
+        /// <summary>
+        /// Object given to synchronize access to the mutable fields in this class.
+        /// </summary>
+        private readonly object _gate = new object();
         private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-        private Task<AnalyzerDependencyResults> _task = Task.FromResult(AnalyzerDependencyResults.Empty);
-        private ImmutableHashSet<string> _analyzerPaths = ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly DiagnosticDescriptor _missingAnalyzerReferenceRule = new DiagnosticDescriptor(
+        /// <summary>
+        /// The most recently started analysis task; if we start a new analysis we will cancel the previous one and start the next one
+        /// as a continuation of this task to ensure any notification to <see cref="_hostDiagnosticUpdateSource"/> was done first.
+        /// </summary>
+        private Task _task = Task.CompletedTask;
+        private ImmutableHashSet<string> _previousAnalyzerPaths = ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
+
+        private static readonly DiagnosticDescriptor s_missingAnalyzerReferenceRule = new DiagnosticDescriptor(
             id: IDEDiagnosticIds.MissingAnalyzerReferenceId,
             title: ServicesVSResources.MissingAnalyzerReference,
             messageFormat: ServicesVSResources.Analyzer_assembly_0_depends_on_1_but_it_was_not_found_Analyzers_may_not_run_correctly_unless_the_missing_assembly_is_added_as_an_analyzer_reference_as_well,
@@ -41,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        private readonly DiagnosticDescriptor _analyzerDependencyConflictRule = new DiagnosticDescriptor(
+        private static readonly DiagnosticDescriptor s_analyzerDependencyConflictRule = new DiagnosticDescriptor(
             id: IDEDiagnosticIds.AnalyzerDependencyConflictId,
             title: ServicesVSResources.AnalyzerDependencyConflict,
             messageFormat: ServicesVSResources.Analyzer_assemblies_0_and_1_both_have_identity_2_but_different_contents_Only_one_will_be_loaded_and_analyzers_using_these_assemblies_may_not_run_correctly,
@@ -49,49 +60,92 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
+
         [ImportingConstructor]
         public AnalyzerDependencyCheckingService(
-            VisualStudioWorkspaceImpl workspace,
-            HostDiagnosticUpdateSource updateSource)
+            VisualStudioWorkspace workspace,
+            HostDiagnosticUpdateSource hostDiagnosticUpdateSource)
         {
             _workspace = workspace;
-            _updateSource = updateSource;
-            _bindingRedirectionService = new BindingRedirectionService();
+            _hostDiagnosticUpdateSource = hostDiagnosticUpdateSource;
         }
 
-        public async void CheckForConflictsAsync()
+        public void ReanalyzeSolutionForConflicts()
         {
-            AnalyzerDependencyResults results = null;
-            try
-            {
-                results = await GetConflictsAsync().ConfigureAwait(continueOnCapturedContext: true);
-            }
-            catch
-            {
-                return;
-            }
+            var solution = _workspace.CurrentSolution;
+            var currentAnalyzerPaths = solution
+                .Projects
+                .SelectMany(p => p.AnalyzerReferences)
+                .OfType<AnalyzerFileReference>()
+                .Select(a => a.FullPath)
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
 
-            if (results == null)
+            lock (_gate)
             {
-                return;
+                // If we've already started analysis for this set of analyzers, no reason to start over
+                if (currentAnalyzerPaths.SetEquals(_previousAnalyzerPaths))
+                {
+                    return;
+                }
+
+                _cancellationTokenSource.Cancel();
+                _cancellationTokenSource = new CancellationTokenSource();
+                _previousAnalyzerPaths = currentAnalyzerPaths;
+
+                // Capturing cancellationToken here so the right instance is passed into the delegates below
+                var cancellationToken = _cancellationTokenSource.Token;
+
+                // We are explicitly relying on SafeContinueWith including LazyCancellation as a continuation option here
+                _task = _task.SafeContinueWith(_ =>
+                {
+                    AnalyzeAndReportConflictsInSolution(solution, currentAnalyzerPaths, _hostDiagnosticUpdateSource, cancellationToken);
+                },
+                cancellationToken, TaskScheduler.Default);
             }
+        }
+
+        // Method is static to prevent accidental use of mutable state in this class
+        private static void AnalyzeAndReportConflictsInSolution(
+            Solution solution,
+            ImmutableHashSet<string> currentAnalyzerPaths,
+            HostDiagnosticUpdateSource hostDiagnosticUpdateSource,
+            CancellationToken cancellationToken)
+        {
+            var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Select(assembly => AssemblyIdentity.FromAssemblyDefinition(assembly));
+            var loadedAssembliesList = new IgnorableAssemblyIdentityList(loadedAssemblies);
+
+            var ignorableAssemblyLists = new[] { s_systemPrefixList, s_codeAnalysisPrefixList, s_explicitlyIgnoredAssemblyList, s_assembliesIgnoredByNameList, loadedAssembliesList };
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var results = AnalyzerDependencyChecker.ComputeDependencyConflicts(currentAnalyzerPaths, ignorableAssemblyLists, s_bindingRedirectionService, cancellationToken);
 
             var builder = ImmutableArray.CreateBuilder<DiagnosticData>();
 
             var conflicts = results.Conflicts;
             var missingDependencies = results.MissingDependencies;
 
-            foreach (var project in _workspace.DeferredState.ProjectTracker.ImmutableProjects)
+            foreach (var project in solution.Projects)
             {
                 builder.Clear();
 
+                // If our analysis has been cancelled, it means another request has been queued behind us; thus it's OK to stop
+                // doing the analysis now and let that other one fix up any stale results.
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var analyzerFilePaths = new HashSet<string>(
+                    project.AnalyzerReferences
+                           .OfType<AnalyzerFileReference>()
+                           .Select(f => f.FullPath),
+                    StringComparer.OrdinalIgnoreCase);
+
                 foreach (var conflict in conflicts)
                 {
-                    if (project.CurrentProjectAnalyzersContains(conflict.AnalyzerFilePath1) ||
-                        project.CurrentProjectAnalyzersContains(conflict.AnalyzerFilePath2))
+                    if (analyzerFilePaths.Contains(conflict.AnalyzerFilePath1) ||
+                        analyzerFilePaths.Contains(conflict.AnalyzerFilePath2))
                     {
                         var messageArguments = new string[] { conflict.AnalyzerFilePath1, conflict.AnalyzerFilePath2, conflict.Identity.ToString() };
-                        if (DiagnosticData.TryCreate(_analyzerDependencyConflictRule, messageArguments, project.Id, _workspace, out var diagnostic))
+                        if (DiagnosticData.TryCreate(s_analyzerDependencyConflictRule, messageArguments, project.Id, solution.Workspace, out var diagnostic))
                         {
                             builder.Add(diagnostic);
                         }
@@ -100,17 +154,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                 foreach (var missingDependency in missingDependencies)
                 {
-                    if (project.CurrentProjectAnalyzersContains(missingDependency.AnalyzerPath))
+                    if (analyzerFilePaths.Contains(missingDependency.AnalyzerPath))
                     {
                         var messageArguments = new string[] { missingDependency.AnalyzerPath, missingDependency.DependencyIdentity.ToString() };
-                        if (DiagnosticData.TryCreate(_missingAnalyzerReferenceRule, messageArguments, project.Id, _workspace, out var diagnostic))
+                        if (DiagnosticData.TryCreate(s_missingAnalyzerReferenceRule, messageArguments, project.Id, solution.Workspace, out var diagnostic))
                         {
                             builder.Add(diagnostic);
                         }
                     }
                 }
 
-                _updateSource.UpdateDiagnosticsForProject(project.Id, s_dependencyConflictErrorId, builder.ToImmutable());
+                hostDiagnosticUpdateSource.UpdateDiagnosticsForProject(project.Id, s_dependencyConflictErrorId, builder.ToImmutable());
             }
 
             foreach (var conflict in conflicts)
@@ -124,7 +178,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
         }
 
-        private void LogConflict(AnalyzerDependencyConflict conflict)
+        private static void LogConflict(AnalyzerDependencyConflict conflict)
         {
             Logger.Log(
                 FunctionId.AnalyzerDependencyCheckingService_LogConflict,
@@ -136,7 +190,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 }));
         }
 
-        private void LogMissingDependency(MissingAnalyzerDependency missingDependency)
+        private static void LogMissingDependency(MissingAnalyzerDependency missingDependency)
         {
             Logger.Log(
                 FunctionId.AnalyzerDependencyCheckingService_LogMissingDependency,
@@ -145,37 +199,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     m["Analyzer"] = missingDependency.AnalyzerPath;
                     m["Identity"] = missingDependency.DependencyIdentity;
                 }));
-        }
-
-        private Task<AnalyzerDependencyResults> GetConflictsAsync()
-        {
-            var currentAnalyzerPaths = _workspace.CurrentSolution
-                .Projects
-                .SelectMany(p => p.AnalyzerReferences)
-                .OfType<AnalyzerFileReference>()
-                .Select(a => a.FullPath)
-                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
-
-            if (currentAnalyzerPaths.SetEquals(_analyzerPaths))
-            {
-                return _task;
-            }
-
-            _cancellationTokenSource.Cancel();
-            _cancellationTokenSource = new CancellationTokenSource();
-            _analyzerPaths = currentAnalyzerPaths;
-
-            _task = _task.SafeContinueWith(_ =>
-            {
-                var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Select(assembly => AssemblyIdentity.FromAssemblyDefinition(assembly));
-                var loadedAssembliesList = new IgnorableAssemblyIdentityList(loadedAssemblies);
-
-                var ignorableAssemblyLists = new[] { s_systemPrefixList, s_codeAnalysisPrefixList, s_explicitlyIgnoredAssemblyList, s_assembliesIgnoredByNameList, loadedAssembliesList };
-                return AnalyzerDependencyChecker.ComputeDependencyConflicts(currentAnalyzerPaths, ignorableAssemblyLists, _bindingRedirectionService, _cancellationTokenSource.Token);
-            },
-            TaskScheduler.Default);
-
-            return _task;
         }
 
         private static IEnumerable<AssemblyIdentity> GetExplicitlyIgnoredAssemblyIdentities()
@@ -198,7 +221,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             list.Add(identity);
         }
 
-        private class BindingRedirectionService : IBindingRedirectionService
+        private sealed class BindingRedirectionService : IBindingRedirectionService
         {
             public AssemblyIdentity ApplyBindingRedirects(AssemblyIdentity originalIdentity)
             {

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         private Task<AnalyzerDependencyResults> GetConflictsAsync()
         {
-            ImmutableHashSet<string> currentAnalyzerPaths = _workspace.CurrentSolution
+            var currentAnalyzerPaths = _workspace.CurrentSolution
                 .Projects
                 .SelectMany(p => p.AnalyzerReferences)
                 .OfType<AnalyzerFileReference>()
@@ -167,10 +167,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             _task = _task.SafeContinueWith(_ =>
             {
-                IEnumerable<AssemblyIdentity> loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Select(assembly => AssemblyIdentity.FromAssemblyDefinition(assembly));
-                IgnorableAssemblyIdentityList loadedAssembliesList = new IgnorableAssemblyIdentityList(loadedAssemblies);
+                var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Select(assembly => AssemblyIdentity.FromAssemblyDefinition(assembly));
+                var loadedAssembliesList = new IgnorableAssemblyIdentityList(loadedAssemblies);
 
-                IIgnorableAssemblyList[] ignorableAssemblyLists = new[] { s_systemPrefixList, s_codeAnalysisPrefixList, s_explicitlyIgnoredAssemblyList, s_assembliesIgnoredByNameList, loadedAssembliesList };
+                var ignorableAssemblyLists = new[] { s_systemPrefixList, s_codeAnalysisPrefixList, s_explicitlyIgnoredAssemblyList, s_assembliesIgnoredByNameList, loadedAssembliesList };
                 return AnalyzerDependencyChecker.ComputeDependencyConflicts(currentAnalyzerPaths, ignorableAssemblyLists, _bindingRedirectionService, _cancellationTokenSource.Token);
             },
             TaskScheduler.Default);
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         {
             public AssemblyIdentity ApplyBindingRedirects(AssemblyIdentity originalIdentity)
             {
-                string redirectedAssemblyName = AppDomain.CurrentDomain.ApplyPolicy(originalIdentity.ToString());
+                var redirectedAssemblyName = AppDomain.CurrentDomain.ApplyPolicy(originalIdentity.ToString());
                 if (AssemblyIdentity.TryParseDisplayName(redirectedAssemblyName, out var redirectedAssemblyIdentity))
                 {
                     return redirectedAssemblyIdentity;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     this.ProjectTracker.NotifyWorkspace(workspace => workspace.OnAnalyzerReferenceAdded(Id, existingReference.GetReference()));
                 }
 
-                GetAnalyzerDependencyCheckingService().CheckForConflictsAsync();
+                GetAnalyzerDependencyCheckingService().ReanalyzeSolutionForConflicts();
             }
 
             if (File.Exists(analyzerAssemblyFullPath))
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 var analyzerReference = analyzer.GetReference();
                 this.ProjectTracker.NotifyWorkspace(workspace => workspace.OnAnalyzerReferenceRemoved(Id, analyzerReference));
 
-                GetAnalyzerDependencyCheckingService().CheckForConflictsAsync();
+                GetAnalyzerDependencyCheckingService().ReanalyzeSolutionForConflicts();
             }
 
             analyzer.Dispose();

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -603,7 +603,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _solutionLoadComplete = true;
 
             // Check that the set of analyzers is complete and consistent.
-            GetAnalyzerDependencyCheckingService()?.CheckForConflictsAsync();
+            GetAnalyzerDependencyCheckingService()?.ReanalyzeSolutionForConflicts();
         }
 
         private AnalyzerDependencyCheckingService GetAnalyzerDependencyCheckingService()

--- a/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
+++ b/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
@@ -34,8 +34,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
             Using directory = New DisposableDirectory(Temp)
                 Dim library = BuildLibrary(directory, "public class A { }", "A")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({library}, GetIgnorableAssemblyLists())
 
                 Assert.Empty(results.Conflicts)
             End Using
@@ -63,8 +62,7 @@ public class A
                 Dim libraryB = BuildLibrary(directory, sourceB, "B")
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB}, GetIgnorableAssemblyLists())
 
                 Assert.Empty(results.Conflicts)
             End Using
@@ -96,8 +94,7 @@ public class A
                 Dim libraryB = BuildLibrary(directory, sourceB, "B")
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB, libraryC}, GetIgnorableAssemblyLists())
 
                 Assert.Empty(results.Conflicts)
                 Assert.Empty(results.MissingDependencies)
@@ -138,8 +135,7 @@ public class C
                 Dim libraryD = BuildLibrary(directory, sourceD, "D")
                 Dim libraryC = BuildLibrary(directory, sourceC, "C", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB, libraryC, libraryD}, GetIgnorableAssemblyLists())
 
                 Assert.Empty(results.Conflicts)
                 Assert.Empty(results.MissingDependencies)
@@ -181,8 +177,7 @@ public class C
                 Dim libraryD = BuildLibrary(directory2, sourceD, "D")
                 Dim libraryC = BuildLibrary(directory2, sourceC, "C", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB, libraryC, libraryD}, GetIgnorableAssemblyLists())
 
                 Assert.Empty(results.Conflicts)
                 Assert.Empty(results.MissingDependencies)
@@ -223,8 +218,7 @@ public class B
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "C")
                 Dim libraryB = BuildLibrary(directory, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB, libraryC}, GetIgnorableAssemblyLists())
 
                 Assert.Empty(results.Conflicts)
                 Assert.Empty(results.MissingDependencies)
@@ -265,8 +259,7 @@ public class B
                 Dim libraryC2 = directory2.CreateFile("C.dll").CopyContentFrom(libraryC1).Path
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB, libraryC1, libraryC2}, GetIgnorableAssemblyLists())
 
                 Assert.Empty(results.Conflicts)
                 Assert.Empty(results.MissingDependencies)
@@ -318,8 +311,7 @@ public class C
                 Dim libraryCPrime = BuildLibrary(directory2, sourceCPrime, "C")
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryCPrime}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB, libraryC, libraryCPrime}, GetIgnorableAssemblyLists())
 
                 Dim conflicts = results.Conflicts
 
@@ -390,8 +382,7 @@ public class D
                 Dim libraryA = BuildLibrary(directory1, sourceA, "A", "C")
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "C")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC1, libraryC2, libraryD, libraryDPrime}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB, libraryC1, libraryC2, libraryD, libraryDPrime}, GetIgnorableAssemblyLists())
 
                 Dim conflicts = results.Conflicts
                 Assert.Equal(expected:=1, actual:=conflicts.Length)
@@ -470,8 +461,7 @@ public class E
                 Dim libraryA = BuildLibrary(directory1, sourceA, "A", "C")
                 Dim libraryB = BuildLibrary(directory2, sourceB, "B", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryE, libraryEPrime}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB, libraryC, libraryD, libraryE, libraryEPrime}, GetIgnorableAssemblyLists())
                 Dim conflicts = results.Conflicts
 
                 Assert.Equal(expected:=1, actual:=conflicts.Length)
@@ -523,8 +513,7 @@ public class B
                 Dim libraryBPrime = BuildLibrary(directory2, sourceBPrime, "B")
                 Dim libraryA2 = directory2.CreateFile("A.dll").CopyContentFrom(libraryA1).Path
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA1, libraryA2, libraryB, libraryBPrime}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA1, libraryA2, libraryB, libraryBPrime}, GetIgnorableAssemblyLists())
                 Dim conflicts = results.Conflicts
 
                 Assert.Equal(expected:=1, actual:=conflicts.Length)
@@ -588,8 +577,7 @@ public class B
                 Dim libraryBPrime = BuildLibrary(directory2, sourceBPrime, "B")
                 Dim libraryAPrime = BuildLibrary(directory2, sourceAPrime, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB, libraryBPrime}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryAPrime, libraryB, libraryBPrime}, GetIgnorableAssemblyLists())
                 Dim conflicts = results.Conflicts
 
                 Assert.Equal(expected:=2, actual:=conflicts.Length)
@@ -640,8 +628,7 @@ public class B
                 Dim libraryB2 = directory2.CreateFile("B.dll").CopyContentFrom(libraryB1).Path
                 Dim libraryAPrime = BuildLibrary(directory2, sourceAPrime, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryAPrime, libraryB1, libraryB2}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryAPrime, libraryB1, libraryB2}, GetIgnorableAssemblyLists())
                 Dim conflicts = results.Conflicts
 
                 Assert.Equal(expected:=1, actual:=conflicts.Length)
@@ -721,8 +708,7 @@ public class D
                 Dim libraryDPrimePrime = BuildLibrary(directory3, sourceDPrimePrime, "D")
                 Dim libraryC = BuildLibrary(directory3, sourceC, "C", "D")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA, libraryB, libraryC, libraryD, libraryDPrime, libraryDPrimePrime}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA, libraryB, libraryC, libraryD, libraryDPrime, libraryDPrimePrime}, GetIgnorableAssemblyLists())
 
                 Assert.Equal(expected:=3, actual:=results.Conflicts.Length)
             End Using
@@ -736,8 +722,7 @@ public class D
             Using directory = New DisposableDirectory(Temp)
                 Dim library = BuildLibrary(directory, "public class A { }", "A")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({library}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({library}, GetIgnorableAssemblyLists())
 
                 Assert.Empty(results.MissingDependencies)
             End Using
@@ -763,8 +748,7 @@ public class A
                 Dim libraryB = BuildLibrary(directory, sourceB, "B")
                 Dim libraryA = BuildLibrary(directory, sourceA, "A", "B")
 
-                Dim dependencyChecker = New AnalyzerDependencyChecker({libraryA}, GetIgnorableAssemblyLists())
-                Dim results = dependencyChecker.Run()
+                Dim results = AnalyzerDependencyChecker.ComputeDependencyConflicts({libraryA}, GetIgnorableAssemblyLists())
                 Dim missingDependencies = results.MissingDependencies
 
                 Assert.Equal(expected:=1, actual:=missingDependencies.Count)

--- a/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
+++ b/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
@@ -5,6 +5,7 @@ Imports System.FormattableString
 Imports System.IO
 Imports System.Text
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.Implementation
 Imports Microsoft.Win32
@@ -15,26 +16,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
     Public Class AnalyzerDependencyCheckerTests
         Inherits TestBase
 
-        Private Shared s_msbuildDirectory As String
-        Private Shared ReadOnly Property MSBuildDirectory As String
-            Get
-                If s_msbuildDirectory Is Nothing Then
-                    Dim vsVersion = If(Environment.GetEnvironmentVariable("VisualStudioVersion"), "14.0")
-                    Dim key = Registry.LocalMachine.OpenSubKey(Invariant($"SOFTWARE\Microsoft\MSBuild\ToolsVersions\{vsVersion}"), False)
-
-                    If key IsNot Nothing Then
-                        Dim toolsPath = key.GetValue("MSBuildToolsPath")
-                        If toolsPath IsNot Nothing Then
-                            s_msbuildDirectory = toolsPath.ToString()
-                        End If
-                    End If
-                End If
-
-                Return s_msbuildDirectory
-            End Get
-        End Property
-
-        Private Shared s_CSharpCompilerExecutable As String = If(MSBuildDirectory IsNot Nothing, Path.Combine(MSBuildDirectory, "csc.exe"), Nothing)
         Private Shared s_mscorlibDisplayName As String = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
 
         Private Shared Function GetIgnorableAssemblyLists() As IEnumerable(Of IIgnorableAssemblyList)
@@ -44,7 +25,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
             Return {New IgnorableAssemblyIdentityList({mscorlib})}
         End Function
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest1()
             ' Dependency Graph:
@@ -61,7 +42,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
 
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest2()
             ' Dependency graph:
@@ -89,7 +70,7 @@ public class A
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest3()
             ' Dependency graph:
@@ -124,7 +105,7 @@ public class A
 
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest4()
             ' Dependency graph:
@@ -165,7 +146,7 @@ public class C
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest5()
             ' Dependency graph:
@@ -208,7 +189,7 @@ public class C
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest6()
             ' Dependency graph:
@@ -250,7 +231,7 @@ public class B
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest7()
             ' Dependency graph:
@@ -292,7 +273,7 @@ public class B
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest8()
             ' Dependency graph:
@@ -353,7 +334,7 @@ public class C
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest9()
             ' Dependency graph:
@@ -424,7 +405,7 @@ public class D
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest10()
             ' Dependency graph:
@@ -505,7 +486,7 @@ public class E
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest11()
             ' Dependency graph:
@@ -557,7 +538,7 @@ public class B
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest12()
             ' Dependency graph:
@@ -615,7 +596,7 @@ public class B
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest13()
             ' Dependency graph:
@@ -674,7 +655,7 @@ public class B
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         <WorkItem(1064914, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064914")>
         Public Sub ConflictsTest14()
             ' Dependency graph:
@@ -746,8 +727,8 @@ public class D
                 Assert.Equal(expected:=3, actual:=results.Conflicts.Length)
             End Using
         End Sub
- 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+
+        <Fact>
         Public Sub MissingTest1()
             ' Dependency Graph:
             '   A
@@ -762,7 +743,7 @@ public class D
             End Using
         End Sub
 
-        <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/16301")>
+        <Fact>
         Public Sub MissingTest2()
             ' Dependency graph:
             '   A --> B*
@@ -898,17 +879,20 @@ public class A
             Dim tempOut = Path.Combine(directory.Path, libraryName + ".out")
             Dim libraryOut = Path.Combine(directory.Path, libraryName + ".dll")
 
-            Dim sb = New StringBuilder
-            For Each name In referenceNames
-                sb.Append(" /r:")
-                sb.Append(Path.Combine(directory.Path, name + ".dll"))
+            Dim syntaxTrees = {CSharpSyntaxTree.ParseText(fileContents, path:=sourceFile)}
+
+            Dim references = New List(Of PortableExecutableReference)
+            For Each referenceName In referenceNames
+                references.Add(PortableExecutableReference.CreateFromFile(Path.Combine(directory.Path, referenceName + ".dll")))
             Next
 
-            Dim references = sb.ToString()
+            references.Add(TestReferences.NetFx.v4_0_30319.mscorlib)
 
-            Dim arguments = $"/C ""{s_CSharpCompilerExecutable}"" /nologo /t:library /out:{libraryOut} {references} {sourceFile} > {tempOut}"
+            Dim compilation = CSharpCompilation.Create(libraryName, syntaxTrees, references, New CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            Dim emitResult = compilation.Emit(libraryOut)
 
-            Dim output = ProcessUtilities.RunAndGetOutput("cmd", arguments, expectedRetCode:=0)
+            Assert.Empty(emitResult.Diagnostics)
+            Assert.True(emitResult.Success)
 
             Return libraryOut
         End Function


### PR DESCRIPTION
The AnalyzerDependencyCheckingService looks at a solution, figures out what analyzers have potential problems, and adds diagnostics to the error list. CheckForConflictsAsync() had to be called any time the solution was changed in a way that might affect the analysis. This had to be called from the UI thread, and although some of the more expensive bits were off the UI thread, it marshalled back to interact with the project system again. Now it's fully off the UI thread and can be called from any thread.

**CODE REVIEW SUGGESTION 1:** review commit-at-a-time.
**CODE REVIEW SUGGESTION 2:** the last commit reorders some code in AnalyzerDependencyCheckingService.cs, you might first find it helpful to quickly scroll through the file to recognize what is moving before you find yourself reviewing code that was already there.

<details><summary>Ask Mode template</summary>

### Customer scenario

This is part of the rewrite for free-threading the language service initialization process.

### Bugs this fixes

Not a bug; part of larger work.

### Risk

Low-to-moderate: this is tinkering in a tricky area, but the code changes are pretty straightforward.

### Performance impact

Expected to improve: more code is now off the UI thread than before, so this is an improvement even without the rest of the work in place. This also unblocks other work down the road.

</details>
