### PR TITLE
Add VisualStudioSetup.Dependencies to the list of VSIX to install.

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -641,6 +641,7 @@ function Deploy-VsixViaTool() {
         "Vsix\VisualStudioInteractiveComponents\Roslyn.VisualStudio.InteractiveComponents.vsix",
         "Vsix\ExpressionEvaluatorPackage\ExpressionEvaluatorPackage.vsix",
         "Vsix\VisualStudioDiagnosticsWindow\Roslyn.VisualStudio.DiagnosticsWindow.vsix",
+        "Vsix\VisualStudioSetup.Dependencies\Roslyn.VisualStudio.Setup.Dependencies.vsix",
         "Vsix\VisualStudioIntegrationTestSetup\Microsoft.VisualStudio.IntegrationTest.Setup.vsix")
 
     Write-Host "Uninstalling old Roslyn VSIX"

--- a/src/VisualStudio/Setup.Dependencies/VisualStudioSetup.Dependencies.csproj
+++ b/src/VisualStudio/Setup.Dependencies/VisualStudioSetup.Dependencies.csproj
@@ -16,9 +16,6 @@
     <TargetFramework>net46</TargetFramework>
     <RuntimeIdentifier>$(RoslynDesktopRuntimeIdentifier)</RuntimeIdentifier>
     <RoslynProjectType>Vsix</RoslynProjectType>
-    <IsProductComponent>true</IsProductComponent>
-    <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot>
-    <ExtensionInstallationFolder>Microsoft\ManagedLanguages\VBCSharp\Dependencies</ExtensionInstallationFolder>
     <Ngen>true</Ngen>
     <NgenArchitecture>All</NgenArchitecture>
     <NgenPriority>3</NgenPriority>


### PR DESCRIPTION
FYI. @jasonmalinowski, @tmat, @dotnet/roslyn-infrastructure 

The commit is based on top of dev15.8-preview3 (so we can insert or retarget elsewhere, as needed), but is currently target master-vs-deps as that is the only place it is actually "required" right now.