### PR TITLE
move off UI thread in option changed event handler

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     // we are not interested in 1 file re-analysis request which can happen from like venus typing
                     var solution = _registration.CurrentSolution;
                     SolutionCrawlerLogger.LogReanalyze(
-                        CorrelationId, analyzer, scope.GetDocumentCount(solution), scope.GetLanguages(solution), highPriority);
+                        CorrelationId, analyzer, scope.GetDocumentCount(solution), scope.GetLanguagesStringForTelemetry(solution), highPriority);
                 }
             }
 
@@ -629,13 +629,12 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             public bool HasMultipleDocuments => _solutionId != null || _projectOrDocumentIds?.Count > 1;
 
-            public string GetLanguages(Solution solution)
+            public string GetLanguagesStringForTelemetry(Solution solution)
             {
                 if (_solutionId != null && solution.Id != _solutionId)
                 {
-                    // this is for telemetry. no reason to make it complex such as 
-                    // TryGetLangage(., var language) ? language : string.Empty
-                    // just to look good. this is a helper nested private type anyway.
+                    // return empty if given solution is not 
+                    // same as solution this scope is created for
                     return string.Empty;
                 }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -633,6 +633,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             {
                 if (_solutionId != null && solution.Id != _solutionId)
                 {
+                    // this is for telemetry. no reason to make it complex such as 
+                    // TryGetLangage(., var language) ? language : string.Empty
+                    // just to look good. this is a helper nested private type anyway.
                     return string.Empty;
                 }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.Versions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SolutionCrawler
@@ -151,15 +150,21 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private void ReanalyzeOnOptionChange(object sender, OptionChangedEventArgs e)
             {
-                // let each analyzer decide what they want on option change
-                foreach (var analyzer in _documentAndProjectWorkerProcessor.Analyzers)
+                // get off from option changed event handler since it runs on UI thread
+                // getting analyzer can be slow for the very first time since it is lazily initialized
+                var asyncToken = _listener.BeginAsyncOperation("ReanalyzeOnOptionChange");
+                _eventProcessingQueue.ScheduleTask(() =>
                 {
-                    if (analyzer.NeedsReanalysisOnOptionChanged(sender, e))
+                    // let each analyzer decide what they want on option change
+                    foreach (var analyzer in _documentAndProjectWorkerProcessor.Analyzers)
                     {
-                        var scope = new ReanalyzeScope(_registration.CurrentSolution.Id);
-                        Reanalyze(analyzer, scope);
+                        if (analyzer.NeedsReanalysisOnOptionChanged(sender, e))
+                        {
+                            var scope = new ReanalyzeScope(_registration.CurrentSolution.Id);
+                            Reanalyze(analyzer, scope);
+                        }
                     }
-                }
+                }, _shutdownToken).CompletesAsyncOperation(asyncToken);
             }
 
             public void Reanalyze(IIncrementalAnalyzer analyzer, ReanalyzeScope scope, bool highPriority = false)
@@ -626,7 +631,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             public string GetLanguages(Solution solution)
             {
-                Contract.ThrowIfFalse(_solutionId == null || solution.Id == _solutionId);
+                if (_solutionId != null && solution.Id != _solutionId)
+                {
+                    return string.Empty;
+                }
 
                 using (var pool = SharedPools.Default<HashSet<string>>().GetPooledObject())
                 {
@@ -665,7 +673,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             public int GetDocumentCount(Solution solution)
             {
-                Contract.ThrowIfFalse(_solutionId == null || solution.Id == _solutionId);
+                if (_solutionId != null && solution.Id != _solutionId)
+                {
+                    return 0;
+                }
 
                 var count = 0;
                 if (_solutionId != null)
@@ -702,7 +713,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             public IEnumerable<Document> GetDocuments(Solution solution)
             {
-                Contract.ThrowIfFalse(_solutionId == null || solution.Id == _solutionId);
+                if (_solutionId != null && solution.Id != _solutionId)
+                {
+                    yield break;
+                }
 
                 if (_solutionId != null)
                 {


### PR DESCRIPTION
### Customer scenario

Users open a solution and changed options and VS got UI freeze.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/590860

### Workarounds, if any

Change options once it got first set of errors

### Risk

option change can theoretically happen a bit more slower than before, but it was async all along so in practice, I dont believe there will be any user noticeable experience changes.

### Performance impact

Low. option change will be put into BG task queue to be processed rather than happening right away in event handler.

### Is this a regression from a previous update?

No

### Root cause analysis

we responded to option changes in option change event handler assuming it would be pretty quick. that is mostly true except the very first time if Analyzer are not already initialized. this makes sure even in such situation, we don't hold option change event (UI thread) for the initialization.

### How was the bug found?

UIDelay watson.

