### PR TITLE
Test stability fixes

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         private static readonly HashSet<string> s_predefinedCodeFixProviderNames = GetPredefinedCodeFixProviderNames();
 
         internal readonly FixAllState FixAllState;
-        private bool _showPreviewChangesDialog;
+        private readonly bool _showPreviewChangesDialog;
 
         internal FixSomeCodeAction(
             FixAllState fixAllState, bool showPreviewChangesDialog)
@@ -83,29 +83,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             }
 
             return names;
-        }
-
-        internal TestAccessor GetTestAccessor()
-        {
-            return new TestAccessor(this);
-        }
-
-        internal readonly struct TestAccessor
-        {
-            private readonly FixSomeCodeAction _fixSomeCodeAction;
-
-            internal TestAccessor(FixSomeCodeAction fixSomeCodeAction)
-            {
-                _fixSomeCodeAction = fixSomeCodeAction;
-            }
-
-            /// <summary>
-            /// Gets a reference to <see cref="_showPreviewChangesDialog"/>, which can be read or written by test code.
-            /// </summary>
-            public ref bool ShowPreviewChangesDialog
-            {
-                get => ref _fixSomeCodeAction._showPreviewChangesDialog;
-            }
         }
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         private static readonly HashSet<string> s_predefinedCodeFixProviderNames = GetPredefinedCodeFixProviderNames();
 
         internal readonly FixAllState FixAllState;
-        private readonly bool _showPreviewChangesDialog;
+        private bool _showPreviewChangesDialog;
 
         internal FixSomeCodeAction(
             FixAllState fixAllState, bool showPreviewChangesDialog)
@@ -83,6 +83,29 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             }
 
             return names;
+        }
+
+        internal TestAccessor GetTestAccessor()
+        {
+            return new TestAccessor(this);
+        }
+
+        internal readonly struct TestAccessor
+        {
+            private readonly FixSomeCodeAction _fixSomeCodeAction;
+
+            internal TestAccessor(FixSomeCodeAction fixSomeCodeAction)
+            {
+                _fixSomeCodeAction = fixSomeCodeAction;
+            }
+
+            /// <summary>
+            /// Gets a reference to <see cref="_showPreviewChangesDialog"/>, which can be read or written by test code.
+            /// </summary>
+            public ref bool ShowPreviewChangesDialog
+            {
+                get => ref _fixSomeCodeAction._showPreviewChangesDialog;
+            }
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
@@ -41,6 +41,7 @@ namespace Roslyn.VisualStudio.IntegrationTests
             catch
             {
                 _messageFilter.Dispose();
+                _messageFilter = null;
                 throw;
             }
         }
@@ -86,7 +87,7 @@ namespace Roslyn.VisualStudio.IntegrationTests
             {
                 try
                 {
-                    _visualStudioContext.Dispose();
+                    _visualStudioContext?.Dispose();
                 }
                 finally
                 {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
@@ -61,8 +61,14 @@ namespace Roslyn.VisualStudio.IntegrationTests
             }
         }
 
-        public Task DisposeAsync()
+        /// <summary>
+        /// This method implements <see cref="IAsyncLifetime.DisposeAsync"/>, and is used for releasing resources
+        /// created by <see cref="IAsyncLifetime.InitializeAsync"/>. This method is only called if
+        /// <see cref="InitializeAsync"/> completes successfully.
+        /// </summary>
+        public virtual Task DisposeAsync()
         {
+            _visualStudioContext.Dispose();
             return Task.CompletedTask;
         }
 
@@ -81,18 +87,17 @@ namespace Roslyn.VisualStudio.IntegrationTests
             Thread.Sleep(timeout);
         }
 
+        /// <summary>
+        /// This method provides the implementation for <see cref="IDisposable.Dispose"/>. This method via the
+        /// <see cref="IDisposable"/> interface (i.e. <paramref name="disposing"/> is <see langword="true"/>) if the
+        /// constructor completes successfully. The <see cref="InitializeAsync"/> may or may not have completed
+        /// successfully.
+        /// </summary>
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
             {
-                try
-                {
-                    _visualStudioContext?.Dispose();
-                }
-                finally
-                {
-                    _messageFilter.Dispose();
-                }
+                _messageFilter.Dispose();
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -215,12 +215,7 @@ csharp_style_expression_bodied_properties = true:warning
             VisualStudio.Editor.Verify.CodeAction(
                 "Use expression body for properties",
                 applyFix: true,
-                fixAllScope: FixAllScope.Project,
-                blockUntilComplete: false);
-
-            var expectedTitle = "Preview Changes - Fix all occurrences";
-            VisualStudio.PreviewChangesDialog.VerifyOpen(expectedTitle, Helper.HangMitigatingTimeout);
-            VisualStudio.PreviewChangesDialog.ClickApplyAndWaitForFeature(expectedTitle, FeatureAttribute.DiagnosticService);
+                fixAllScope: FixAllScope.Project);
 
             Assert.Equal(expectedText, VisualStudio.Editor.GetText());
 
@@ -243,11 +238,7 @@ csharp_style_expression_bodied_properties = true:warning
             VisualStudio.Editor.Verify.CodeAction(
                 "Use block body for properties",
                 applyFix: true,
-                fixAllScope: FixAllScope.Project,
-                blockUntilComplete: false);
-
-            VisualStudio.PreviewChangesDialog.VerifyOpen(expectedTitle, Helper.HangMitigatingTimeout);
-            VisualStudio.PreviewChangesDialog.ClickApplyAndWaitForFeature(expectedTitle, FeatureAttribute.DiagnosticService);
+                fixAllScope: FixAllScope.Project);
 
             expectedText = @"
 class C

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveBoxSelection.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveBoxSelection.cs
@@ -22,19 +22,10 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.SubmitText("#cls");
         }
 
-        protected override void Dispose(bool disposing)
+        public override Task DisposeAsync()
         {
-            try
-            {
-                if (disposing && VisualStudio != null)
-                {
-                    VisualStudio.ExecuteCommand(WellKnownCommandNames.Edit_SelectionCancel);
-                }
-            }
-            finally
-            {
-                base.Dispose(disposing);
-            }
+            VisualStudio.ExecuteCommand(WellKnownCommandNames.Edit_SelectionCancel);
+            return base.DisposeAsync();
         }
 
         [WpfFact]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveBoxSelection.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveBoxSelection.cs
@@ -24,12 +24,17 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
+            try
             {
-                VisualStudio.ExecuteCommand(WellKnownCommandNames.Edit_SelectionCancel);
+                if (disposing && VisualStudio != null)
+                {
+                    VisualStudio.ExecuteCommand(WellKnownCommandNames.Edit_SelectionCancel);
+                }
             }
-
-            base.Dispose(disposing);
+            finally
+            {
+                base.Dispose(disposing);
+            }
         }
 
         [WpfFact]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
@@ -24,14 +24,19 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
+            try
             {
-                VisualStudio.Workspace.SetUseSuggestionMode(false);
-                VisualStudio.InteractiveWindow.ClearReplText();
-                VisualStudio.InteractiveWindow.Reset();
+                if (disposing && VisualStudio != null)
+                {
+                    VisualStudio.Workspace.SetUseSuggestionMode(false);
+                    VisualStudio.InteractiveWindow.ClearReplText();
+                    VisualStudio.InteractiveWindow.Reset();
+                }
             }
-
-            base.Dispose(disposing);
+            finally
+            {
+                base.Dispose(disposing);
+            }
         }
 
         [WpfFact]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
@@ -22,21 +22,12 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.Workspace.SetUseSuggestionMode(true);
         }
 
-        protected override void Dispose(bool disposing)
+        public override Task DisposeAsync()
         {
-            try
-            {
-                if (disposing && VisualStudio != null)
-                {
-                    VisualStudio.Workspace.SetUseSuggestionMode(false);
-                    VisualStudio.InteractiveWindow.ClearReplText();
-                    VisualStudio.InteractiveWindow.Reset();
-                }
-            }
-            finally
-            {
-                base.Dispose(disposing);
-            }
+            VisualStudio.Workspace.SetUseSuggestionMode(false);
+            VisualStudio.InteractiveWindow.ClearReplText();
+            VisualStudio.InteractiveWindow.Reset();
+            return base.DisposeAsync();
         }
 
         [WpfFact]

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Text.Tagging;
+using Roslyn.Utilities;
 using OLECMDEXECOPT = Microsoft.VisualStudio.OLE.Interop.OLECMDEXECOPT;
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
@@ -319,7 +320,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void ApplyLightBulbAction(string actionName, FixAllScope? fixAllScope, bool blockUntilComplete)
         {
-            var lightBulbAction = GetLightBulbApplicationAction(actionName, fixAllScope);
+            var lightBulbAction = GetLightBulbApplicationAction(actionName, fixAllScope, blockUntilComplete);
             var task = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -340,7 +341,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         private void BeginInvokeExecuteOnActiveView(Action<IWpfTextView> action)
             => BeginInvokeOnUIThread(GetExecuteOnActionViewCallback(action));
 
-        private Func<IWpfTextView, Task> GetLightBulbApplicationAction(string actionName, FixAllScope? fixAllScope)
+        private Func<IWpfTextView, Task> GetLightBulbApplicationAction(string actionName, FixAllScope? fixAllScope, bool willBlockUntilComplete)
         {
             return async view =>
             {
@@ -376,6 +377,17 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                     if (action == null)
                     {
                         throw new InvalidOperationException($"Unable to find FixAll in {fixAllScope.ToString()} code fix for suggested action '{action.DisplayText}'.");
+                    }
+
+                    if (willBlockUntilComplete
+                        && action is FixAllSuggestedAction fixAllSuggestedAction
+                        && fixAllSuggestedAction.CodeAction is FixSomeCodeAction fixSomeCodeAction)
+                    {
+                        // Ensure the preview changes dialog will not be shown. Since the operation 'willBlockUntilComplete',
+                        // the caller would not be able to interact with the preview changes dialog, and the tests would
+                        // either timeout or deadlock.
+                        fixSomeCodeAction.GetTestAccessor().ShowPreviewChangesDialog = false;
+
                     }
 
                     if (string.IsNullOrEmpty(actionName))

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -386,8 +387,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                         // Ensure the preview changes dialog will not be shown. Since the operation 'willBlockUntilComplete',
                         // the caller would not be able to interact with the preview changes dialog, and the tests would
                         // either timeout or deadlock.
-                        fixSomeCodeAction.GetTestAccessor().ShowPreviewChangesDialog = false;
-
+                        var field = typeof(FixSomeCodeAction).GetField("_showPreviewChangesDialog", BindingFlags.Instance | BindingFlags.NonPublic);
+                        field.SetValue(fixSomeCodeAction, false);
                     }
 
                     if (string.IsNullOrEmpty(actionName))

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -185,14 +185,17 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
             else
             {
-                // We are going to reuse the currently running instance, so ensure that we grab the host Process and Dte
+                // We are going to reuse the currently running instance, so ensure that we grab the host Process and DTE
                 // before cleaning up any hooks or remoting services created by the previous instance. We will then
                 // create a new VisualStudioInstance from the previous to ensure that everything is in a 'clean' state.
+                //
+                // We create a new DTE instance in the current context since the COM object could have been separated
+                // from its RCW during the previous test.
 
                 Debug.Assert(_currentlyRunningInstance != null);
 
                 hostProcess = _currentlyRunningInstance.HostProcess;
-                dte = _currentlyRunningInstance.Dte;
+                dte = await IntegrationHelper.WaitForNotNullAsync(() => IntegrationHelper.TryLocateDteForProcess(hostProcess)).ConfigureAwait(false);
                 supportedPackageIds = _currentlyRunningInstance.SupportedPackageIds;
                 installationPath = _currentlyRunningInstance.InstallationPath;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -105,10 +105,19 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         {
             ThrowExceptionIfAlreadyHasActiveContext();
 
-            bool shouldStartNewInstance = ShouldStartNewInstance(requiredPackageIds);
-            await UpdateCurrentlyRunningInstanceAsync(requiredPackageIds, shouldStartNewInstance).ConfigureAwait(false);
+            try
+            {
+                bool shouldStartNewInstance = ShouldStartNewInstance(requiredPackageIds);
+                await UpdateCurrentlyRunningInstanceAsync(requiredPackageIds, shouldStartNewInstance).ConfigureAwait(false);
 
-            return new VisualStudioInstanceContext(_currentlyRunningInstance, this);
+                return new VisualStudioInstanceContext(_currentlyRunningInstance, this);
+            }
+            catch
+            {
+                // Make sure the next test doesn't try to reuse the same instance
+                NotifyCurrentInstanceContextDisposed(canReuse: false);
+                throw;
+            }
         }
 
         internal void NotifyCurrentInstanceContextDisposed(bool canReuse)


### PR DESCRIPTION
This pull request contains all the features from #27764 except for automatic retry for UI Automation calls. The documentation in **TextViewWindow_InProc.cs** was updated per the review from @tannergooding.

* Improves ability for integration test failures to be isolated to the particular test(s) that failed (785834f9787dcac564acfd801bdc3c0cfe0dc7c6)
* Apply additional timeouts to mitigate hangs (6476450665c4c983bbd23784a46402b4966ee2fe)
* Improve robustness of new .editorconfig Fix All tests (3e4cf945dbe3ef70e43d7d472c1276bcad1e1be8)

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
