### PR TITLE
Replace a hard crash with an NFW

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableItem.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
@@ -29,22 +30,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         public TableItem(IEnumerable<TableItem<T>> items)
         {
-#if DEBUG
-            // If code reached here,
-            // There must be at least 1 item in the list
-            Contract.ThrowIfFalse(items.Count() > 0);
+            var itemCount = items.Count();
+            if (itemCount == 0)
+            {
+                // There must be at least 1 item in the list
+                FatalError.ReportWithoutCrash(new ArgumentException("Contains no items", nameof(items)));
+            }
 
-            // There must be document id
-            Contract.ThrowIfTrue(items.Any(i => i.PrimaryDocumentId == null));
-#endif
+            var filteredItems = items.Where(i => i.PrimaryDocumentId != null);
+            if (filteredItems.Count() != itemCount)
+            {
+                // There must be document id for provided items.
+                FatalError.ReportWithoutCrash(new ArgumentException("Contains an item with null PrimaryDocumentId", nameof(items)));
+            }
 
             var first = true;
             var collectionHash = 1;
             var count = 0;
 
             // Make things to be deterministic. 
-            var ordereditems = items.OrderBy(i => i.PrimaryDocumentId.Id);
-            foreach (var item in ordereditems)
+            var orderedItems = filteredItems.OrderBy(i => i.PrimaryDocumentId.Id);
+            foreach (var item in orderedItems)
             {
                 count++;
 
@@ -68,7 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             }
 
             // order of item is important. make sure we maintain it.
-            _cache = SharedInfoCache.GetOrAdd(collectionHash, ordereditems, c => new SharedInfoCache(c.Select(i => i.PrimaryDocumentId).ToImmutableArray()));
+            _cache = SharedInfoCache.GetOrAdd(collectionHash, orderedItems, c => new SharedInfoCache(c.Select(i => i.PrimaryDocumentId).ToImmutableArray()));
         }
 
         public DocumentId PrimaryDocumentId

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableItem.cs
@@ -30,26 +30,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         public TableItem(IEnumerable<TableItem<T>> items)
         {
-            var itemCount = items.Count();
-            if (itemCount == 0)
-            {
-                // There must be at least 1 item in the list
-                FatalError.ReportWithoutCrash(new ArgumentException("Contains no items", nameof(items)));
-            }
-
-            var filteredItems = items.Where(i => i.PrimaryDocumentId != null);
-            if (filteredItems.Count() != itemCount)
-            {
-                // There must be document id for provided items.
-                FatalError.ReportWithoutCrash(new ArgumentException("Contains an item with null PrimaryDocumentId", nameof(items)));
-            }
-
             var first = true;
             var collectionHash = 1;
             var count = 0;
 
             // Make things to be deterministic. 
-            var orderedItems = filteredItems.OrderBy(i => i.PrimaryDocumentId.Id);
+            var orderedItems = items.Where(i => i.PrimaryDocumentId != null).OrderBy(i => i.PrimaryDocumentId.Id).ToList();
+            if (orderedItems.Count == 0)
+            {
+                // There must be at least 1 item in the list
+                FatalError.ReportWithoutCrash(new ArgumentException("Contains no items", nameof(items)));
+            }
+            else if (orderedItems.Count != items.Count())
+            {
+                // There must be document id for provided items.
+                FatalError.ReportWithoutCrash(new ArgumentException("Contains an item with null PrimaryDocumentId", nameof(items)));
+            }
+
             foreach (var item in orderedItems)
             {
                 count++;


### PR DESCRIPTION
Fixes Watson bug VSO [400829](https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/400829)

<details><summary>Ask Mode template</summary>

### Customer scenario

The NullReferenceException is coming from large number of Watson reports. We are reaching a code path that violates existing asserts during de-duplication of build/live diagnostics in error list - we are somehow getting diagnostics with no DocumentId in the TableItem constructor that takes list of items, which should never happen. Existing dumps are not very useful as there is only a callstack for us to look at.

### Bugs this fixes

VSO [400829](https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/400829)

### Workarounds, if any

None

### Risk

Low - we are replacing existing asserts with NFW, and then handling the violating case more gracefully instead of crashing.

### Performance impact

None

### Is this a regression from a previous update?

No

### Root cause analysis

We already have asserts, but crash if asserts are violated, instead of NFW.

### How was the bug found?

Watsons

### Test documentation updated?

N/A

</details>
