### PR TITLE
Fix implicit type use analyzer.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.TypeStyle;
@@ -369,6 +370,150 @@ class C
         [|int|] i = (i = 20);
     }
 }", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(26894, "https://github.com/dotnet/roslyn/issues/26894")]
+        public async Task NotOnVariablesOfEnumTypeNamedAsEnumTypeUsedInInitalizerExpressionAtFirstPosition()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+enum A { X, Y }
+
+class C
+{
+    void M()
+    {
+        [|A|] A = A.X;
+    }
+}", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(26894, "https://github.com/dotnet/roslyn/issues/26894")]
+        public async Task NotOnVariablesNamedAsTypeUsedInInitalizerExpressionContainingTypeNameAtFirstPositionOfMemberAccess()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class A 
+{ 
+    public static A Instance;
+}
+
+class C
+{
+    void M()
+    {
+        [|A|] A = A.Instance;
+    }
+}", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(26894, "https://github.com/dotnet/roslyn/issues/26894")]
+        public async Task SuggestOnVariablesUsedInInitalizerExpressionAsInnerPartsOfQualifiedNameStartedWithGlobal()
+        {
+            await TestAsync(
+@"enum A { X, Y }
+
+class C
+{
+    void M()
+    {
+        [|A|] A = global::A.X;
+    }
+}",
+@"enum A { X, Y }
+
+class C
+{
+    void M()
+    {
+        var A = global::A.X;
+    }
+}", CSharpParseOptions.Default, options: ImplicitTypeEverywhere());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(26894, "https://github.com/dotnet/roslyn/issues/26894")]
+        public async Task SuggestOnVariablesUsedInInitalizerExpressionAsInnerPartsOfQualifiedName()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+namespace N
+{
+    class A 
+    { 
+        public static A Instance;
+    }
+}
+
+class C
+{
+    void M()
+    {
+        [|N.A|] A = N.A.Instance;
+    }
+}",
+@"using System;
+
+namespace N
+{
+    class A 
+    { 
+        public static A Instance;
+    }
+}
+
+class C
+{
+    void M()
+    {
+        var A = N.A.Instance;
+    }
+}", options: ImplicitTypeEverywhere());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(26894, "https://github.com/dotnet/roslyn/issues/26894")]
+        public async Task SuggestOnVariablesUsedInInitalizerExpressionAsLastPartOfQualifiedName()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class A {}
+
+class X
+{ 
+    public static A A;
+}
+
+class C
+{
+    void M()
+    {
+        [|A|] A = X.A;
+    }
+}",
+@"using System;
+
+class A {}
+
+class X
+{ 
+    public static A A;
+}
+
+class C
+{
+    void M()
+    {
+        var A = X.A;
+    }
+}", options: ImplicitTypeEverywhere());
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]


### PR DESCRIPTION
Fixes edge cases where variable identifier name is reused in the initializer as first part of member access qualification.
Example: SomeEnum SomeEnum = SomeEnum.EnumVal1

Fixes dotnet/roslyn#26894

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/26894

### Workarounds, if any

no

### Risk

?

### Performance impact

Low

### Is this a regression from a previous update?

?

### Root cause analysis

?

### How was the bug found?

?

### Test documentation updated?

n/a