### PR TITLE
Cleaner test accessor

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
@@ -103,9 +103,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             /// Gets a reference to <see cref="_showPreviewChangesDialog"/>, which can be read or written by test code.
             /// </summary>
             public ref bool ShowPreviewChangesDialog
-            {
-                get => ref _fixSomeCodeAction._showPreviewChangesDialog;
-            }
+                => ref _fixSomeCodeAction._showPreviewChangesDialog;
         }
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixSomeCodeAction.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         private static readonly HashSet<string> s_predefinedCodeFixProviderNames = GetPredefinedCodeFixProviderNames();
 
         internal readonly FixAllState FixAllState;
-        private readonly bool _showPreviewChangesDialog;
+        private bool _showPreviewChangesDialog;
 
         internal FixSomeCodeAction(
             FixAllState fixAllState, bool showPreviewChangesDialog)
@@ -83,6 +83,29 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             }
 
             return names;
+        }
+
+        internal TestAccessor GetTestAccessor()
+        {
+            return new TestAccessor(this);
+        }
+
+        internal readonly struct TestAccessor
+        {
+            private readonly FixSomeCodeAction _fixSomeCodeAction;
+
+            internal TestAccessor(FixSomeCodeAction fixSomeCodeAction)
+            {
+                _fixSomeCodeAction = fixSomeCodeAction;
+            }
+
+            /// <summary>
+            /// Gets a reference to <see cref="_showPreviewChangesDialog"/>, which can be read or written by test code.
+            /// </summary>
+            public ref bool ShowPreviewChangesDialog
+            {
+                get => ref _fixSomeCodeAction._showPreviewChangesDialog;
+            }
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -387,7 +387,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                         // the caller would not be able to interact with the preview changes dialog, and the tests would
                         // either timeout or deadlock.
                         fixSomeCodeAction.GetTestAccessor().ShowPreviewChangesDialog = false;
-
                     }
 
                     if (string.IsNullOrEmpty(actionName))

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -387,8 +386,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                         // Ensure the preview changes dialog will not be shown. Since the operation 'willBlockUntilComplete',
                         // the caller would not be able to interact with the preview changes dialog, and the tests would
                         // either timeout or deadlock.
-                        var field = typeof(FixSomeCodeAction).GetField("_showPreviewChangesDialog", BindingFlags.Instance | BindingFlags.NonPublic);
-                        field.SetValue(fixSomeCodeAction, false);
+                        fixSomeCodeAction.GetTestAccessor().ShowPreviewChangesDialog = false;
+
                     }
 
                     if (string.IsNullOrEmpty(actionName))


### PR DESCRIPTION
This pull request contains the production code cleanup change extracted from #27838.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
