### PR TITLE
Don't push an empty batch of projects

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -625,7 +625,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             AssertIsForeground();
 
-            if (!fIsBackgroundIdleBatch)
+            if (!fIsBackgroundIdleBatch && _projectsLoadedThisBatch.Count > 0)
             {
                 // This batch was loaded eagerly. This might be because the user is force expanding the projects in the
                 // Solution Explorer, or they had some files open in an .suo we need to push.


### PR DESCRIPTION
Our batch load optimization in the project system interaction means we try to avoid pushing anything but a full project, and ideally the entire solution in one go. We were getting OnAfterLoadProjectBatch called before we were being told about projects, which meant we'd push an empty solution. Once we were told about projects we would then add each project as a batch, but we'd still do O(n) WorkspaceChanged events when one would have worked.

I'm intentionally not putting this check in StartPushingToWorkspaceAndNotifyOfOpenDocuments because some calls (namely the call in VisualStudioProjectTracker.FinishLoad) still need to ensure the base solution state is pushed to the workspace even if the solution is empty.

<details><summary>Ask Mode template</summary>

### Customer scenario

Customer opens a solution that was previously opened before. We end up kicking off some repeated solution notifications when we don't need to.

### Bugs this fixes

None filed, observed while fixing other issues.

### Workarounds, if any

None.

### Risk

Extremely low; trivial change.

### Performance impact

Should improve.

### Is this a regression from a previous update?

Possibly? Enough has changed around project loads and how we do batching events in VS that this might have worked before. I don't have the necessary installs setup to test older VS versions to track down what might have changed it; the fix is the same either way.

### Root cause analysis

We get an event from the solution load manager saying a batch of projects was loaded, but no actual projects (at least of ours) were told. This caused us to stop taking the most efficient path for later projects.

### How was the bug found?

Debugging to verify another perf proposal.

</details>
