### PR TITLE
Check for invalid file paths in ContainsChildrenGraphQuery

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ContainsChildrenGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ContainsChildrenGraphQuery.cs
@@ -42,32 +42,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                             var uri = node.Id.GetNestedValueByName<Uri>(CodeGraphNodeIdName.File);
                             if (uri != null)
                             {
+                                // Since a solution load is not yet completed, there is no document available to answer this query.
+                                // The solution explorer presumes that if somebody doesn't answer for a file, they never will. 
+                                // See Providers\GraphContextAttachedCollectionSource.cs for more. Therefore we should answer by setting
+                                // ContainsChildren property to either true or false, so any following updates will be tractable.
+                                // We will set it to false since the solution explorer assumes the default for this query response is 'false'.
+
+                                // Todo: we may need fallback to check if this node actually represents a C# or VB language 
+                                // even when its extension fails to say so. One option would be to call DTEWrapper.IsRegisteredForLangService,
+                                // which may not be called here however since deadlock could happen.
+
                                 // The Uri returned by `GetNestedValueByName()` above isn't necessarily absolute and the `OriginalString` is
                                 // the only property that doesn't throw if the UriKind is relative, so `OriginalString` must be used instead
                                 // of `AbsolutePath`.
                                 var path = uri.OriginalString;
 
-                                // We have seen cases where the URI in the graph node has the following
-                                // form, including the quotes (which are invalid path characters):
+                                // Recorded in https://github.com/dotnet/roslyn/issues/27805, we
+                                // have seen crashes because the URI in the graph node has the
+                                // following form, including the quotes (which are invalid path
+                                // characters):
                                 //     C:\path\to\"some path\App.config"
-                                // So, we choose to be defensive in the presence of invalid path characters.
-                                if (path.IndexOfAny(Path.GetInvalidPathChars()) == -1)
+                                // So we avoid calling Path.GetExtension here. Alternatively, we
+                                // could check for illegal path characters directly first, but then
+                                // that check would actually happen twice because GetExtension will
+                                // also perform the check.
+                                if (path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) || path.EndsWith(".vb", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    // Since a solution load is not yet completed, there is no document available to answer this query.
-                                    // The solution explorer presumes that if somebody doesn't answer for a file, they never will. 
-                                    // See Providers\GraphContextAttachedCollectionSource.cs for more. Therefore we should answer by setting
-                                    // ContainsChildren property to either true or false, so any following updates will be tractable.
-                                    // We will set it to false since the solution explorer assumes the default for this query response is 'false'.
-
-                                    // Todo: we may need fallback to check if this node actually represents a C# or VB language 
-                                    // even when its extension fails to say so. One option would be to call DTEWrapper.IsRegisteredForLangService,
-                                    // which may not be called here however since deadlock could happen.
-
-                                    string ext = Path.GetExtension(path);
-                                    if (ext.Equals(".cs", StringComparison.OrdinalIgnoreCase) || ext.Equals(".vb", StringComparison.OrdinalIgnoreCase))
-                                    {
-                                        graphBuilder.AddDeferredPropertySet(node, DgmlNodeProperties.ContainsChildren, false);
-                                    }
+                                    graphBuilder.AddDeferredPropertySet(node, DgmlNodeProperties.ContainsChildren, false);
                                 }
                             }
                         }

--- a/src/VisualStudio/Core/Test/Progression/ContainsChildrenGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/ContainsChildrenGraphQueryTests.vb
@@ -69,6 +69,22 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
             End Using
         End Function
 
+        <WorkItem(27805, "https://github.com/dotnet/roslyn/issues/27805")>
+        <WorkItem(233666, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/233666")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
+        Public Async Function ContainsChildrenForFileWithIllegalPath() As Task
+            Using testState = ProgressionTestState.Create(<Workspace/>)
+                Dim graph = New Graph
+                graph.Nodes.GetOrCreate(
+                    GraphNodeId.GetNested(GraphNodeId.GetPartial(CodeGraphNodeIdName.File, New Uri("C:\path\to\""some folder\App.config""", UriKind.RelativeOrAbsolute))),
+                    label:=String.Empty,
+                    CodeNodeCategories.File)
+
+                ' Just making sure it doesn't throw.
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(graph, New ContainsChildrenGraphQuery(), GraphContextDirection.Self)
+            End Using
+        End Function
+
         <WorkItem(789685, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/789685")>
         <WorkItem(794846, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/794846")>
         <Fact, Trait(Traits.Feature, Traits.Features.Progression)>

--- a/src/VisualStudio/Core/Test/Progression/ProgressionTestState.vb
+++ b/src/VisualStudio/Core/Test/Progression/ProgressionTestState.vb
@@ -41,7 +41,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
             End If
 
             Dim graphBuilder As New GraphBuilder(_workspace.CurrentSolution, CancellationToken.None)
-
             graphBuilder.AddNodeForSymbolAsync(symbol, document.Project, document).Wait(CancellationToken.None)
             Return graphBuilder.Graph
         End Function

--- a/src/VisualStudio/Core/Test/Progression/ProgressionTestState.vb
+++ b/src/VisualStudio/Core/Test/Progression/ProgressionTestState.vb
@@ -41,6 +41,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
             End If
 
             Dim graphBuilder As New GraphBuilder(_workspace.CurrentSolution, CancellationToken.None)
+
             graphBuilder.AddNodeForSymbolAsync(symbol, document.Project, document).Wait(CancellationToken.None)
             Return graphBuilder.Graph
         End Function


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/27805
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/233666

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
