### PR TITLE
Disable NuGet restore in the IDE

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,9 +2,8 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <configuration>
   <packageRestore>
-    <!-- Currently, the repository's version of NuGet.exe and Visual Studio's version
-         fight over the format of project.lock.json because the one in the respository
-         is newer. To prevent that, turn off package restore.
+    <!-- NuGet Restore was observed to cause performance problems for in-IDE builds,
+         so it has been disabled.
 
          ⚠ THIS IS A PERFORMANCE-CRITICAL LINE. DO NOT REMOVE. ⚠ -->
     <add key="enabled" value="false" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<configuration>
+  <packageRestore>
+    <!-- Currently, the repository's version of NuGet.exe and Visual Studio's version
+         fight over the format of project.lock.json because the one in the respository
+         is newer. To prevent that, turn off package restore.
+
+         ⚠ THIS IS A PERFORMANCE-CRITICAL LINE. DO NOT REMOVE. ⚠ -->
+    <add key="enabled" value="false" />
+  </packageRestore>
+</configuration>


### PR DESCRIPTION
Reverts a performance regression introduced in #25876.

The problem seems to be the worst if you do the following:

1. Build on command line with `.\Build.cmd -restore -deployExtensions`
2. Build in the IDE

Prior to this pull request, step 2 attempts to restore NuGet packages which is unnecessary and takes a long time.