### PR TITLE
Integration test stability improvements

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/AutomationElementExtensions.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/AutomationElementExtensions.cs
@@ -39,7 +39,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
 
             var condition = Helper.Automation.CreatePropertyCondition(AutomationElementIdentifiers.AutomationIdProperty.Id, automationId);
-            var child = parent.FindFirst(TreeScope.TreeScope_Descendants, condition);
+            var child = Helper.Retry(
+                () => parent.FindFirst(TreeScope.TreeScope_Descendants, condition),
+                AutomationRetryDelay,
+                retryCount: AutomationRetryCount);
 
             if (child == null)
             {
@@ -61,7 +64,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
 
             var condition = Helper.Automation.CreatePropertyCondition(AutomationElementIdentifiers.NameProperty.Id, name);
-            var child = parent.FindFirst(TreeScope.TreeScope_Descendants, condition);
+            var child = Helper.Retry(
+                () => parent.FindFirst(TreeScope.TreeScope_Descendants, condition),
+                AutomationRetryDelay,
+                retryCount: AutomationRetryCount);
 
             if (child == null)
             {
@@ -83,7 +89,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
 
             var condition = Helper.Automation.CreatePropertyCondition(AutomationElementIdentifiers.ClassNameProperty.Id, className);
-            var child = parent.FindFirst(TreeScope.TreeScope_Descendants, condition);
+            var child = Helper.Retry(
+                () => parent.FindFirst(TreeScope.TreeScope_Descendants, condition),
+                AutomationRetryDelay,
+                retryCount: AutomationRetryCount);
 
             if (child == null)
             {
@@ -340,10 +349,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// </summary>
         private static string GetNameForExceptionMessage(this IUIAutomationElement element)
         {
-            return element.CurrentAutomationId ?? element.CurrentName ?? "<unnamed>";
+            return RetryIfNotAvailable(e => e.CurrentAutomationId, element)
+                ?? RetryIfNotAvailable(e => e.CurrentName, element)
+                ?? "<unnamed>";
         }
 
-        private static void RetryIfNotAvailable<T>(Action<T> action, T state)
+        internal static void RetryIfNotAvailable<T>(Action<T> action, T state)
         {
             // NOTE: The loop termination condition if exceptions are thrown is in the exception filter
             for (var i = 0; true; i++)
@@ -361,7 +372,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
         }
 
-        private static TResult RetryIfNotAvailable<T, TResult>(Func<T, TResult> function, T state)
+        internal static TResult RetryIfNotAvailable<T, TResult>(Func<T, TResult> function, T state)
         {
             // NOTE: The loop termination condition if exceptions are thrown is in the exception filter
             for (var i = 0; true; i++)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Helper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Helper.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// <param name="delay">the amount of time to wait between retries</param>
         /// <typeparam name="T">type of return value</typeparam>
         /// <returns>the return value of 'action'</returns>
-        public static T Retry<T>(Func<T> action, TimeSpan delay)
+        public static T Retry<T>(Func<T> action, TimeSpan delay, int retryCount = -1)
         {
             return RetryHelper(() =>
                 {
@@ -77,7 +77,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                         return default(T);
                     }
                 },
-                delay);
+                delay,
+                retryCount);
         }
 
         /// <summary>
@@ -115,7 +116,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// <param name="delay">the amount of time to wait between retries in milliseconds</param>
         /// <typeparam name="T">type of return value</typeparam>
         /// <returns>the return value of 'action'</returns>
-        public static T RetryIgnoringExceptions<T>(Func<T> action, TimeSpan delay)
+        public static T RetryIgnoringExceptions<T>(Func<T> action, TimeSpan delay, int retryCount = -1)
         {
             return RetryHelper(() =>
                 {
@@ -128,14 +129,19 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                         return default(T);
                     }
                 },
-                delay);
+                delay,
+                retryCount);
         }
 
-        private static T RetryHelper<T>(Func<T> action, TimeSpan delay)
+        private static T RetryHelper<T>(Func<T> action, TimeSpan delay, int retryCount)
         {
-            while (true)
+            for (var i = 0; true; i++)
             {
                 var retval = action();
+                if (i == retryCount)
+                {
+                    return retval;
+                }
 
                 if (!Equals(default(T), retval))
                 {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc_NavigationBar.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc_NavigationBar.cs
@@ -3,10 +3,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.ReflectionExtensions;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
@@ -95,53 +95,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var topMarginControl = control.GetPropertyValue<ContentControl>("TopMarginControl");
             var vsDropDownBarAdapterMargin = topMarginControl.Content as UIElement;
             return vsDropDownBarAdapterMargin;
-        }
-    }
-
-    internal static class ReflectionExtensions
-    {
-        public static PropertyType GetPropertyValue<PropertyType>(this object instance, string propertyName)
-        {
-            return (PropertyType)GetPropertyValue(instance, propertyName);
-        }
-
-        public static object GetPropertyValue(this object instance, string propertyName)
-        {
-            Type type = instance.GetType();
-            PropertyInfo propertyInfo = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            if (propertyInfo == null)
-            {
-                throw new ArgumentException("Property " + propertyName + " was not found on type " + type.ToString());
-            }
-            object result = propertyInfo.GetValue(instance, null);
-            return result;
-        }
-
-        public static object GetFieldValue(this object instance, string fieldName)
-        {
-            Type type = instance.GetType();
-            FieldInfo fieldInfo = null;
-            while (type != null)
-            {
-                fieldInfo = type.GetField(fieldName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                if (fieldInfo != null)
-                {
-                    break;
-                }
-                type = type.BaseType;
-            }
-
-            if (fieldInfo == null)
-            {
-                throw new FieldAccessException("Field " + fieldName + " was not found on type " + type.ToString());
-            }
-            object result = fieldInfo.GetValue(instance);
-            return result; // you can place a breakpoint here (for debugging purposes)
-        }
-
-        public static FieldType GetFieldValue<FieldType>(this object instance, string fieldName)
-        {
-            return (FieldType)GetFieldValue(instance, fieldName);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
@@ -29,13 +29,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             => Application.Current.Dispatcher;
 
         protected static void BeginInvokeOnUIThread(Action action)
-            => CurrentApplicationDispatcher.BeginInvoke(action);
+            => CurrentApplicationDispatcher.BeginInvoke(action, DispatcherPriority.Background);
 
         protected static void InvokeOnUIThread(Action action)
-            => CurrentApplicationDispatcher.Invoke(action);
+            => CurrentApplicationDispatcher.Invoke(action, DispatcherPriority.Background);
 
         protected static T InvokeOnUIThread<T>(Func<T> action)
-            => CurrentApplicationDispatcher.Invoke(action);
+            => CurrentApplicationDispatcher.Invoke(action, DispatcherPriority.Background);
 
         protected static TInterface GetGlobalService<TService, TInterface>()
             where TService : class

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ObjectBrowserWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ObjectBrowserWindow_InProc.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
+{
+    internal class ObjectBrowserWindow_InProc : InProcComponent
+    {
+        public static ObjectBrowserWindow_InProc Create() => new ObjectBrowserWindow_InProc();
+
+        public bool CloseWindow()
+        {
+            return InvokeOnUIThread(() =>
+            {
+                var uiShell = GetGlobalService<SVsUIShell, IVsUIShell>();
+                if (ErrorHandler.Failed(uiShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fFrameOnly, new Guid(ToolWindowGuids.ObjectBrowser), out var frame)))
+                {
+                    return false;
+                }
+
+                ErrorHandler.ThrowOnFailure(frame.CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_NoSave));
+                return true;
+            });
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ReflectionExtensions/ObjectExtensions.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ReflectionExtensions/ObjectExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.ReflectionExtensions
+{
+    internal static class ObjectExtensions
+    {
+        public static PropertyType GetPropertyValue<PropertyType>(this object instance, string propertyName)
+        {
+            return (PropertyType)GetPropertyValue(instance, propertyName);
+        }
+
+        public static object GetPropertyValue(this object instance, string propertyName)
+        {
+            Type type = instance.GetType();
+            PropertyInfo propertyInfo = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (propertyInfo == null)
+            {
+                throw new ArgumentException("Property " + propertyName + " was not found on type " + type.ToString());
+            }
+            object result = propertyInfo.GetValue(instance, null);
+            return result;
+        }
+
+        public static object GetFieldValue(this object instance, string fieldName)
+        {
+            Type type = instance.GetType();
+            FieldInfo fieldInfo = null;
+            while (type != null)
+            {
+                fieldInfo = type.GetField(fieldName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (fieldInfo != null)
+                {
+                    break;
+                }
+                type = type.BaseType;
+            }
+
+            if (fieldInfo == null)
+            {
+                throw new FieldAccessException("Field " + fieldName + " was not found on type " + type.ToString());
+            }
+            object result = fieldInfo.GetValue(instance);
+            return result; // you can place a breakpoint here (for debugging purposes)
+        }
+
+        public static FieldType GetFieldValue<FieldType>(this object instance, string fieldName)
+        {
+            return (FieldType)GetFieldValue(instance, fieldName);
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ChangeSignatureDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ChangeSignatureDialog_OutOfProc.cs
@@ -81,12 +81,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             {
                 // Modifier | Type | Parameter | Default
                 var item = gridPattern.GetItem(i, columnToSelect);
-                var name = item.CurrentName;
+                var name = AutomationElementExtensions.RetryIfNotAvailable(element => element.CurrentName, item);
                 if (name == parameterName)
                 {
                     // The parent of a cell is of DataItem control type, which support SelectionItemPattern.
                     var walker = Helper.Automation.ControlViewWalker;
-                    var parent = walker.GetParentElement(item);
+                    var parent = AutomationElementExtensions.RetryIfNotAvailable(element => walker.GetParentElement(element), item);
                     parent.Select();
                     return;
                 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ObjectBrowserWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ObjectBrowserWindow_OutOfProc.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
+{
+    public class ObjectBrowserWindow_OutOfProc : OutOfProcComponent
+    {
+        internal readonly ObjectBrowserWindow_InProc _inProc;
+
+        internal ObjectBrowserWindow_OutOfProc(VisualStudioInstance visualStudioInstance)
+            : base(visualStudioInstance)
+        {
+            _inProc = CreateInProcComponent<ObjectBrowserWindow_InProc>(visualStudioInstance);
+        }
+
+        public void CloseWindow()
+            => _inProc.CloseWindow();
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Ipc;
 using System.Threading;
@@ -211,7 +212,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
             finally
             {
-                if (_integrationServiceChannel != null)
+                if (_integrationServiceChannel != null
+                    && ChannelServices.RegisteredChannels.Contains(_integrationServiceChannel))
                 {
                     ChannelServices.UnregisterChannel(_integrationServiceChannel);
                 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -25,6 +25,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
         public CSharpInteractiveWindow_OutOfProc InteractiveWindow { get; }
 
+        public ObjectBrowserWindow_OutOfProc ObjectBrowserWindow { get; }
+
         public Debugger_OutOfProc Debugger { get; }
 
         public Dialog_OutOfProc Dialog { get; }
@@ -99,6 +101,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
             ChangeSignatureDialog = new ChangeSignatureDialog_OutOfProc(this);
             InteractiveWindow = new CSharpInteractiveWindow_OutOfProc(this);
+            ObjectBrowserWindow = new ObjectBrowserWindow_OutOfProc(this);
             Debugger = new Debugger_OutOfProc(this);
             Dialog = new Dialog_OutOfProc(this);
             Editor = new Editor_OutOfProc(this);
@@ -171,6 +174,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
             // Close any windows leftover from previous (failed) tests
             InteractiveWindow.CloseInteractiveWindow();
+            ObjectBrowserWindow.CloseWindow();
             ChangeSignatureDialog.CloseWindow();
             GenerateTypeDialog.CloseWindow();
             ExtractInterfaceDialog.CloseWindow();


### PR DESCRIPTION
Various improvements for integration testing

* Invoke UI thread operations at **Background** priority, allowing other initialization/input/render operations to complete before them
* Close the **Object Browser** window as part of the between-test cleanup
* Avoid hiding true failures caused by a second exception thrown in a `finally` block
* Add more UI Automation retry operations
* Avoid polluting completion for `System.Object` by moving extension methods to a nested namespace

Fixes #26039

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
