### PR TITLE
Revert "Fixed error messages around fixed fields (#27424)"

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -133,4 +133,3 @@ Example:
 - Visual Studio 2017 version 15.8: https://github.com/dotnet/roslyn/issues/27047 The C# compiler will now produce diagnostics for operators marked as obsolete when they are used as part of a tuple comparison.
 - Visual Studio 2017 version 15.8: https://github.com/dotnet/roslyn/pull/27461 The method `LanguaguageVersionFacts.TryParse` is no longer an extension method.
 - Visual Studio 2017 version 15.8: https://github.com/dotnet/roslyn/pull/27803 pattern matching now will produce errors when trying to return a stack bound value to an invalid escape scope.
-- Visual Studio 2017 version 15.8: https://github.com/dotnet/roslyn/issues/26743 C# will now reject expressions such as `public int* M => &this.Bar[0];` if `Bar` is a fixed field of the containing type.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return BindObjectCreationExpression((ObjectCreationExpressionSyntax)node, diagnostics);
                 case SyntaxKind.IdentifierName:
                 case SyntaxKind.GenericName:
-                    return BindIdentifier((SimpleNameSyntax)node, invoked, indexed, diagnostics);
+                    return BindIdentifier((SimpleNameSyntax)node, invoked, diagnostics);
                 case SyntaxKind.SimpleMemberAccessExpression:
                 case SyntaxKind.PointerMemberAccessExpression:
                     return BindMemberAccess((MemberAccessExpressionSyntax)node, invoked, indexed, diagnostics: diagnostics);
@@ -1150,7 +1150,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression BindIdentifier(
             SimpleNameSyntax node,
             bool invoked,
-            bool indexed,
             DiagnosticBag diagnostics)
         {
             Debug.Assert(node != null);
@@ -1248,7 +1247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         symbol = ConstructNamedTypeUnlessTypeArgumentOmitted(node, (NamedTypeSymbol)symbol, typeArgumentList, typeArguments, diagnostics);
                     }
 
-                    expression = BindNonMethod(node, symbol, diagnostics, lookupResult.Kind, indexed, isError);
+                    expression = BindNonMethod(node, symbol, diagnostics, lookupResult.Kind, isError);
 
                     if (!isNamedType && (hasTypeArguments || node.Kind() == SyntaxKind.GenericName))
                     {
@@ -1435,7 +1434,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        private BoundExpression BindNonMethod(SimpleNameSyntax node, Symbol symbol, DiagnosticBag diagnostics, LookupResultKind resultKind, bool indexed, bool isError)
+        private BoundExpression BindNonMethod(SimpleNameSyntax node, Symbol symbol, DiagnosticBag diagnostics, LookupResultKind resultKind, bool isError)
         {
             // Events are handled later as we don't know yet if we are binding to the event or it's backing field.
             if (symbol.Kind != SymbolKind.Event)
@@ -1577,7 +1576,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SymbolKind.Field:
                     {
                         BoundExpression receiver = SynthesizeReceiver(node, symbol, diagnostics);
-                        return BindFieldAccess(node, receiver, (FieldSymbol)symbol, diagnostics, resultKind, indexed, hasErrors: isError);
+                        return BindFieldAccess(node, receiver, (FieldSymbol)symbol, diagnostics, resultKind, indexed: false, hasErrors: isError);
                     }
 
                 case SymbolKind.Namespace:
@@ -5204,7 +5203,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var node = (IdentifierNameSyntax)left;
                 var valueDiagnostics = DiagnosticBag.GetInstance();
-                var boundValue = BindIdentifier(node, invoked: false, indexed: false, diagnostics: valueDiagnostics);
+                var boundValue = BindIdentifier(node, invoked: false, diagnostics: valueDiagnostics);
 
                 Symbol leftSymbol;
                 if (boundValue.Kind == BoundKind.Conversion)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case SyntaxKind.IdentifierName:
                 case SyntaxKind.GenericName:
-                    return BindIdentifier((SimpleNameSyntax)node, invoked, indexed, diagnostics);
+                    return BindIdentifier((SimpleNameSyntax)node, invoked, diagnostics);
                 case SyntaxKind.SimpleMemberAccessExpression:
                 case SyntaxKind.PointerMemberAccessExpression:
                     return BindMemberAccess((MemberAccessExpressionSyntax)node, invoked, indexed, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2228,14 +2228,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return localSymbol.RefKind == RefKind.None;
                         }
                     case BoundKind.PointerIndirectionOperator: //Covers ->, since the receiver will be one of these.
+                    case BoundKind.PointerElementAccess:
                     case BoundKind.ConvertedStackAllocExpression:
                         {
                             return true;
-                        }
-                    case BoundKind.PointerElementAccess:
-                        {
-                            expr = ((BoundPointerElementAccess)expr).Expression;
-                            continue;
                         }
                     case BoundKind.PropertyAccess: // Never a variable.
                     case BoundKind.IndexerAccess: // Never a variable.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
@@ -1016,56 +1016,5 @@ public unsafe struct Test
                     });
             }
         }
-
-        [Fact, WorkItem(26688, "https://github.com/dotnet/roslyn/issues/26688")]
-        public void FixedFieldDoesNotRequirePinningWithThis()
-        {
-            CompileAndVerify(@"
-using System;
-unsafe struct Foo
-{
-    public fixed int Bar[2];
-
-    public Foo(int value1, int value2)
-    {
-        this.Bar[0] = value1;
-        this.Bar[1] = value2;
-    }
-
-    public int M1 => this.Bar[0];
-    public int M2 => Bar[1];
-}
-class Program
-{
-    static void Main()
-    {
-        Foo foo = new Foo(1, 2);
-
-        Console.WriteLine(foo.M1);
-        Console.WriteLine(foo.M2);
-    }
-}", options: TestOptions.UnsafeReleaseExe, verify: Verification.Skipped, expectedOutput: @"
-1
-2");
-        }
-
-        [Fact, WorkItem(26743, "https://github.com/dotnet/roslyn/issues/26743")]
-        public void FixedFieldDoesNotAllowAddressOfOperator()
-        {
-            CreateCompilation(@"
-unsafe struct Foo
-{
-    private fixed int Bar[2];
-
-    public int* M1 => &this.Bar[0];
-    public int* M2 => &Bar[1];
-}", options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (6,23): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
-                //     public int* M1 => &this.Bar[0];
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&this.Bar[0]").WithLocation(6, 23),
-                // (7,23): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
-                //     public int* M2 => &Bar[1];
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&Bar[1]").WithLocation(7, 23));
-        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -2022,7 +2022,7 @@ Yes, PointerIndirectionOperator '*p' is a non-moveable variable
 Yes, Parameter 'p' is a non-moveable variable with underlying symbol 'p'
 No, AssignmentOperator 's = p[0]' is not a non-moveable variable
 Yes, Local 's' is a non-moveable variable with underlying symbol 's'
-Yes, PointerElementAccess 'p[0]' is a non-moveable variable with underlying symbol 'p'
+Yes, PointerElementAccess 'p[0]' is a non-moveable variable
 Yes, Parameter 'p' is a non-moveable variable with underlying symbol 'p'
 No, Literal '0' is not a non-moveable variable
 No, TypeExpression 'int' is not a non-moveable variable
@@ -2033,8 +2033,8 @@ Yes, PointerIndirectionOperator '*p' is a non-moveable variable
 Yes, Parameter 'p' is a non-moveable variable with underlying symbol 'p'
 No, AssignmentOperator 'j = p[0].i' is not a non-moveable variable
 Yes, Local 'j' is a non-moveable variable with underlying symbol 'j'
-Yes, FieldAccess 'p[0].i' is a non-moveable variable with underlying symbol 'p'
-Yes, PointerElementAccess 'p[0]' is a non-moveable variable with underlying symbol 'p'
+Yes, FieldAccess 'p[0].i' is a non-moveable variable
+Yes, PointerElementAccess 'p[0]' is a non-moveable variable
 Yes, Parameter 'p' is a non-moveable variable with underlying symbol 'p'
 No, Literal '0' is not a non-moveable variable
 No, AssignmentOperator 'j = p->i' is not a non-moveable variable


### PR DESCRIPTION
Reverts #27424

This caused a build break for the following scenario:

```csharp
using System;
public unsafe sealed class PinnedStreamReader
{
    public unsafe byte* GetPointer(int position)
    {
        return (&bufferStart[position]);
    }
 	
    byte* bufferStart;
}
```

It now produced: `error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer`
We should investigate this and bring back the fix, without breaking additional scenarios.