### PR TITLE
Only qualify the first symbol in Quick Info

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            if (format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseSpecialTypes))
+            if (CanUseSpecialTypes)
             {
                 if (AddSpecialTypeKeyword(symbol))
                 {
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (IncludeNamedType(symbol.ContainingType))
                 {
-                    symbol.ContainingType.Accept(this.NotFirstVisitor);
+                    symbol.ContainingType.Accept(this.FirstSymbolContainingTypeVisitor);
                     AddPunctuation(SyntaxKind.DotToken);
                 }
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -39,6 +39,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             _lazyAliasMap = aliasMap;
         }
 
+        protected override AbstractSymbolDisplayVisitor MakeFirstSymbolContainingTypeVisitor()
+        {
+            if (!isFirstSymbolVisited || format.KindOptions == SymbolDisplayKindOptions.None)
+            {
+                return this;
+            }
+
+            return new SymbolDisplayVisitor(
+                this.builder,
+                this.format.WithKindOptions(SymbolDisplayKindOptions.None),
+                this.semanticModelOpt,
+                this.positionOpt,
+                _escapeKeywordIdentifiers,
+                _lazyAliasMap,
+                isFirstSymbolVisited: true,
+                inNamespaceOrType);
+        }
+
         protected override AbstractSymbolDisplayVisitor MakeNotFirstVisitor(bool inNamespaceOrType = false)
         {
             return new SymbolDisplayVisitor(

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -11,6 +11,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.IIsNullOperation.Operand.get -> Microsoft.Co
 Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation
 Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation.Local.get -> Microsoft.CodeAnalysis.ILocalSymbol
 Microsoft.CodeAnalysis.Operations.CommonConversion.IsImplicit.get -> bool
+Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions.QualifyFirstSymbol = 64 -> Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions
 abstract Microsoft.CodeAnalysis.Compilation.ClassifyCommonConversion(Microsoft.CodeAnalysis.ITypeSymbol source, Microsoft.CodeAnalysis.ITypeSymbol destination) -> Microsoft.CodeAnalysis.Operations.CommonConversion
 abstract Microsoft.CodeAnalysis.Compilation.ContainsSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> bool
 abstract Microsoft.CodeAnalysis.Compilation.GetSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>

--- a/src/Compilers/Core/Portable/SymbolDisplay/AbstractSymbolDisplayVisitor.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/AbstractSymbolDisplayVisitor.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.SymbolDisplay
         protected readonly SemanticModel semanticModelOpt;
         protected readonly int positionOpt;
 
+        private AbstractSymbolDisplayVisitor _lazyFirstSymbolContainingTypeVisitor;
         private AbstractSymbolDisplayVisitor _lazyNotFirstVisitor;
         private AbstractSymbolDisplayVisitor _lazyNotFirstVisitorNamespaceOrType;
 
@@ -45,6 +46,19 @@ namespace Microsoft.CodeAnalysis.SymbolDisplay
             }
         }
 
+        protected AbstractSymbolDisplayVisitor FirstSymbolContainingTypeVisitor
+        {
+            get
+            {
+                if (_lazyFirstSymbolContainingTypeVisitor == null)
+                {
+                    _lazyFirstSymbolContainingTypeVisitor = MakeFirstSymbolContainingTypeVisitor();
+                }
+
+                return _lazyFirstSymbolContainingTypeVisitor;
+            }
+        }
+
         protected AbstractSymbolDisplayVisitor NotFirstVisitor
         {
             get
@@ -70,6 +84,8 @@ namespace Microsoft.CodeAnalysis.SymbolDisplay
                 return _lazyNotFirstVisitorNamespaceOrType;
             }
         }
+
+        protected abstract AbstractSymbolDisplayVisitor MakeFirstSymbolContainingTypeVisitor();
 
         protected abstract AbstractSymbolDisplayVisitor MakeNotFirstVisitor(bool inNamespaceOrType = false);
 

--- a/src/Compilers/Core/Portable/SymbolDisplay/AbstractSymbolDisplayVisitor_Minimal.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/AbstractSymbolDisplayVisitor_Minimal.cs
@@ -12,7 +12,38 @@ namespace Microsoft.CodeAnalysis.SymbolDisplay
 
         protected bool IsMinimizing
         {
-            get { return this.semanticModelOpt != null; }
+            get
+            {
+                if (semanticModelOpt == null)
+                {
+                    return false;
+                }
+
+                if (isFirstSymbolVisited && format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.QualifyFirstSymbol))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        protected bool CanUseSpecialTypes
+        {
+            get
+            {
+                if (!format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseSpecialTypes))
+                {
+                    return false;
+                }
+
+                if (isFirstSymbolVisited && format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.QualifyFirstSymbol))
+                {
+                    return false;
+                }
+
+                return true;
+            }
         }
 
         protected bool NameBoundSuccessfullyToSameSymbol(INamedTypeSymbol symbol)

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayMiscellaneousOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayMiscellaneousOptions.cs
@@ -55,5 +55,13 @@ namespace Microsoft.CodeAnalysis
         /// the special question mark syntax.
         /// </summary>
         ExpandNullable = 1 << 5,
+
+        /// <summary>
+        /// Suppresses minimization of the first visited symbol.
+        /// </summary>
+        /// <remarks>
+        /// Has no effect outside <see cref="ISymbol.ToMinimalDisplayString"/>.
+        /// </remarks>
+        QualifyFirstSymbol = 1 << 6,
     }
 }

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return
             End If
 
-            If format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseSpecialTypes) Then
+            If CanUseSpecialTypes Then
                 If AddSpecialTypeKeyword(symbol) Then
                     Return
                 End If
@@ -157,7 +157,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim containingType = symbol.ContainingType
                 If containingType IsNot Nothing Then
                     visitedParents = True
-                    containingType.Accept(Me.NotFirstVisitor())
+                    containingType.Accept(Me.FirstSymbolContainingTypeVisitor())
                     AddOperator(SyntaxKind.DotToken)
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.vb
@@ -43,6 +43,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Me._escapeKeywordIdentifiers = escapeKeywordIdentifiers
         End Sub
 
+        Protected Overrides Function MakeFirstSymbolContainingTypeVisitor() As AbstractSymbolDisplayVisitor
+            If Not isFirstSymbolVisited OrElse format.KindOptions = SymbolDisplayKindOptions.None Then
+                Return Me
+            End If
+
+            Return New SymbolDisplayVisitor(
+                    Me.builder,
+                    Me.format.WithKindOptions(SymbolDisplayKindOptions.None),
+                    Me.semanticModelOpt,
+                    Me.positionOpt,
+                    Me._escapeKeywordIdentifiers,
+                    isFirstSymbolVisited:=True,
+                    inNamespaceOrType)
+        End Function
+
         ' in case the display of a symbol is different for a type that acts as a container, use this visitor
         Protected Overrides Function MakeNotFirstVisitor(Optional inNamespaceOrType As Boolean = False) As AbstractSymbolDisplayVisitor
             Return New SymbolDisplayVisitor(

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -745,7 +745,7 @@ public class GenericList<T> { Generic$$List<int> t; }";
         {
             await TestInClassAsync(
 @"event $$EventHandler e;",
-                MainDescription("delegate void System.EventHandler(object sender, System.EventArgs e)"));
+                MainDescription("delegate void System.EventHandler(object sender, EventArgs e)"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -911,6 +911,25 @@ class C<T> { $$T t; }";
         {
             await TestAsync(@"class C<T> where $$T : IEnumerable<int>",
                 MainDescription($"T {FeaturesResources.in_} C<T> where T : IEnumerable<int>"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(547, "https://github.com/dotnet/roslyn/issues/547")]
+        public async Task TestMinimallyQualifiedConstraint2()
+        {
+            await TestAsync(@"using System.Collections.Generic;
+ 
+class C<T, U> where T : struct where U : List<T>
+{
+    void M()
+    {
+        v$$ar x = new C<int, List<int>>();
+    }
+}",
+                MainDescription("class C<T, U> where T : struct where U : List<T>"),
+                TypeParameterMap(Lines(
+                    $"\r\nT {FeaturesResources.is_} int",
+                    $"U {FeaturesResources.is_} List<int>")));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
@@ -5747,7 +5766,7 @@ public class C
     }
 }
 " + TestResources.NetFX.ValueTuple.tuplelib_cs,
-                MainDescription("ValueTuple<System.Int32>"));
+                MainDescription("ValueTuple<int>"));
         }
 
         [WorkItem(18311, "https://github.com/dotnet/roslyn/issues/18311")]
@@ -5783,7 +5802,7 @@ public class C
     }
 }
 " + TestResources.NetFX.ValueTuple.tuplelib_cs,
-                MainDescription("(System.Int32, System.Int32)"));
+                MainDescription("(int, int)"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -287,7 +287,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Async Function TestEventHandler() As Task
             Await TestInClassAsync("Dim e As $$EventHandler",
-             MainDescription("Delegate Sub System.EventHandler(sender As Object, e As System.EventArgs)",
+             MainDescription("Delegate Sub System.EventHandler(sender As Object, e As EventArgs)",
               ExpectedClassifications(
                Keyword("Delegate"),
                WhiteSpace(" "),
@@ -308,8 +308,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                WhiteSpace(" "),
                Keyword("As"),
                WhiteSpace(" "),
-               Identifier("System"),
-               Operators.Dot,
                [Class]("EventArgs"),
                Punctuation.CloseParen)))
         End Function
@@ -351,6 +349,32 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
                     End Class
                 </Text>.NormalizedValue,
              MainDescription($"T1 {FeaturesResources.in_} C.Meth1(Of T1 As Class)"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(547, "https://github.com/dotnet/roslyn/issues/547")>
+        Public Async Function TestMinimallyQualifiedConstraint() As Task
+            Await TestAsync(<Text>
+                    Class C(Of T As Structure, U As List(Of T))
+                        Sub M()
+                            D$$im x = New C(Of Integer, List(Of Integer))()
+                        End Sub
+                    End Class
+                </Text>.NormalizedValue,
+                MainDescription($"Class C(Of T As Structure, U As List(Of T))"),
+                TypeParameterMap(Lines(
+                    vbCrLf & $"T {FeaturesResources.is_} Integer",
+                    $"U {FeaturesResources.is_} List(Of Integer)")))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(547, "https://github.com/dotnet/roslyn/issues/547")>
+        Public Async Function TestNestedInGeneric() As Task
+            Await TestInMethodAsync(<Text>
+                    Dim e As List(Of Integer).Enu$$merator
+                </Text>.NormalizedValue,
+                MainDescription($"Structure System.Collections.Generic.List(Of T).Enumerator"),
+                TypeParameterMap(vbCrLf & $"T {FeaturesResources.is_} Integer"))
         End Function
 
         <WorkItem(538732, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538732")>

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -66,12 +66,13 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                     delegateStyle: SymbolDisplayDelegateStyle.NameAndSignature,
                     genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeVariance | SymbolDisplayGenericsOptions.IncludeTypeConstraints,
                     parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeParamsRefOut,
-                    miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers,
+                    miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes | SymbolDisplayMiscellaneousOptions.QualifyFirstSymbol,
                     kindOptions: SymbolDisplayKindOptions.IncludeNamespaceKeyword | SymbolDisplayKindOptions.IncludeTypeKeyword);
 
             private static readonly SymbolDisplayFormat s_globalNamespaceStyle =
                 new SymbolDisplayFormat(
-                    globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included);
+                    globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
+                    miscellaneousOptions: SymbolDisplayMiscellaneousOptions.QualifyFirstSymbol);
 
             private readonly ISymbolDisplayService _displayService;
             private readonly SemanticModel _semanticModel;
@@ -394,17 +395,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                     }
                 }
 
-                if (symbol.TypeKind == TypeKind.Delegate)
-                {
-                    var style = s_descriptionStyle.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
-                    AddToGroup(SymbolDescriptionGroups.MainDescription,
-                        ToDisplayParts(symbol.OriginalDefinition, style));
-                }
-                else
-                {
-                    AddToGroup(SymbolDescriptionGroups.MainDescription,
-                        ToDisplayParts(symbol.OriginalDefinition, s_descriptionStyle));
-                }
+                AddToGroup(SymbolDescriptionGroups.MainDescription, ToMinimalDisplayParts(symbol.OriginalDefinition, s_descriptionStyle));
 
                 if (!symbol.IsUnboundGenericType && !TypeArgumentsAndParametersAreSame(symbol))
                 {
@@ -440,12 +431,12 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                 if (symbol.IsGlobalNamespace)
                 {
                     AddToGroup(SymbolDescriptionGroups.MainDescription,
-                        ToDisplayParts(symbol, s_globalNamespaceStyle));
+                        ToMinimalDisplayParts(symbol, s_globalNamespaceStyle));
                 }
                 else
                 {
                     AddToGroup(SymbolDescriptionGroups.MainDescription,
-                        ToDisplayParts(symbol, s_descriptionStyle));
+                        ToMinimalDisplayParts(symbol, s_descriptionStyle));
                 }
             }
 
@@ -725,11 +716,6 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             {
                 format = format ?? MinimallyQualifiedFormat;
                 return _displayService.ToMinimalDisplayParts(_semanticModel, _position, symbol, format);
-            }
-
-            protected IEnumerable<SymbolDisplayPart> ToDisplayParts(ISymbol symbol, SymbolDisplayFormat format = null)
-            {
-                return _displayService.ToDisplayParts(symbol, format);
             }
 
             private IEnumerable<SymbolDisplayPart> Part(SymbolDisplayPartKind kind, ISymbol symbol, string text)


### PR DESCRIPTION
Fixes #547

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
