### PR TITLE
Stop calling IVsHerarchy.ParseCanonicalName if we don't need it

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -959,7 +959,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             string filename,
             SourceCodeKind sourceCodeKind,
             Func<IVisualStudioHostDocument, bool> getIsCurrentContext,
-            Func<uint, IReadOnlyList<string>> getFolderNames)
+            ImmutableArray<string> folderNames)
         {
             AssertIsForeground();
 
@@ -969,7 +969,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 this,
                 filePath: filename,
                 sourceCodeKind: sourceCodeKind,
-                getFolderNames: getFolderNames,
+                folderNames: folderNames,
                 canUseTextBuffer: CanUseTextBuffer,
                 updatedOnDiskHandler: s_documentUpdatedOnDiskEventHandler,
                 openedHandler: s_documentOpenedEventHandler,
@@ -1536,9 +1536,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         #region FolderNames
         private readonly List<string> _tmpFolders = new List<string>();
-        private readonly Dictionary<uint, IReadOnlyList<string>> _folderNameMap = new Dictionary<uint, IReadOnlyList<string>>();
+        private readonly Dictionary<uint, ImmutableArray<string>> _folderNameMap = new Dictionary<uint, ImmutableArray<string>>();
 
-        public IReadOnlyList<string> GetFolderNamesFromHierarchy(uint documentItemID)
+        public ImmutableArray<string> GetFolderNamesFromHierarchy(uint documentItemID)
         {
             AssertIsForeground();
 
@@ -1551,10 +1551,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
-            return SpecializedCollections.EmptyReadOnlyList<string>();
+            return ImmutableArray<string>.Empty;
         }
 
-        private IReadOnlyList<string> GetFolderNamesForFolder(uint folderItemID)
+        private ImmutableArray<string> GetFolderNamesForFolder(uint folderItemID)
         {
             AssertIsForeground();
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 this,
                 filePath: additionalFilePath,
                 sourceCodeKind: SourceCodeKind.Regular,
-                getFolderNames: _ => SpecializedCollections.EmptyReadOnlyList<string>(),
+                folderNames: ImmutableArray<string>.Empty,
                 canUseTextBuffer: _ => true,
                 updatedOnDiskHandler: s_additionalDocumentUpdatedOnDiskEventHandler,
                 openedHandler: s_additionalDocumentOpenedEventHandler,

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.CodeAnalysis;
@@ -47,13 +48,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             /// <summary>
             /// Creates a <see cref="StandardTextDocument"/>.
-            /// <para>Note: getFolderNames maps from a VSITEMID to the folders this document should be contained in.</para>
             /// </summary>
             public StandardTextDocument(
                 DocumentProvider documentProvider,
                 AbstractProject project,
                 DocumentKey documentKey,
-                Func<uint, IReadOnlyList<string>> getFolderNames,
+                ImmutableArray<string> folderNames,
                 SourceCodeKind sourceCodeKind,
                 IVsFileChangeEx fileChangeService,
                 ITextBuffer openTextBuffer,
@@ -68,10 +68,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 this.Id = id ?? DocumentId.CreateNewId(project.Id, documentKey.Moniker);
                 _itemMoniker = documentKey.Moniker;
 
-                var itemid = this.GetItemId();
-                this.Folders = itemid == (uint)VSConstants.VSITEMID.Nil
-                    ? SpecializedCollections.EmptyReadOnlyList<string>()
-                    : getFolderNames(itemid);
+                this.Folders = folderNames;
 
                 _documentProvider = documentProvider;
 
@@ -238,9 +235,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     return (uint)VSConstants.VSITEMID.Nil;
                 }
 
-                return Project.Hierarchy.ParseCanonicalName(_itemMoniker, out var itemId) == VSConstants.S_OK
-                    ? itemId
-                    : (uint)VSConstants.VSITEMID.Nil;
+                return Project.Hierarchy.TryGetItemId(_itemMoniker);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -84,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         [Obsolete("This overload is a compatibility shim for TypeScript; please do not use it.")]
         public IVisualStudioHostDocument TryGetDocumentForFile(
-            IVisualStudioHostProject hostProject,
+            AbstractProject hostProject,
             string filePath,
             SourceCodeKind sourceCodeKind,
             Func<ITextBuffer, bool> canUseTextBuffer,
@@ -93,12 +94,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             EventHandler<bool> openedHandler = null,
             EventHandler<bool> closingHandler = null)
         {
+            var itemid = hostProject.Hierarchy.TryGetItemId(filePath);
+
+            var folderNames = getFolderNames(itemid).AsImmutableOrEmpty();
             return TryGetDocumentForFile(
-                (AbstractProject)hostProject,
+                hostProject,
                 filePath,
                 sourceCodeKind,
                 canUseTextBuffer,
-                getFolderNames,
+                folderNames,
                 updatedOnDiskHandler,
                 openedHandler,
                 closingHandler);
@@ -116,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             string filePath,
             SourceCodeKind sourceCodeKind,
             Func<ITextBuffer, bool> canUseTextBuffer,
-            Func<uint, IReadOnlyList<string>> getFolderNames,
+            ImmutableArray<string> folderNames,
             EventHandler updatedOnDiskHandler = null,
             EventHandler<bool> openedHandler = null,
             EventHandler<bool> closingHandler = null)
@@ -180,7 +184,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     this,
                     hostProject,
                     documentKey,
-                    getFolderNames,
+                    folderNames,
                     sourceCodeKind,
                     _fileChangeService,
                     openTextBuffer,

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
@@ -80,6 +81,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         public static bool TryGetTargetFrameworkMoniker(this IVsHierarchy hierarchy, uint itemId, out string targetFrameworkMoniker)
         {
             return hierarchy.TryGetItemProperty(itemId, (int)__VSHPROPID4.VSHPROPID_TargetFrameworkMoniker, out targetFrameworkMoniker);
+        }
+
+        public static uint TryGetItemId(this IVsHierarchy hierarchy, string moniker)
+        {
+            uint itemid;
+            if (ErrorHandler.Succeeded(hierarchy.ParseCanonicalName(moniker, out itemid)))
+            {
+                return itemid;
+            }
+
+            return VSConstants.VSITEMID_NIL;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostProject.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
     /// <summary>
-    /// This interface only exists to maintain an overload of <see cref="DocumentProvider.TryGetDocumentForFile(IVisualStudioHostProject, string, CodeAnalysis.SourceCodeKind, System.Func{Text.ITextBuffer, bool}, System.Func{uint, System.Collections.Generic.IReadOnlyList{string}}, System.EventHandler, System.EventHandler{bool}, System.EventHandler{bool})"/>.
+    /// This interface only exists to maintain an overload of <see cref="DocumentProvider.TryGetDocumentForFile(AbstractProject, string, SourceCodeKind, Func{Text.ITextBuffer, bool}, Func{uint, System.Collections.Generic.IReadOnlyList{string}}, EventHandler, EventHandler{bool}, EventHandler{bool})"/>.
     /// </summary>
     [Obsolete("This overload is a compatibility shim for TypeScript; please do not use it.")]
     internal interface IVisualStudioHostProject

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -64,7 +65,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
         protected void AddFile(string filename, SourceCodeKind sourceCodeKind)
         {
             bool getIsCurrentContext(IVisualStudioHostDocument document) => LinkedFileUtilities.IsCurrentContextHierarchy(document, RunningDocumentTable);
-            AddFile(filename, sourceCodeKind, getIsCurrentContext, GetFolderNamesFromHierarchy);
+            var itemid = Hierarchy?.TryGetItemId(filename) ?? VSConstants.VSITEMID_NIL;
+
+            var folderNames = ImmutableArray<string>.Empty;
+
+            if (itemid != VSConstants.VSITEMID_NIL)
+            {
+                folderNames = GetFolderNamesFromHierarchy(itemid);
+            }
+
+            AddFile(filename, sourceCodeKind, getIsCurrentContext, folderNames);
         }
 
         protected void SetOutputPathAndRelatedData(string objOutputPath)

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -198,7 +198,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         {
             ExecuteForegroundAction(() =>
             {
-                AddFile(filePath, sourceCodeKind, _ => isInCurrentContext, _ => folderNames.ToImmutableArrayOrEmpty());
+                AddFile(filePath, sourceCodeKind, _ => isInCurrentContext, folderNames.ToImmutableArrayOrEmpty());
             });
         }
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             vsDocument = _vsWorkspace.DeferredState.ProjectTracker.DocumentProvider.TryGetDocumentForFile(
                 project, filePath, SourceCodeKind.Regular,
                 tb => tb.ContentType.IsOfType(ContentTypeNames.XamlContentType),
-                _ => SpecializedCollections.EmptyReadOnlyList<string>());
+                ImmutableArray<string>.Empty);
 
             return vsDocument != null;
         }


### PR DESCRIPTION
We were calling IVsHierarchy.ParseCanonicalName to get the item ID of a file, to then turn around and use that to get the folder names. In some cases, we already had the folder names so this was just silly.

Note: I update a compatibility overload for TypeScript here. They had since moved off of the compatibility overload, so updating it and repurposing it is safe to do.

**Remaining Work**

- [x] Test TypeScript
- [x] Test F#
- [x] Test the code actions that consume this data in CPS projects
- [x] Test the code actions that consume this data in legacy projects
- [x] Verify we are getting the expected performance

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>