### PR TITLE
Move basic test utilities to netstandard1.3

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/BasicCompilerTestUtilities.vbproj
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicCompilerTestUtilities.vbproj
@@ -9,7 +9,7 @@
     <AssemblyName>Roslyn.Compilers.VisualBasic.Test.Utilities</AssemblyName>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
     <Nonshipping>true</Nonshipping>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\..\Test\PdbUtilities\PdbUtilities.csproj" />
@@ -20,12 +20,6 @@
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
   <ItemGroup>
     <Import Include="IdentifierComparison = Microsoft.CodeAnalysis.CaseInsensitiveComparison" />
     <Import Include="Microsoft.CodeAnalysis" />
@@ -48,6 +42,9 @@
     <InternalsVisibleToTest Include="Roslyn.ExpressionEvaluator.VisualBasic.ResultProvider.UnitTests" />
     <InternalsVisibleToTest Include="Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.VisualBasic.UnitTests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.Extensions" Version="$(SystemRuntimeExtensionsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="My Project\" />

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Reflection
 Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.PooledObjects
@@ -221,7 +222,7 @@ Friend Module Extensions
 
     ''' For argument is not simple 'Type' (generic or array)
     Private Function IsEqual(typeSym As TypeSymbol, expType As Type) As Boolean
-        '' namedType
+        Dim expTypeInfo = expType.GetTypeInfo()
         Dim typeSymTypeKind As TypeKind = typeSym.TypeKind
         If typeSymTypeKind = TypeKind.Interface OrElse typeSymTypeKind = TypeKind.Class OrElse
             typeSymTypeKind = TypeKind.Structure OrElse typeSymTypeKind = TypeKind.Delegate Then
@@ -232,7 +233,7 @@ Friend Module Extensions
                 Return typeSym.Name = expType.Name
             End If
             ' generic
-            If Not (expType.IsGenericType) Then
+            If Not (expTypeInfo.IsGenericType) Then
                 Return False
             End If
 
@@ -245,7 +246,7 @@ Friend Module Extensions
             If Not (typeSym.Name = nameOnly) Then
                 Return False
             End If
-            Dim expArgs = expType.GetGenericArguments()
+            Dim expArgs = expTypeInfo.GenericTypeArguments()
             Dim actArgs = namedType.TypeArguments()
             If Not (expArgs.Count = actArgs.Length) Then
                 Return False
@@ -266,7 +267,7 @@ Friend Module Extensions
             If Not IsEqual(arySym.ElementType, expType.GetElementType()) Then
                 Return False
             End If
-            If Not IsEqual(arySym.BaseType, expType.BaseType) Then
+            If Not IsEqual(arySym.BaseType, expTypeInfo.BaseType) Then
                 Return False
             End If
             Return arySym.Rank = expType.GetArrayRank()

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
@@ -3,20 +3,17 @@
 Imports System.IO
 Imports System.Reflection
 Imports System.Runtime.InteropServices
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic
 
 Friend Class MockVbi
     Inherits VisualBasicCompiler
 
     Public Sub New(responseFile As String, workingDirectory As String, args As String())
-        MyBase.New(VisualBasicCommandLineParser.Script, responseFile, args, CreateBuildPaths(workingDirectory), Nothing, New DesktopAnalyzerAssemblyLoader())
+        MyBase.New(VisualBasicCommandLineParser.Script, responseFile, args, CreateBuildPaths(workingDirectory), Nothing, RuntimeUtilities.CreateAnalyzerAssemblyLoader())
     End Sub
 
     Private Shared Function CreateBuildPaths(workingDirectory As String) As BuildPaths
-        Return New BuildPaths(
-            clientDir:=Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location),
-            workingDir:=workingDirectory,
-            sdkDir:=RuntimeEnvironment.GetRuntimeDirectory(),
-            tempDir:=Path.GetTempPath())
+        Return RuntimeUtilities.CreateBuildPaths(workingDirectory)
     End Function
 End Class

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -4,6 +4,7 @@ Imports System.Collections.Immutable
 Imports System.IO
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Test.Utilities
 
 Friend Class MockVisualBasicCompiler
     Inherits VisualBasicCompiler
@@ -28,17 +29,13 @@ Friend Class MockVisualBasicCompiler
     End Sub
 
     Public Sub New(responseFile As String, buildPaths As BuildPaths, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
-        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, buildPaths, Environment.GetEnvironmentVariable("LIB"), New DesktopAnalyzerAssemblyLoader())
+        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, buildPaths, Environment.GetEnvironmentVariable("LIB"), RuntimeUtilities.CreateAnalyzerAssemblyLoader())
 
         _analyzers = analyzers
     End Sub
 
     Private Shared Function CreateBuildPaths(workingDirectory As String, tempDirectory As String) As BuildPaths
-        Return New BuildPaths(
-            clientDir:=Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location),
-            workingDir:=workingDirectory,
-            sdkDir:=RuntimeEnvironment.GetRuntimeDirectory(),
-            tempDir:=tempDirectory)
+        Return RuntimeUtilities.CreateBuildPaths(workingDirectory, tempDirectory)
     End Function
 
     Protected Overrides Function ResolveAnalyzersFromArguments(

--- a/src/Compilers/Test/Utilities/VisualBasic/VBParser.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/VBParser.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Text
+Imports System.Reflection
 Imports Microsoft.CodeAnalysis.Test.Utilities
 
 Public Class VBParser
@@ -19,6 +20,6 @@ End Class
 'TODO: We need this only temporarily until 893565 is fixed.
 Public Class VBKindProvider : Implements ISyntaxNodeKindProvider
     Public Function Kind(node As Object) As String Implements ISyntaxNodeKindProvider.Kind
-        Return node.GetType().GetProperty("Kind").GetValue(node, Nothing).ToString()
+        Return node.GetType().GetTypeInfo().GetDeclaredProperty("Kind").GetValue(node, Nothing).ToString()
     End Function
 End Class

--- a/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
+++ b/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
@@ -13,20 +13,21 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     /// </summary>
     public static partial class RuntimeUtilities
     {
-        internal static BuildPaths CreateBuildPaths(string workingDirectory)
+        internal static BuildPaths CreateBuildPaths(string workingDirectory, string tempDirectory = null)
         {
+            tempDirectory = tempDirectory ?? Path.GetTempPath();
 #if NET46
             return new BuildPaths(
                 clientDir: Path.GetDirectoryName(typeof(BuildPathsUtil).Assembly.Location),
                 workingDir: workingDirectory,
                 sdkDir: RuntimeEnvironment.GetRuntimeDirectory(),
-                tempDir: Path.GetTempPath());
+                tempDir: tempDirectory);
 #else
             return new BuildPaths(
                 clientDir: AppContext.BaseDirectory,
                 workingDir: workingDirectory,
                 sdkDir: null,
-                tempDir: Path.GetTempPath());
+                tempDir: tempDirectory);
 #endif
         }
 

--- a/src/Test/Utilities/Portable/Platform/Custom/OSVersion.cs
+++ b/src/Test/Utilities/Portable/Platform/Custom/OSVersion.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Roslyn.Test.Utilities
+{
+    public static class OSVersion
+    {
+        /// <summary>
+        /// True when the operating system is at least Windows version 8
+        /// </summary>
+        public static bool IsWin8 =>
+#if NET46 || NETCOREAPP2_0
+            System.Environment.OSVersion.Version.Build >= 9200;
+#else
+            throw new InvalidOperationException();
+#endif
+    }
+}

--- a/src/Test/Utilities/Portable/Platform/Desktop/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Platform/Desktop/ConditionalFactAttribute.cs
@@ -78,11 +78,6 @@ namespace Roslyn.Test.Utilities
             }
         }
     }
-
-    public sealed class OSVersion
-    {
-        public static readonly bool IsWin8 = System.Environment.OSVersion.Version.Build >= 9200;
-    }
 }
 
 #endif


### PR DESCRIPTION
Necessary pre-req for getting the VB tests running on CoreClr. 