### PR TITLE
Promote experimental out-of-process features to stable

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -67,7 +67,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
         {
             var outOfProcess = (bool)parameters.fixProviderData;
             workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)
-                                                 .WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess)
                                                  .WithChangedOption(RemoteFeatureOptions.AddImportEnabled, outOfProcess);
 
             return base.CreateDiagnosticProviderAndFixer(workspace, parameters);

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
         {
             var outOfProcess = (bool)parameters.fixProviderData;
             workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)
-                                                 .WithChangedOption(RemoteFeatureOptions.OutOfProcessAllowed, outOfProcess)
+                                                 .WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess)
                                                  .WithChangedOption(RemoteFeatureOptions.AddImportEnabled, outOfProcess);
 
             return base.CreateDiagnosticProviderAndFixer(workspace, parameters);

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -46,7 +46,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
 
             Using workspace = TestWorkspace.Create(element)
                 workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess).
-                                                      WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess).
                                                       WithChangedOption(RemoteFeatureOptions.SymbolFinderEnabled, outOfProcess)
 
                 Assert.True(workspace.Documents.Any(Function(d) d.CursorPosition.HasValue))
@@ -171,7 +170,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                        outOfProcess As Boolean) As Task
             Using workspace = TestWorkspace.Create(definition)
                 workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess).
-                                                      WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess).
                                                       WithChangedOption(RemoteFeatureOptions.SymbolFinderEnabled, outOfProcess)
 
                 workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
 
             Using workspace = TestWorkspace.Create(element)
                 workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess).
-                                                      WithChangedOption(RemoteFeatureOptions.OutOfProcessAllowed, outOfProcess).
+                                                      WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess).
                                                       WithChangedOption(RemoteFeatureOptions.SymbolFinderEnabled, outOfProcess)
 
                 Assert.True(workspace.Documents.Any(Function(d) d.CursorPosition.HasValue))
@@ -171,7 +171,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                        outOfProcess As Boolean) As Task
             Using workspace = TestWorkspace.Create(definition)
                 workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess).
-                                                      WithChangedOption(RemoteFeatureOptions.OutOfProcessAllowed, outOfProcess).
+                                                      WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess).
                                                       WithChangedOption(RemoteFeatureOptions.SymbolFinderEnabled, outOfProcess)
 
                 workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -27,7 +27,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                 WpfTestRunner.RequireWpfFact($"{NameOf(AbstractReferenceHighlightingTests)}.{NameOf(Me.VerifyHighlightsAsync)} creates asynchronous taggers")
 
                 workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess).
-                                                      WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess).
                                                       WithChangedOption(RemoteFeatureOptions.DocumentHighlightingEnabled, outOfProcess)
 
                 Dim tagProducer = New ReferenceHighlightingViewTaggerProvider(

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                 WpfTestRunner.RequireWpfFact($"{NameOf(AbstractReferenceHighlightingTests)}.{NameOf(Me.VerifyHighlightsAsync)} creates asynchronous taggers")
 
                 workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess).
-                                                      WithChangedOption(RemoteFeatureOptions.OutOfProcessAllowed, outOfProcess).
+                                                      WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess).
                                                       WithChangedOption(RemoteFeatureOptions.DocumentHighlightingEnabled, outOfProcess)
 
                 Dim tagProducer = New ReferenceHighlightingViewTaggerProvider(

--- a/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
+++ b/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
             using (var workspace = SetupWorkspace(content))
             {
                 workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)
-                                                     .WithChangedOption(RemoteFeatureOptions.OutOfProcessAllowed, outOfProcess)
+                                                     .WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess)
                                                      .WithChangedOption(RemoteFeatureOptions.NavigateToEnabled, outOfProcess);
 
                 await body(workspace);

--- a/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
+++ b/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
@@ -67,7 +67,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
             using (var workspace = SetupWorkspace(content))
             {
                 workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)
-                                                     .WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess)
                                                      .WithChangedOption(RemoteFeatureOptions.NavigateToEnabled, outOfProcess);
 
                 await body(workspace);

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace, parameters As TestParameters) As (DiagnosticAnalyzer, CodeFixProvider)
             Dim outOfProcess = DirectCast(parameters.fixProviderData, Boolean)
             workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess).
-                                                  WithChangedOption(RemoteFeatureOptions.OutOfProcessAllowed, outOfProcess).
+                                                  WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess).
                                                   WithChangedOption(RemoteFeatureOptions.AddImportEnabled, outOfProcess)
 
             Return MyBase.CreateDiagnosticProviderAndFixer(workspace, parameters)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -47,7 +47,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace, parameters As TestParameters) As (DiagnosticAnalyzer, CodeFixProvider)
             Dim outOfProcess = DirectCast(parameters.fixProviderData, Boolean)
             workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess).
-                                                  WithChangedOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed, outOfProcess).
                                                   WithChangedOption(RemoteFeatureOptions.AddImportEnabled, outOfProcess)
 
             Return MyBase.CreateDiagnosticProviderAndFixer(workspace, parameters)

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -17,8 +17,8 @@
                 <StackPanel>
                     <CheckBox x:Name="Enable_full_solution_analysis"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_full_solution_analysis}" />
-                    <CheckBox x:Name="Perform_editor_feature_analysis_in_external_process"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Perform_editor_feature_analysis_in_external_process}" />
+                    <CheckBox x:Name="Perform_editor_feature_analysis_in_external_process_experimental"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Perform_editor_feature_analysis_in_external_process_experimental}" />
                     <CheckBox x:Name="Enable_navigation_to_decompiled_sources"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_navigation_to_decompiled_sources}" />
                 </StackPanel>

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -17,8 +17,6 @@
                 <StackPanel>
                     <CheckBox x:Name="Enable_full_solution_analysis"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_full_solution_analysis}" />
-                    <CheckBox x:Name="Perform_editor_feature_analysis_in_external_process_experimental"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Perform_editor_feature_analysis_in_external_process_experimental}" />
                     <CheckBox x:Name="Enable_navigation_to_decompiled_sources"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_navigation_to_decompiled_sources}" />
                 </StackPanel>

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.ExtractMethod;
 using Microsoft.CodeAnalysis.Fading;
 using Microsoft.CodeAnalysis.ImplementType;
-using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.SymbolSearch;
 using Microsoft.CodeAnalysis.ValidateFormatString;
@@ -23,7 +22,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             InitializeComponent();
 
             BindToFullSolutionAnalysisOption(Enable_full_solution_analysis, LanguageNames.CSharp);
-            BindToOption(Perform_editor_feature_analysis_in_external_process_experimental, RemoteFeatureOptions.ExperimentalOutOfProcessAllowed);
             BindToOption(Enable_navigation_to_decompiled_sources, FeatureOnOffOptions.NavigateToDecompiledSources);
 
             BindToOption(PlaceSystemNamespaceFirst, GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             InitializeComponent();
 
             BindToFullSolutionAnalysisOption(Enable_full_solution_analysis, LanguageNames.CSharp);
-            BindToOption(Perform_editor_feature_analysis_in_external_process, RemoteFeatureOptions.OutOfProcessAllowed);
+            BindToOption(Perform_editor_feature_analysis_in_external_process_experimental, RemoteFeatureOptions.ExperimentalOutOfProcessAllowed);
             BindToOption(Enable_navigation_to_decompiled_sources, FeatureOnOffOptions.NavigateToDecompiledSources);
 
             BindToOption(PlaceSystemNamespaceFirst, GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -15,8 +15,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_Enable_full_solution_analysis
             => ServicesVSResources.Enable_full_solution_analysis;
 
-        public static string Option_Perform_editor_feature_analysis_in_external_process
-            => ServicesVSResources.Perform_editor_feature_analysis_in_external_process;
+        public static string Option_Perform_editor_feature_analysis_in_external_process_experimental
+            => ServicesVSResources.Perform_editor_feature_analysis_in_external_process_experimental;
 
         public static string Option_Enable_navigation_to_decompiled_sources
             => ServicesVSResources.Enable_navigation_to_decompiled_sources;

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -15,9 +15,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_Enable_full_solution_analysis
             => ServicesVSResources.Enable_full_solution_analysis;
 
-        public static string Option_Perform_editor_feature_analysis_in_external_process_experimental
-            => ServicesVSResources.Perform_editor_feature_analysis_in_external_process_experimental;
-
         public static string Option_Enable_navigation_to_decompiled_sources
             => ServicesVSResources.Enable_navigation_to_decompiled_sources;
 

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1714,15 +1714,6 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Perform editor _feature analysis in external process (experimental).
-        /// </summary>
-        internal static string Perform_editor_feature_analysis_in_external_process_experimental {
-            get {
-                return ResourceManager.GetString("Perform_editor_feature_analysis_in_external_process_experimental", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Pick members.
         /// </summary>
         internal static string Pick_members {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1716,9 +1716,9 @@ namespace Microsoft.VisualStudio.LanguageServices {
         /// <summary>
         ///   Looks up a localized string similar to Perform editor _feature analysis in external process (experimental).
         /// </summary>
-        internal static string Perform_editor_feature_analysis_in_external_process {
+        internal static string Perform_editor_feature_analysis_in_external_process_experimental {
             get {
-                return ResourceManager.GetString("Perform_editor_feature_analysis_in_external_process", resourceCulture);
+                return ResourceManager.GetString("Perform_editor_feature_analysis_in_external_process_experimental", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -939,9 +939,6 @@ Additional information: {1}</value>
   <data name="Enable_full_solution_analysis" xml:space="preserve">
     <value>Enable full solution _analysis</value>
   </data>
-  <data name="Perform_editor_feature_analysis_in_external_process_experimental" xml:space="preserve">
-    <value>Perform editor _feature analysis in external process (experimental)</value>
-  </data>
   <data name="Fade_out_unreachable_code" xml:space="preserve">
     <value>Fade out unreachable code</value>
   </data>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -939,7 +939,7 @@ Additional information: {1}</value>
   <data name="Enable_full_solution_analysis" xml:space="preserve">
     <value>Enable full solution _analysis</value>
   </data>
-  <data name="Perform_editor_feature_analysis_in_external_process" xml:space="preserve">
+  <data name="Perform_editor_feature_analysis_in_external_process_experimental" xml:space="preserve">
     <value>Perform editor _feature analysis in external process (experimental)</value>
   </data>
   <data name="Fade_out_unreachable_code" xml:space="preserve">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1373,11 +1373,6 @@ Další informace: {1}</target>
         <target state="translated">Povolit úplnou _analýzu řešení</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Provést analýzu _funkcí editoru v externím procesu (experimentální)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">Zesvětlit nedosažitelný kód</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1373,7 +1373,7 @@ Další informace: {1}</target>
         <target state="translated">Povolit úplnou _analýzu řešení</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">Provést analýzu _funkcí editoru v externím procesu (experimentální)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1373,7 +1373,7 @@ Zusätzliche Informationen: {1}</target>
         <target state="translated">Vollständige Lösungs_analyse aktivieren</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">Editor-_Funktionsanalyse in externem Prozess ausführen (experimentell)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1373,11 +1373,6 @@ Zusätzliche Informationen: {1}</target>
         <target state="translated">Vollständige Lösungs_analyse aktivieren</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Editor-_Funktionsanalyse in externem Prozess ausführen (experimentell)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">Unerreichbaren Code ausblenden</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1373,11 +1373,6 @@ Información adicional: {1}</target>
         <target state="translated">Habilitar _análisis de la solución completa</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Realizar el análisis de _características del editor en proceso externo (experimental)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">Atenuar código inaccesible</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1373,7 +1373,7 @@ Información adicional: {1}</target>
         <target state="translated">Habilitar _análisis de la solución completa</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">Realizar el análisis de _características del editor en proceso externo (experimental)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1373,11 +1373,6 @@ Informations supplémentaires : {1}</target>
         <target state="translated">Activer l'_analyse complète de la solution</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Effectuer l'analyse des _fonctionnalités de l'éditeur dans un processus externe (expérimental)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">Supprimer le code inaccessible</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1373,7 +1373,7 @@ Informations supplémentaires : {1}</target>
         <target state="translated">Activer l'_analyse complète de la solution</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">Effectuer l'analyse des _fonctionnalités de l'éditeur dans un processus externe (expérimental)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1373,7 +1373,7 @@ Informazioni aggiuntive: {1}</target>
         <target state="translated">Abilita _analisi della soluzione completa</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">Esegui analisi delle _funzionalità dell'editor in processo esterno (sperimentale)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1373,11 +1373,6 @@ Informazioni aggiuntive: {1}</target>
         <target state="translated">Abilita _analisi della soluzione completa</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Esegui analisi delle _funzionalità dell'editor in processo esterno (sperimentale)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">Applica dissolvenza a codice non eseguibile</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1373,11 +1373,6 @@ Additional information: {1}</source>
         <target state="translated">完全ソリューション解析を有効にする(_A)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">外部プロセスでエディター機能解析を実行する (試験段階)(_F)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">到達できないコードをフェードアウトします</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1373,7 +1373,7 @@ Additional information: {1}</source>
         <target state="translated">完全ソリューション解析を有効にする(_A)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">外部プロセスでエディター機能解析を実行する (試験段階)(_F)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1373,11 +1373,6 @@ Additional information: {1}</source>
         <target state="translated">전체 솔루션 분석 사용(_A)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">외부 프로세스에서 편집기 기능 분석 수행(_F)(실험적)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">접근할 수 없는 코드 페이드 아웃</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1373,7 +1373,7 @@ Additional information: {1}</source>
         <target state="translated">전체 솔루션 분석 사용(_A)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">외부 프로세스에서 편집기 기능 분석 수행(_F)(실험적)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1373,7 +1373,7 @@ Dodatkowe informacje: {1}</target>
         <target state="translated">Włącz pełną _analizę rozwiązania</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">Przeprowadź analizę _funkcji edytora w procesie zewnętrznym (eksperymentalne)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1373,11 +1373,6 @@ Dodatkowe informacje: {1}</target>
         <target state="translated">Włącz pełną _analizę rozwiązania</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Przeprowadź analizę _funkcji edytora w procesie zewnętrznym (eksperymentalne)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">Zanikanie nieosiągalnego kodu</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1373,7 +1373,7 @@ Informações adicionais: {1}</target>
         <target state="translated">Habilitar _análise de solução completa</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">Executar análise de _recurso do editor no processo externo (experimental)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1373,11 +1373,6 @@ Informações adicionais: {1}</target>
         <target state="translated">Habilitar _análise de solução completa</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Executar análise de _recurso do editor no processo externo (experimental)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">Esmaecer código inacessível</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1373,7 +1373,7 @@ Additional information: {1}</source>
         <target state="translated">Включить полный _анализ решения</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">Выполнить анализ функций редактора во _внешнем процессе (экспериментальная функция)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1373,11 +1373,6 @@ Additional information: {1}</source>
         <target state="translated">Включить полный _анализ решения</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Выполнить анализ функций редактора во _внешнем процессе (экспериментальная функция)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">Скрывать недостижимый код</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1373,11 +1373,6 @@ Ek bilgiler: {1}</target>
         <target state="translated">Tam çözüm _analizini etkinleştir</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Dış işlemde düzenleyici ö_zellik analizi gerçekleştir (deneysel)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">Erişilemeyen kodu soluklaştır</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1373,7 +1373,7 @@ Ek bilgiler: {1}</target>
         <target state="translated">Tam çözüm _analizini etkinleştir</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">Dış işlemde düzenleyici ö_zellik analizi gerçekleştir (deneysel)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1373,11 +1373,6 @@ Additional information: {1}</source>
         <target state="translated">启用完整解决方案分析(_A)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">在外部进程中执行编辑器功能分析(_F)(实验)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">淡出无法访问的代码</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1373,7 +1373,7 @@ Additional information: {1}</source>
         <target state="translated">启用完整解决方案分析(_A)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">在外部进程中执行编辑器功能分析(_F)(实验)</target>
         <note />

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1373,11 +1373,6 @@ Additional information: {1}</source>
         <target state="translated">啟用完整解決方案分析(_A)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">在外部處理序中執編輯器功能分析 (_F)(實驗性)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">
         <source>Fade out unreachable code</source>
         <target state="translated">淡出執行不到的程式碼</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1373,7 +1373,7 @@ Additional information: {1}</source>
         <target state="translated">啟用完整解決方案分析(_A)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Perform_editor_feature_analysis_in_external_process">
+      <trans-unit id="Perform_editor_feature_analysis_in_external_process_experimental">
         <source>Perform editor _feature analysis in external process (experimental)</source>
         <target state="translated">在外部處理序中執編輯器功能分析 (_F)(實驗性)</target>
         <note />

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -18,8 +18,8 @@
                 <StackPanel>
                     <CheckBox x:Name="Enable_full_solution_analysis"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_full_solution_analysis}" />
-                    <CheckBox x:Name="Perform_editor_feature_analysis_in_external_process"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Perform_editor_feature_analysis_in_external_process}" />
+                    <CheckBox x:Name="Perform_editor_feature_analysis_in_external_process_experimental"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Perform_editor_feature_analysis_in_external_process_experimental}" />
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Uid="ImportDirectivesGroupBox"

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -18,8 +18,6 @@
                 <StackPanel>
                     <CheckBox x:Name="Enable_full_solution_analysis"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_full_solution_analysis}" />
-                    <CheckBox x:Name="Perform_editor_feature_analysis_in_external_process_experimental"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Perform_editor_feature_analysis_in_external_process_experimental}" />
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Uid="ImportDirectivesGroupBox"

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             InitializeComponent()
 
             BindToFullSolutionAnalysisOption(Enable_full_solution_analysis, LanguageNames.VisualBasic)
-            BindToOption(Perform_editor_feature_analysis_in_external_process, RemoteFeatureOptions.OutOfProcessAllowed)
+            BindToOption(Perform_editor_feature_analysis_in_external_process_experimental, RemoteFeatureOptions.ExperimentalOutOfProcessAllowed)
 
             BindToOption(PlaceSystemNamespaceFirst, GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.VisualBasic)
             BindToOption(SeparateImportGroups, GenerationOptions.SeparateImportDirectiveGroups, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -6,7 +6,6 @@ Imports Microsoft.CodeAnalysis.Editor.Shared.Options
 Imports Microsoft.CodeAnalysis.ExtractMethod
 Imports Microsoft.CodeAnalysis.Fading
 Imports Microsoft.CodeAnalysis.ImplementType
-Imports Microsoft.CodeAnalysis.Remote
 Imports Microsoft.CodeAnalysis.Structure
 Imports Microsoft.CodeAnalysis.SymbolSearch
 Imports Microsoft.CodeAnalysis.ValidateFormatString
@@ -20,7 +19,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             InitializeComponent()
 
             BindToFullSolutionAnalysisOption(Enable_full_solution_analysis, LanguageNames.VisualBasic)
-            BindToOption(Perform_editor_feature_analysis_in_external_process_experimental, RemoteFeatureOptions.ExperimentalOutOfProcessAllowed)
 
             BindToOption(PlaceSystemNamespaceFirst, GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.VisualBasic)
             BindToOption(SeparateImportGroups, GenerationOptions.SeparateImportDirectiveGroups, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -21,9 +21,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         Public ReadOnly Property Option_Enable_full_solution_analysis As String =
             ServicesVSResources.Enable_full_solution_analysis
 
-        Public ReadOnly Property Option_Perform_editor_feature_analysis_in_external_process_experimental As String =
-            ServicesVSResources.Perform_editor_feature_analysis_in_external_process_experimental
-
         Public ReadOnly Property Option_DisplayLineSeparators As String
             Get
                 Return BasicVSResources.Show_procedure_line_separators

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -21,8 +21,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         Public ReadOnly Property Option_Enable_full_solution_analysis As String =
             ServicesVSResources.Enable_full_solution_analysis
 
-        Public ReadOnly Property Option_Perform_editor_feature_analysis_in_external_process As String =
-            ServicesVSResources.Perform_editor_feature_analysis_in_external_process
+        Public ReadOnly Property Option_Perform_editor_feature_analysis_in_external_process_experimental As String =
+            ServicesVSResources.Perform_editor_feature_analysis_in_external_process_experimental
 
         Public ReadOnly Property Option_DisplayLineSeparators As String
             Get

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.Experiments
 
     internal static class WellKnownExperimentNames
     {
-        public const string RoslynFeatureOOP = nameof(RoslynFeatureOOP);
         public const string RoslynOOP64bit = nameof(RoslynOOP64bit);
     }
 }

--- a/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
@@ -10,33 +10,10 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         private const string LocalRegistryPath = @"Roslyn\Features\Remote\";
 
-        /// <summary>
-        /// Global switch that determines of OOP can be used for a language feature. Exposed through
-        /// user visible switch to let people opt-in/out of this behavior.
-        /// </summary>
-        public static readonly Option<bool> ExperimentalOutOfProcessAllowed = new Option<bool>(
-            nameof(RemoteFeatureOptions), nameof(OutOfProcessAllowed), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OutOfProcessAllowed)));
-
-        /// <summary>
-        /// This field contains the original name of the experimental OOP feature, which is used as the key for saving
-        /// the setting.
-        /// </summary>
-        private static readonly Option<bool> OutOfProcessAllowed = ExperimentalOutOfProcessAllowed;
-
         // Individual feature switches.  Not exposed to the user.  Supplied as an escape hatch for
         // features if necessary.  If all features use OOP then no indices will need to be built
         // within VS.  However, if any features need to run in VS, then we have to build our indices
         // in VS as well.
-
-        #region Experimental out-of-process features
-
-        internal static ImmutableArray<Option<bool>> ExperimentalFeatureOptions { get; } =
-            ImmutableArray<Option<bool>>.Empty;
-
-        #endregion
-
-        #region Stable out-of-process features
 
         public static readonly Option<bool> AddImportEnabled = new Option<bool>(
             nameof(RemoteFeatureOptions), nameof(AddImportEnabled), defaultValue: true,
@@ -62,11 +39,8 @@ namespace Microsoft.CodeAnalysis.Remote
             nameof(RemoteFeatureOptions), nameof(DiagnosticsEnabled), defaultValue: true,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(DiagnosticsEnabled)));
 
-        #endregion
-
         private static ImmutableArray<Option<bool>> AllFeatureOptions { get; } =
-            ImmutableArray.Create(AddImportEnabled, DocumentHighlightingEnabled, NavigateToEnabled, SymbolSearchEnabled, SymbolFinderEnabled)
-                .AddRange(ExperimentalFeatureOptions);
+            ImmutableArray.Create(AddImportEnabled, DocumentHighlightingEnabled, NavigateToEnabled, SymbolSearchEnabled, SymbolFinderEnabled);
 
         public static bool AnyFeatureRunsInProcess(Workspace workspace)
             => AllFeatureOptions.Any(o => !workspace.IsOutOfProcessEnabled(o));

--- a/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Remote
@@ -15,14 +14,29 @@ namespace Microsoft.CodeAnalysis.Remote
         /// Global switch that determines of OOP can be used for a language feature. Exposed through
         /// user visible switch to let people opt-in/out of this behavior.
         /// </summary>
-        public static readonly Option<bool> OutOfProcessAllowed = new Option<bool>(
+        public static readonly Option<bool> ExperimentalOutOfProcessAllowed = new Option<bool>(
             nameof(RemoteFeatureOptions), nameof(OutOfProcessAllowed), defaultValue: false,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OutOfProcessAllowed)));
+
+        /// <summary>
+        /// This field contains the original name of the experimental OOP feature, which is used as the key for saving
+        /// the setting.
+        /// </summary>
+        private static readonly Option<bool> OutOfProcessAllowed = ExperimentalOutOfProcessAllowed;
 
         // Individual feature switches.  Not exposed to the user.  Supplied as an escape hatch for
         // features if necessary.  If all features use OOP then no indices will need to be built
         // within VS.  However, if any features need to run in VS, then we have to build our indices
         // in VS as well.
+
+        #region Experimental out-of-process features
+
+        internal static ImmutableArray<Option<bool>> ExperimentalFeatureOptions { get; } =
+            ImmutableArray<Option<bool>>.Empty;
+
+        #endregion
+
+        #region Stable out-of-process features
 
         public static readonly Option<bool> AddImportEnabled = new Option<bool>(
             nameof(RemoteFeatureOptions), nameof(AddImportEnabled), defaultValue: true,
@@ -48,8 +62,11 @@ namespace Microsoft.CodeAnalysis.Remote
             nameof(RemoteFeatureOptions), nameof(DiagnosticsEnabled), defaultValue: true,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(DiagnosticsEnabled)));
 
+        #endregion
+
         private static ImmutableArray<Option<bool>> AllFeatureOptions { get; } =
-            ImmutableArray.Create(AddImportEnabled, DocumentHighlightingEnabled, NavigateToEnabled, SymbolSearchEnabled, SymbolFinderEnabled);
+            ImmutableArray.Create(AddImportEnabled, DocumentHighlightingEnabled, NavigateToEnabled, SymbolSearchEnabled, SymbolFinderEnabled)
+                .AddRange(ExperimentalFeatureOptions);
 
         public static bool AnyFeatureRunsInProcess(Workspace workspace)
             => AllFeatureOptions.Any(o => !workspace.IsOutOfProcessEnabled(o));

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -113,13 +113,15 @@ namespace Microsoft.CodeAnalysis.Remote
                 return false;
             }
 
-            if (workspace.Options.GetOption(RemoteFeatureOptions.OutOfProcessAllowed))
+            if (!RemoteFeatureOptions.ExperimentalFeatureOptions.Contains(featureOption)
+                || workspace.Options.GetOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed))
             {
-                // If the user has explicitly enabled OOP, then the feature is allowed to run in OOP.
+                // If the OOP functionality for the feature is stable, or if the user has enabled experimental OOP
+                // features, then the feature is allowed to run in OOP.
                 return true;
             }
 
-            // Otherwise we check if the user is in the AB experiment enabling OOP.
+            // Otherwise we check if the user is in the AB experiment enabling experimental OOP features.
             var experimentEnabled = workspace.Services.GetService<IExperimentationService>();
             if (!experimentEnabled.IsExperimentEnabled(WellKnownExperimentNames.RoslynFeatureOOP))
             {

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Experiments;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Execution;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Options;
 using Roslyn.Utilities;
-using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -109,21 +108,6 @@ namespace Microsoft.CodeAnalysis.Remote
             // If the feature has explicitly opted out of OOP then we won't run it OOP.
             var outOfProcessAllowed = workspace.Options.GetOption(featureOption);
             if (!outOfProcessAllowed)
-            {
-                return false;
-            }
-
-            if (!RemoteFeatureOptions.ExperimentalFeatureOptions.Contains(featureOption)
-                || workspace.Options.GetOption(RemoteFeatureOptions.ExperimentalOutOfProcessAllowed))
-            {
-                // If the OOP functionality for the feature is stable, or if the user has enabled experimental OOP
-                // features, then the feature is allowed to run in OOP.
-                return true;
-            }
-
-            // Otherwise we check if the user is in the AB experiment enabling experimental OOP features.
-            var experimentEnabled = workspace.Services.GetService<IExperimentationService>();
-            if (!experimentEnabled.IsExperimentEnabled(WellKnownExperimentNames.RoslynFeatureOOP))
             {
                 return false;
             }


### PR DESCRIPTION
This is the first of two ways to transition OOP features from experimental to stable.

* Features deemed stable by prior experiments are transitioned to stable, and will run out of process via the "normal" mechanism (as long as OOP itself is enabled) rather than guarded by `RemoteFeatureOptions.OutOfProcessEnabled`
* ~~The UI is not touched; the setting for enabling experimental OOP features remains in place and we can use it for future work in this space~~ Edit: The previous UI for experimental OOP features has been eliminated. The option is not enabled by default, with no exposed way to disable it.

See #27985 for the second option.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
