### PR TITLE
Remove the experimental designation for RemoteFeatureOptions.OutOfProcessAllowed

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1714,7 +1714,7 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Perform editor _feature analysis in external process (experimental).
+        ///   Looks up a localized string similar to Perform editor _feature analysis in external process.
         /// </summary>
         internal static string Perform_editor_feature_analysis_in_external_process {
             get {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -940,7 +940,7 @@ Additional information: {1}</value>
     <value>Enable full solution _analysis</value>
   </data>
   <data name="Perform_editor_feature_analysis_in_external_process" xml:space="preserve">
-    <value>Perform editor _feature analysis in external process (experimental)</value>
+    <value>Perform editor _feature analysis in external process</value>
   </data>
   <data name="Fade_out_unreachable_code" xml:space="preserve">
     <value>Fade out unreachable code</value>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1374,8 +1374,8 @@ Další informace: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Provést analýzu _funkcí editoru v externím procesu (experimentální)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">Provést analýzu _funkcí editoru v externím procesu (experimentální)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1374,8 +1374,8 @@ Zusätzliche Informationen: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Editor-_Funktionsanalyse in externem Prozess ausführen (experimentell)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">Editor-_Funktionsanalyse in externem Prozess ausführen (experimentell)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1374,8 +1374,8 @@ Información adicional: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Realizar el análisis de _características del editor en proceso externo (experimental)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">Realizar el análisis de _características del editor en proceso externo (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1374,8 +1374,8 @@ Informations supplémentaires : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Effectuer l'analyse des _fonctionnalités de l'éditeur dans un processus externe (expérimental)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">Effectuer l'analyse des _fonctionnalités de l'éditeur dans un processus externe (expérimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1374,8 +1374,8 @@ Informazioni aggiuntive: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Esegui analisi delle _funzionalità dell'editor in processo esterno (sperimentale)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">Esegui analisi delle _funzionalità dell'editor in processo esterno (sperimentale)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1374,8 +1374,8 @@ Additional information: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">外部プロセスでエディター機能解析を実行する (試験段階)(_F)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">外部プロセスでエディター機能解析を実行する (試験段階)(_F)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1374,8 +1374,8 @@ Additional information: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">외부 프로세스에서 편집기 기능 분석 수행(_F)(실험적)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">외부 프로세스에서 편집기 기능 분석 수행(_F)(실험적)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1374,8 +1374,8 @@ Dodatkowe informacje: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Przeprowadź analizę _funkcji edytora w procesie zewnętrznym (eksperymentalne)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">Przeprowadź analizę _funkcji edytora w procesie zewnętrznym (eksperymentalne)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1374,8 +1374,8 @@ Informações adicionais: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Executar análise de _recurso do editor no processo externo (experimental)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">Executar análise de _recurso do editor no processo externo (experimental)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1374,8 +1374,8 @@ Additional information: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Выполнить анализ функций редактора во _внешнем процессе (экспериментальная функция)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">Выполнить анализ функций редактора во _внешнем процессе (экспериментальная функция)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1374,8 +1374,8 @@ Ek bilgiler: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">Dış işlemde düzenleyici ö_zellik analizi gerçekleştir (deneysel)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">Dış işlemde düzenleyici ö_zellik analizi gerçekleştir (deneysel)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1374,8 +1374,8 @@ Additional information: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">在外部进程中执行编辑器功能分析(_F)(实验)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">在外部进程中执行编辑器功能分析(_F)(实验)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1374,8 +1374,8 @@ Additional information: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="Perform_editor_feature_analysis_in_external_process">
-        <source>Perform editor _feature analysis in external process (experimental)</source>
-        <target state="translated">在外部處理序中執編輯器功能分析 (_F)(實驗性)</target>
+        <source>Perform editor _feature analysis in external process</source>
+        <target state="needs-review-translation">在外部處理序中執編輯器功能分析 (_F)(實驗性)</target>
         <note />
       </trans-unit>
       <trans-unit id="Fade_out_unreachable_code">

--- a/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Remote
@@ -16,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// user visible switch to let people opt-in/out of this behavior.
         /// </summary>
         public static readonly Option<bool> OutOfProcessAllowed = new Option<bool>(
-            nameof(RemoteFeatureOptions), nameof(OutOfProcessAllowed), defaultValue: false,
+            nameof(RemoteFeatureOptions), nameof(OutOfProcessAllowed), defaultValue: true,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OutOfProcessAllowed)));
 
         // Individual feature switches.  Not exposed to the user.  Supplied as an escape hatch for


### PR DESCRIPTION
This is the second of two alternatives for enabling additional OOP features by default.

* The "experimental" designation is removed from the option in Tools &rarr; Options, and the feature is enabled by default
* The check box still controls the same OOP features it controlled previously (which is a subset of overall OOP features and cannot be used to disable OOP altogether)
* Future experimental work in this space will not be able to use the same control to enable experimental features

See #27983  for the fist option.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
