### PR TITLE
Fix generating types into an existing file

### DIFF
--- a/src/VisualStudio/Core/Test/GenerateType/GenerateTypeViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/GenerateType/GenerateTypeViewModelTests.vb
@@ -195,7 +195,7 @@ namespace A
 
             ' Only 2 Projects can be selected because CS2 and CS3 will introduce cyclic dependency
             Assert.Equal(2, viewModel.ProjectList.Count)
-            Assert.Equal(2, viewModel.GetDocumentList(CancellationToken.None).Count)
+            Assert.Equal(2, viewModel.DocumentList.Count())
 
             viewModel.DocumentSelectIndex = 1
 
@@ -205,7 +205,7 @@ namespace A
 
             ' Check to see if the values are reset when there is a change in the project selection
             viewModel.SelectedProject = projectToSelect
-            Assert.Equal(2, viewModel.GetDocumentList(CancellationToken.None).Count())
+            Assert.Equal(2, viewModel.DocumentList.Count())
             Assert.Equal(0, viewModel.DocumentSelectIndex)
             Assert.Equal(1, viewModel.ProjectSelectIndex)
 
@@ -247,7 +247,7 @@ namespace A
 
 
             ' Check if the option for Existing File is disabled
-            Assert.Equal(0, viewModel.GetDocumentList(CancellationToken.None).Count())
+            Assert.Equal(0, viewModel.DocumentList.Count())
             Assert.Equal(False, viewModel.IsExistingFileEnabled)
 
             ' Select the project CS1 which has documents
@@ -255,7 +255,7 @@ namespace A
             viewModel.SelectedProject = projectToSelect
 
             ' Check if the option for Existing File is enabled
-            Assert.Equal(2, viewModel.GetDocumentList(CancellationToken.None).Count())
+            Assert.Equal(2, viewModel.DocumentList.Count())
             Assert.Equal(True, viewModel.IsExistingFileEnabled)
         End Function
 
@@ -585,7 +585,7 @@ class Program
             Dim viewModel = Await GetViewModelAsync(workspaceXml, LanguageNames.CSharp)
 
             Dim expectedDocuments = {"Test1.cs", "Test2.cs", "AssemblyInfo.cs", "Test3.cs"}
-            Assert.Equal(expectedDocuments, viewModel.GetDocumentList(CancellationToken.None).Select(Function(d) d.Document.Name).ToArray())
+            Assert.Equal(expectedDocuments, viewModel.DocumentList.Select(Function(d) d.Document.Name).ToArray())
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>


### PR DESCRIPTION
An errant refactoring changed a property being consumed by XAML during binding from a property to a method, which isn't going to work. Change this back.

<details><summary>Ask Mode template</summary>

### Customer scenario

User tries to invoke "generate type" into an existing file with our dialog, but the list of files to generate into is unpopulated.

### Bugs this fixes

Bug not filed; discovered this while testing #27973.

### Workarounds, if any

Nope, feature is totally broken.

### Risk

Very low -- unbreaking code that is 100% broken.

### Performance impact

None.

### Is this a regression from a previous update?

Yes; this was regressed about a year or so ago, so this may have not been working during all of Dev15.

### Root cause analysis

A large refactoring changed a property to a method in a XAML view model. This isn't supported in binding so it broke.

### How was the bug found?

While testing #27973.

</details>
