### PR TITLE
Fix issues with the windows_loc_status check

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -38,14 +38,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="All" />
+    <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="All" Condition="'$(NonShipping)' != 'true'" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <!-- Disable localization for non-shipping projects -->
-    <EnableXlfLocalization Condition="'$(NonShipping)' == 'true'">false</EnableXlfLocalization>
-  </PropertyGroup>
 
   <Choose>
     <When Condition="'$(SignAssembly)' == 'true'">
@@ -500,4 +495,13 @@
   </PropertyGroup>
 
   <Import Project="RepoToolset\SymStore.targets" />
+
+  <!--
+    Delegates to XliffTasks to validate that all localizable resources have been translated.
+    We can't use EnsureAllResoucesTranslated directly because the XliffTasks package is only pulled in by projects that
+    produce shipping binaries.
+  -->
+  <Target Name="CheckLocStatus"
+          DependsOnTargets="EnsureAllResourcesTranslated"
+          Condition="'$(NonShipping)' != 'true'" />
 </Project>

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -482,7 +482,7 @@ function Build-DeployToSymStore() {
 }
 
 function Build-CheckLocStatus() {
-    Run-MSBuild "Roslyn.sln" "/t:EnsureAllResourcesTranslated" -logFileName "RoslynCheckLocStatus"
+    Run-MSBuild "Roslyn.sln" "/t:CheckLocStatus" -logFileName "RoslynCheckLocStatus"
 }
 
 # These are tests that don't follow our standard restore, build, test pattern. They customize

--- a/netci.groovy
+++ b/netci.groovy
@@ -238,18 +238,23 @@ commitPullList.each { isPr ->
 
 // Loc status check
 commitPullList.each { isPr ->
-  def jobName = Utilities.getFullJobName(projectName, "windows_loc_status", isPr)
-  def myJob = job(jobName) {
-    description('Check for untranslated resources')
-    steps {
-      batchFile(""".\\build\\scripts\\check-loc-status.cmd""")
+  // Only add the check to PR builds for now. At some point we'll change this check
+  // to instead look for particular branch names.
+  if (isPr) {
+    def jobName = Utilities.getFullJobName(projectName, "windows_loc_status", isPr)
+    def myJob = job(jobName) {
+      description('Check for untranslated resources')
+      steps {
+        batchFile(""".\\build\\scripts\\check-loc-status.cmd""")
+      }
     }
-  }
 
-  def triggerPhraseOnly = true
-  def triggerPhraseExtra = "loc"
-  Utilities.setMachineAffinity(myJob, 'Windows_NT', windowsUnitTestMachine)
-  addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
+    // For now we'll only run this when explicitly asked.
+    def triggerPhraseOnly = true
+    def triggerPhraseExtra = "loc"
+    Utilities.setMachineAffinity(myJob, 'Windows_NT', windowsUnitTestMachine)
+    addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
+  }
 }
 
 JobReport.Report.generateJobReport(out)


### PR DESCRIPTION
1. Only restore the `XliffTasks` package for shipping projects. It turns out some non-shipping projects use NuGet feeds that do not include this package, leading to errors in the signed build.
2. Don't run the `windows_loc_status` check in CI builds for the moment--just in PR builds and only when requested with `test loc`.