### PR TITLE
Use RTM dotnet SDK versions

### DIFF
--- a/build/Targets/Tools.props
+++ b/build/Targets/Tools.props
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <dotnetRuntimeVersion>2.0.0</dotnetRuntimeVersion>
-    <dotnetSdkVersion>2.1.300-preview2-008324</dotnetSdkVersion>
+    <dotnetRuntimeVersion>2.1.0</dotnetRuntimeVersion>
+    <dotnetSdkVersion>2.1.300</dotnetSdkVersion>
     <monoVersion>5.8.0.88</monoVersion>
     <vsMinimumVersion>15.3</vsMinimumVersion>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.1.300-preview2-008324"
+    "version": "2.1.300"
   }
 }


### PR DESCRIPTION
Dotnet Core 2.1.0 and SDK 2.1.300 have been officially released.
Rather than force a download of a prerelease, this moves us onto
the official bits.
