### PR TITLE
[WIP] Enable UseSharedCompilation by default in *.Compilers packages

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
@@ -11,8 +11,6 @@
              AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll" />
 
   <PropertyGroup>
-    <!-- Don't use the compiler server by default in the NuGet package. -->
-    <UseSharedCompilation Condition="'$(UseSharedCompilation)' == ''">false</UseSharedCompilation>
     <CSharpCoreTargetsPath>$(MSBuildThisFileDirectory)..\tools\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
     <VisualBasicCoreTargetsPath>$(MSBuildThisFileDirectory)..\tools\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
   </PropertyGroup>

--- a/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
@@ -27,8 +27,6 @@
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly"
              AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll" />
   <PropertyGroup>
-    <!-- By default don't use the compiler server in Visual Studio. -->
-    <UseSharedCompilation Condition="'$(UseSharedCompilation)' == ''">false</UseSharedCompilation>
     <CSharpCoreTargetsPath>$(MSBuildThisFileDirectory)..\tools\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
     <VisualBasicCoreTargetsPath>$(MSBuildThisFileDirectory)..\tools\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
   </PropertyGroup>


### PR DESCRIPTION
### Customer scenario

Customer installs one of the Compilers NuGet packages and performance is
much slower than the in-box compilers because the compiler server isn't enabled
by default.

This wasn't done before because it could cause the ASP.NET bin/ directory
to be locked during a build. However, that seems to be fixed and the
CodeDom packages even provide customization about whether the package
will be used during development or only during deployment.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/27975

### Workarounds, if any

The user can turn this on manually, but there really isn't a way for the user to
know this.

### Risk

This shouldn't affect compiler semantics in any way and is well tested. We turn
on UseSharedCompilation for our bootstrap. The biggest risk is that ASP.NET's CodeDom
package somehow relies on us not locking the compiler directory.

### Performance impact

This should heavily increase performance.

### Is this a regression from a previous update?

No.

### Root cause analysis

Design decision.

### How was the bug found?

Design decision. Revisited due to customer feedback.
