### PR TITLE
Consistently parse .editorconfig option values containing spaces

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.Parsers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.Parsers.cs
@@ -47,13 +47,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         internal static BinaryOperatorSpacingOptions ParseEditorConfigSpacingAroundBinaryOperator(string binaryOperatorSpacingValue)
-            => s_binaryOperatorSpacingOptionsEditorConfigMap.TryGetValue(binaryOperatorSpacingValue, out var value) ? value : BinaryOperatorSpacingOptions.Single;
+            => s_binaryOperatorSpacingOptionsEditorConfigMap.TryGetValue(binaryOperatorSpacingValue.Trim(), out var value) ? value : BinaryOperatorSpacingOptions.Single;
 
         private static string GetSpacingAroundBinaryOperatorEditorConfigString(BinaryOperatorSpacingOptions value)
             => s_binaryOperatorSpacingOptionsEditorConfigMap.TryGetKey(value, out string key) ? key : null;
 
         internal static LabelPositionOptions ParseEditorConfigLabelPositioning(string labelIndentationValue)
-            => s_labelPositionOptionsEditorConfigMap.TryGetValue(labelIndentationValue, out var value) ? value : LabelPositionOptions.NoIndent;
+            => s_labelPositionOptionsEditorConfigMap.TryGetValue(labelIndentationValue.Trim(), out var value) ? value : LabelPositionOptions.NoIndent;
 
         private static string GetLabelPositionOptionEditorConfigString(LabelPositionOptions value)
             => s_labelPositionOptionsEditorConfigMap.TryGetKey(value, out string key) ? key : null;

--- a/src/Workspaces/CSharpTest/CodeStyle/CSharpEditorConfigCodeStyleParserTests.cs
+++ b/src/Workspaces/CSharpTest/CodeStyle/CSharpEditorConfigCodeStyleParserTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeStyle
+{
+    public class CSharpEditorConfigCodeStyleParserTests
+    {
+        [Theory]
+        [InlineData("ignore", BinaryOperatorSpacingOptions.Ignore)]
+        [InlineData("none", BinaryOperatorSpacingOptions.Remove)]
+        [InlineData("before_and_after", BinaryOperatorSpacingOptions.Single)]
+
+        [WorkItem(27685, "https://github.com/dotnet/roslyn/issues/27685")]
+        [InlineData(" ignore ", BinaryOperatorSpacingOptions.Ignore)]
+        [InlineData(" none ", BinaryOperatorSpacingOptions.Remove)]
+        [InlineData(" before_and_after ", BinaryOperatorSpacingOptions.Single)]
+        public void TestParseSpacingAroundBinaryOperator(string rawValue, BinaryOperatorSpacingOptions parsedValue)
+        {
+            Assert.Equal(parsedValue, CSharpFormattingOptions.ParseEditorConfigSpacingAroundBinaryOperator(rawValue));
+        }
+
+        [Theory]
+        [InlineData("flush_left", LabelPositionOptions.LeftMost)]
+        [InlineData("no_change", LabelPositionOptions.NoIndent)]
+        [InlineData("one_less_than_current", LabelPositionOptions.OneLess)]
+
+        [WorkItem(27685, "https://github.com/dotnet/roslyn/issues/27685")]
+        [InlineData(" flush_left ", LabelPositionOptions.LeftMost)]
+        [InlineData(" no_change ", LabelPositionOptions.NoIndent)]
+        [InlineData(" one_less_than_current ", LabelPositionOptions.OneLess)]
+        public void TestParseLabelPositioning(string rawValue, LabelPositionOptions parsedValue)
+        {
+            Assert.Equal(parsedValue, CSharpFormattingOptions.ParseEditorConfigLabelPositioning(rawValue));
+        }
+
+        [Theory]
+        [InlineData("false:none", (int)ExpressionBodyPreference.Never, ReportDiagnostic.Suppress)]
+        [InlineData("true:warning", (int)ExpressionBodyPreference.WhenPossible, ReportDiagnostic.Warn)]
+        [InlineData("when_on_single_line:error", (int)ExpressionBodyPreference.WhenOnSingleLine, ReportDiagnostic.Error)]
+
+        [WorkItem(27685, "https://github.com/dotnet/roslyn/issues/27685")]
+        [InlineData("false : none", (int)ExpressionBodyPreference.Never, ReportDiagnostic.Suppress)]
+        [InlineData("true : warning", (int)ExpressionBodyPreference.WhenPossible, ReportDiagnostic.Warn)]
+        [InlineData("when_on_single_line : error", (int)ExpressionBodyPreference.WhenOnSingleLine, ReportDiagnostic.Error)]
+        public void TestParseExpressionBodyPreference(string optionString, int parsedValue, ReportDiagnostic severity)
+        {
+            var defaultValue = new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.Error);
+            var codeStyleOption = CSharpCodeStyleOptions.ParseExpressionBodyPreference(optionString, defaultValue);
+
+            Assert.NotSame(defaultValue, codeStyleOption);
+            Assert.Equal((ExpressionBodyPreference)parsedValue, codeStyleOption.Value);
+            Assert.Equal(severity, codeStyleOption.Notification.Severity);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                     arg, out string value, out NotificationOption notificationOpt))
             {
                 // First value has to be true or false.  Anything else is unsupported.
-                if (bool.TryParse(value.Trim(), out var isEnabled))
+                if (bool.TryParse(value, out var isEnabled))
                 {
                     // We allow 'false' to be provided without a notification option.  However,
                     // 'true' must always be provided with a notification option.

--- a/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
+++ b/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             });
 
         private static Optional<string> ParseEditorConfigEndOfLine(string endOfLineValue)
-            => s_parenthesesPreferenceMap.TryGetValue(endOfLineValue, out var parsedOption) ? parsedOption : NewLine.DefaultValue;
+            => s_parenthesesPreferenceMap.TryGetValue(endOfLineValue.Trim(), out var parsedOption) ? parsedOption : NewLine.DefaultValue;
 
         private static string GetEndOfLineEditorConfigString(string option)
             => s_parenthesesPreferenceMap.TryGetKey(option, out var editorConfigString) ? editorConfigString : null;

--- a/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
+++ b/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
@@ -29,7 +29,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
         [InlineData("false", false, ReportDiagnostic.Hidden)]
         [InlineData("*", false, ReportDiagnostic.Hidden)]
         [InlineData("false:false", false, ReportDiagnostic.Hidden)]
-        static void TestParseEditorConfigCodeStyleOption(string args, bool isEnabled, ReportDiagnostic severity)
+
+        [WorkItem(27685, "https://github.com/dotnet/roslyn/issues/27685")]
+        [InlineData("true : warning", true, ReportDiagnostic.Warn)]
+        [InlineData("false : warning", false, ReportDiagnostic.Warn)]
+        [InlineData("true : error", true, ReportDiagnostic.Error)]
+        [InlineData("false : error", false, ReportDiagnostic.Error)]
+        public void TestParseEditorConfigCodeStyleOption(string args, bool isEnabled, ReportDiagnostic severity)
         {
             var notificationOption = NotificationOption.Silent;
             switch (severity)
@@ -55,6 +61,50 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
                         $"Expected {nameof(isEnabled)} to be {isEnabled}, was {result.Value}");
             Assert.True(result.Notification.Severity == severity,
                         $"Expected {nameof(severity)} to be {severity}, was {result.Notification.Severity}");
+        }
+
+        [Theory]
+        [InlineData("never:none", (int)AccessibilityModifiersRequired.Never, ReportDiagnostic.Suppress)]
+        [InlineData("always:suggestion", (int)AccessibilityModifiersRequired.Always, ReportDiagnostic.Info)]
+        [InlineData("for_non_interface_members:warning", (int)AccessibilityModifiersRequired.ForNonInterfaceMembers, ReportDiagnostic.Warn)]
+        [InlineData("omit_if_default:error", (int)AccessibilityModifiersRequired.OmitIfDefault, ReportDiagnostic.Error)]
+
+        [WorkItem(27685, "https://github.com/dotnet/roslyn/issues/27685")]
+        [InlineData("never : none", (int)AccessibilityModifiersRequired.Never, ReportDiagnostic.Suppress)]
+        [InlineData("always : suggestion", (int)AccessibilityModifiersRequired.Always, ReportDiagnostic.Info)]
+        [InlineData("for_non_interface_members : warning", (int)AccessibilityModifiersRequired.ForNonInterfaceMembers, ReportDiagnostic.Warn)]
+        [InlineData("omit_if_default : error", (int)AccessibilityModifiersRequired.OmitIfDefault, ReportDiagnostic.Error)]
+        public void TestParseEditorConfigAccessibilityModifiers(string args, int value, ReportDiagnostic severity)
+        {
+            var storageLocation = CodeStyleOptions.RequireAccessibilityModifiers.StorageLocations
+                .OfType<EditorConfigStorageLocation<CodeStyleOption<AccessibilityModifiersRequired>>>()
+                .Single();
+            var allRawConventions = new Dictionary<string, object> { { storageLocation.KeyName, args } };
+
+            Assert.True(storageLocation.TryGetOption(null, allRawConventions, typeof(CodeStyleOption<AccessibilityModifiersRequired>), out var parsedCodeStyleOption));
+            var codeStyleOption = (CodeStyleOption<AccessibilityModifiersRequired>)parsedCodeStyleOption;
+            Assert.Equal((AccessibilityModifiersRequired)value, codeStyleOption.Value);
+            Assert.Equal(severity, codeStyleOption.Notification.Severity);
+        }
+
+        [Theory]
+        [InlineData("lf", "\n")]
+        [InlineData("cr", "\r")]
+        [InlineData("crlf", "\r\n")]
+
+        [WorkItem(27685, "https://github.com/dotnet/roslyn/issues/27685")]
+        [InlineData(" lf ", "\n")]
+        [InlineData(" cr ", "\r")]
+        [InlineData(" crlf ", "\r\n")]
+        public void TestParseEditorConfigEndOfLine(string configurationString, string newLine)
+        {
+            var storageLocation = FormattingOptions.NewLine.StorageLocations
+                .OfType<EditorConfigStorageLocation<string>>()
+                .Single();
+            var allRawConventions = new Dictionary<string, object> { { storageLocation.KeyName, configurationString } };
+
+            Assert.True(storageLocation.TryGetOption(null, allRawConventions, typeof(string), out var parsedNewLine));
+            Assert.Equal(newLine, (string)parsedNewLine);
         }
     }
 }


### PR DESCRIPTION
Fixes #27685

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
