### PR TITLE
Rename KeyValuePair

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9294,16 +9294,16 @@ class C {
 
             parsedArgs = DefaultParse(new[] { "/pathmap:K1=V1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePair.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePairUtil.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:C:\\goo\\=/", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePair.Create("C:\\goo\\", "/"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePairUtil.Create("C:\\goo\\", "/"), parsedArgs.PathMap[0]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:K1=V1,K2=V2", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePair.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
-            Assert.Equal(KeyValuePair.Create("K2\\", "V2\\"), parsedArgs.PathMap[1]);
+            Assert.Equal(KeyValuePairUtil.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePairUtil.Create("K2\\", "V2\\"), parsedArgs.PathMap[1]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:,,,", "a.cs" }, _baseDirectory);
             Assert.Equal(4, parsedArgs.Errors.Count());
@@ -9323,17 +9323,17 @@ class C {
 
             parsedArgs = DefaultParse(new[] { "/pathmap:\"supporting spaces=is hard\"", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePair.Create("supporting spaces\\", "is hard\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePairUtil.Create("supporting spaces\\", "is hard\\"), parsedArgs.PathMap[0]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:\"K 1=V 1\",\"K 2=V 2\"", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePair.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
-            Assert.Equal(KeyValuePair.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
+            Assert.Equal(KeyValuePairUtil.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePairUtil.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:\"K 1\"=\"V 1\",\"K 2\"=\"V 2\"", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePair.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
-            Assert.Equal(KeyValuePair.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
+            Assert.Equal(KeyValuePairUtil.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePairUtil.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
         }
 
         [Fact]
@@ -9805,7 +9805,7 @@ class C
                 cscCopy,
                 arguments + " /deterministic",
                 workingDirectory: dir.Path,
-                additionalEnvironmentVars: new[] { KeyValuePair.Create("MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH", cscDir) });
+                additionalEnvironmentVars: new[] { KeyValuePairUtil.Create("MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH", cscDir) });
 
             Assert.Equal("", result.Output.Trim());
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
@@ -1011,7 +1011,7 @@ A: goto B;";
 @"#load ""a.csx""
 goto B;
 B: goto A;";
-            var resolver = TestSourceReferenceResolver.Create(KeyValuePair.Create("a.csx", sourceA));
+            var resolver = TestSourceReferenceResolver.Create(KeyValuePairUtil.Create("a.csx", sourceA));
             var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
             var compilation = CreateCompilationWithMscorlib45(sourceB, options: options, parseOptions: TestOptions.Script);
             compilation.GetDiagnostics().Verify(

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -132,7 +132,7 @@ public class C : NotFound
 }";
             // TODO: Compilation create doesn't accept analyzers anymore.
             var options = TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(
-                new[] { Roslyn.Utilities.KeyValuePair.Create("CA9999_UseOfVariableThatStartsWithX", ReportDiagnostic.Suppress) });
+                new[] { KeyValuePairUtil.Create("CA9999_UseOfVariableThatStartsWithX", ReportDiagnostic.Suppress) });
 
             CreateCompilationWithMscorlib45(source, options: options/*, analyzers: new IDiagnosticAnalyzerFactory[] { new ComplainAboutX() }*/).VerifyDiagnostics(
                 // (2,18): error CS0246: The type or namespace name 'NotFound' could not be found (are you missing a using directive or an assembly reference?)
@@ -155,7 +155,7 @@ public class C : NotFound
 }";
             // TODO: Compilation create doesn't accept analyzers anymore.
             var options = TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(
-                new[] { Roslyn.Utilities.KeyValuePair.Create("CA9999_UseOfVariableThatStartsWithX", ReportDiagnostic.Error) });
+                new[] { KeyValuePairUtil.Create("CA9999_UseOfVariableThatStartsWithX", ReportDiagnostic.Error) });
 
             CreateCompilationWithMscorlib45(source, options: options).VerifyDiagnostics(
                 // (2,18): error CS0246: The type or namespace name 'NotFound' could not be found (are you missing a using directive or an assembly reference?)

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -23,7 +23,7 @@ using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using VB = Microsoft.CodeAnalysis.VisualBasic;
-using KeyValuePair = Roslyn.Utilities.KeyValuePair;
+using KeyValuePairUtil = Roslyn.Utilities.KeyValuePairUtil;
 using System.Security.Cryptography;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -2545,7 +2545,7 @@ System.Func<object> f = delegate ()
         public void LoadedFileWithWrongReturnType()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", "return \"Who returns a string?\";"));
+                KeyValuePairUtil.Create("a.csx", "return \"Who returns a string?\";"));
             var script = CreateSubmission(@"
 #load ""a.csx""
 42", returnType: typeof(int), options: TestOptions.DebugDll.WithSourceReferenceResolver(resolver));

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             {
                 var code = "#load \"a.csx\"";
                 var resolver = TestSourceReferenceResolver.Create(
-                    KeyValuePair.Create("a.csx", @"
+                    KeyValuePairUtil.Create("a.csx", @"
                     #load ""b.csx""
                     asdf();"));
                 var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
@@ -69,8 +69,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var code = "#load \"b.csx\"";
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create<string, object>("a.csx", new byte[] { 0xd8, 0x00, 0x00, 0x00 }),
-                KeyValuePair.Create<string, object>("b.csx", "#load \"a.csx\""));
+                KeyValuePairUtil.Create<string, object>("a.csx", new byte[] { 0xd8, 0x00, 0x00, 0x00 }),
+                KeyValuePairUtil.Create<string, object>("b.csx", "#load \"a.csx\""));
             var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
             var compilation = CreateCompilationWithMscorlib45(code, sourceFileName: "external1.csx", options: options, parseOptions: TestOptions.Script);
             var external1 = compilation.SyntaxTrees.Last();
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void Cycles()
         {
             var code = "#load \"a.csx\"";
-            var resolver = TestSourceReferenceResolver.Create(KeyValuePair.Create("a.csx", code));
+            var resolver = TestSourceReferenceResolver.Create(KeyValuePairUtil.Create("a.csx", code));
             var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
             var compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Script);
 
@@ -167,8 +167,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             compilation.VerifyDiagnostics();
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", "#load \"b.csx\""),
-                KeyValuePair.Create("b.csx", code));
+                KeyValuePairUtil.Create("a.csx", "#load \"b.csx\""),
+                KeyValuePairUtil.Create("b.csx", code));
             options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
             compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Script);
 

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
@@ -11,7 +11,7 @@ using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers;
-using KeyValuePair = Roslyn.Utilities.KeyValuePair;
+using KeyValuePairUtil = Roslyn.Utilities.KeyValuePairUtil;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 {
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         {
             var c = CSharpCompilation.Create("c", options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).
                 WithSpecificDiagnosticOptions(
-                    new[] { KeyValuePair.Create($"CS{(int)ErrorCode.WRN_AlwaysNull:D4}", ReportDiagnostic.Suppress) }));
+                    new[] { KeyValuePairUtil.Create($"CS{(int)ErrorCode.WRN_AlwaysNull:D4}", ReportDiagnostic.Suppress) }));
 
             var d1 = SimpleDiagnostic.Create(MessageProvider.Instance, (int)ErrorCode.WRN_AlignmentMagnitude);
             var d2 = SimpleDiagnostic.Create(MessageProvider.Instance, (int)ErrorCode.WRN_AlwaysNull);

--- a/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 new SourceFileResolver(
                     ImmutableArray.Create(""),
                     isABaseDirectory,
-                    ImmutableArray.Create(KeyValuePair.Create<string, string>("key", null)));
+                    ImmutableArray.Create(KeyValuePairUtil.Create<string, string>("key", null)));
                 AssertEx.Fail("Didn't throw");
             }
             catch (ArgumentException argException)
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             new SourceFileResolver(
                 ImmutableArray.Create(""),
                 isABaseDirectory,
-                ImmutableArray.Create(KeyValuePair.Create<string, string>("key", "")));
+                ImmutableArray.Create(KeyValuePairUtil.Create<string, string>("key", "")));
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 new SourceFileResolver(
                     ImmutableArray.Create(""),
                     "not_a_root directory",
-                    ImmutableArray.Create(KeyValuePair.Create<string, string>("key", "value")));
+                    ImmutableArray.Create(KeyValuePairUtil.Create<string, string>("key", "value")));
                 AssertEx.Fail("Didn't throw");
             }
             catch (ArgumentException argExeption)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -903,7 +903,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            var tuples = nodeActionsByKind.Select(kvp => KeyValuePair.Create(kvp.Key, kvp.Value.ToImmutableAndFree()));
+            var tuples = nodeActionsByKind.Select(kvp => KeyValuePairUtil.Create(kvp.Key, kvp.Value.ToImmutableAndFree()));
             var map = ImmutableDictionary.CreateRange(tuples);
             nodeActionsByKind.Free();
             return map;
@@ -1045,7 +1045,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            var tuples = operationActionsByKind.Select(kvp => KeyValuePair.Create(kvp.Key, kvp.Value.ToImmutableAndFree()));
+            var tuples = operationActionsByKind.Select(kvp => KeyValuePairUtil.Create(kvp.Key, kvp.Value.ToImmutableAndFree()));
             var map = ImmutableDictionary.CreateRange(tuples);
             operationActionsByKind.Free();
             return map;

--- a/src/Compilers/Core/Portable/DocumentationComments/DocumentationCommentIncludeCache.cs
+++ b/src/Compilers/Core/Portable/DocumentationComments/DocumentationCommentIncludeCache.cs
@@ -57,7 +57,7 @@ So we suppress this error until the reporting for CA3053 has been updated to acc
                 using (XmlReader reader = XmlReader.Create(stream, s_xmlSettings))
                 {
                     var document = XDocument.Load(reader, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
-                    return KeyValuePair.Create(resolvedPath, document);
+                    return KeyValuePairUtil.Create(resolvedPath, document);
                 }
             }
         }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.Emit
             for (int i = 0; i < lambdaDebugInfo.Length; i++)
             {
                 var lambdaInfo = lambdaDebugInfo[i];
-                lambdas[lambdaInfo.SyntaxOffset] = KeyValuePair.Create(lambdaInfo.LambdaId, lambdaInfo.ClosureOrdinal);
+                lambdas[lambdaInfo.SyntaxOffset] = KeyValuePairUtil.Create(lambdaInfo.LambdaId, lambdaInfo.ClosureOrdinal);
             }
 
             for (int i = 0; i < closureDebugInfo.Length; i++)

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -510,7 +510,7 @@ namespace Microsoft.CodeAnalysis.Emit
                     foreach (var paramDef in this.GetParametersToEmit(methodDef))
                     {
                         _parameterDefs.Add(paramDef);
-                        _parameterDefList.Add(KeyValuePair.Create(methodDef, paramDef));
+                        _parameterDefList.Add(KeyValuePairUtil.Create(methodDef, paramDef));
                     }
 
                     if (methodDef.GenericParameterCount > 0)

--- a/src/Compilers/Core/Portable/InternalUtilities/KeyValuePairUtil.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/KeyValuePairUtil.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Roslyn.Utilities
 {
-    internal static class KeyValuePair
+    internal static class KeyValuePairUtil
     {
         public static KeyValuePair<K, V> Create<K, V>(K key, V value)
         {

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis
                 bool argumentRefersToNoPia;
                 SignatureTypeCode typeCode;
                 ImmutableArray<ModifierInfo<TypeSymbol>> modifiers = DecodeModifiersOrThrow(ref ppSig, AllowedRequiredModifierType.None, out typeCode, out _);
-                argumentsBuilder.Add(KeyValuePair.Create(DecodeTypeOrThrow(ref ppSig, typeCode, out argumentRefersToNoPia), modifiers));
+                argumentsBuilder.Add(KeyValuePairUtil.Create(DecodeTypeOrThrow(ref ppSig, typeCode, out argumentRefersToNoPia), modifiers));
                 argumentRefersToNoPiaLocalTypeBuilder.Add(argumentRefersToNoPia);
             }
 

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
@@ -851,7 +851,7 @@ namespace Microsoft.CodeAnalysis
                         {
                             Debug.Assert(keyIndex < i);
                             var primaryPair = nestedNamespaces[keyIndex];
-                            nestedNamespaces[keyIndex] = KeyValuePair.Create(primaryPair.Key, primaryPair.Value.Concat(pair.Value));
+                            nestedNamespaces[keyIndex] = KeyValuePairUtil.Create(primaryPair.Key, primaryPair.Value.Concat(pair.Value));
                             nestedNamespaces[i] = default(KeyValuePair<string, IEnumerable<IGrouping<string, TypeDefinitionHandle>>>);
                         }
                     }

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityMap.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityMap.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
 
         public void Add(AssemblyIdentity identity, TValue value)
         {
-            var pair = KeyValuePair.Create(identity, value);
+            var pair = KeyValuePairUtil.Create(identity, value);
 
             OneOrMany<KeyValuePair<AssemblyIdentity, TValue>> sameName;
             _map[identity.Name] = _map.TryGetValue(identity.Name, out sameName) ? sameName.Add(pair) : OneOrMany.Create(pair);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1175,7 +1175,7 @@ namespace Microsoft.Cci
 
             signatureBlob = builder.ToImmutableArray();
             result = metadata.GetOrAddBlob(signatureBlob);
-            _signatureIndex.Add(methodReference, KeyValuePair.Create(result, signatureBlob));
+            _signatureIndex.Add(methodReference, KeyValuePairUtil.Create(result, signatureBlob));
             builder.Free();
             return result;
         }
@@ -1304,7 +1304,7 @@ namespace Microsoft.Cci
             var blob = builder.ToImmutableArray();
             var result = metadata.GetOrAddBlob(blob);
 
-            _signatureIndex.Add(propertyDef, KeyValuePair.Create(result, blob));
+            _signatureIndex.Add(propertyDef, KeyValuePairUtil.Create(result, blob));
             builder.Free();
             return result;
         }

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
@@ -632,7 +632,7 @@ namespace Microsoft.CodeAnalysis
 
         internal sealed override IEnumerable<KeyValuePair<MetadataReference, IAssemblySymbol>> GetReferencedAssemblies()
         {
-            return ReferencedAssembliesMap.Select(ra => KeyValuePair.Create(ra.Key, (IAssemblySymbol)ReferencedAssemblies[ra.Value]));
+            return ReferencedAssembliesMap.Select(ra => KeyValuePairUtil.Create(ra.Key, (IAssemblySymbol)ReferencedAssemblies[ra.Value]));
         }
 
         internal TAssemblySymbol GetReferencedAssemblySymbol(MetadataReference reference)
@@ -681,7 +681,7 @@ namespace Microsoft.CodeAnalysis
         {
             foreach (PortableExecutableReference reference in ImplicitReferences)
             {
-                yield return KeyValuePair.Create(ReferencedAssemblies[ReferencedAssembliesMap[reference]].Identity, reference);
+                yield return KeyValuePairUtil.Create(ReferencedAssemblies[ReferencedAssembliesMap[reference]].Identity, reference);
             }
         }
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -1872,7 +1872,7 @@ ProduceBoundNode:
                                                          callerInfoOpt:=callerInfoOpt,
                                                          representCandidateInDiagnosticsOpt:=Nothing)
 
-                diagnosticPerSymbol.Add(KeyValuePair.Create(candidates(i).Candidate.UnderlyingSymbol, candidateDiagnostics.ToReadOnlyAndFree()))
+                diagnosticPerSymbol.Add(KeyValuePairUtil.Create(candidates(i).Candidate.UnderlyingSymbol, candidateDiagnostics.ToReadOnlyAndFree()))
 
             Next
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -980,7 +980,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             If useOfLocalBeforeDeclaration AndAlso Not type.IsErrorType() Then
                                 conversion = New Conversion(Conversions.ClassifyConversion(type, convertedType, Nothing))
                             Else
-                                conversion = New Conversion(KeyValuePair.Create(conversionNode.ConversionKind,
+                                conversion = New Conversion(KeyValuePairUtil.Create(conversionNode.ConversionKind,
                                                                                 TryCast(conversionNode.ExpressionSymbol, MethodSymbol)))
                             End If
                         End If

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
@@ -518,9 +518,9 @@ Namespace Microsoft.CodeAnalysis.Operations
                 If conversionKind.HasFlag(VisualBasic.ConversionKind.UserDefined) AndAlso conversion.Operand.Kind = BoundKind.UserDefinedConversion Then
                     method = DirectCast(conversion.Operand, BoundUserDefinedConversion).Call.Method
                 End If
-                Return New Conversion(KeyValuePair.Create(conversionKind, method))
+                Return New Conversion(KeyValuePairUtil.Create(conversionKind, method))
             ElseIf expression.Kind = BoundKind.TryCast OrElse expression.Kind = BoundKind.DirectCast Then
-                Return New Conversion(KeyValuePair.Create(Of ConversionKind, MethodSymbol)(DirectCast(expression, BoundConversionOrCast).ConversionKind, Nothing))
+                Return New Conversion(KeyValuePairUtil.Create(Of ConversionKind, MethodSymbol)(DirectCast(expression, BoundConversionOrCast).ConversionKind, Nothing))
             End If
             Return New Conversion(Conversions.Identity)
         End Function

--- a/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared ReadOnly Property DefaultPreprocessorSymbols As ImmutableArray(Of KeyValuePair(Of String, Object))
             Get
                 If s_defaultPreprocessorSymbols.IsDefaultOrEmpty Then
-                    s_defaultPreprocessorSymbols = ImmutableArray.Create(KeyValuePair.Create("_MYTYPE", CObj("Empty")))
+                    s_defaultPreprocessorSymbols = ImmutableArray.Create(KeyValuePairUtil.Create("_MYTYPE", CObj("Empty")))
                 End If
 
                 Return s_defaultPreprocessorSymbols

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -3104,16 +3104,16 @@ print Goodbye, World"
 
             parsedArgs = DefaultParse({"/pathmap:K1=V1", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePair.Create("K1\", "V1\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePairUtil.Create("K1\", "V1\"), parsedArgs.PathMap(0))
 
             parsedArgs = DefaultParse({"/pathmap:C:\goo\=/", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePair.Create("C:\goo\", "/"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePairUtil.Create("C:\goo\", "/"), parsedArgs.PathMap(0))
 
             parsedArgs = DefaultParse({"/pathmap:K1=V1,K2=V2", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePair.Create("K1\", "V1\"), parsedArgs.PathMap(0))
-            Assert.Equal(KeyValuePair.Create("K2\", "V2\"), parsedArgs.PathMap(1))
+            Assert.Equal(KeyValuePairUtil.Create("K1\", "V1\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePairUtil.Create("K2\", "V2\"), parsedArgs.PathMap(1))
 
             parsedArgs = DefaultParse({"/pathmap:,,,", "a.vb"}, _baseDirectory)
             Assert.Equal(4, parsedArgs.Errors.Count())
@@ -3133,17 +3133,17 @@ print Goodbye, World"
 
             parsedArgs = DefaultParse({"/pathmap:""supporting spaces=is hard""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePair.Create("supporting spaces\", "is hard\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePairUtil.Create("supporting spaces\", "is hard\"), parsedArgs.PathMap(0))
 
             parsedArgs = DefaultParse({"/pathmap:""K 1=V 1"",""K 2=V 2""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePair.Create("K 1\", "V 1\"), parsedArgs.PathMap(0))
-            Assert.Equal(KeyValuePair.Create("K 2\", "V 2\"), parsedArgs.PathMap(1))
+            Assert.Equal(KeyValuePairUtil.Create("K 1\", "V 1\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePairUtil.Create("K 2\", "V 2\"), parsedArgs.PathMap(1))
 
             parsedArgs = DefaultParse({"/pathmap:""K 1""=""V 1"",""K 2""=""V 2""", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(KeyValuePair.Create("K 1\", "V 1\"), parsedArgs.PathMap(0))
-            Assert.Equal(KeyValuePair.Create("K 2\", "V 2\"), parsedArgs.PathMap(1))
+            Assert.Equal(KeyValuePairUtil.Create("K 1\", "V 1\"), parsedArgs.PathMap(0))
+            Assert.Equal(KeyValuePairUtil.Create("K 2\", "V 2\"), parsedArgs.PathMap(1))
         End Sub
 
         ' PathMapKeepsCrossPlatformRoot and PathMapInconsistentSlashes should be in an

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -189,7 +189,7 @@ End Class
 </compilation>
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
 
@@ -3980,7 +3980,7 @@ End Class
 </compilation>
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
 
@@ -4293,11 +4293,11 @@ End Class
 </compilation>
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(
                 OutputKind.WindowsApplication,
-                KeyValuePair.Create(Of String, Object)("_MyType", "WindowsForms"),
-                KeyValuePair.Create(Of String, Object)("Config", "Debug"),
-                KeyValuePair.Create(Of String, Object)("DEBUG", -1),
-                KeyValuePair.Create(Of String, Object)("TRACE", -1),
-                KeyValuePair.Create(Of String, Object)("PLATFORM", "AnyCPU"))
+                KeyValuePairUtil.Create(Of String, Object)("_MyType", "WindowsForms"),
+                KeyValuePairUtil.Create(Of String, Object)("Config", "Debug"),
+                KeyValuePairUtil.Create(Of String, Object)("DEBUG", -1),
+                KeyValuePairUtil.Create(Of String, Object)("TRACE", -1),
+                KeyValuePairUtil.Create(Of String, Object)("PLATFORM", "AnyCPU"))
 
             Dim parseOptions As VisualBasicParseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compOptions As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/MyTemplateTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/MyTemplateTests.vb
@@ -128,7 +128,7 @@ End Module
 
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithParseOptions(parseOptions)
@@ -206,7 +206,7 @@ End Class
 
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.WindowsApplication)
-            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("WindowsForms")))
+            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("WindowsForms")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithOutputKind(OutputKind.WindowsApplication).WithParseOptions(parseOptions).WithMainTypeName("Form1")
@@ -237,7 +237,7 @@ End Module
 
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithParseOptions(parseOptions)
@@ -295,7 +295,7 @@ End Namespace
 
 
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
 
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithParseOptions(parseOptions)

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/CompilationEventTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/CompilationEventTests.vb
@@ -136,7 +136,7 @@ End Module
     </compilation>
             Dim q = New AsyncQueue(Of CompilationEvent)()
             Dim defines = PredefinedPreprocessorSymbols.AddPredefinedPreprocessorSymbols(OutputKind.ConsoleApplication)
-            defines = defines.Add(KeyValuePair.Create("_MyType", CObj("Console")))
+            defines = defines.Add(KeyValuePairUtil.Create("_MyType", CObj("Console")))
             Dim parseOptions = New VisualBasicParseOptions(preprocessorSymbols:=defines)
             Dim compilationOptions = TestOptions.ReleaseExe.WithParseOptions(parseOptions)
             Dim compilation = CreateCompilationWithMscorlib40AndVBRuntime(source, options:=compilationOptions).WithEventQueue(q)

--- a/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/RegionAnalysisTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/RegionAnalysisTests.vb
@@ -923,7 +923,7 @@ End Namespace
             Dim comp = CompileAndGetModelAndSpan(program, startNodes, endNodes, Nothing, Nothing,
                                                  parseOptions:=
                                                     VisualBasicParseOptions.Default.WithPreprocessorSymbols(
-                                                        KeyValuePair.Create("SQLITE_DEBUG", CObj(True))))
+                                                        KeyValuePairUtil.Create("SQLITE_DEBUG", CObj(True))))
 
             Assert.Equal(4, startNodes.Count)
             Assert.Equal(SyntaxKind.DictionaryAccessExpression, startNodes(2).Kind)

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDirectives.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDirectives.vb
@@ -1574,7 +1574,7 @@ BC30059: Constant expression is required.
     <Fact>
     Public Sub ParseProjConstsCaseInsensitivity()
 
-        Dim psymbols = ImmutableArray.Create({Roslyn.Utilities.KeyValuePair.Create("Blah", CObj(False)), Roslyn.Utilities.KeyValuePair.Create("blah", CObj(True))})
+        Dim psymbols = ImmutableArray.Create({Roslyn.Utilities.KeyValuePairUtil.Create("Blah", CObj(False)), Roslyn.Utilities.KeyValuePairUtil.Create("blah", CObj(True))})
 
         Dim options As VisualBasicParseOptions = VisualBasicParseOptions.Default.WithPreprocessorSymbols(psymbols)
 

--- a/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
@@ -404,7 +404,7 @@ class Program
                 CompilationName,
                 new[] { tree },
                 References,
-                TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(new[] { KeyValuePair.Create("CS0219", ReportDiagnostic.Suppress) }));
+                TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(new[] { KeyValuePairUtil.Create("CS0219", ReportDiagnostic.Suppress) }));
         }
 
         protected override bool CompilationSucceeded(Compilation compilation, Stream temporaryStream)

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             if (scope == FixAllScope.Custom)
             {
                 // Bulk fixing diagnostics in selected scope.                    
-                var diagnosticsToFix = ImmutableDictionary.CreateRange(SpecializedCollections.SingletonEnumerable(KeyValuePair.Create(document, diagnostics.ToImmutableArray())));
+                var diagnosticsToFix = ImmutableDictionary.CreateRange(SpecializedCollections.SingletonEnumerable(KeyValuePairUtil.Create(document, diagnostics.ToImmutableArray())));
                 return FixAllState.Create(fixAllProvider, diagnosticsToFix, fixer, equivalenceKey);
             }
 

--- a/src/EditorFeatures/TestUtilities/Diagnostics/TestDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/TestDiagnosticAnalyzerService.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private static HostAnalyzerManager CreateHostAnalyzerManager(string language, ImmutableArray<DiagnosticAnalyzer> analyzers, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource)
         {
             var map = ImmutableDictionary.CreateRange(
-                SpecializedCollections.SingletonEnumerable(KeyValuePair.Create(language, analyzers)));
+                SpecializedCollections.SingletonEnumerable(KeyValuePairUtil.Create(language, analyzers)));
             return CreateHostAnalyzerManager(map, hostDiagnosticUpdateSource);
         }
 

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/DeclaratorMapDescription.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/DeclaratorMapDescription.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             {
                 for (int j = 0; j < OldSpans[i].Length; j++)
                 {
-                    yield return KeyValuePair.Create(OldSpans[i][j], NewSpans[i][j]);
+                    yield return KeyValuePairUtil.Create(OldSpans[i][j], NewSpans[i][j]);
                 }
             }
         }

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         {
             foreach (var pair in mapping)
             {
-                yield return KeyValuePair.Create(pair.Value, pair.Key);
+                yield return KeyValuePairUtil.Create(pair.Value, pair.Key);
             }
         }
     }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             else if (language == LanguageNames.VisualBasic)
             {
                 return new VisualBasicParseOptions(preprocessorSymbols: preprocessorSymbolsAttribute.Value
-                    .Split(',').Select(v => KeyValuePair.Create(v.Split('=').ElementAt(0), (object)v.Split('=').ElementAt(1))).ToImmutableArray());
+                    .Split(',').Select(v => KeyValuePairUtil.Create(v.Split('=').ElementAt(0), (object)v.Split('=').ElementAt(1))).ToImmutableArray());
             }
             else
             {

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
                                                source.IndexOf(s_endSpanMark, start, length, StringComparison.Ordinal))
                 End If
 
-                Yield KeyValuePair.Create(position, span)
+                Yield KeyValuePairUtil.Create(position, span)
                 i = [end] + 1
             End While
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Semantics/SpeculationAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Semantics/SpeculationAnalyzerTests.vb
@@ -39,7 +39,7 @@ End Module
                 CompilationName,
                 {DirectCast(tree, VisualBasicSyntaxTree)},
                 References,
-                TestOptions.ReleaseDll.WithSpecificDiagnosticOptions({KeyValuePair.Create("BC0219", ReportDiagnostic.Suppress)}))
+                TestOptions.ReleaseDll.WithSpecificDiagnosticOptions({KeyValuePairUtil.Create("BC0219", ReportDiagnostic.Suppress)}))
         End Function
 
         Protected Overrides Function CompilationSucceeded(compilation As Compilation, temporaryStream As Stream) As Boolean

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             var importStringGroups = CustomDebugInfoReader.GetCSharpGroupedImportStrings(
                 methodToken,
-                KeyValuePair.Create(reader, methodVersion),
+                KeyValuePairUtil.Create(reader, methodVersion),
                 getMethodCustomDebugInfo: (token, arg) => GetCustomDebugInfoBytes(arg.Key, token, arg.Value),
                 getMethodImportStrings: (token, arg) => GetImportStrings(arg.Key, token, arg.Value),
                 externAliasStrings: out externAliasStrings);
@@ -532,7 +532,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             var importStrings = CustomDebugInfoReader.GetVisualBasicImportStrings(
                 methodToken,  
-                KeyValuePair.Create(reader, methodVersion),
+                KeyValuePairUtil.Create(reader, methodVersion),
                 (token, arg) => GetImportStrings(arg.Key, token, arg.Value));
 
             if (importStrings.IsDefault)

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -685,11 +685,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                     if (parent.IsKind(SyntaxKind.Block))
                     {
-                        yield return KeyValuePair.Create(parent, (int)(direction > 0 ? BlockPart.CloseBrace : BlockPart.OpenBrace));
+                        yield return KeyValuePairUtil.Create(parent, (int)(direction > 0 ? BlockPart.CloseBrace : BlockPart.OpenBrace));
                     }
                     else if (parent.IsKind(SyntaxKind.ForEachStatement))
                     {
-                        yield return KeyValuePair.Create(parent, (int)ForEachPart.ForEach);
+                        yield return KeyValuePairUtil.Create(parent, (int)ForEachPart.ForEach);
                     }
 
                     if (direction > 0)
@@ -705,14 +705,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         // We don't have any better place where to place the span than the initial field.
                         // Consider: in non-partial classes we could find a single constructor. 
                         // Otherwise, it would be confusing to select one arbitrarily.
-                        yield return KeyValuePair.Create(statement, -1);
+                        yield return KeyValuePairUtil.Create(statement, -1);
                     }
 
                     nodeOrToken = statement = parent;
                     fieldOrPropertyModifiers = SyntaxUtilities.TryGetFieldOrPropertyModifiers(statement);
                     direction = +1;
 
-                    yield return KeyValuePair.Create(nodeOrToken.AsNode(), 0);
+                    yield return KeyValuePairUtil.Create(nodeOrToken.AsNode(), 0);
                 }
                 else
                 {
@@ -735,14 +735,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                     if (node.IsKind(SyntaxKind.Block))
                     {
-                        yield return KeyValuePair.Create(node, (int)(direction > 0 ? BlockPart.OpenBrace : BlockPart.CloseBrace));
+                        yield return KeyValuePairUtil.Create(node, (int)(direction > 0 ? BlockPart.OpenBrace : BlockPart.CloseBrace));
                     }
                     else if (node.IsKind(SyntaxKind.ForEachStatement))
                     {
-                        yield return KeyValuePair.Create(node, (int)ForEachPart.ForEach);
+                        yield return KeyValuePairUtil.Create(node, (int)ForEachPart.ForEach);
                     }
 
-                    yield return KeyValuePair.Create(node, 0);
+                    yield return KeyValuePairUtil.Create(node, 0);
                 }
             }
         }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageFixAllCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageFixAllCodeAction.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 var builder = new List<KeyValuePair<ISymbol, ImmutableArray<Diagnostic>>>();
                 foreach (var kvp in diagnosticsMapBuilder)
                 {
-                    builder.Add(KeyValuePair.Create(kvp.Key, GetUniqueDiagnostics(kvp.Value)));
+                    builder.Add(KeyValuePairUtil.Create(kvp.Key, GetUniqueDiagnostics(kvp.Value)));
                 }
 
                 return builder.OrderBy(kvp => kvp.Key.GetDocumentationCommentId() ?? string.Empty);

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1397,7 +1397,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         lazyKnownMatches = new List<KeyValuePair<SyntaxNode, SyntaxNode>>();
                     }
 
-                    lazyKnownMatches.Add(KeyValuePair.Create(activeNode.OldNode, activeNode.NewTrackedNodeOpt));
+                    lazyKnownMatches.Add(KeyValuePairUtil.Create(activeNode.OldNode, activeNode.NewTrackedNodeOpt));
                 }
             }
         }
@@ -1421,7 +1421,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 for (int i = 0; i < oldStateMachineSuspensionPoints.Length; i++)
                 {
-                    lazyKnownMatches.Add(KeyValuePair.Create(oldStateMachineSuspensionPoints[i], newStateMachineSuspensionPoints[i]));
+                    lazyKnownMatches.Add(KeyValuePairUtil.Create(oldStateMachineSuspensionPoints[i], newStateMachineSuspensionPoints[i]));
                 }
             }
             else
@@ -1435,7 +1435,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     if (editKind == EditKind.Update)
                     {
-                        lazyKnownMatches.Add(KeyValuePair.Create(oldStateMachineSuspensionPoints[edit.OldIndex], newStateMachineSuspensionPoints[edit.NewIndex]));
+                        lazyKnownMatches.Add(KeyValuePairUtil.Create(oldStateMachineSuspensionPoints[edit.OldIndex], newStateMachineSuspensionPoints[edit.NewIndex]));
                     }
                     else
                     {

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -783,7 +783,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
 
                     If propertyOrFieldModifiers.HasValue Then
-                        Yield KeyValuePair.Create(statement, -1)
+                        Yield KeyValuePairUtil.Create(statement, -1)
                     End If
 
                     nodeOrToken = parent
@@ -806,7 +806,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
                 End If
 
-                Yield KeyValuePair.Create(node, 0)
+                Yield KeyValuePairUtil.Create(node, 0)
             End While
         End Function
 

--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -86,7 +86,7 @@ Environment.Exit(0)
             var dir = Temp.CreateDirectory();
             dir.CreateFile("C.dll").WriteAllBytes(TestResources.General.C1);
 
-            var result = ProcessUtilities.Run(CsiPath, "/r:C.dll a.csx", workingDirectory: cwd.Path, additionalEnvironmentVars: new[] { KeyValuePair.Create("LIB", dir.Path) });
+            var result = ProcessUtilities.Run(CsiPath, "/r:C.dll a.csx", workingDirectory: cwd.Path, additionalEnvironmentVars: new[] { KeyValuePairUtil.Create("LIB", dir.Path) });
 
             // error CS0006: Metadata file 'C.dll' could not be found
             Assert.True(result.Errors.StartsWith("error CS0006", StringComparison.Ordinal));

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using KeyValuePair = Roslyn.Utilities.KeyValuePair;
+using KeyValuePairUtil = Roslyn.Utilities.KeyValuePairUtil;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 {
@@ -620,7 +620,7 @@ if (true)
         public async Task ReturnInLoadedFile()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", "return 42;"));
+                KeyValuePairUtil.Create("a.csx", "return 42;"));
             var options = ScriptOptions.Default.WithSourceResolver(resolver);
 
             var script = CSharpScript.Create("#load \"a.csx\"", options);
@@ -638,7 +638,7 @@ if (true)
         public async Task ReturnInLoadedFileTrailingExpression()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", @"
+                KeyValuePairUtil.Create("a.csx", @"
 if (false)
 {
     return 42;
@@ -661,7 +661,7 @@ if (false)
         public void ReturnInLoadedFileTrailingVoidExpression()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", @"
+                KeyValuePairUtil.Create("a.csx", @"
 if (false)
 {
     return 1;
@@ -684,8 +684,8 @@ System.Console.WriteLine(42)"));
         public async Task MultipleLoadedFilesWithTrailingExpression()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", "1"),
-                KeyValuePair.Create("b.csx", @"
+                KeyValuePairUtil.Create("a.csx", "1"),
+                KeyValuePairUtil.Create("b.csx", @"
 #load ""a.csx""
 2"));
             var options = ScriptOptions.Default.WithSourceResolver(resolver);
@@ -694,8 +694,8 @@ System.Console.WriteLine(42)"));
             Assert.Null(result);
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", "1"),
-                KeyValuePair.Create("b.csx", "2"));
+                KeyValuePairUtil.Create("a.csx", "1"),
+                KeyValuePairUtil.Create("b.csx", "2"));
             options = ScriptOptions.Default.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
@@ -704,8 +704,8 @@ System.Console.WriteLine(42)"));
             Assert.Null(result);
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", "1"),
-                KeyValuePair.Create("b.csx", "2"));
+                KeyValuePairUtil.Create("a.csx", "1"),
+                KeyValuePairUtil.Create("b.csx", "2"));
             options = ScriptOptions.Default.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
@@ -719,8 +719,8 @@ System.Console.WriteLine(42)"));
         public async Task MultipleLoadedFilesWithReturnAndTrailingExpression()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", "return 1;"),
-                KeyValuePair.Create("b.csx", @"
+                KeyValuePairUtil.Create("a.csx", "return 1;"),
+                KeyValuePairUtil.Create("b.csx", @"
 #load ""a.csx""
 2"));
             var options = ScriptOptions.Default.WithSourceResolver(resolver);
@@ -729,8 +729,8 @@ System.Console.WriteLine(42)"));
             Assert.Equal(1, result);
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", "return 1;"),
-                KeyValuePair.Create("b.csx", "2"));
+                KeyValuePairUtil.Create("a.csx", "return 1;"),
+                KeyValuePairUtil.Create("b.csx", "2"));
             options = ScriptOptions.Default.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
@@ -739,8 +739,8 @@ System.Console.WriteLine(42)"));
             Assert.Equal(1, result);
 
             resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", "return 1;"),
-                KeyValuePair.Create("b.csx", "2"));
+                KeyValuePairUtil.Create("a.csx", "return 1;"),
+                KeyValuePairUtil.Create("b.csx", "2"));
             options = ScriptOptions.Default.WithSourceResolver(resolver);
             script = CSharpScript.Create(@"
 #load ""a.csx""
@@ -754,7 +754,7 @@ return 3;", options);
         public async Task LoadedFileWithReturnAndGoto()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", @"
+                KeyValuePairUtil.Create("a.csx", @"
 goto EOF;
 NEXT:
 return 1;
@@ -803,7 +803,7 @@ b");
         public async Task LoadedFileWithVoidReturn()
         {
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create("a.csx", @"
+                KeyValuePairUtil.Create("a.csx", @"
 var i = 42;
 return;
 i = -1;"));

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -470,7 +470,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
 
                     // If pActiveStatements is null the EnC Manager failed to retrieve the module corresponding 
                     // to the project in the debuggee. We won't include such projects in the edit session.
-                    s_breakStateEnteredProjects.Add(KeyValuePair.Create(_vsProject.Id, state));
+                    s_breakStateEnteredProjects.Add(KeyValuePairUtil.Create(_vsProject.Id, state));
                     s_breakStateProjectCount++;
 
                     // EnC service is global, but the debugger calls this for each project.

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectOptionsHelper.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectOptionsHelper.vb
@@ -172,7 +172,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
         Private Shared Function GetConditionalCompilationSymbols(kind As OutputKind, str As String) As ImmutableArray(Of KeyValuePair(Of String, Object))
             Debug.Assert(str IsNot Nothing)
-            Dim key = KeyValuePair.Create(str, kind)
+            Dim key = KeyValuePairUtil.Create(str, kind)
 
             Dim result As ImmutableArray(Of KeyValuePair(Of String, Object)) = Nothing
             If s_conditionalCompilationSymbolsCache.TryGetValue(key, result) Then

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                             if (document != null && !document.IsGeneratedCode(cancellationToken))
                             {
                                 var documentDiagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
-                                var kvp = SpecializedCollections.SingletonEnumerable(KeyValuePair.Create(document, documentDiagnostics));
+                                var kvp = SpecializedCollections.SingletonEnumerable(KeyValuePairUtil.Create(document, documentDiagnostics));
                                 return ImmutableDictionary.CreateRange(kvp);
                             }
 
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                         {
                             case FixAllScope.Project:
                                 var diagnostics = await fixAllContext.GetProjectDiagnosticsAsync(project).ConfigureAwait(false);
-                                var kvp = SpecializedCollections.SingletonEnumerable(KeyValuePair.Create(project, diagnostics));
+                                var kvp = SpecializedCollections.SingletonEnumerable(KeyValuePairUtil.Create(project, diagnostics));
                                 return ImmutableDictionary.CreateRange(kvp);
 
                             case FixAllScope.Solution:

--- a/src/Workspaces/Core/Portable/Execution/AbstractOptionsSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractOptionsSerializationService.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Execution
                     var key = reader.ReadString();
                     var value = (ReportDiagnostic)reader.ReadInt32();
 
-                    specificDiagnosticOptionsList.Add(KeyValuePair.Create(key, value));
+                    specificDiagnosticOptionsList.Add(KeyValuePairUtil.Create(key, value));
                 }
             }
 
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Execution
                     var key = reader.ReadString();
                     var value = reader.ReadString();
 
-                    featuresList.Add(KeyValuePair.Create(key, value));
+                    featuresList.Add(KeyValuePairUtil.Create(key, value));
                 }
             }
 

--- a/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
@@ -490,7 +490,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelWorkspaceService
                         var documentId = project.GetDocumentId(tree);
                         if (documentId != null)
                         {
-                            yield return KeyValuePair.Create(documentId, tree);
+                            yield return KeyValuePairUtil.Create(documentId, tree);
                         }
                     }
                 }

--- a/src/Workspaces/Core/Portable/Utilities/BidirectionalMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/BidirectionalMap.cs
@@ -17,7 +17,7 @@ namespace Roslyn.Utilities
         public BidirectionalMap(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
         {
             _forwardMap = ImmutableDictionary.CreateRange<TKey, TValue>(pairs);
-            _backwardMap = ImmutableDictionary.CreateRange<TValue, TKey>(pairs.Select(p => KeyValuePair.Create(p.Value, p.Key)));
+            _backwardMap = ImmutableDictionary.CreateRange<TValue, TKey>(pairs.Select(p => KeyValuePairUtil.Create(p.Value, p.Key)));
         }
 
         private BidirectionalMap(ImmutableDictionary<TKey, TValue> forwardMap, ImmutableDictionary<TValue, TKey> backwardMap)

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -99,8 +99,8 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ISetExtensions.cs">
       <Link>InternalUtilities\ISetExtensions.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\KeyValuePair.cs">
-      <Link>InternalUtilities\KeyValuePair.cs</Link>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\KeyValuePairUtil.cs">
+      <Link>InternalUtilities\KeyValuePairUtil.cs</Link>
     </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\MultiDictionary.cs">
       <Link>InternalUtilities\MultiDictionary.cs</Link>

--- a/src/Workspaces/CoreTest/Differencing/MatchTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/MatchTests.cs
@@ -20,13 +20,13 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
                 x2 = new TestNode(1, 2));
 
             var m = TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot,
-                new[] { KeyValuePair.Create(x1, x2), KeyValuePair.Create(x1, x2) });
+                new[] { KeyValuePairUtil.Create(x1, x2), KeyValuePairUtil.Create(x1, x2) });
             Assert.True(m.TryGetNewNode(x1, out var n));
             Assert.Equal(n, x2);
 
-            Assert.Throws<ArgumentException>(() => TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[] { KeyValuePair.Create(x1, x1) }));
+            Assert.Throws<ArgumentException>(() => TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[] { KeyValuePairUtil.Create(x1, x1) }));
 
-            Assert.Throws<ArgumentException>(() => TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[] { KeyValuePair.Create(x1, x2), KeyValuePair.Create(x1, new TestNode(0, 0)) }));
+            Assert.Throws<ArgumentException>(() => TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[] { KeyValuePairUtil.Create(x1, x2), KeyValuePairUtil.Create(x1, new TestNode(0, 0)) }));
         }
 
         [Fact]
@@ -44,8 +44,8 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             var m = TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[]
             {
-                KeyValuePair.Create(x1, x2),
-                KeyValuePair.Create(y1, x2),
+                KeyValuePairUtil.Create(x1, x2),
+                KeyValuePairUtil.Create(y1, x2),
             });
 
             // the first one wins:
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             var m = TestTreeComparer.Instance.ComputeMatch(oldRoot, newRoot, new[]
             {
-                KeyValuePair.Create(x1, newRoot),
+                KeyValuePairUtil.Create(x1, newRoot),
             });
 
             // the root wins:

--- a/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
@@ -118,7 +118,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Execution
             For i = 0 To count - 1
                 Dim key = reader.ReadString()
                 Dim value = reader.ReadValue()
-                builder.Add(KeyValuePair.Create(key, value))
+                builder.Add(KeyValuePairUtil.Create(key, value))
             Next
             Dim options = New VisualBasicParseOptions(languageVersion, documentationMode, kind, builder.MoveToImmutable())
             Return options.WithFeatures(features)


### PR DESCRIPTION
The target framework netcoreapp2.0 includes a new type: `KeyValuePair`.
This conflicts with our `KeyValuePair` utility class and causes a lot of
friction whenever netcoreapp2.0 is added as a target framework for a
project.

Renaming the type to `KeyValuePairUtil` to remove the ambiguity.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
