### PR TITLE
VenusCommandFilter/AbstractVsTextViewFilter uses incorrect buffer whe…servicing into 15.7

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Roslyn.Utilities;
@@ -48,17 +49,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         protected virtual int GetDataTipTextImpl(TextSpan[] pSpan, out string pbstrText)
         {
+            var subjectBuffer = WpfTextView.GetBufferContainingCaret();
+            if (subjectBuffer == null)
+            {
+                pbstrText = null;
+                return VSConstants.E_FAIL;
+            }
+
+            return GetDataTipTextImpl(subjectBuffer, pSpan, out pbstrText);
+        }
+ 
+        protected int GetDataTipTextImpl(ITextBuffer subjectBuffer, TextSpan[] pSpan, out string pbstrText)
+        {
             pbstrText = null;
 
             var debugInfo = LanguageService.LanguageDebugInfo;
             if (debugInfo != null)
             {
-                var subjectBuffer = WpfTextView.GetBufferContainingCaret();
-                if (subjectBuffer == null)
-                {
-                    return VSConstants.E_FAIL;
-                }
-
                 var vsBuffer = EditorAdaptersFactory.GetBufferAdapter(subjectBuffer);
 
                 // TODO: broken in REPL

--- a/src/VisualStudio/Core/Def/Implementation/Venus/VenusCommandFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/VenusCommandFilter.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 // Next, we'll check to see if there is actually a DataTip for this candidate.
                 // If there is, we'll map this span back to the DataBuffer and return it.
                 pSpan[0] = candidateSpan.ToVsTextSpan();
-                int hr = base.GetDataTipTextImpl(pSpan, out pbstrText);
+                int hr = base.GetDataTipTextImpl(_subjectBuffer, pSpan, out pbstrText);
                 if (ErrorHandler.Succeeded(hr))
                 {
                     var subjectSpan = _subjectBuffer.CurrentSnapshot.GetSpan(pSpan[0]);


### PR DESCRIPTION
Copy of #26956 against dev15.7.x

### Customer scenario

**Steps to Reproduce**:

1.  Try to debug a CSHTML file with some C# code
2.  Hover over on a variable with C# object.

**Expected Behavior**:
See object type description and value.

**Actual Behavior**:
See object type description but no value.

### Bugs this fixes
Partially fixes: https://github.com/dotnet/roslyn/issues/26873
and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/635108

### Workarounds, if any
No

### Risk
Low

### Performance impact
None

### Is this a regression from a previous update?
No

### Root cause analysis
This error was there for a long time but as we heard appeared only in 15.7 when VS changed its approach to communication with Roslyn for Quick Info Data Tips. Likely, it previously used other approach.

The root cause that this code is on the boundary between Roslyn and VS and we do not have enough unit test coverage for this.

### How was the bug found?
Customer feedback (VS Feedback)