### PR TITLE
optimize checks in AbstractVsTextViewFilter.GetDataTipTextImpl

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
@@ -39,7 +39,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         {
             try
             {
-                return GetDataTipTextImpl(pSpan, out pbstrText);
+                if (pSpan == null || pSpan.Length != 1)
+                {
+                    pbstrText = null;
+                    return VSConstants.E_INVALIDARG;
+                }
+
+                var debugInfo = LanguageService.LanguageDebugInfo;
+                if (debugInfo == null)
+                {
+                    pbstrText = null;
+                    return VSConstants.E_FAIL;
+                }
+
+                return GetDataTipTextImpl(pSpan, debugInfo, out pbstrText);
             }
             catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
@@ -47,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
         }
 
-        protected virtual int GetDataTipTextImpl(TextSpan[] pSpan, out string pbstrText)
+        protected virtual int GetDataTipTextImpl(TextSpan[] pSpan, AbstractLanguageService<TPackage, TLanguageService>.VsLanguageDebugInfo debugInfo, out string pbstrText)
         {
             var subjectBuffer = WpfTextView.GetBufferContainingCaret();
             if (subjectBuffer == null)
@@ -56,28 +69,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return VSConstants.E_FAIL;
             }
 
-            return GetDataTipTextImpl(subjectBuffer, pSpan, out pbstrText);
+            return GetDataTipTextImpl(subjectBuffer, pSpan, debugInfo, out pbstrText);
         }
- 
-        protected int GetDataTipTextImpl(ITextBuffer subjectBuffer, TextSpan[] pSpan, out string pbstrText)
+        
+        protected int GetDataTipTextImpl(ITextBuffer subjectBuffer, TextSpan[] pSpan, AbstractLanguageService<TPackage, TLanguageService>.VsLanguageDebugInfo debugInfo, out string pbstrText)
         {
             pbstrText = null;
 
-            var debugInfo = LanguageService.LanguageDebugInfo;
-            if (debugInfo != null)
+            var vsBuffer = EditorAdaptersFactory.GetBufferAdapter(subjectBuffer);
+            
+            // TODO: broken in REPL
+            if (vsBuffer == null)
             {
-                var vsBuffer = EditorAdaptersFactory.GetBufferAdapter(subjectBuffer);
-
-                // TODO: broken in REPL
-                if (vsBuffer == null)
-                {
-                    return VSConstants.E_FAIL;
-                }
-
-                return debugInfo.GetDataTipText(vsBuffer, pSpan, pbstrText);
+                return VSConstants.E_FAIL;
             }
 
-            return VSConstants.E_FAIL;
+            return debugInfo.GetDataTipText(vsBuffer, pSpan, out pbstrText);
         }
 
         int IVsTextViewFilter.GetPairExtents(int iLine, int iIndex, TextSpan[] pSpan)

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -373,7 +373,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 return VSConstants.E_NOTIMPL;
             }
 
-            public int GetDataTipText(IVsTextBuffer pBuffer, VsTextSpan[] pSpan, string pbstrText)
+            public int GetDataTipText(IVsTextBuffer pBuffer, VsTextSpan[] pSpan, out string pbstrText)
             {
                 using (Logger.LogBlock(FunctionId.Debugging_VsLanguageDebugInfo_GetDataTipText, CancellationToken.None))
                 {
@@ -384,6 +384,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     }
 
                     int result = VSConstants.E_FAIL;
+                    string pbstrTextInternal = null;
 
                     _waitIndicator.Wait(
                         title: ServicesVSResources.Debugger,
@@ -417,13 +418,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                                         string textOpt = dataTipInfo.Text;
 
                                         pSpan[0] = resultSpan.ToVsTextSpan();
-                                        result = debugger.GetDataTipValue((IVsTextLines)pBuffer, pSpan, textOpt, out pbstrText);
+                                        result = debugger.GetDataTipValue((IVsTextLines)pBuffer, pSpan, textOpt, out pbstrTextInternal);
                                     }
                                 }
                             }
                         }
                     });
 
+                    pbstrText = pbstrTextInternal;
                     return result;
                 }
             }

--- a/src/VisualStudio/Core/Def/Implementation/Venus/VenusCommandFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/VenusCommandFilter.cs
@@ -48,14 +48,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             return _subjectBuffer;
         }
 
-        protected override int GetDataTipTextImpl(TextSpan[] pSpan, out string pbstrText)
+        protected override int GetDataTipTextImpl(TextSpan[] pSpan, AbstractLanguageService<TPackage, TLanguageService>.VsLanguageDebugInfo debugInfo, out string pbstrText)
         {
-            if (pSpan == null || pSpan.Length != 1)
-            {
-                pbstrText = null;
-                return VSConstants.E_INVALIDARG;
-            }
-
             var textViewModel = WpfTextView.TextViewModel;
             if (textViewModel == null)
             {
@@ -83,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 // Next, we'll check to see if there is actually a DataTip for this candidate.
                 // If there is, we'll map this span back to the DataBuffer and return it.
                 pSpan[0] = candidateSpan.ToVsTextSpan();
-                int hr = base.GetDataTipTextImpl(_subjectBuffer, pSpan, out pbstrText);
+                int hr = base.GetDataTipTextImpl(_subjectBuffer, pSpan, debugInfo, out pbstrText);
                 if (ErrorHandler.Succeeded(hr))
                 {
                     var subjectSpan = _subjectBuffer.CurrentSnapshot.GetSpan(pSpan[0]);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/28064

1. Moving two checks to a root method.
2. Restoring a missed out parameter.
