### PR TITLE
add PerformAdditionalCodeCleanupDuringFormattingCheckBox

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -52,7 +52,7 @@ class Program
 }
 ";
             return AssertCodeCleanupResult(expected, code,
-                (CodeCleanupOptions.AreCodeCleanupRulesConfigured, enabled: true),
+                (CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, enabled: true),
                 (CodeCleanupOptions.RemoveUnusedImports, enabled: true),
                 (CodeCleanupOptions.AddAccessibilityModifiers, enabled: false));
         }
@@ -85,7 +85,7 @@ class Program
 }
 ";
             return AssertCodeCleanupResult(expected, code,
-                (CodeCleanupOptions.AreCodeCleanupRulesConfigured, enabled: true),
+                (CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, enabled: true),
                 (CodeCleanupOptions.SortImports, enabled: true),
                 (CodeCleanupOptions.AddAccessibilityModifiers, enabled: false));
         }
@@ -117,7 +117,7 @@ class Program
 }
 ";
             return AssertCodeCleanupResult(expected, code,
-                (CodeCleanupOptions.AreCodeCleanupRulesConfigured, enabled: true),
+                (CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, enabled: true),
                 (CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements, enabled: true),
                 (CodeCleanupOptions.AddAccessibilityModifiers, enabled: false));
         }
@@ -142,7 +142,7 @@ class Program
 }
 ";
             return AssertCodeCleanupResult(expected, code,
-                (CodeCleanupOptions.AreCodeCleanupRulesConfigured, enabled: true),
+                (CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, enabled: true),
                 (CodeCleanupOptions.RemoveUnusedVariables, enabled: true),
                 (CodeCleanupOptions.AddAccessibilityModifiers, enabled: false));
         }
@@ -168,7 +168,7 @@ class Program
 }
 ";
             return AssertCodeCleanupResult(expected, code,
-                (CodeCleanupOptions.AreCodeCleanupRulesConfigured, enabled: true),
+                (CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, enabled: true),
                 (CodeCleanupOptions.AddAccessibilityModifiers, enabled: true));
         }
 

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -46,7 +46,7 @@ int y;
 }
 ";
 
-            AssertFormatWithView(expected, code, (CodeCleanupOptions.AreCodeCleanupRulesConfigured, true));
+            AssertFormatWithView(expected, code, (CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, true));
         }
 
         [WpfFact]

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -7,39 +7,43 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Extensions;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Utilities;
-using static Microsoft.CodeAnalysis.Options.OptionServiceFactory;
 using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 {
     internal partial class FormatCommandHandler : ForegroundThreadAffinitizedObject
     {
-        private bool _infoBarOpen = false;
         public VSCommanding.CommandState GetCommandState(FormatDocumentCommandArgs args)
         {
             return GetCommandState(args.SubjectBuffer);
         }
 
-        private void ShowGoldBarForCodeCleanupConfiguration(Document document)
+        private void ShowGoldBarForCodeCleanupConfigurationIfNeeded(Document document)
         {
             AssertIsForeground();
 
-            // If the gold bar is already open, do not show
-            if (_infoBarOpen)
+            var workspace = document.Project.Solution.Workspace;
+
+            // if info bar was shown before, no need to show it again
+            if (workspace.Options.GetOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain, document.Project.Language) ||
+                workspace.Options.GetOption(CodeCleanupOptions.CodeCleanupInfoBarShown, document.Project.Language))
             {
                 return;
             }
 
-            _infoBarOpen = true;
+            // set as infobar shown so that we never show it again in same VS session. we might show it again
+            // in other VS sessions if it is not explicitly configured yet
+            workspace.Options = workspace.Options.WithChangedOption(
+                CodeCleanupOptions.CodeCleanupInfoBarShown, document.Project.Language, value: true);
 
             var optionPageService = document.GetLanguageService<IOptionPageService>();
             var infoBarService = document.Project.Solution.Workspace.Services.GetRequiredService<IInfoBarService>();
+
             infoBarService.ShowInfoBarInGlobalView(
                 EditorFeaturesResources.Code_cleanup_is_not_configured,
                 new InfoBarUI(EditorFeaturesResources.Configure_it_now,
@@ -47,17 +51,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                               () =>
                               {
                                   optionPageService.ShowFormattingOptionPage();
-                                  _infoBarOpen = false;
                               }),
                 new InfoBarUI(EditorFeaturesResources.Do_not_show_this_message_again,
                               kind: InfoBarUI.UIKind.Button,
                               () =>
                               {
-                                  var optionService = document.Project.Solution.Workspace.Services.GetService<IOptionService>();
-                                  var oldOptions = optionService.GetOptions();
-                                  var newOptions = oldOptions.WithChangedOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain,
-                                      document.Project.Language, true);
-                                  optionService.SetOptions(newOptions);
+                                  workspace.Options = workspace.Options.WithChangedOption(
+                                      CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain, document.Project.Language, value: true);
                               }));
         }
 
@@ -78,42 +78,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
             {
                 var cancellationToken = context.OperationContext.UserCancellationToken;
 
-                var docOptions = document.GetOptionsAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-
                 using (var transaction = new CaretPreservingEditTransaction(
                     EditorFeaturesResources.Formatting, args.TextView, _undoHistoryRegistry, _editorOperationsFactoryService))
                 {
                     var codeCleanupService = document.GetLanguageService<ICodeCleanupService>();
-
                     if (codeCleanupService == null)
                     {
                         Format(args.TextView, document, selectionOpt: null, cancellationToken);
                     }
                     else
                     {
-                        if (!docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured)
-                            && !docOptions.GetOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain))
-                        {
-                            ShowGoldBarForCodeCleanupConfiguration(document);
-                        }
-
-                        if (docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured)
-                            && docOptions.GetOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting))
-                        {
-                            // Code cleanup
-                            var oldDoc = document;
-                            var codeCleanupChanges = GetCodeCleanupAndFormatChangesAsync(document, codeCleanupService, cancellationToken).WaitAndGetResult(cancellationToken);
-
-                            if (codeCleanupChanges != null && codeCleanupChanges.Count() > 0)
-                            {
-                                ApplyChanges(oldDoc, codeCleanupChanges.ToList(), selectionOpt: null, cancellationToken);
-                            }
-                        }
-                        else
-                        {
-                            Format(args.TextView, document, selectionOpt: null, cancellationToken);
-                        }
-
+                        CodeCleanupOrFormat(args, document, cancellationToken);
                     }
 
                     transaction.Complete();
@@ -121,6 +96,31 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
             }
 
             return true;
+        }
+
+        private void CodeCleanupOrFormat(FormatDocumentCommandArgs args, Document document, CancellationToken cancellationToken)
+        {
+            var codeCleanupService = document.GetLanguageService<ICodeCleanupService>();
+
+            var docOptions = document.GetOptionsAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+
+            // simplest pass. code cleanup is on. just run code clean up.
+            if (docOptions.GetOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting))
+            {
+                // Code cleanup
+                var oldDoc = document;
+                var codeCleanupChanges = GetCodeCleanupAndFormatChangesAsync(document, codeCleanupService, cancellationToken).WaitAndGetResult(cancellationToken);
+
+                if (codeCleanupChanges != null && codeCleanupChanges.Count() > 0)
+                {
+                    ApplyChanges(oldDoc, codeCleanupChanges.ToList(), selectionOpt: null, cancellationToken);
+                }
+
+                return;
+            }
+
+            ShowGoldBarForCodeCleanupConfigurationIfNeeded(document);
+            Format(args.TextView, document, selectionOpt: null, cancellationToken);
         }
 
         private async Task<IEnumerable<TextChange>> GetCodeCleanupAndFormatChangesAsync(Document document, ICodeCleanupService codeCleanupService, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -91,7 +91,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                     }
                     else
                     {
-                        if (docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured))
+                        if (!docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured)
+                            && !docOptions.GetOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain))
+                        {
+                            ShowGoldBarForCodeCleanupConfiguration(document);
+                        }
+
+                        if (docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured)
+                            && docOptions.GetOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting))
                         {
                             // Code cleanup
                             var oldDoc = document;
@@ -105,11 +112,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                         else
                         {
                             Format(args.TextView, document, selectionOpt: null, cancellationToken);
-
-                            if (!docOptions.GetOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain))
-                            {
-                                ShowGoldBarForCodeCleanupConfiguration(document);
-                            }
                         }
 
                     }

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupOptions.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupOptions.cs
@@ -9,21 +9,16 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
 {
     internal static class CodeCleanupOptions
     {
-        public static readonly PerLanguageOption<bool> AreCodeCleanupRulesConfigured = new PerLanguageOption<bool>(
-            nameof(CodeCleanupOptions), nameof(AreCodeCleanupRulesConfigured), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Are Code Cleanup Rules Configured"));
+        // runtime only option. it is not saved anywhere
+        public static readonly PerLanguageOption<bool> CodeCleanupInfoBarShown = new PerLanguageOption<bool>(
+            nameof(CodeCleanupOptions), nameof(CodeCleanupInfoBarShown), defaultValue: false);
 
         public static readonly PerLanguageOption<bool> NeverShowCodeCleanupInfoBarAgain = new PerLanguageOption<bool>(
             nameof(CodeCleanupOptions), nameof(NeverShowCodeCleanupInfoBarAgain), defaultValue: false,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Never Show Code Cleanup Info Bar Again"));
 
-        /// <summary>
-        /// Set default value to true for 15.8 Preview to promote this new code cleanup feature
-        /// Will set it back to false for RTM so users are not silently opting into this feature
-        /// https://github.com/dotnet/roslyn/issues/28068
-        /// </summary>
         public static readonly PerLanguageOption<bool> PerformAdditionalCodeCleanupDuringFormatting = new PerLanguageOption<bool>(
-            nameof(CodeCleanupOptions), nameof(PerformAdditionalCodeCleanupDuringFormatting), defaultValue: true,
+            nameof(CodeCleanupOptions), nameof(PerformAdditionalCodeCleanupDuringFormatting), defaultValue: false,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Perform Additional Code Cleanup During Formatting"));
 
         public static readonly PerLanguageOption<bool> RemoveUnusedImports = new PerLanguageOption<bool>(
@@ -35,15 +30,15 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Sort Imports"));
 
         public static readonly PerLanguageOption<bool> AddRemoveBracesForSingleLineControlStatements = new PerLanguageOption<bool>(
-            nameof(CodeCleanupOptions), nameof(AddRemoveBracesForSingleLineControlStatements), defaultValue: true,
+            nameof(CodeCleanupOptions), nameof(AddRemoveBracesForSingleLineControlStatements), defaultValue: false,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Add Remove Braces For Single Line Control Statements"));
 
         public static readonly PerLanguageOption<bool> AddAccessibilityModifiers = new PerLanguageOption<bool>(
-            nameof(CodeCleanupOptions), nameof(AddAccessibilityModifiers), defaultValue: true,
+            nameof(CodeCleanupOptions), nameof(AddAccessibilityModifiers), defaultValue: false,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Add Accessibility Modifiers"));
 
         public static readonly PerLanguageOption<bool> SortAccessibilityModifiers = new PerLanguageOption<bool>(
-            nameof(CodeCleanupOptions), nameof(SortAccessibilityModifiers), defaultValue: true,
+            nameof(CodeCleanupOptions), nameof(SortAccessibilityModifiers), defaultValue: false,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Sort Accessibility Modifiers"));
 
         public static readonly PerLanguageOption<bool> ApplyExpressionBlockBodyPreferences = new PerLanguageOption<bool>(
@@ -51,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Apply Expression Block Body Preferences"));
 
         public static readonly PerLanguageOption<bool> ApplyImplicitExplicitTypePreferences = new PerLanguageOption<bool>(
-            nameof(CodeCleanupOptions), nameof(ApplyImplicitExplicitTypePreferences), defaultValue: true,
+            nameof(CodeCleanupOptions), nameof(ApplyImplicitExplicitTypePreferences), defaultValue: false,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Apply Implicit Explicit Type Preferences"));
 
         public static readonly PerLanguageOption<bool> ApplyInlineOutVariablePreferences = new PerLanguageOption<bool>(
@@ -59,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Apply Inline Out Variable Preferences"));
 
         public static readonly PerLanguageOption<bool> ApplyLanguageFrameworkTypePreferences = new PerLanguageOption<bool>(
-            nameof(CodeCleanupOptions), nameof(ApplyLanguageFrameworkTypePreferences), defaultValue: true,
+            nameof(CodeCleanupOptions), nameof(ApplyLanguageFrameworkTypePreferences), defaultValue: false,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Apply Language Framework Type Preferences"));
 
         public static readonly PerLanguageOption<bool> ApplyObjectCollectionInitializationPreferences = new PerLanguageOption<bool>(
@@ -67,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Apply Object Collection Initialization Preferences"));
 
         public static readonly PerLanguageOption<bool> ApplyThisQualificationPreferences = new PerLanguageOption<bool>(
-            nameof(CodeCleanupOptions), nameof(ApplyThisQualificationPreferences), defaultValue: true,
+            nameof(CodeCleanupOptions), nameof(ApplyThisQualificationPreferences), defaultValue: false,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Apply This Qualification Preferences"));
 
         public static readonly PerLanguageOption<bool> MakePrivateFieldReadonlyWhenPossible = new PerLanguageOption<bool>(
@@ -87,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
     internal class CodeCleanupOptionsProvider : IOptionProvider
     {
         public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
-            CodeCleanupOptions.AreCodeCleanupRulesConfigured,
+            CodeCleanupOptions.CodeCleanupInfoBarShown,
             CodeCleanupOptions.AddAccessibilityModifiers,
             CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements,
             CodeCleanupOptions.ApplyExpressionBlockBodyPreferences,
@@ -102,6 +97,6 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             CodeCleanupOptions.RemoveUnusedVariables,
             CodeCleanupOptions.SortAccessibilityModifiers,
             CodeCleanupOptions.SortImports
-            );
+        );
     }
 }

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupOptions.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupOptions.cs
@@ -17,6 +17,15 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             nameof(CodeCleanupOptions), nameof(NeverShowCodeCleanupInfoBarAgain), defaultValue: false,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Never Show Code Cleanup Info Bar Again"));
 
+        /// <summary>
+        /// Set default value to true for 15.8 Preview to promote this new code cleanup feature
+        /// Will set it back to false for RTM so users are not silently opting into this feature
+        /// https://github.com/dotnet/roslyn/issues/28068
+        /// </summary>
+        public static readonly PerLanguageOption<bool> PerformAdditionalCodeCleanupDuringFormatting = new PerLanguageOption<bool>(
+            nameof(CodeCleanupOptions), nameof(PerformAdditionalCodeCleanupDuringFormatting), defaultValue: true,
+            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Perform Additional Code Cleanup During Formatting"));
+
         public static readonly PerLanguageOption<bool> RemoveUnusedImports = new PerLanguageOption<bool>(
             nameof(CodeCleanupOptions), nameof(RemoveUnusedImports), defaultValue: true,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Remove Unused Imports"));

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -835,6 +835,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Perform additional code cleanup during formatting.
+        /// </summary>
+        internal static string Perform_additional_code_cleanup_during_formatting {
+            get {
+                return ResourceManager.GetString("Perform_additional_code_cleanup_during_formatting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Performance.
         /// </summary>
         internal static string Performance {

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -591,5 +591,8 @@
   </data>
   <data name="In_relational_binary_operators" xml:space="preserve">
     <value>In relational operators:  &lt;   &gt;   &lt;=   &gt;=   is   as   ==   !=</value>
+  </data>
+  <data name="Perform_additional_code_cleanup_during_formatting" xml:space="preserve">
+    <value>Perform additional code cleanup during formatting</value>
   </data>
 </root>

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPage.cs
@@ -10,17 +10,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
     internal class FormattingOptionPage : AbstractOptionPage
     {
         private FormattingOptionPageControl _optionPageControl;
+
         protected override AbstractOptionPageControl CreateOptionPage(IServiceProvider serviceProvider)
         {
             _optionPageControl = new FormattingOptionPageControl(serviceProvider);
             return _optionPageControl;
-        }
-
-        public override void SaveSettingsToStorage()
-        {
-            _optionPageControl.SetCodeCleanupAsConfigured();
-
-            base.SaveSettingsToStorage();
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
@@ -15,8 +15,7 @@
             <GroupBox x:Uid="GroupBox_1" Header="General">
                 <StackPanel x:Uid="StackPanel_2">
                     <CheckBox x:Name="FormatWhenTypingCheckBox" x:Uid="FormatWhenTypingCheckBox" />
-                    <StackPanel Margin="15, 0, 0, 0" x:Name="FormatWhenTypingPanel" x:Uid="FormatWhenTypingPanel" 
-                                IsEnabled="{Binding ElementName=FormatWhenTypingCheckBox, Path=IsChecked}">
+                    <StackPanel Margin="15, 0, 0, 0" IsEnabled="{Binding ElementName=FormatWhenTypingCheckBox, Path=IsChecked}">
                         <CheckBox x:Name="FormatOnSemicolonCheckBox" x:Uid="FormatOnSemicolonCheckBox" />
                         <CheckBox x:Name="FormatOnCloseBraceCheckBox" x:Uid="FormatOnCloseBraceCheckBox" />
                     </StackPanel>
@@ -28,8 +27,7 @@
                 <StackPanel x:Uid="StackPanel_2">
                     <CheckBox x:Name="AllCSharpFormattingRulesCheckBox" x:Uid="AllCSharpFormattingRulesCheckBox" IsEnabled="False" IsChecked="True"/>
                     <CheckBox x:Name="PerformAdditionalCodeCleanupDuringFormattingCheckBox" x:Uid="PerformAdditionalCodeCleanupDuringFormattingCheckBox" />
-                    <StackPanel Margin="15, 0, 0, 0" x:Name="CodeCleanupRulesStackPanel" x:Uid="CodeCleanupRulesStackPanel"
-                                IsEnabled="{Binding ElementName=PerformAdditionalCodeCleanupDuringFormattingCheckBox, Path=IsChecked}">
+                    <StackPanel Margin="15, 0, 0, 0" IsEnabled="{Binding ElementName=PerformAdditionalCodeCleanupDuringFormattingCheckBox, Path=IsChecked}">
                         <CheckBox x:Name="RemoveUnusedUsingsCheckBox" x:Uid="RemoveUnusedUsingsCheckBox" />
                         <CheckBox x:Name="SortUsingsCheckBox" x:Uid="SortUsingsCheckBox" />
                         <CheckBox x:Name="AddRemoveBracesForSingleLineControlStatementsCheckBox" x:Uid="AddRemoveBracesForSingleLineControlStatementsCheckBox" />

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
@@ -7,13 +7,11 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:options="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Options;assembly=Microsoft.VisualStudio.LanguageServices.Implementation"
-    xmlns:formatting="clr-namespace:Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting"
-    xmlns:csvs="clr-namespace:Microsoft.VisualStudio.LanguageServices.CSharp"
     mc:Ignorable="d" d:DesignHeight="279" d:DesignWidth="514">
-    <ScrollViewer x:Uid="ScrollViewer_1" VerticalScrollBarVisibility="Auto">
-        <StackPanel x:Uid="StackPanel_1">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
             <GroupBox x:Uid="GroupBox_1" Header="General">
-                <StackPanel x:Uid="StackPanel_2">
+                <StackPanel>
                     <CheckBox x:Name="FormatWhenTypingCheckBox" x:Uid="FormatWhenTypingCheckBox" />
                     <StackPanel Margin="15, 0, 0, 0" IsEnabled="{Binding ElementName=FormatWhenTypingCheckBox, Path=IsChecked}">
                         <CheckBox x:Name="FormatOnSemicolonCheckBox" x:Uid="FormatOnSemicolonCheckBox" />
@@ -24,7 +22,7 @@
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Name="FormatDocumentSettingsGroupBox" x:Uid="FormatDocumentSettingsGroupBox" >
-                <StackPanel x:Uid="StackPanel_2">
+                <StackPanel>
                     <CheckBox x:Name="AllCSharpFormattingRulesCheckBox" x:Uid="AllCSharpFormattingRulesCheckBox" IsEnabled="False" IsChecked="True"/>
                     <CheckBox x:Name="PerformAdditionalCodeCleanupDuringFormattingCheckBox" x:Uid="PerformAdditionalCodeCleanupDuringFormattingCheckBox" />
                     <StackPanel Margin="15, 0, 0, 0" IsEnabled="{Binding ElementName=PerformAdditionalCodeCleanupDuringFormattingCheckBox, Path=IsChecked}">
@@ -43,7 +41,6 @@
                         <CheckBox x:Name="RemoveUnnecessaryCastsCheckBox" x:Uid="RemoveUnnecessaryCastsCheckBox" />
                         <CheckBox x:Name="RemoveUnusedVariablesCheckBox" x:Uid="RemoveUnusedVariablesCheckBox" />
                     </StackPanel>
-
                 </StackPanel>
             </GroupBox>
         </StackPanel>

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
@@ -14,10 +14,9 @@
         <StackPanel x:Uid="StackPanel_1">
             <GroupBox x:Uid="GroupBox_1" Header="General">
                 <StackPanel x:Uid="StackPanel_2">
-                    <CheckBox x:Name="FormatWhenTypingCheckBox" x:Uid="FormatWhenTypingCheckBox"
-                              Checked="FormatWhenTypingCheckBox_Checked"
-                              Unchecked="FormatWhenTypingCheckBox_Unchecked"/>
-                    <StackPanel Margin="15, 0, 0, 0">
+                    <CheckBox x:Name="FormatWhenTypingCheckBox" x:Uid="FormatWhenTypingCheckBox" />
+                    <StackPanel Margin="15, 0, 0, 0" x:Name="FormatWhenTypingPanel" x:Uid="FormatWhenTypingPanel" 
+                                IsEnabled="{Binding ElementName=FormatWhenTypingCheckBox, Path=IsChecked}">
                         <CheckBox x:Name="FormatOnSemicolonCheckBox" x:Uid="FormatOnSemicolonCheckBox" />
                         <CheckBox x:Name="FormatOnCloseBraceCheckBox" x:Uid="FormatOnCloseBraceCheckBox" />
                     </StackPanel>
@@ -28,9 +27,9 @@
             <GroupBox x:Name="FormatDocumentSettingsGroupBox" x:Uid="FormatDocumentSettingsGroupBox" >
                 <StackPanel x:Uid="StackPanel_2">
                     <CheckBox x:Name="AllCSharpFormattingRulesCheckBox" x:Uid="AllCSharpFormattingRulesCheckBox" IsEnabled="False" IsChecked="True"/>
-                    <CheckBox x:Name="PerformAdditionalCodeCleanupDuringFormattingCheckBox" x:Uid="PerformAdditionalCodeCleanupDuringFormattingCheckBox" 
-                              Checked="PerformAdditionalCodeCleanupDuringFormattingCheckBox_Checked" Unchecked="PerformAdditionalCodeCleanupDuringFormattingCheckBox_Unchecked"/>
-                    <StackPanel Margin="15, 0, 0, 0" x:Name="CodeCleanupRulesStackPanel" x:Uid="CodeCleanupRulesStackPanel">
+                    <CheckBox x:Name="PerformAdditionalCodeCleanupDuringFormattingCheckBox" x:Uid="PerformAdditionalCodeCleanupDuringFormattingCheckBox" />
+                    <StackPanel Margin="15, 0, 0, 0" x:Name="CodeCleanupRulesStackPanel" x:Uid="CodeCleanupRulesStackPanel"
+                                IsEnabled="{Binding ElementName=PerformAdditionalCodeCleanupDuringFormattingCheckBox, Path=IsChecked}">
                         <CheckBox x:Name="RemoveUnusedUsingsCheckBox" x:Uid="RemoveUnusedUsingsCheckBox" />
                         <CheckBox x:Name="SortUsingsCheckBox" x:Uid="SortUsingsCheckBox" />
                         <CheckBox x:Name="AddRemoveBracesForSingleLineControlStatementsCheckBox" x:Uid="AddRemoveBracesForSingleLineControlStatementsCheckBox" />

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
@@ -28,20 +28,24 @@
             <GroupBox x:Name="FormatDocumentSettingsGroupBox" x:Uid="FormatDocumentSettingsGroupBox" >
                 <StackPanel x:Uid="StackPanel_2">
                     <CheckBox x:Name="AllCSharpFormattingRulesCheckBox" x:Uid="AllCSharpFormattingRulesCheckBox" IsEnabled="False" IsChecked="True"/>
-                    <CheckBox x:Name="RemoveUnusedUsingsCheckBox" x:Uid="RemoveUnusedUsingsCheckBox" />
-                    <CheckBox x:Name="SortUsingsCheckBox" x:Uid="SortUsingsCheckBox" />
-                    <CheckBox x:Name="AddRemoveBracesForSingleLineControlStatementsCheckBox" x:Uid="AddRemoveBracesForSingleLineControlStatementsCheckBox" />
-                    <CheckBox x:Name="AddAccessibilityModifiersCheckBox" x:Uid="AddAccessibilityModifiersCheckBox" />
-                    <CheckBox x:Name="SortAccessibilityModifiersCheckBox" x:Uid="SortAccessibilityModifiersCheckBox" />
-                    <CheckBox x:Name="ApplyExpressionBlockBodyPreferencesCheckBox" x:Uid="ApplyExpressionBlockBodyPreferencesCheckBox" />
-                    <CheckBox x:Name="ApplyImplicitExplicitTypePreferencesCheckBox" x:Uid="ApplyImplicitExplicitTypePreferencesCheckBox" />
-                    <CheckBox x:Name="ApplyInlineOutVariablePreferencesCheckBox" x:Uid="ApplyInlineOutVariablePreferencesCheckBox" />
-                    <CheckBox x:Name="ApplyLanguageFrameworkTypePreferencesCheckBox" x:Uid="ApplyLanguageFrameworkTypePreferencesCheckBox" />
-                    <CheckBox x:Name="ApplyObjectCollectionInitializationPreferencesCheckBox" x:Uid="ApplyObjectCollectionInitializationPreferencesCheckBox" />
-                    <CheckBox x:Name="ApplyThisQualificationPreferencesCheckBox" x:Uid="ApplyThisQualificationPreferencesCheckBox" />
-                    <CheckBox x:Name="MakePrivateFieldReadonlyWhenPossibleCheckBox" x:Uid="MakePrivateFieldReadonlyWhenPossibleCheckBox" />
-                    <CheckBox x:Name="RemoveUnnecessaryCastsCheckBox" x:Uid="RemoveUnnecessaryCastsCheckBox" />
-                    <CheckBox x:Name="RemoveUnusedVariablesCheckBox" x:Uid="RemoveUnusedVariablesCheckBox" />
+                    <CheckBox x:Name="PerformAdditionalCodeCleanupDuringFormattingCheckBox" x:Uid="PerformAdditionalCodeCleanupDuringFormattingCheckBox" 
+                              Checked="PerformAdditionalCodeCleanupDuringFormattingCheckBox_Checked" Unchecked="PerformAdditionalCodeCleanupDuringFormattingCheckBox_Unchecked"/>
+                    <StackPanel Margin="15, 0, 0, 0" x:Name="CodeCleanupRulesStackPanel" x:Uid="CodeCleanupRulesStackPanel">
+                        <CheckBox x:Name="RemoveUnusedUsingsCheckBox" x:Uid="RemoveUnusedUsingsCheckBox" />
+                        <CheckBox x:Name="SortUsingsCheckBox" x:Uid="SortUsingsCheckBox" />
+                        <CheckBox x:Name="AddRemoveBracesForSingleLineControlStatementsCheckBox" x:Uid="AddRemoveBracesForSingleLineControlStatementsCheckBox" />
+                        <CheckBox x:Name="AddAccessibilityModifiersCheckBox" x:Uid="AddAccessibilityModifiersCheckBox" />
+                        <CheckBox x:Name="SortAccessibilityModifiersCheckBox" x:Uid="SortAccessibilityModifiersCheckBox" />
+                        <CheckBox x:Name="ApplyExpressionBlockBodyPreferencesCheckBox" x:Uid="ApplyExpressionBlockBodyPreferencesCheckBox" />
+                        <CheckBox x:Name="ApplyImplicitExplicitTypePreferencesCheckBox" x:Uid="ApplyImplicitExplicitTypePreferencesCheckBox" />
+                        <CheckBox x:Name="ApplyInlineOutVariablePreferencesCheckBox" x:Uid="ApplyInlineOutVariablePreferencesCheckBox" />
+                        <CheckBox x:Name="ApplyLanguageFrameworkTypePreferencesCheckBox" x:Uid="ApplyLanguageFrameworkTypePreferencesCheckBox" />
+                        <CheckBox x:Name="ApplyObjectCollectionInitializationPreferencesCheckBox" x:Uid="ApplyObjectCollectionInitializationPreferencesCheckBox" />
+                        <CheckBox x:Name="ApplyThisQualificationPreferencesCheckBox" x:Uid="ApplyThisQualificationPreferencesCheckBox" />
+                        <CheckBox x:Name="MakePrivateFieldReadonlyWhenPossibleCheckBox" x:Uid="MakePrivateFieldReadonlyWhenPossibleCheckBox" />
+                        <CheckBox x:Name="RemoveUnnecessaryCastsCheckBox" x:Uid="RemoveUnnecessaryCastsCheckBox" />
+                        <CheckBox x:Name="RemoveUnusedVariablesCheckBox" x:Uid="RemoveUnusedVariablesCheckBox" />
+                    </StackPanel>
 
                 </StackPanel>
             </GroupBox>

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
@@ -69,7 +69,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             base.SaveSettings();
 
-            // once formatting option is set, we never show code cleanup info bar again
+            // once formatting option is explicitly set (regardless codeclean is on or off), 
+            // we never show code cleanup info bar again
             var oldOptions = OptionService.GetOptions();
             var newOptions = oldOptions.WithChangedOption(
                 CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain, LanguageNames.CSharp, value: true);

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
             FormatDocumentSettingsGroupBox.Header = CSharpVSResources.Format_document_settings;
             AllCSharpFormattingRulesCheckBox.Content = CSharpVSResources.Apply_all_csharp_formatting_rules_indentation_wrapping_spacing;
+            PerformAdditionalCodeCleanupDuringFormattingCheckBox.Content = CSharpVSResources.Perform_additional_code_cleanup_during_formatting;
             RemoveUnusedUsingsCheckBox.Content = CSharpVSResources.Remove_unnecessary_usings;
             SortUsingsCheckBox.Content = CSharpVSResources.Sort_usings;
             AddRemoveBracesForSingleLineControlStatementsCheckBox.Content = CSharpVSResources.Add_remove_braces_for_single_line_control_statements;
@@ -48,6 +49,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             MakePrivateFieldReadonlyWhenPossibleCheckBox.Content = CSharpVSResources.Make_private_field_readonly_when_possible;
             RemoveUnnecessaryCastsCheckBox.Content = CSharpVSResources.Remove_unnecessary_casts;
             RemoveUnusedVariablesCheckBox.Content = CSharpVSResources.Remove_unused_variables;
+
+            BindToOption(PerformAdditionalCodeCleanupDuringFormattingCheckBox, CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, LanguageNames.CSharp);
+            CodeCleanupRulesStackPanel.IsEnabled = (PerformAdditionalCodeCleanupDuringFormattingCheckBox.IsChecked == true);
 
             BindToOption(RemoveUnusedUsingsCheckBox, CodeCleanupOptions.RemoveUnusedImports, LanguageNames.CSharp);
             BindToOption(SortUsingsCheckBox, CodeCleanupOptions.SortImports, LanguageNames.CSharp);
@@ -99,6 +103,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
                 OptionService.SetOptions(newOptions);
                 OptionLogger.Log(oldOptions, newOptions);
             }
+        }
+
+        private void PerformAdditionalCodeCleanupDuringFormattingCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            CodeCleanupRulesStackPanel.IsEnabled = true;
+        }
+
+        private void PerformAdditionalCodeCleanupDuringFormattingCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            CodeCleanupRulesStackPanel.IsEnabled = false;
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="new">Make private fields readonly when possible</target>
         <note />
       </trans-unit>
+      <trans-unit id="Perform_additional_code_cleanup_during_formatting">
+        <source>Perform additional code cleanup during formatting</source>
+        <target state="new">Perform additional code cleanup during formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Prefer_is_null_for_reference_equality_checks">
         <source>Prefer 'is null' for reference equality checks</source>
         <target state="new">Prefer 'is null' for reference equality checks</target>

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
@@ -8,7 +8,6 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 {
@@ -54,11 +53,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             radioButtonStyle.Setters.Add(new Setter(RadioButton.MarginProperty, new Thickness() { Bottom = 7 }));
             radioButtonStyle.Setters.Add(new Setter(RadioButton.ForegroundProperty, new DynamicResourceExtension(SystemColors.WindowTextBrushKey)));
             Resources.Add(typeof(RadioButton), radioButtonStyle);
-        }
-
-        protected void AddBinding(BindingExpressionBase bindingExpression)
-        {
-            _bindingExpressions.Add(bindingExpression);
         }
 
         protected void BindToOption(CheckBox checkbox, Option<bool> optionKey)
@@ -132,7 +126,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         {
             checkbox.Visibility = Visibility.Visible;
 
-            Binding binding = new Binding()
+            var binding = new Binding()
             {
                 Source = new FullSolutionAnalysisOptionBinding(OptionService, languageName),
                 Path = new PropertyPath("Value"),


### PR DESCRIPTION
Add PerformAdditionalCodeCleanupDuringFormattingCheckBox in the formatting options page https://github.com/dotnet/roslyn/issues/27974#issuecomment-398942340

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
