### PR TITLE
Resolve function to native offset uint.MaxValue

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.cs
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     module.RuntimeInstance,
                     module,
                     new DkmClrMethodId(Token: token, Version: (uint)version),
-                    NativeOffset: 0,
+                    NativeOffset: uint.MaxValue,
                     ILOffset: (uint)ilOffset,
                     CPUInstruction: null);
                 // Use async overload of OnFunctionResolved to avoid deadlock.


### PR DESCRIPTION
Previously the FunctionResolver used 0 for the native offset of all
instruction address of resolved function names. The debugger inteprets
this literally, which causes function BP's to be bound on the first
native instruciton of a JIT'd method. This is incorrect as the bp should
be bound to the native instruction that represents IL offset zero. The
function resolver should use uint.MaxValue for native offset to
communicate that the instruction address always represents IL offset 0,
even for a JIT'd method.

Fixes #28071 
