### PR TITLE
Use System.Runtime.Loader light-up package

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -159,6 +159,7 @@
     <RoslynToolsReferenceAssembliesVersion>0.1.3</RoslynToolsReferenceAssembliesVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
     <RoslynToolsBuildTasksVersion>1.0.0-beta2-62731-01</RoslynToolsBuildTasksVersion>
+    <RoslynToolsLightUpSystemRuntimeLoaderFixedVersion>4.3.0</RoslynToolsLightUpSystemRuntimeLoaderFixedVersion>
     <RoslynMicrosoftVisualStudioExtensionManagerVersion>0.0.4</RoslynMicrosoftVisualStudioExtensionManagerVersion>
     <StreamJsonRpcVersion>1.1.92</StreamJsonRpcVersion>
     <SystemAppContextVersion>4.3.0</SystemAppContextVersion>
@@ -206,7 +207,6 @@
     <SystemRuntimeHandlesVersion>4.3.0</SystemRuntimeHandlesVersion>
     <SystemRuntimeInteropServicesVersion>4.3.0</SystemRuntimeInteropServicesVersion>
     <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
-    <SystemRuntimeLoaderVersion>4.3.0</SystemRuntimeLoaderVersion>
     <SystemRuntimeNumericsVersion>4.3.0</SystemRuntimeNumericsVersion>
     <SystemRuntimeSerializationJsonVersion>4.3.0</SystemRuntimeSerializationJsonVersion>
     <SystemRuntimeSerializationPrimitivesVersion>4.3.0</SystemRuntimeSerializationPrimitivesVersion>

--- a/build/ToolsetPackages/RoslynToolset.csproj
+++ b/build/ToolsetPackages/RoslynToolset.csproj
@@ -37,6 +37,5 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="dotnet-xunit" Version="$(dotnetxunitVersion)" ExcludeAssets="all" />
     <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersVersion)" ExcludeAssets="all" />
-    <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" ExcludeAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/NuGet/NuGetProjectPackUtil.csproj
+++ b/src/NuGet/NuGetProjectPackUtil.csproj
@@ -85,7 +85,6 @@
       <NuspecProperties>$(NuspecProperties);SystemResourcesResourceManagerVersion=$(SystemResourcesResourceManagerVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);SystemRuntimeVersion=$(SystemRuntimeVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);SystemRuntimeExtensionsVersion=$(SystemRuntimeExtensionsVersion)</NuspecProperties>
-      <NuspecProperties>$(NuspecProperties);SystemRuntimeLoaderVersion=$(SystemRuntimeLoaderVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);SystemRuntimeInteropServicesVersion=$(SystemRuntimeInteropServicesVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);SystemRuntimeNumericsVersion=$(SystemRuntimeNumericsVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);SystemSecurityAccessControlVersion=$(SystemSecurityAccessControlVersion)</NuspecProperties>

--- a/src/Scripting/Core/Scripting.csproj
+++ b/src/Scripting/Core/Scripting.csproj
@@ -18,9 +18,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <!-- Workaround for https://github.com/NuGet/Home/issues/1471 -->
-    <Reference Include="$(NuGetPackageRoot)\system.runtime.loader\$(SystemRuntimeLoaderVersion)\ref\netstandard1.5\System.Runtime.Loader.dll">
-      <Private>False</Private>
-    </Reference>
+    <PackageReference Include="RoslynTools.LightUp.System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="$(SystemDiagnosticsStackTraceVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Scripting/Core/Scripting.csproj
+++ b/src/Scripting/Core/Scripting.csproj
@@ -17,8 +17,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
-    <!-- Workaround for https://github.com/NuGet/Home/issues/1471 -->
-    <PackageReference Include="RoslynTools.LightUp.System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
+    <!-- 
+      Workaround for https://github.com/NuGet/Home/issues/1471.
+
+      RoslynTools.LightUp.System.Runtime.Loader distributes System.Runtime.Loader in ref/netstandard1.3 directory,
+      so that it can be referenced in libraries targeting netstandard1.3 once they check that the executing runtime 
+      is .NET Core.
+    -->
+    <PackageReference Include="RoslynTools.LightUp.System.Runtime.Loader" Version="$(RoslynToolsLightUpSystemRuntimeLoaderFixedVersion)" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="$(SystemDiagnosticsStackTraceVersion)" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Infrastructure only.

Microsoft.Scripting projects need to reference System.Runtime.Loader, but this dependency is not compatible with netstandard1.3. 

Instead of restoring SRL in toolset project and then referencing the binary using a path to nuget cache reference a new package RoslynTools.LightUp.System.Runtime.Loader that includes the original SRL 
assembly as a netstandard1.3 reference assembly. 

The problem with the current implementation is that SRL is not restored to nuget package root anymore, but it's in nuget fallback packages directory.