### PR TITLE
Fix NRE when handling multiline documentation comments in C#

### DIFF
--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -1141,6 +1141,32 @@ class C{}";
             VerifyPressingEnter(code, expected);
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        [WorkItem(25746, "https://github.com/dotnet/roslyn/issues/25746")]
+        public void PressingEnter_ExtraSlashesAfterExteriorTrivia()
+        {
+            var code =
+@"class C
+{
+C()
+{
+//////$$
+}
+}";
+
+            var expected =
+@"class C
+{
+C()
+{
+//////
+///$$
+}
+}";
+
+            VerifyPressingEnter(code, expected);
+        }
+
         [WorkItem(542426, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542426")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void PressingEnter_PreserveParams()
@@ -1385,6 +1411,36 @@ class C
 /// </summary>
 class C
 {
+}";
+
+            VerifyPressingEnter(code, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        [WorkItem(27223, "https://github.com/dotnet/roslyn/issues/27223")]
+        public void PressingEnter_XmldocInStringLiteral()
+        {
+            var code =
+@"class C
+{
+C()
+{
+string s = @""
+/// <summary>$$</summary>
+void M() {}""
+}
+}";
+
+            var expected =
+@"class C
+{
+C()
+{
+string s = @""
+/// <summary>
+/// $$</summary>
+void M() {}""
+}
 }";
 
             VerifyPressingEnter(code, expected);

--- a/src/Workspaces/CSharp/Portable/Extensions/DocumentationCommentExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/DocumentationCommentExtensions.cs
@@ -12,6 +12,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     {
         public static bool IsMultilineDocComment(this DocumentationCommentTriviaSyntax documentationComment)
         {
+            if (documentationComment == null)
+            {
+                return false;
+            }
             return documentationComment.ToFullString().StartsWith("/**", StringComparison.Ordinal);
         }
     }


### PR DESCRIPTION
Fixes #25746.  
Fixes #27223.

This is a small fix: the extension method that caused the exception/crash now returns `false` when the parameter is `null`.

Side note: I don't know whether the current behaviour (insert exterior trivia text on the next line in both cases) is the expected behaviour, but it's in line with VB's behaviour.