### PR TITLE
Visit local function bodies in NullableWalker

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3026,7 +3026,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     methodSignatureOpt: null,
                     returnTypes: null,
                     initialState: GetVariableState(),
-                    callbackOpt: null);
+                    callbackOpt: _callbackOpt);
             }
             _result = _invalidType;
             return null;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3013,17 +3013,21 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
-            Analyze(
-                compilation,
-                node.Symbol,
-                node.Body,
-                Diagnostics,
-                useMethodSignatureReturnType: false,
-                useMethodSignatureParameterTypes: false,
-                methodSignatureOpt: null,
-                returnTypes: null,
-                initialState: GetVariableState(),
-                callbackOpt: null);
+            var body = node.Body;
+            if (body != null)
+            {
+                Analyze(
+                    compilation,
+                    node.Symbol,
+                    body,
+                    Diagnostics,
+                    useMethodSignatureReturnType: false,
+                    useMethodSignatureParameterTypes: false,
+                    methodSignatureOpt: null,
+                    returnTypes: null,
+                    initialState: GetVariableState(),
+                    callbackOpt: null);
+            }
             _result = _invalidType;
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3011,6 +3011,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
+        {
+            Analyze(
+                compilation,
+                node.Symbol,
+                node.Body,
+                Diagnostics,
+                useMethodSignatureReturnType: false,
+                useMethodSignatureParameterTypes: false,
+                methodSignatureOpt: null,
+                returnTypes: null,
+                initialState: GetVariableState(),
+                callbackOpt: null);
+            _result = _invalidType;
+            return null;
+        }
+
         public override BoundNode VisitThisReference(BoundThisReference node)
         {
             VisitThisOrBaseReference(node);


### PR DESCRIPTION
Visit local function bodies in `NullableWalker` to report warnings.

Currently, the null state of a captured variable inside and outside a local function is independent: the null state at the entry point of the local function is the initial state, and any changes to the state within the local function are ignored by the caller.