### PR TITLE
Handle Nullable<T> in AsNotNullableReferenceType()

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -631,6 +631,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 Debug.Assert((object)typeSymbol != null);
                 Debug.Assert(!customModifiers.IsDefault);
+                Debug.Assert(!typeSymbol.IsNullableType() || isNullable == true);
                 _typeSymbol = typeSymbol;
                 _isNullable = isNullable;
                 _customModifiers = customModifiers;
@@ -665,7 +666,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
             {
-                return _isNullable == false ?
+                return _isNullable == false || _typeSymbol.IsNullableType() ?
                     this :
                     new NonLazyType(_typeSymbol, isNullable: false, _customModifiers);
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -32409,7 +32409,7 @@ partial class B<T> where T : A? { }";
 
         [WorkItem(27008, "https://github.com/dotnet/roslyn/issues/27008")]
         [Fact]
-        public void OverriddenMethodNullableValueTypeParameter()
+        public void OverriddenMethodNullableValueTypeParameter_01()
         {
             var source0 =
 @"public abstract class A
@@ -32422,6 +32422,29 @@ partial class B<T> where T : A? { }";
 @"class B : A
 {
     public override void F(int? i) { }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void OverriddenMethodNullableValueTypeParameter_02()
+        {
+            var source0 =
+@"public abstract class A<T> where T : struct
+{
+    public abstract void F(T? t);
+}";
+            var comp0 = CreateCompilation(source0, parseOptions: TestOptions.Regular8);
+            var ref0 = comp0.EmitToImageReference();
+            var source =
+@"class B1<T> : A<T> where T : struct
+{
+    public override void F(T? t) { }
+}
+class B2 : A<int>
+{
+    public override void F(int? t) { }
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
             comp.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -32406,5 +32406,25 @@ partial class B<T> where T : A? { }";
                 //         (z2 = x2).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z2 = x2").WithLocation(12, 10));
         }
+
+        [WorkItem(27008, "https://github.com/dotnet/roslyn/issues/27008")]
+        [Fact]
+        public void OverriddenMethodNullableValueTypeParameter()
+        {
+            var source0 =
+@"public abstract class A
+{
+    public abstract void F(int? i);
+}";
+            var comp0 = CreateCompilation(source0, parseOptions: TestOptions.Regular8);
+            var ref0 = comp0.EmitToImageReference();
+            var source =
+@"class B : A
+{
+    public override void F(int? i) { }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
+            comp.VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
`NonLazyType.AsNotNullableReferenceType()` was returning a `TypeSymbolWithAnnotations` with `IsNullable=false` for `Nullable<T>`.

Fixes #27008.