### PR TITLE
Fix 'else without if' parsing - better error msg

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6613,6 +6613,7 @@ tryAgain:
                 case SyntaxKind.GotoKeyword:
                     return this.ParseGotoStatement();
                 case SyntaxKind.IfKeyword:
+                case SyntaxKind.ElseKeyword:
                     return this.ParseIfStatement();
                 case SyntaxKind.LockKeyword:
                     return this.ParseLockStatement();
@@ -7250,6 +7251,7 @@ tryAgain:
                 case SyntaxKind.ForEachKeyword:
                 case SyntaxKind.GotoKeyword:
                 case SyntaxKind.IfKeyword:
+                case SyntaxKind.ElseKeyword:
                 case SyntaxKind.LockKeyword:
                 case SyntaxKind.ReturnKeyword:
                 case SyntaxKind.SwitchKeyword:
@@ -7845,14 +7847,17 @@ tryAgain:
 
         private IfStatementSyntax ParseIfStatement()
         {
-            Debug.Assert(this.CurrentToken.Kind == SyntaxKind.IfKeyword);
+            Debug.Assert(this.CurrentToken.Kind == SyntaxKind.IfKeyword || this.CurrentToken.Kind == SyntaxKind.ElseKeyword);
+
             var @if = this.EatToken(SyntaxKind.IfKeyword);
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var condition = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = this.ParseEmbeddedStatement();
-            var elseClause = ParseElseClauseOpt();
-
+            // when 'if' is missing, then we parse an expression statement in a standard way (which adds missing syntax properly)
+            // parsing embedded one expects non-null statement to be present
+            var statement = this.CurrentToken.Kind == SyntaxKind.ElseKeyword ? this.ParseExpressionStatement() : this.ParseEmbeddedStatement();
+            var elseClause = this.ParseElseClauseOpt();
+            
             return _syntaxFactory.IfStatement(@if, openParen, condition, closeParen, statement, elseClause);
         }
 
@@ -8687,6 +8692,7 @@ tryAgain:
                 case SyntaxKind.ForEachKeyword:
                 case SyntaxKind.GotoKeyword:
                 case SyntaxKind.IfKeyword:
+                case SyntaxKind.ElseKeyword:
                 case SyntaxKind.LockKeyword:
                 case SyntaxKind.ReturnKeyword:
                 case SyntaxKind.SwitchKeyword:

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IIfStatement.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IIfStatement.cs
@@ -960,68 +960,94 @@ class P
 
     private void M(bool flag)
     {
-        /*<bind>*/if (flag)
-        {
-            Op();
-        }
-        else
-        {
-            Console.WriteLine(flag);
-        }
-        else 
-        {
-            Console.WriteLine(!flag);
-        }
-/*</bind>*/    }
+        /*<bind>*/{
+            if (flag)
+            {
+                Op();
+            }
+            else
+            {
+                Console.WriteLine(flag);
+            }
+            else 
+            {
+                Console.WriteLine(!flag);
+            }
+        }/*</bind>*/
+    }
 }
 ";
             string expectedOperationTree = @"
-IConditionalOperation (OperationKind.Conditional, Type: null, IsInvalid) (Syntax: 'if (flag) ... }')
-  Condition: 
-    IParameterReferenceOperation: flag (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'flag')
-  WhenTrue: 
-    IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
-      IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'Op();')
+IBlockOperation (2 statements) (OperationKind.Block, Type: null, IsInvalid) (Syntax: '{ ... }')
+  IConditionalOperation (OperationKind.Conditional, Type: null, IsInvalid) (Syntax: 'if (flag) ... }')
+    Condition: 
+      IParameterReferenceOperation: flag (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'flag')
+    WhenTrue: 
+      IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'Op();')
+          Expression: 
+            IInvocationOperation ( void P.Op()) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Op()')
+              Instance Receiver: 
+                IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: P, IsImplicit) (Syntax: 'Op')
+              Arguments(0)
+    WhenFalse: 
+      IBlockOperation (1 statements) (OperationKind.Block, Type: null, IsInvalid) (Syntax: '{ ... }')
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'Console.WriteLine(flag);')
+          Expression: 
+            IInvocationOperation (void System.Console.WriteLine(System.Boolean value)) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Console.WriteLine(flag)')
+              Instance Receiver: 
+                null
+              Arguments(1):
+                  IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value) (OperationKind.Argument, Type: null) (Syntax: 'flag')
+                    IParameterReferenceOperation: flag (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'flag')
+                    InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+  IConditionalOperation (OperationKind.Conditional, Type: null) (Syntax: 'else ... }')
+    Condition: 
+      IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
+        Children(0)
+    WhenTrue: 
+      IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: '')
         Expression: 
-          IInvocationOperation ( void P.Op()) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Op()')
-            Instance Receiver: 
-              IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: P, IsImplicit) (Syntax: 'Op')
-            Arguments(0)
-  WhenFalse: 
-    IBlockOperation (1 statements) (OperationKind.Block, Type: null, IsInvalid) (Syntax: '{ ... }')
-      IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'Console.WriteLine(flag);')
-        Expression: 
-          IInvocationOperation (void System.Console.WriteLine(System.Boolean value)) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Console.WriteLine(flag)')
-            Instance Receiver: 
-              null
-            Arguments(1):
-                IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value) (OperationKind.Argument, Type: null) (Syntax: 'flag')
-                  IParameterReferenceOperation: flag (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'flag')
-                  InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                  OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+          IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
+            Children(0)
+    WhenFalse: 
+      IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'Console.Wri ... ine(!flag);')
+          Expression: 
+            IInvocationOperation (void System.Console.WriteLine(System.Boolean value)) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Console.WriteLine(!flag)')
+              Instance Receiver: 
+                null
+              Arguments(1):
+                  IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value) (OperationKind.Argument, Type: null) (Syntax: '!flag')
+                    IUnaryOperation (UnaryOperatorKind.Not) (OperationKind.UnaryOperator, Type: System.Boolean) (Syntax: '!flag')
+                      Operand: 
+                        IParameterReferenceOperation: flag (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'flag')
+                    InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // file.cs(19,10): error CS1003: Syntax error, 'if' expected
-                //         }
-                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("if", "else").WithLocation(19, 10),
-                // file.cs(19,10): error CS1003: Syntax error, '(' expected
-                //         }
-                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("(", "else").WithLocation(19, 10),
-                // file.cs(19,10): error CS1525: Invalid expression term 'else'
-                //         }
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(19, 10),
-                // file.cs(19,10): error CS1026: ) expected
-                //         }
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(19, 10),
-                // file.cs(19,10): error CS1525: Invalid expression term 'else'
-                //         }
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(19, 10),
-                // file.cs(19,10): error CS1002: ; expected
-                //         }
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(19, 10)
+                // file.cs(20,14): error CS1003: Syntax error, 'if' expected
+                //             }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("if", "else").WithLocation(20, 14),
+                // file.cs(20,14): error CS1003: Syntax error, '(' expected
+                //             }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("(", "else").WithLocation(20, 14),
+                // file.cs(20,14): error CS1525: Invalid expression term 'else'
+                //             }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(20, 14),
+                // file.cs(20,14): error CS1026: ) expected
+                //             }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(20, 14),
+                // file.cs(20,14): error CS1525: Invalid expression term 'else'
+                //             }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(20, 14),
+                // file.cs(20,14): error CS1002: ; expected
+                //             }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(20, 14)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<IfStatementSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<BlockSyntax>(source, expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1092,70 +1118,89 @@ class P
 
     private void M()
     {
-        /*<bind>*/else
-        {
-        }
-        else
-        {
-            Op();
-        }
-/*</bind>*/    }
+        /*<bind>*/{
+            else
+            {
+            }
+            else
+            {
+                Op();
+            }
+        }/*</bind>*/
+    }
 }
 ";
             string expectedOperationTree = @"
-IConditionalOperation (OperationKind.Conditional, Type: null, IsInvalid) (Syntax: '/*<bind>*/e ... }')
-  Condition: 
-    IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
-      Children(0)
-  WhenTrue: 
-    IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: '')
-      Expression: 
-        IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
-          Children(0)
-  WhenFalse: 
-    IBlockOperation (0 statements) (OperationKind.Block, Type: null, IsInvalid) (Syntax: '{ ... }')
+IBlockOperation (2 statements) (OperationKind.Block, Type: null, IsInvalid) (Syntax: '{ ... }')
+  IConditionalOperation (OperationKind.Conditional, Type: null, IsInvalid) (Syntax: 'else ... }')
+    Condition: 
+      IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
+        Children(0)
+    WhenTrue: 
+      IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: '')
+        Expression: 
+          IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
+            Children(0)
+    WhenFalse: 
+      IBlockOperation (0 statements) (OperationKind.Block, Type: null, IsInvalid) (Syntax: '{ ... }')
+  IConditionalOperation (OperationKind.Conditional, Type: null) (Syntax: 'else ... }')
+    Condition: 
+      IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
+        Children(0)
+    WhenTrue: 
+      IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: '')
+        Expression: 
+          IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
+            Children(0)
+    WhenFalse: 
+      IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'Op();')
+          Expression: 
+            IInvocationOperation ( void P.Op()) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Op()')
+              Instance Receiver: 
+                IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: P, IsImplicit) (Syntax: 'Op')
+              Arguments(0)
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                
-                // file.cs(11,6): error CS1003: Syntax error, 'if' expected
-                //     {
-                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("if", "else").WithLocation(11, 6),
-                // file.cs(11,6): error CS1003: Syntax error, '(' expected
-                //     {
-                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("(", "else").WithLocation(11, 6),
-                // file.cs(11,6): error CS1525: Invalid expression term 'else'
-                //     {
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(11, 6),
-                // file.cs(11,6): error CS1026: ) expected
-                //     {
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(11, 6),
-                // file.cs(11,6): error CS1525: Invalid expression term 'else'
-                //     {
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(11, 6),
-                // file.cs(11,6): error CS1002: ; expected
-                //     {
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(11, 6),
-                // file.cs(14,10): error CS1003: Syntax error, 'if' expected
-                //         }
-                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("if", "else").WithLocation(14, 10),
-                // file.cs(14,10): error CS1003: Syntax error, '(' expected
-                //         }
-                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("(", "else").WithLocation(14, 10),
-                // file.cs(14,10): error CS1525: Invalid expression term 'else'
-                //         }
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(14, 10),
-                // file.cs(14,10): error CS1026: ) expected
-                //         }
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(14, 10),
-                // file.cs(14,10): error CS1525: Invalid expression term 'else'
-                //         }
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(14, 10),
-                // file.cs(14,10): error CS1002: ; expected
-                //         }
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(14, 10)
+                // file.cs(12,20): error CS1003: Syntax error, 'if' expected
+                //         /*<bind>*/{
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("if", "else").WithLocation(12, 20),
+                // file.cs(12,20): error CS1003: Syntax error, '(' expected
+                //         /*<bind>*/{
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("(", "else").WithLocation(12, 20),
+                // file.cs(12,20): error CS1525: Invalid expression term 'else'
+                //         /*<bind>*/{
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(12, 20),
+                // file.cs(12,20): error CS1026: ) expected
+                //         /*<bind>*/{
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(12, 20),
+                // file.cs(12,20): error CS1525: Invalid expression term 'else'
+                //         /*<bind>*/{
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(12, 20),
+                // file.cs(12,20): error CS1002: ; expected
+                //         /*<bind>*/{
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(12, 20),
+                // file.cs(15,14): error CS1003: Syntax error, 'if' expected
+                //             }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("if", "else").WithLocation(15, 14),
+                // file.cs(15,14): error CS1003: Syntax error, '(' expected
+                //             }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("(", "else").WithLocation(15, 14),
+                // file.cs(15,14): error CS1525: Invalid expression term 'else'
+                //             }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(15, 14),
+                // file.cs(15,14): error CS1026: ) expected
+                //             }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(15, 14),
+                // file.cs(15,14): error CS1525: Invalid expression term 'else'
+                //             }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("else").WithLocation(15, 14),
+                // file.cs(15,14): error CS1002: ; expected
+                //             }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(15, 14)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<IfStatementSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<BlockSyntax>(source, expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -2054,6 +2054,40 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void TestIfElseIf()
+        {
+            var text = "if (a) { } else if (b) { }";
+            var statement = this.ParseStatement(text);
+
+            Assert.NotNull(statement);
+            Assert.Equal(SyntaxKind.IfStatement, statement.Kind());
+            Assert.Equal(text, statement.ToString());
+            Assert.Equal(0, statement.Errors().Length);
+
+            var ss = (IfStatementSyntax)statement;
+            Assert.NotNull(ss.IfKeyword);
+            Assert.Equal(SyntaxKind.IfKeyword, ss.IfKeyword.Kind());
+            Assert.NotNull(ss.OpenParenToken);
+            Assert.NotNull(ss.Condition);
+            Assert.Equal("a", ss.Condition.ToString());
+            Assert.NotNull(ss.CloseParenToken);
+            Assert.NotNull(ss.Statement);
+
+            Assert.NotNull(ss.Else);
+            Assert.NotNull(ss.Else.ElseKeyword);
+            Assert.Equal(SyntaxKind.ElseKeyword, ss.Else.ElseKeyword.Kind());
+            Assert.NotNull(ss.Else.Statement);
+
+            var subIf = (IfStatementSyntax) ss.Else.Statement;
+            Assert.NotNull(subIf.IfKeyword);
+            Assert.Equal(SyntaxKind.IfKeyword, subIf.IfKeyword.Kind());
+            Assert.NotNull(subIf.Condition);
+            Assert.Equal("b", subIf.Condition.ToString());
+            Assert.NotNull(subIf.CloseParenToken);
+            Assert.NotNull(subIf.Statement);
+        }
+
+        [Fact]
         public void TestLock()
         {
             var text = "lock (a) { }";
@@ -2738,6 +2772,185 @@ System.Console.WriteLine(true)";
                 // { label: public
                 Diagnostic(ErrorCode.ERR_RbraceExpected, "public").WithLocation(1, 10)
                 );
+        }
+
+        [WorkItem(27866, "https://github.com/dotnet/roslyn/issues/27866")]
+        [Fact]
+        public void ParseElseWithoutPrecedingIfStatement()
+        {
+            UsingStatement("else {}",
+                // (1,1): error CS1003: Syntax error, 'if' expected
+                // else {}
+                Diagnostic(ErrorCode.ERR_SyntaxError, "else").WithArguments("if", "else").WithLocation(1, 1),
+                // (1,1): error CS1003: Syntax error, '(' expected
+                // else {}
+                Diagnostic(ErrorCode.ERR_SyntaxError, "else").WithArguments("(", "else").WithLocation(1, 1),
+                // (1,1): error CS1525: Invalid expression term 'else'
+                // else {}
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "else").WithArguments("else").WithLocation(1, 1),
+                // (1,1): error CS1026: ) expected
+                // else {}
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "else").WithLocation(1, 1),
+                // (1,1): error CS1525: Invalid expression term 'else'
+                // else {}
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "else").WithArguments("else").WithLocation(1, 1),
+                // (1,1): error CS1002: ; expected
+                // else {}
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "else").WithLocation(1, 1)
+                );
+            N(SyntaxKind.IfStatement);
+            {
+                M(SyntaxKind.IfKeyword);
+                M(SyntaxKind.OpenParenToken);
+                M(SyntaxKind.IdentifierName);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+                M(SyntaxKind.CloseParenToken);
+                M(SyntaxKind.ExpressionStatement);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.ElseClause);
+                {
+                    N(SyntaxKind.ElseKeyword);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [WorkItem(27866, "https://github.com/dotnet/roslyn/issues/27866")]
+        [Fact]
+        public void ParseSubsequentElseWithoutPrecedingIfStatement()
+        {
+            UsingStatement("{ if (a) { } else { } else { } }",
+                // (1,23): error CS1003: Syntax error, 'if' expected
+                // { if (a) { } else { } else { } }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "else").WithArguments("if", "else").WithLocation(1, 23),
+                // (1,23): error CS1003: Syntax error, '(' expected
+                // { if (a) { } else { } else { } }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "else").WithArguments("(", "else").WithLocation(1, 23),
+                // (1,23): error CS1525: Invalid expression term 'else'
+                // { if (a) { } else { } else { } }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "else").WithArguments("else").WithLocation(1, 23),
+                // (1,23): error CS1026: ) expected
+                // { if (a) { } else { } else { } }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "else").WithLocation(1, 23),
+                // (1,23): error CS1525: Invalid expression term 'else'
+                // { if (a) { } else { } else { } }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "else").WithArguments("else").WithLocation(1, 23),
+                // (1,23): error CS1002: ; expected
+                // { if (a) { } else { } else { } }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "else").WithLocation(1, 23)
+                );
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.IfStatement);
+                {
+                    N(SyntaxKind.IfKeyword);
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                    N(SyntaxKind.ElseClause);
+                    {
+                        N(SyntaxKind.ElseKeyword);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.IfStatement);
+                {
+                    M(SyntaxKind.IfKeyword);
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.CloseParenToken);
+                    M(SyntaxKind.ExpressionStatement);
+                    {
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.ElseClause);
+                    {
+                        N(SyntaxKind.ElseKeyword);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
+        [WorkItem(27866, "https://github.com/dotnet/roslyn/issues/27866")]
+        [Fact]
+        public void ParseElseKeywordPlacedAsIfEmbeddedStatement()
+        {
+            UsingStatement("if (a) else {}",
+                // (1,8): error CS1525: Invalid expression term 'else'
+                // if (a) else {}
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "else").WithArguments("else").WithLocation(1, 8),
+                // (1,8): error CS1002: ; expected
+                // if (a) else {}
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "else").WithLocation(1, 8)
+                );
+            N(SyntaxKind.IfStatement);
+            {
+                N(SyntaxKind.IfKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+                N(SyntaxKind.CloseParenToken);
+                M(SyntaxKind.ExpressionStatement);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.ElseClause);
+                {
+                    N(SyntaxKind.ElseKeyword);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+            }
+            EOF();
         }
 
         private sealed class TokenAndTriviaWalker : CSharpSyntaxWalker

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -2830,6 +2830,110 @@ System.Console.WriteLine(true)";
 
         [WorkItem(27866, "https://github.com/dotnet/roslyn/issues/27866")]
         [Fact]
+        public void ParseElseAndElseWithoutPrecedingIfStatement()
+        {
+            UsingStatement("{ else {} else {} }",
+                // (1,3): error CS1003: Syntax error, 'if' expected
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "else").WithArguments("if", "else").WithLocation(1, 3),
+                // (1,3): error CS1003: Syntax error, '(' expected
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "else").WithArguments("(", "else").WithLocation(1, 3),
+                // (1,3): error CS1525: Invalid expression term 'else'
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "else").WithArguments("else").WithLocation(1, 3),
+                // (1,3): error CS1026: ) expected
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "else").WithLocation(1, 3),
+                // (1,3): error CS1525: Invalid expression term 'else'
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "else").WithArguments("else").WithLocation(1, 3),
+                // (1,3): error CS1002: ; expected
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "else").WithLocation(1, 3),
+                // (1,11): error CS1003: Syntax error, 'if' expected
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "else").WithArguments("if", "else").WithLocation(1, 11),
+                // (1,11): error CS1003: Syntax error, '(' expected
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "else").WithArguments("(", "else").WithLocation(1, 11),
+                // (1,11): error CS1525: Invalid expression term 'else'
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "else").WithArguments("else").WithLocation(1, 11),
+                // (1,11): error CS1026: ) expected
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "else").WithLocation(1, 11),
+                // (1,11): error CS1525: Invalid expression term 'else'
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "else").WithArguments("else").WithLocation(1, 11),
+                // (1,11): error CS1002: ; expected
+                // { else {} else {} }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "else").WithLocation(1, 11)
+                );
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.IfStatement);
+                {
+                    M(SyntaxKind.IfKeyword);
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.CloseParenToken);
+                    M(SyntaxKind.ExpressionStatement);
+                    {
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.ElseClause);
+                    {
+                        N(SyntaxKind.ElseKeyword);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.IfStatement);
+                {
+                    M(SyntaxKind.IfKeyword);
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.CloseParenToken);
+                    M(SyntaxKind.ExpressionStatement);
+                    {
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.ElseClause);
+                    {
+                        N(SyntaxKind.ElseKeyword);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
+        [WorkItem(27866, "https://github.com/dotnet/roslyn/issues/27866")]
+        [Fact]
         public void ParseSubsequentElseWithoutPrecedingIfStatement()
         {
             UsingStatement("{ if (a) { } else { } else { } }",


### PR DESCRIPTION
Instead of a general syntax error } expected message we want
sth like Syntax error 'if' expected.

Fixes dotnet/roslyn#27866