### PR TITLE
Make immediate window buffer writable before applying completion edit

### DIFF
--- a/src/EditorFeatures/Core/IDebuggerTextView.cs
+++ b/src/EditorFeatures/Core/IDebuggerTextView.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.VisualStudio.Language.Intellisense;
 
 namespace Microsoft.CodeAnalysis.Editor
@@ -9,5 +10,8 @@ namespace Microsoft.CodeAnalysis.Editor
         bool IsImmediateWindow { get; }
 
         void HACK_StartCompletionSession(IIntellisenseSession editorSessionOpt);
+
+        uint StartBufferUpdate();
+        void EndBufferUpdate(uint cookie);
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -114,11 +114,26 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     var adjustedNewText = AdjustForVirtualSpace(textChange);
                     var editOptions = GetEditOptions(mappedSpan, adjustedNewText);
 
+                    // The immediate window is always marked read-only and the language service is
+                    // responsible for asking the buffer to make itself writable. We'll have to do that for
+                    // commit, so we need to drag the IVsTextLines around, too.
+                    // We have to ask the buffer to make itself writable, if it isn't already
+                    uint immediateWindowBufferUpdateCookie = 0;
+                    if (_isImmediateWindow)
+                    {
+                        immediateWindowBufferUpdateCookie = ((IDebuggerTextView)TextView).StartBufferUpdate();
+                    }
+
                     // Now actually make the text change to the document.
                     using (var textEdit = this.SubjectBuffer.CreateEdit(editOptions, reiteratedVersionNumber: null, editTag: null))
                     {
                         textEdit.Replace(mappedSpan.Span, adjustedNewText);
                         textEdit.ApplyAndLogExceptions();
+                    }
+
+                    if (_isImmediateWindow)
+                    {
+                        ((IDebuggerTextView)TextView).EndBufferUpdate(immediateWindowBufferUpdateCookie);
                     }
 
                     // If the completion change requested a new position for the caret to go,

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
 
             var bufferGraph = _bufferGraphFactoryService.CreateBufferGraph(_projectionBuffer);
 
-            _debuggerTextView = new DebuggerTextView(_textView, bufferGraph, this.InImmediateWindow);
+            _debuggerTextView = new DebuggerTextView(_textView, bufferGraph, _debuggerTextLines, InImmediateWindow);
             return true;
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -64,7 +64,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         }
 
         // Constructor for testing
-        protected AbstractDebuggerIntelliSenseContext(IWpfTextView wpfTextView,
+        protected AbstractDebuggerIntelliSenseContext(
+            IWpfTextView wpfTextView,
             ITextBuffer contextBuffer,
             Microsoft.VisualStudio.TextManager.Interop.TextSpan[] currentStatementSpan,
             IComponentModel componentModel,

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
@@ -24,16 +24,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         /// The actual debugger view of the watch or immediate window that we're wrapping
         /// </summary>
         private readonly IWpfTextView _innerTextView;
-        private readonly IVsTextLines _debuggerTextLines;
+        private readonly IVsTextLines _debuggerTextLinesOpt;
 
         public DebuggerTextView(
             IWpfTextView innerTextView,
             IBufferGraph bufferGraph,
-            IVsTextLines debuggerTextLines,
+            IVsTextLines debuggerTextLinesOpt,
             bool isImmediateWindow)
         {
             _innerTextView = innerTextView;
-            _debuggerTextLines = debuggerTextLines;
+            _debuggerTextLinesOpt = debuggerTextLinesOpt;
             BufferGraph = bufferGraph;
             IsImmediateWindow = isImmediateWindow;
         }
@@ -66,15 +66,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
 
         public uint StartBufferUpdate()
         {
-            _debuggerTextLines.GetStateFlags(out var bufferFlags);
-            _debuggerTextLines.SetStateFlags((uint)((BUFFERSTATEFLAGS)bufferFlags & ~BUFFERSTATEFLAGS.BSF_USER_READONLY));
+            // null in unit tests
+            if (_debuggerTextLinesOpt == null)
+            {
+                return 0;
+            }
 
+            _debuggerTextLinesOpt.GetStateFlags(out var bufferFlags);
+            _debuggerTextLinesOpt.SetStateFlags((uint)((BUFFERSTATEFLAGS)bufferFlags & ~BUFFERSTATEFLAGS.BSF_USER_READONLY));
             return bufferFlags;
         }
 
         public void EndBufferUpdate(uint cookie)
         {
-            _debuggerTextLines.SetStateFlags(cookie);
+            // null in unit tests
+            _debuggerTextLinesOpt?.SetStateFlags(cookie);
         }
 
         public ITextCaret Caret


### PR DESCRIPTION
### Customer scenario

VS crashes when completion in Immediate Window is committed by double-clicking on the completion item.

### Bugs this fixes

[VSO 384025](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/384025) 
https://github.com/dotnet/roslyn/issues/24565 

### Workarounds, if any

Complete using `tab`.

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

Customer reported.

### Test documentation updated?

