### PR TITLE
Assert that IArrayInitializationOperation.Type is always null in test visitors

### DIFF
--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1443,6 +1443,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             LogString($" ({operation.ElementValues.Length} elements)");
             LogCommonPropertiesAndNewLine(operation);
 
+            Assert.Null(operation.Type);
             VisitArray(operation.ElementValues, "Element Values", logElementCount: true);
         }
 

--- a/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
@@ -937,6 +937,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public override void VisitArrayInitializer(IArrayInitializerOperation operation)
         {
             Assert.Equal(OperationKind.ArrayInitializer, operation.Kind);
+            Assert.Null(operation.Type);
             AssertEx.Equal(operation.ElementValues, operation.Children);
         }
 


### PR DESCRIPTION
Fixes #8891
