### PR TITLE
Reduce IO costs in AnalyzerFileWatcherService

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
@@ -61,8 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             if (File.Exists(analyzerAssemblyFullPath))
             {
-                GetAnalyzerFileWatcherService().AddPath(analyzerAssemblyFullPath);
-                GetAnalyzerFileWatcherService().ErrorIfAnalyzerAlreadyLoaded(Id, analyzerAssemblyFullPath);
+                GetAnalyzerFileWatcherService().TrackFilePathAndReportErrorIfChanged(analyzerAssemblyFullPath, projectId: Id);
             }
             else
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
@@ -67,6 +67,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             get { return _filePath; }
         }
 
+        /// <summary>
+        /// Returns true if a previous call to <see cref="StartFileChangeListeningAsync"/> has completed.
+        /// </summary>
+        public bool PreviousCallToStartFileChangeHasAsynchronouslyCompleted
+        {
+            get
+            {
+                var cookie = _fileChangeCookie;
+                return cookie != s_none && cookie.IsValueCreated;
+            }
+        }
+
         public void AssertUnsubscription()
         {
             // We must have been disposed properly.


### PR DESCRIPTION
This service tries to watch analyzer files to see if they've changed, and if they have inform the user that they'll have to restart Visual Studio. It did this via two ways:

1. When a file was first added, it's modification time was stored in a dictionary, which was checked in any subsequent entry.
2. Via file watchers.

The first approach was broken in an interesting way: each time a reference was added, we'd add the modification time to the map (doing the IO to get the time). This overwrote the previous value, even if the value had changed in the middle. Then, we'd do the IO a second time, checking against the value we had just stored. As a result, the window where we could detect a change in the first approach was very
tiny.

I attempt to rectify what seems to be the intent here and also speed it up. First off, we won't overwrite previous values so the first approach has a better chance of actually working. Also, we'll read the data
once instead of twice. Further more, once the file watcher (second approach) is active, we'll just stop reading timesetamps entirely, because by then there's no reason to use the first approach at all.

Note this approach still has a flaw: if the file is modified between when we do any timestamp checking, and the file watcher is active, we'll completely miss the change and report nothing, at least until somebody tries adding the analyzer again. This isn't new; it seems this was already broken anyways. We could just always force the file watcher immediately, but that might be tied up if somebody else is using the service so we're still assuming IO is cheaper in that case.

This change is intended as a quick reward without churning this area more fully; it's also possible we could move more of this to a separate thread; doing so would require the proof that it's safe. I'll revisit this once this becomes the big fish to fry again.

<details><summary>Ask Mode template</summary>

### Customer scenario

User opens a large solution; it takes longer than they'd like.

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Don't use analyzers.

### Risk

Low: just changing how one particular codepath is handled when adding analyzers.

### Performance impact

Better: opening a csproj/msvbprj-based Roslyn.sln, this shaves off approximately 600ms from solution load in my testing on my dev VM.

### Is this a regression from a previous update?

No, always been like this.

### Root cause analysis

We were repeatedly asking for file modification times for a file when we could reduce the number of IO operations. Even if IO was free, the CPU overhead wasn't.

### How was the bug found?

Performance trace analysis of solution load, looking for low-hanging fruit.

</details>
