### PR TITLE
Defer reading of the metadata timestamp until later

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Execution;
 using Microsoft.CodeAnalysis.Host;
@@ -31,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         internal sealed class Snapshot : PortableExecutableReference, ISupportTemporaryStorage
         {
             private readonly VisualStudioMetadataReferenceManager _provider;
-            private readonly DateTime _timestamp;
+            private readonly Lazy<DateTime> _timestamp;
             private Exception _error;
 
             internal Snapshot(VisualStudioMetadataReferenceManager provider, MetadataReferenceProperties properties, string fullPath)
@@ -40,20 +41,29 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 Contract.Requires(Properties.Kind == MetadataImageKind.Assembly);
                 _provider = provider;
 
-                try
-                {
-                    _timestamp = FileUtilities.GetFileTimeStamp(this.FilePath);
-                }
-                catch (IOException e)
-                {
-                    // Reading timestamp of a file might fail. 
-                    // Let's remember the failure and report it to the compiler when it asks for metadata.
-                    _error = e;
-                }
+                _timestamp = new Lazy<DateTime>(() => {
+                    try
+                    {
+                        return FileUtilities.GetFileTimeStamp(this.FilePath);
+                    }
+                    catch (IOException e)
+                    {
+                        // Reading timestamp of a file might fail. 
+                        // Let's remember the failure and report it to the compiler when it asks for metadata.
+                        // We could let the Lazy hold onto this (since it knows how to rethrow exceptions), but
+                        // our support of GetStorages needs to gracefully handle the case where we have no timestamp.
+                        // If Lazy had a "IsValueFaulted" we could be cleaner here.
+                        _error = e;
+                        return DateTime.MinValue;
+                    }
+                }, LazyThreadSafetyMode.PublicationOnly);
             }
 
             protected override Metadata GetMetadataImpl()
             {
+                // Fetch the timestamp first, so as to populate _error if needed
+                var timestamp = _timestamp.Value;
+
                 if (_error != null)
                 {
                     throw _error;
@@ -61,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 try
                 {
-                    return _provider.GetMetadata(this.FilePath, _timestamp);
+                    return _provider.GetMetadata(this.FilePath, timestamp);
                 }
                 catch (Exception e) when (SaveMetadataReadingException(e))
                 {
@@ -98,7 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             public IEnumerable<ITemporaryStreamStorage> GetStorages()
             {
-                return _provider.GetStorages(this.FilePath, _timestamp);
+                return _provider.GetStorages(this.FilePath, _timestamp.Value);
             }
         }
     }


### PR DESCRIPTION
When we were creating new metadata reference snapshots, we were reading the timestamp far earlier than needed; all that matters is we actually read it prior to reading it. This is inline with our patterns around syntax trees and analyzers.

This change is a fairly paranoid change as I try to preserve existing semantics (and perhaps bugs too). This area is quite sensitive.

<details><summary>Ask Mode template</summary>

### Customer scenario

User opens a solution with lots of metadata references. It takes longer to open than it should.

### Bugs this fixes

No explicit bug at this point -- fixing as part of targeted investigations.

### Workarounds, if any

User a smaller project or a computer that is infinitely fast.

### Risk

Low to moderate -- this area is somewhat sensitive to exception handling and such, but efforts were made to avoid that impact as much as possible.

### Performance impact

This improves opening a warm Roslyn.sln that is using csproj/msvbprj by 800 ms on my test VM.

### Is this a regression from a previous update?

Nope.

### Root cause analysis

Every time we were told about a new metadata reference, we were querying the timestamp of the metadata reference on the UI thread, immediately. There's no reason to do this until we actually need the metadata, which can then be done on other threads.

### How was the bug found?

Perf trace analysis.

</details>
