### PR TITLE
Revert "Remove SpecializedTasks.EmptyTask"

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/Preview/ErrorCases/ExceptionInCodeAction.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/Preview/ErrorCases/ExceptionInCodeAction.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.ErrorC
         public override Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
             context.RegisterRefactoring(new ExceptionCodeAction());
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         internal class ExceptionCodeAction : CodeAction

--- a/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             {
                 var codeAction = new MyCodeAction(context.Document);
                 context.RegisterRefactoring(codeAction);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             private class MyCodeAction : CodeAction

--- a/src/EditorFeatures/Core.Wpf/SymbolSearch/SymbolSearchUpdateEngine.Update.cs
+++ b/src/EditorFeatures/Core.Wpf/SymbolSearch/SymbolSearchUpdateEngine.Update.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             if (ourSentinel != currentSentinel)
             {
                 // We already have an update loop for this source.  Nothing for us to do.
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             // We were the first ones to try to update this source.  Spawn off a task to do

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
@@ -73,10 +73,10 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
 
             // Do nothing functions.  The streaming far service doesn't care about
             // any of these.
-            public Task OnStartedAsync() => Task.CompletedTask;
-            public Task OnCompletedAsync() => Task.CompletedTask;
-            public Task OnFindInDocumentStartedAsync(Document document) => Task.CompletedTask;
-            public Task OnFindInDocumentCompletedAsync(Document document) => Task.CompletedTask;
+            public Task OnStartedAsync() => SpecializedTasks.EmptyTask;
+            public Task OnCompletedAsync() => SpecializedTasks.EmptyTask;
+            public Task OnFindInDocumentStartedAsync(Document document) => SpecializedTasks.EmptyTask;
+            public Task OnFindInDocumentCompletedAsync(Document document) => SpecializedTasks.EmptyTask;
 
             // Simple context forwarding functions.
             public Task ReportProgressAsync(int current, int maximum) =>

--- a/src/EditorFeatures/Core/FindUsages/FindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/FindUsagesContext.cs
@@ -15,16 +15,16 @@ namespace Microsoft.CodeAnalysis.FindUsages
         {
         }
 
-        public virtual Task ReportMessageAsync(string message) => Task.CompletedTask;
+        public virtual Task ReportMessageAsync(string message) => SpecializedTasks.EmptyTask;
 
-        public virtual Task SetSearchTitleAsync(string title) => Task.CompletedTask;
+        public virtual Task SetSearchTitleAsync(string title) => SpecializedTasks.EmptyTask;
 
-        public virtual Task OnCompletedAsync() => Task.CompletedTask;
+        public virtual Task OnCompletedAsync() => SpecializedTasks.EmptyTask;
 
-        public virtual Task OnDefinitionFoundAsync(DefinitionItem definition) => Task.CompletedTask;
+        public virtual Task OnDefinitionFoundAsync(DefinitionItem definition) => SpecializedTasks.EmptyTask;
 
-        public virtual Task OnReferenceFoundAsync(SourceReferenceItem reference) => Task.CompletedTask;
+        public virtual Task OnReferenceFoundAsync(SourceReferenceItem reference) => SpecializedTasks.EmptyTask;
 
-        public virtual Task ReportProgressAsync(int current, int maximum) => Task.CompletedTask;
+        public virtual Task ReportProgressAsync(int current, int maximum) => SpecializedTasks.EmptyTask;
     }
 }

--- a/src/EditorFeatures/Core/FindUsages/SimpleFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/SimpleFindUsagesContext.cs
@@ -34,13 +34,13 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
         public override Task ReportMessageAsync(string message)
         {
             Message = message;
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public override Task SetSearchTitleAsync(string title)
         {
             SearchTitle = title;
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public ImmutableArray<DefinitionItem> GetDefinitions()
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 _definitionItems.Add(definition);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public override Task OnReferenceFoundAsync(SourceReferenceItem reference)
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 _referenceItems.Add(reference);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightingViewTaggerProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.BraceMatching
             var document = documentSnapshotSpan.Document;
             if (!caretPosition.HasValue || document == null)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             return ProduceTagsAsync(context, document, documentSnapshotSpan.SnapshotSpan.Snapshot, caretPosition.Value);

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.Tagger.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                         context, documentSpan, delegationService, classificationService, typeMap);
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             var classificationService = document?.GetLanguageService<TClassificationService>();
             if (classificationService == null)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             return SemanticClassificationUtilities.ProduceTagsAsync(

--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 verifyArguments: false,
                 cancellationToken: cancellationToken);
 
-            var task = fixer.RegisterCodeFixesAsync(context) ?? Task.CompletedTask;
+            var task = fixer.RegisterCodeFixesAsync(context) ?? SpecializedTasks.EmptyTask;
             await task.ConfigureAwait(false);
             return fixes.ToImmutableAndFree();
         }
@@ -497,7 +497,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             // we do have fixer. now let's see whether it actually can fix it
             foreach (var fixer in allFixers)
             {
-                await extensionManager.PerformActionAsync(fixer, () => fixer.RegisterCodeFixesAsync(context) ?? Task.CompletedTask).ConfigureAwait(false);
+                await extensionManager.PerformActionAsync(fixer, () => fixer.RegisterCodeFixesAsync(context) ?? SpecializedTasks.EmptyTask).ConfigureAwait(false);
                 foreach (var fix in fixes)
                 {
                     if (!fix.Action.PerformFinalApplicabilityCheck)

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
         protected override Task ProduceTagsAsync(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag, int? caretPosition)
         {
             ProduceTags(context, spanToTag);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private void ProduceTags(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag)

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/AbstractRenameTrackingCodeFixProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/AbstractRenameTrackingCodeFixProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 context.RegisterCodeFix(action, diagnostic);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
@@ -216,27 +216,27 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
         #region not used
         public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public void RemoveProject(ProjectId projectId)

--- a/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -82,26 +82,26 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
             // don't generate all the tags then the user will cycle through an incorrect subset.
             if (context.CaretPosition == null)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             var caretPosition = context.CaretPosition.Value;
             if (!Workspace.TryGetWorkspace(caretPosition.Snapshot.AsText().Container, out var workspace))
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             // GetSpansToTag may have produced no actual spans to tag.  Be resilient to that.
             var document = context.SpansToTag.FirstOrDefault(vt => vt.SnapshotSpan.Snapshot == caretPosition.Snapshot).Document;
             if (document == null)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             // Don't produce tags if the feature is not enabled.
             if (!workspace.Options.GetOption(FeatureOnOffOptions.ReferenceHighlighting, document.Project.Language))
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             var existingTags = context.GetExistingTags(new SnapshotSpan(caretPosition, 0));
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
                 // tag to another.  In this case we don't want to recompute anything.  Let our caller
                 // know that we should preserve all tags.
                 context.SetSpansTagged(SpecializedCollections.EmptyEnumerable<DocumentSnapshotSpan>());
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             // Otherwise, we need to go produce all tags.

--- a/src/EditorFeatures/Core/Shared/Threading/AsynchronousSerialWorkQueue.cs
+++ b/src/EditorFeatures/Core/Shared/Threading/AsynchronousSerialWorkQueue.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Threading
 
             // Initialize so we don't have to check for null below. Force the background task to run
             // on the threadpool. 
-            _currentBackgroundTask = Task.CompletedTask;
+            _currentBackgroundTask = SpecializedTasks.EmptyTask;
         }
 
         public CancellationToken CancellationToken => _cancellationTokenSource.Token;

--- a/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
                 // and there's no pending user input.
                 action();
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
             else
             {

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -483,7 +483,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 if (ShouldSkipTagProduction())
                 {
                     // If the feature is disabled, then just produce no tags.
-                    return Task.CompletedTask;
+                    return SpecializedTasks.EmptyTask;
                 }
 
                 return _dataSource.ProduceTagsAsync(context);

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
         protected virtual Task ProduceTagsAsync(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag, int? caretPosition)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected virtual void ProduceTagsSynchronously(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag, int? caretPosition)

--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
             {
                 Called = true;
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 

--- a/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                     Result.Add(definition);
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -1171,7 +1171,7 @@ End Class";
             public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
             {
                 this.ProjectIds.Add(project.Id);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
@@ -1181,14 +1181,14 @@ End Class";
                     this.DocumentIds.Add(document.Id);
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken)
             {
                 this.SyntaxDocumentIds.Add(document.Id);
                 Process(document.Id, cancellationToken);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public void RemoveDocument(DocumentId documentId)
@@ -1228,22 +1228,22 @@ End Class";
             #region unused 
             public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
             #endregion
         }
@@ -1255,17 +1255,17 @@ End Class";
             public Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
             {
                 this.DocumentIds.Add(document.Id);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             #region unused 
             public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e) => false;
-            public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken) => Task.CompletedTask;
-            public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken) => Task.CompletedTask;
-            public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken) => Task.CompletedTask;
-            public Task DocumentResetAsync(Document document, CancellationToken cancellationToken) => Task.CompletedTask;
-            public Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken) => Task.CompletedTask;
-            public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken) => SpecializedTasks.EmptyTask;
+            public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken) => SpecializedTasks.EmptyTask;
+            public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken) => SpecializedTasks.EmptyTask;
+            public Task DocumentResetAsync(Document document, CancellationToken cancellationToken) => SpecializedTasks.EmptyTask;
+            public Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken) => SpecializedTasks.EmptyTask;
+            public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken) => SpecializedTasks.EmptyTask;
             public void RemoveDocument(DocumentId documentId) { }
             public void RemoveProject(ProjectId projectId) { }
             #endregion

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
                     }
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -91,11 +91,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             End Sub
 
             Public Function AddSemanticClassificationsAsync(document As Document, textSpan As TextSpan, result As List(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IEditorClassificationService.AddSemanticClassificationsAsync
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
 
             Public Function AddSyntacticClassificationsAsync(document As Document, textSpan As TextSpan, result As List(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IEditorClassificationService.AddSyntacticClassificationsAsync
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
 
             Public Function AdjustStaleClassification(text As SourceText, classifiedSpan As ClassifiedSpan) As ClassifiedSpan Implements IEditorClassificationService.AdjustStaleClassification

--- a/src/EditorFeatures/Test2/Diagnostics/AddImport/AddImportCrossLanguageTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/AddImport/AddImportCrossLanguageTests.vb
@@ -530,7 +530,7 @@ namespace CSAssembly2
                                                    Select p.Name
 
                         Assert.True(newProjectReferences.Contains(addedReference))
-                        Return Task.CompletedTask
+                        Return SpecializedTasks.EmptyTask
                     End Function
             End If
 

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                     Me.Definitions.Add(definition)
                 End SyncLock
 
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
 
             Public Overrides Function OnReferenceFoundAsync(reference As SourceReferenceItem) As Task
@@ -156,7 +156,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                     References.Add(reference)
                 End SyncLock
 
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
         End Class
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3859,7 +3859,7 @@ class C
                 context.AddItem(CompletionItem.Create(
                     "CustomItem",
                     rules:=CompletionItemRules.Default.WithMatchPriority(1000)))
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
 
             Public Overrides Function ShouldTriggerCompletion(text As SourceText, caretPosition As Integer, trigger As CompletionTrigger, options As OptionSet) As Boolean

--- a/src/EditorFeatures/Test2/IntelliSense/MockCompletionProvider.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/MockCompletionProvider.vb
@@ -23,20 +23,20 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
             If _getItems Is Nothing Then
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End If
 
             Dim items = _getItems(context.Document, context.Position, context.CancellationToken)
 
             If items Is Nothing Then
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End If
 
             For Each item In items
                 context.AddItem(item)
             Next
 
-            Return Task.CompletedTask
+            Return SpecializedTasks.EmptyTask
         End Function
 
         Friend Overrides Function IsInsertionTrigger(text As SourceText, characterPosition As Integer, options As OptionSet) As Boolean

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/Preview/PreviewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/Preview/PreviewTests.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
             Public NotOverridable Overrides Function ComputeRefactoringsAsync(context As CodeRefactoringContext) As Task
                 Dim codeAction = New MyCodeAction(context.Document)
                 context.RegisterRefactoring(codeAction)
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
 
             Private Class MyCodeAction : Inherits CodeAction

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/NamespaceContextTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/NamespaceContextTests.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
         Protected Overrides Function CheckResultAsync(validLocation As Boolean, position As Integer, syntaxTree As SyntaxTree) As Task
             Dim token = syntaxTree.GetTargetToken(position, CancellationToken.None)
             Assert.Equal(validLocation, syntaxTree.IsNamespaceContext(position, token, CancellationToken.None))
-            Return Task.CompletedTask
+            Return SpecializedTasks.EmptyTask
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/TypeContextTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/TypeContextTests.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
         Protected Overrides Function CheckResultAsync(validLocation As Boolean, position As Integer, syntaxTree As SyntaxTree) As Task
             Dim token = syntaxTree.GetTargetToken(position, CancellationToken.None)
             Assert.Equal(validLocation, syntaxTree.IsTypeContext(position, token, CancellationToken.None))
-            Return Task.CompletedTask
+            Return SpecializedTasks.EmptyTask
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>

--- a/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesCodeFixProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 });
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private sealed class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/CSharp/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryCast
                 FeaturesResources.Remove_Unnecessary_Cast,
                 c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessCodeFixProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
                 AddEdits(editor, diagnostic, cancellationToken);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private void AddEdits(

--- a/src/Features/CSharp/Portable/RemoveUnreachableCode/CSharpRemoveUnreachableCodeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveUnreachableCode/CSharpRemoveUnreachableCodeCodeFixProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnreachableCode
                 c => FixAsync(context.Document, diagnostic, c),
                 priority), diagnostic);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnreachableCode
                 }
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/CSharp/Portable/RemoveUnusedLocalFunction/CSharpRemoveUnusedLocalFunctionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedLocalFunction/CSharpRemoveUnusedLocalFunctionCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedLocalFunction
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(Document document, ImmutableArray<Diagnostic> diagnostics, SyntaxEditor editor, CancellationToken cancellationToken)
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedLocalFunction
                 editor.RemoveNode(localFunction);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
                 c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/CSharp/Portable/TypeStyle/UseImplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseImplicitTypeCodeFixProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
                 ReplaceTypeWithVar(editor, node);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         internal static void ReplaceTypeWithVar(SyntaxEditor editor, SyntaxNode node)

--- a/src/Features/CSharp/Portable/UseDeconstruction/CSharpUseDeconstructionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseDeconstruction/CSharpUseDeconstructionCodeFixProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics[0], c)),
                 context.Diagnostics);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(

--- a/src/Features/CSharp/Portable/UseDefaultLiteral/CSharpUseDefaultLiteralCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseDefaultLiteral/CSharpUseDefaultLiteralCodeFixProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDefaultLiteral
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckForCastAndEqualityOperatorCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckForCastAndEqualityOperatorCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
                 new MyCodeAction(CSharpFeaturesResources.Use_is_null_check,
                 c => this.FixAsync(context.Document, diagnostic, c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
                     (current, g) => Rewrite((BinaryExpressionSyntax)current));
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private static ExpressionSyntax Rewrite(BinaryExpressionSyntax binary)

--- a/src/Features/CSharp/Portable/UseLocalFunction/CSharpUseLocalFunctionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseLocalFunction/CSharpUseLocalFunctionCodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseLocalFunction
             context.RegisterCodeFix(
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 AddEdits(editor, diagnostic, cancellationToken);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private static ExpressionSyntax GetCondition(SyntaxNode node)

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckCodeFixProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 AddEdits(editor, diagnostic, cancellationToken);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private void AddEdits(

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             context.RegisterCodeFix(
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/Core/Portable/AddAccessibilityModifiers/AbstractAddAccessibilityModifiersCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddAccessibilityModifiers/AbstractAddAccessibilityModifiersCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.AddAccessibilityModifiers
             context.RegisterCodeFix(
                 new MyCodeAction(priority, c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected sealed override async Task FixAllAsync(

--- a/src/Features/Core/Portable/AddRequiredParentheses/AddRequiredParenthesesCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddRequiredParentheses/AddRequiredParenthesesCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.AddRequiredParentheses
                     c => FixAsync(context.Document, firstDiagnostic, c),
                     firstDiagnostic.Properties[AddRequiredParenthesesConstants.EquivalenceKey]),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.AddRequiredParentheses
                         current, includeElasticTrivia: false, addSimplifierAnnotation: false));
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/Core/Portable/CodeFixes/PreferFrameworkType/PreferFrameworkTypeCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/PreferFrameworkType/PreferFrameworkTypeCodeFixProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.PreferFrameworkType
                     equivalenceKey),
                 context.Diagnostics);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                     },
                     cancellationToken);
 
-                var task = provider.ComputeRefactoringsAsync(context) ?? Task.CompletedTask;
+                var task = provider.ComputeRefactoringsAsync(context) ?? SpecializedTasks.EmptyTask;
                 await task.ConfigureAwait(false);
 
                 var result = actions.Count > 0

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // no closed file diagnostic and file is not opened, remove any existing diagnostics
                 RemoveDocument(document.Id);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
@@ -146,17 +146,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public void RemoveProject(ProjectId projectId)

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return analyzer.SynchronizeWithBuildAsync(workspace, diagnostics);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _stateManager.OnDocumentReset(stateSets, document);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public void RemoveDocument(DocumentId documentId)
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             // let other components knows about this event
             _compilationManager.OnNewSolution();
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private static bool AnalysisEnabled(Document document)

--- a/src/Features/Core/Portable/IncrementalCaches/SyntaxTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SyntaxTreeInfoIncrementalAnalyzerProvider.cs
@@ -25,12 +25,12 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                 if (!document.SupportsSyntaxTree)
                 {
                     // Not a language we can produce indices for (i.e. TypeScript).  Bail immediately.
-                    return Task.CompletedTask;
+                    return SpecializedTasks.EmptyTask;
                 }
 
                 if (!RemoteFeatureOptions.ShouldComputeIndex(document.Project.Solution.Workspace))
                 {
-                    return Task.CompletedTask;
+                    return SpecializedTasks.EmptyTask;
                 }
 
                 return SyntaxTreeIndex.PrecalculateAsync(document, cancellationToken);

--- a/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyCodeFixProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.MakeFieldReadonly
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics[0], c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private async Task FixWithEditorAsync(

--- a/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodSynchronous
             context.RegisterCodeFix(
                 new MyCodeAction(c => FixNodeAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private const string AsyncSuffix = "Async";

--- a/src/Features/Core/Portable/Notification/SemanticChangeNotificationService.cs
+++ b/src/Features/Core/Portable/Notification/SemanticChangeNotificationService.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Notification
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
                 RemoveDocument(document.Id);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
@@ -95,22 +95,22 @@ namespace Microsoft.CodeAnalysis.Notification
             #region unused 
             public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             #endregion

--- a/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersCodeFixProvider.cs
+++ b/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersCodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
             context.RegisterCodeFix(
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics[0], c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
                     context.Diagnostics);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private Task<Document> FixAsync(

--- a/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsCodeFixProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
                     GetTitle(),
                     c => RemoveUnnecessaryImportsAsync(context.Document, c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected abstract string GetTitle();

--- a/src/Features/Core/Portable/RemoveUnnecessaryParentheses/AbstractRemoveUnnecessaryParenthesesCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveUnnecessaryParentheses/AbstractRemoveUnnecessaryParenthesesCodeFixProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryParentheses
                 new MyCodeAction(
                     c => FixAsync(context.Document, context.Diagnostics[0], c)),
                     context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(

--- a/src/Features/Core/Portable/SolutionCrawler/GlobalOperationAwareIdleProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/GlobalOperationAwareIdleProcessor.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             base(listener, backOffTimeSpanInMs, shutdownToken)
         {
             _globalOperation = null;
-            _globalOperationTask = Task.CompletedTask;
+            _globalOperationTask = SpecializedTasks.EmptyTask;
 
             _globalOperationNotificationService = globalOperationNotificationService;
             _globalOperationNotificationService.Started += OnGlobalOperationStarted;
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             _globalOperation = null;
 
             // set to empty task so that we don't need a lock
-            _globalOperationTask = Task.CompletedTask;
+            _globalOperationTask = SpecializedTasks.EmptyTask;
         }
 
         public virtual void Shutdown()

--- a/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             {
                 if (_processorTask == null)
                 {
-                    return Task.CompletedTask;
+                    return SpecializedTasks.EmptyTask;
                 }
 
                 return _processorTask;

--- a/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerBase.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerBase.cs
@@ -15,22 +15,22 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public virtual Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public virtual Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public virtual Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public virtual Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
@@ -40,17 +40,17 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public virtual Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public virtual Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public virtual Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public virtual void RemoveDocument(DocumentId documentId)

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerProgressReporter.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerProgressReporter.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     return RaiseStarted().CompletesAsyncOperation(asyncToken);
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task Stop()
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     return RaiseStopped().CompletesAsyncOperation(asyncToken);
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             private Task RaiseStarted()
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     });
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         _processor = processor;
                         _lazyAnalyzers = lazyAnalyzers;
 
-                        _running = Task.CompletedTask;
+                        _running = SpecializedTasks.EmptyTask;
                         _workItemQueue = new AsyncDocumentWorkItemQueue(processor._registration.ProgressReporter, processor._registration.Workspace);
 
                         Start();

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         CancellationToken shutdownToken) :
                         base(listener, processor, lazyAnalyzers, globalOperationNotificationService, backOffTimeSpanInMs, shutdownToken)
                     {
-                        _running = Task.CompletedTask;
+                        _running = SpecializedTasks.EmptyTask;
                         _workItemQueue = new AsyncDocumentWorkItemQueue(processor._registration.ProgressReporter, processor._registration.Workspace);
                         _higherPriorityDocumentsNotProcessed = new ConcurrentDictionary<DocumentId, IDisposable>(concurrencyLevel: 2, capacity: 20);
 

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                     diagnostic);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private async Task<Solution> ProcessResultAsync(CodeFixContext context, Diagnostic diagnostic, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/UseCoalesceExpression/UseCoalesceExpressionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseCoalesceExpression/UseCoalesceExpressionCodeFixProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics[0], c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/Core/Portable/UseCoalesceExpression/UseCoalesceExpressionForNullableCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseCoalesceExpression/UseCoalesceExpressionForNullableCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics[0], c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             context.RegisterCodeFix(
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
             context.RegisterCodeFix(
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForReturn/AbstractUseConditionalExpressionForReturnCodeFixProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
             context.RegisterCodeFix(
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixOneAsync(

--- a/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameCodeFixProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.UseExplicitTupleName
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics[0], c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.UseExplicitTupleName
                 editor.ReplaceNode(oldNameNode, newNameNode);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/Core/Portable/UseInferredMemberName/AbstractUseInferredMemberNameCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseInferredMemberName/AbstractUseInferredMemberNameCodeFixProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.UseInferredMemberName
                 c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.UseInferredMemberName
                 LanguageSpecificRemoveSuggestedNode(editor, node);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
 

--- a/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullForReferenceEqualsCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullForReferenceEqualsCodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
             context.RegisterCodeFix(
                 new MyCodeAction(title, c => this.FixAsync(context.Document, diagnostic, c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                     replacement.WithTriviaFrom(toReplace));
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/Core/Portable/UseNullPropagation/AbstractUseNullPropagationCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseNullPropagation/AbstractUseNullPropagationCodeFixProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
             context.RegisterCodeFix(new MyCodeAction(
                 c => FixAsync(context.Document, context.Diagnostics[0], c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
             context.RegisterCodeFix(
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override async Task FixAllAsync(

--- a/src/Features/Core/Portable/UseThrowExpression/UseThrowExpressionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/UseThrowExpressionCodeFixProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                 new MyCodeAction(c => FixAsync(context.Document, diagnostic, c)),
                 diagnostic);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected override Task FixAllAsync(
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                     generator.ThrowExpression(throwStatementExpression)));
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
+++ b/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Host
             {
                 _owner.ClearExpiredImplicitCache(DateTime.UtcNow - TimeSpan.FromMilliseconds(BackOffTimeSpanInMS));
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public void Touch()
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Host
                     return _gate.WaitAsync(cancellationToken);
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
     }

--- a/src/Features/VisualBasic/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.RemoveUnnecessaryCast
                 FeaturesResources.Remove_Unnecessary_Cast,
                 Function(c) FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics)
-            Return Task.CompletedTask
+            Return SpecializedTasks.EmptyTask
         End Function
 
         Private Shared Function IsUnnecessaryCast(node As ExpressionSyntax, model As SemanticModel, cancellationToken As CancellationToken) As Boolean

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -266,27 +266,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         #region unused
         public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
         #endregion
     }

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -222,7 +222,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             {
                 // Note: IFindAllReferenceWindow.Title is safe to set from any thread.
                 _findReferencesWindow.Title = title;
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public sealed override async Task OnCompletedAsync()
@@ -331,7 +331,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 }
 #endif
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             #endregion

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
             // Nothing to do on completion.
             protected override Task OnCompletedAsyncWorkerAsync()
-                => Task.CompletedTask;
+                => SpecializedTasks.EmptyTask;
 
             protected override async Task OnDefinitionFoundWorkerAsync(DefinitionItem definition)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 }
             }
 
-            return System.Threading.Tasks.Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private object GetFirstOrDefaultValue(OptionKey optionKey, IEnumerable<RoamingProfileStorageLocation> roamingSerializations)

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemotableDataJsonRpcEx.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemotableDataJsonRpcEx.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         private Task WriteNoAssetAsync(ObjectWriter writer)
         {
             writer.WriteInt32(0);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private async Task WriteOneAssetAsync(ObjectWriter writer, int scopeId, Checksum checksum, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/SymbolSearch/VisualStudioSymbolSearchService.ProgressService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/SymbolSearch/VisualStudioSymbolSearchService.ProgressService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             var handler = _taskCenterServiceOpt.Value?.PreRegister(options, data);
             handler?.RegisterTask(localTaskCompletionSource.Task);
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private static TaskHandlerOptions GetOptions(string title)
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             lock (_gate)
             {
                 _taskCompletionSource?.TrySetResult(true);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             lock (_gate)
             {
                 _taskCompletionSource?.TrySetCanceled();
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             lock (_gate)
             {
                 _taskCompletionSource?.TrySetException(new Exception(message));
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
     }

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.LogService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.LogService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             private Task LogAsync(string text, __ACTIVITYLOG_ENTRYTYPE type)
             {
                 Log(text, type);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             private void Log(string text, __ACTIVITYLOG_ENTRYTYPE type)

--- a/src/VisualStudio/Core/Def/Telemetry/ProjectTelemetryIncrementalAnalyzerProvider.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/ProjectTelemetryIncrementalAnalyzerProvider.cs
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.LangaugeServices.Telemetry
 
             public Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             /// <summary>
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.LangaugeServices.Telemetry
             {
                 if (!semanticsChanged)
                 {
-                    return Task.CompletedTask;
+                    return SpecializedTasks.EmptyTask;
                 }
 
                 var projectId = project.Id;
@@ -195,27 +195,27 @@ namespace Microsoft.VisualStudio.LangaugeServices.Telemetry
                     }
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
@@ -225,7 +225,7 @@ namespace Microsoft.VisualStudio.LangaugeServices.Telemetry
 
             public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public void RemoveDocument(DocumentId documentId)

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             {
                 FireEvents(document.Id, cancellationToken);
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public void RemoveDocument(DocumentId documentId)
@@ -104,22 +104,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             #region unused
             public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
@@ -129,12 +129,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             public Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public void RemoveProject(ProjectId projectId)

--- a/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
@@ -245,7 +245,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             {
                 Event.WaitOne();
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 
@@ -264,13 +264,13 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
         private class MockLogAndProgressService : ISymbolSearchLogService, ISymbolSearchProgressService
         {
-            public Task LogExceptionAsync(string exception, string text) => Task.CompletedTask;
-            public Task LogInfoAsync(string text) => Task.CompletedTask;
+            public Task LogExceptionAsync(string exception, string text) => SpecializedTasks.EmptyTask;
+            public Task LogInfoAsync(string text) => SpecializedTasks.EmptyTask;
 
-            public Task OnDownloadFullDatabaseStartedAsync(string title) => Task.CompletedTask;
-            public Task OnDownloadFullDatabaseSucceededAsync() => Task.CompletedTask;
-            public Task OnDownloadFullDatabaseCanceledAsync() => Task.CompletedTask;
-            public Task OnDownloadFullDatabaseFailedAsync(string message) => Task.CompletedTask;
+            public Task OnDownloadFullDatabaseStartedAsync(string title) => SpecializedTasks.EmptyTask;
+            public Task OnDownloadFullDatabaseSucceededAsync() => SpecializedTasks.EmptyTask;
+            public Task OnDownloadFullDatabaseCanceledAsync() => SpecializedTasks.EmptyTask;
+            public Task OnDownloadFullDatabaseFailedAsync(string message) => SpecializedTasks.EmptyTask;
         }
     }
 }

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -403,7 +403,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 public override Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
                 {
                     _source.SetResult(true);
-                    return Task.CompletedTask;
+                    return SpecializedTasks.EmptyTask;
                 }
 
                 public Task<bool> Called => _source.Task;

--- a/src/VisualStudio/Core/Test/Completion/MockCompletionProvider.vb
+++ b/src/VisualStudio/Core/Test/Completion/MockCompletionProvider.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Completion
             Dim item = CommonCompletionItem.Create("DisplayText", rules:=CompletionItemRules.Default)
             context.AddItem(item)
 
-            Return Task.CompletedTask
+            Return SpecializedTasks.EmptyTask
         End Function
 
         Friend Overrides Function IsInsertionTrigger(text As SourceText, characterPosition As Integer, options As OptionSet) As Boolean

--- a/src/VisualStudio/Core/Test/SymbolSearch/SymbolSearchUpdateEngineTests.vb
+++ b/src/VisualStudio/Core/Test/SymbolSearch/SymbolSearchUpdateEngineTests.vb
@@ -752,11 +752,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
             End Sub
 
             Public Function LogExceptionAsync(exception As String, text As String) As Task Implements ISymbolSearchLogService.LogExceptionAsync
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
 
             Public Function LogInfoAsync(text As String) As Task Implements ISymbolSearchLogService.LogInfoAsync
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
         End Class
 
@@ -769,19 +769,19 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
             End Sub
 
             Public Function OnDownloadFullDatabaseStartedAsync(title As String) As Task Implements ISymbolSearchProgressService.OnDownloadFullDatabaseStartedAsync
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
 
             Public Function OnDownloadFullDatabaseSucceededAsync() As Task Implements ISymbolSearchProgressService.OnDownloadFullDatabaseSucceededAsync
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
 
             Public Function OnDownloadFullDatabaseCanceledAsync() As Task Implements ISymbolSearchProgressService.OnDownloadFullDatabaseCanceledAsync
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
 
             Public Function OnDownloadFullDatabaseFailedAsync(message As String) As Task Implements ISymbolSearchProgressService.OnDownloadFullDatabaseFailedAsync
-                Return Task.CompletedTask
+                Return SpecializedTasks.EmptyTask
             End Function
         End Class
     End Class

--- a/src/VisualStudio/Xaml/Impl/CodeFixes/RemoveUnnecessaryUsings/XamlRemoveUnnecessaryUsingsCodeFixProvider.cs
+++ b/src/VisualStudio/Xaml/Impl/CodeFixes/RemoveUnnecessaryUsings/XamlRemoveUnnecessaryUsingsCodeFixProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.CodeFixes.RemoveUnusedUsings
                 new MyCodeAction(
                     c => RemoveUnnecessaryImportsAsync(context.Document, c)),
                 context.Diagnostics);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private Task<Document> RemoveUnnecessaryImportsAsync(

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_WriteBatching.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_WriteBatching.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.SQLite
                     // Find the existing task responsible for writing to this queue.
                     var existingWriteTask = keyToWriteTask.TryGetValue(key, out var task)
                         ? task
-                        : Task.CompletedTask;
+                        : SpecializedTasks.EmptyTask;
 
                     if (writesToProcess.Count == 0)
                     {

--- a/src/Workspaces/Core/Desktop/Workspace/SolutionSize/SolutionSizeTracker.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SolutionSize/SolutionSizeTracker.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.SolutionSize
                     _map.Clear();
                 }
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public async Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken)
@@ -113,22 +113,22 @@ namespace Microsoft.CodeAnalysis.SolutionSize
             #region Not Used
             public Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.SolutionSize
 
             public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public void RemoveProject(ProjectId projectId)

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
                     // TODO: Wrap call to ComputeFixesAsync() below in IExtensionManager.PerformFunctionAsync() so that
                     // a buggy extension that throws can't bring down the host?
-                    return fixAllState.CodeFixProvider.RegisterCodeFixesAsync(context) ?? Task.CompletedTask;
+                    return fixAllState.CodeFixProvider.RegisterCodeFixesAsync(context) ?? SpecializedTasks.EmptyTask;
                 }));
             }
 
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
             // TODO: Wrap call to ComputeFixesAsync() below in IExtensionManager.PerformFunctionAsync() so that
             // a buggy extension that throws can't bring down the host?
-            return fixAllState.CodeFixProvider.RegisterCodeFixesAsync(context) ?? Task.CompletedTask;
+            return fixAllState.CodeFixProvider.RegisterCodeFixesAsync(context) ?? SpecializedTasks.EmptyTask;
         }
 
         public virtual async Task<CodeAction> TryGetMergedFixAsync(

--- a/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 (e, d, c) =>
             {
                 editAction(e, d);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             },
             cancellationToken);
         }
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 (e, d, c) =>
                 {
                     editAction(e, d);
-                    return Task.CompletedTask;
+                    return SpecializedTasks.EmptyTask;
                 },
                 cancellationToken);
         }
@@ -436,7 +436,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 (e, d, c) =>
                 {
                     editAction(e, d);
-                    return Task.CompletedTask;
+                    return SpecializedTasks.EmptyTask;
                 },
                 cancellationToken);
         }
@@ -517,7 +517,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 (e, d, c) =>
                 {
                     editAction(e, d);
-                    return Task.CompletedTask;
+                    return SpecializedTasks.EmptyTask;
                 },
                 cancellationToken);
         }

--- a/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Execution
         public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
         {
             _writer(writer, cancellationToken);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         private static Checksum CreateChecksumFromStreamWriter(WellKnownSynchronizationKind kind, Action<ObjectWriter, CancellationToken> writer)
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Execution
             const bool usePathFromAssembly = false;
 
             _serializer.SerializeAnalyzerReference(_reference, writer, usePathFromAssembly, cancellationToken);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Execution/RemotableData.cs
+++ b/src/Workspaces/Core/Portable/Execution/RemotableData.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Execution
             {
                 // it write out nothing to stream. for null kind and checksum, checksum/transportation framework knows
                 // there is no data in stream and skip reading any data from the stream.
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Execution/SolutionAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/SolutionAsset.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Execution
             public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
             {
                 _serializer.Serialize(_value, writer, cancellationToken);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 

--- a/src/Workspaces/Core/Portable/ExtensionManager/IExtensionManagerExtensions.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IExtensionManagerExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Extensions
             {
                 if (!extensionManager.IsDisabled(extension))
                 {
-                    var task = function() ?? Task.CompletedTask;
+                    var task = function() ?? SpecializedTasks.EmptyTask;
                     await task.ConfigureAwait(false);
                 }
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/StreamingFindReferencesProgress.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/StreamingFindReferencesProgress.cs
@@ -17,14 +17,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
         }
 
-        public Task ReportProgressAsync(int current, int maximum) => Task.CompletedTask;
+        public Task ReportProgressAsync(int current, int maximum) => SpecializedTasks.EmptyTask;
 
-        public Task OnCompletedAsync() => Task.CompletedTask;
-        public Task OnStartedAsync() => Task.CompletedTask;
-        public Task OnDefinitionFoundAsync(SymbolAndProjectId symbol) => Task.CompletedTask;
-        public Task OnReferenceFoundAsync(SymbolAndProjectId symbol, ReferenceLocation location) => Task.CompletedTask;
-        public Task OnFindInDocumentStartedAsync(Document document) => Task.CompletedTask;
-        public Task OnFindInDocumentCompletedAsync(Document document) => Task.CompletedTask;
+        public Task OnCompletedAsync() => SpecializedTasks.EmptyTask;
+        public Task OnStartedAsync() => SpecializedTasks.EmptyTask;
+        public Task OnDefinitionFoundAsync(SymbolAndProjectId symbol) => SpecializedTasks.EmptyTask;
+        public Task OnReferenceFoundAsync(SymbolAndProjectId symbol, ReferenceLocation location) => SpecializedTasks.EmptyTask;
+        public Task OnFindInDocumentStartedAsync(Document document) => SpecializedTasks.EmptyTask;
+        public Task OnFindInDocumentCompletedAsync(Document document) => SpecializedTasks.EmptyTask;
     }
 
     /// <summary>
@@ -43,43 +43,43 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public Task OnCompletedAsync()
         {
             _progress.OnCompleted();
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task OnDefinitionFoundAsync(SymbolAndProjectId symbolAndProjectId)
         {
             _progress.OnDefinitionFound(symbolAndProjectId.Symbol);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task OnFindInDocumentCompletedAsync(Document document)
         {
             _progress.OnFindInDocumentCompleted(document);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task OnFindInDocumentStartedAsync(Document document)
         {
             _progress.OnFindInDocumentStarted(document);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task OnReferenceFoundAsync(SymbolAndProjectId symbolAndProjectId, ReferenceLocation location)
         {
             _progress.OnReferenceFound(symbolAndProjectId.Symbol, location);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task OnStartedAsync()
         {
             _progress.OnStarted();
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public Task ReportProgressAsync(int current, int maximum)
         {
             _progress.ReportProgress(current, maximum);
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/TaskExecutor.cs
+++ b/src/Workspaces/Core/Portable/Formatting/TaskExecutor.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
                 action();
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public override Task<T> StartNew<T>(Func<T> action, CancellationToken cancellationToken)
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
                 nextAction(previousTask);
 
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             public override void ForEach<T>(IEnumerable<T> source, Action<T> action, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Notification/GlobalOperationNotificationService.cs
+++ b/src/Workspaces/Core/Portable/Notification/GlobalOperationNotificationService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Notification
                 }).CompletesAsyncOperation(asyncToken);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         protected virtual Task RaiseGlobalOperationStopped(IReadOnlyList<string> operations, bool cancelled)
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Notification
                 }).CompletesAsyncOperation(asyncToken);
             }
 
-            return Task.CompletedTask;
+            return SpecializedTasks.EmptyTask;
         }
 
         public override event EventHandler Started

--- a/src/Workspaces/Core/Portable/Shared/Utilities/StreamingProgressTracker.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/StreamingProgressTracker.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         {
             if (_updateActionOpt == null)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             return _updateActionOpt(_completedItems, _totalItems);

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchProgressService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchProgressService.cs
@@ -21,9 +21,9 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     [ExportWorkspaceService(typeof(ISymbolSearchProgressService)), Shared]
     internal class DefaultSymbolSearchProgressService: ISymbolSearchProgressService
     {
-        public Task OnDownloadFullDatabaseStartedAsync(string title) => Task.CompletedTask;
-        public Task OnDownloadFullDatabaseSucceededAsync() => Task.CompletedTask;
-        public Task OnDownloadFullDatabaseCanceledAsync() => Task.CompletedTask;
-        public Task OnDownloadFullDatabaseFailedAsync(string message) => Task.CompletedTask;
+        public Task OnDownloadFullDatabaseStartedAsync(string title) => SpecializedTasks.EmptyTask;
+        public Task OnDownloadFullDatabaseSucceededAsync() => SpecializedTasks.EmptyTask;
+        public Task OnDownloadFullDatabaseCanceledAsync() => SpecializedTasks.EmptyTask;
+        public Task OnDownloadFullDatabaseFailedAsync(string message) => SpecializedTasks.EmptyTask;
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/SimpleTaskQueue.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SimpleTaskQueue.cs
@@ -26,7 +26,7 @@ namespace Roslyn.Utilities
             _taskScheduler = taskScheduler;
 
             _taskCount = 0;
-            _latestTask = Task.CompletedTask;
+            _latestTask = SpecializedTasks.EmptyTask;
         }
 
         private TTask ScheduleTaskWorker<TTask>(Func<int, TTask> taskCreator, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Utilities/SpecializedTasks.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SpecializedTasks.cs
@@ -9,8 +9,9 @@ namespace Roslyn.Utilities
 {
     internal static class SpecializedTasks
     {
-        public static readonly Task<bool> True = Task.FromResult(true);
-        public static readonly Task<bool> False = Task.FromResult(false);
+        public static readonly Task<bool> True = Task.FromResult<bool>(true);
+        public static readonly Task<bool> False = Task.FromResult<bool>(false);
+        public static readonly Task EmptyTask = Task.CompletedTask;
 
         public static Task<T> Default<T>()
         {

--- a/src/Workspaces/Core/Portable/Utilities/ValuesSources/RecoverableWeakValueSource.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ValuesSources/RecoverableWeakValueSource.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Host
         protected abstract T Recover(CancellationToken cancellationToken);
 
         // enforce saving in a queue so save's don't overload the thread pool.
-        private static Task s_latestTask = Task.CompletedTask;
+        private static Task s_latestTask = SpecializedTasks.EmptyTask;
         private static readonly NonReentrantLock s_taskGuard = new NonReentrantLock();
 
         private SemaphoreSlim Gate => LazyInitialization.EnsureInitialized(ref _gateDoNotAccessDirectly, SemaphoreSlimFactory.Instance);

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/TrivialTemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/TrivialTemporaryStorageService.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis
             public Task WriteTextAsync(SourceText text, CancellationToken cancellationToken = default)
             {
                 WriteText(text, cancellationToken);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis
 
             if (oldSolution == newSolution)
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
 
             if (projectId == null && documentId != null)
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
 
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
     }

--- a/src/Workspaces/CoreTest/Host/WorkspaceServices/TestTemporaryStorageService.cs
+++ b/src/Workspaces/CoreTest/Host/WorkspaceServices/TestTemporaryStorageService.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Persistence
             public Task WriteTextAsync(SourceText text, CancellationToken cancellationToken = default(CancellationToken))
             {
                 WriteText(text, cancellationToken);
-                return Task.CompletedTask;
+                return SpecializedTasks.EmptyTask;
             }
         }
     }

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -620,7 +620,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private async Task ValidateChecksumAsync(Checksum givenSolutionChecksum, Solution solution)
         {
             // have this to avoid error on async
-            await Task.CompletedTask.ConfigureAwait(false);
+            await SpecializedTasks.EmptyTask.ConfigureAwait(false);
 
 #if DEBUG
             var currentSolutionChecksum = await solution.State.GetChecksumAsync(_cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Reverts dotnet/roslyn#28109

This change appeared to be causing a hard crash for integration tests. Attempting to revert the change and see if it restores tests to a good state.