### PR TITLE
Minor IOperation-related documentation fixes and enhancements

### DIFF
--- a/src/Compilers/Core/Portable/Operations/BinaryOperatorKind.cs
+++ b/src/Compilers/Core/Portable/Operations/BinaryOperatorKind.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Operations
         // Relational operations.
 
         /// <summary>
-        /// Represents the C# '=' operator and VB 'Is' operator and '=' operator for non-object typed operands.
+        /// Represents the C# '==' operator and VB 'Is' operator and '=' operator for non-object typed operands.
         /// </summary>
         Equals = 0x10,
 

--- a/src/Compilers/Core/Portable/Operations/CaseKind.cs
+++ b/src/Compilers/Core/Portable/Operations/CaseKind.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>
@@ -15,27 +13,27 @@ namespace Microsoft.CodeAnalysis.Operations
         None = 0x0,
 
         /// <summary>
-        /// Indicates case x in C# or Case x in VB.
+        /// Indicates an <see cref="ISingleValueCaseClauseOperation"/> in C# or VB.
         /// </summary>
         SingleValue = 0x1,
 
         /// <summary>
-        /// Indicates Case Is op x in VB.
+        /// Indicates an <see cref="IRelationalCaseClauseOperation"/> in VB.
         /// </summary>
         Relational = 0x2,
 
         /// <summary>
-        /// Indicates Case x To Y in VB.
+        /// Indicates an <see cref="IRangeCaseClauseOperation"/> in VB.
         /// </summary>
         Range = 0x3,
 
         /// <summary>
-        /// Indicates default in C# or Case Else in VB.
+        /// Indicates an <see cref="IDefaultCaseClauseOperation"/> in C# or VB.
         /// </summary>
         Default = 0x4,
 
         /// <summary>
-        /// Indicates pattern case in C#.
+        /// Indicates an <see cref="IPatternCaseClauseOperation" /> in C#.
         /// </summary>
         Pattern = 0x5
     }

--- a/src/Compilers/Core/Portable/Operations/OperationKind.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationKind.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis
         VariableDeclarationGroup = 0x3,
         /// <summary>Indicates an <see cref="ISwitchOperation"/>.</summary>
         Switch = 0x4,
-        /// <summary>Indicates an <see cref="ILoopOperation"/>.</summary>
+        /// <summary>Indicates an <see cref="ILoopOperation"/>, which is further differentiated by <see cref="ILoopOperation.LoopKind"/>.</summary>
         Loop = 0x5,
         /// <summary>Indicates an <see cref="ILabeledOperation"/>.</summary>
         Labeled = 0x6,
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis
         CatchClause = 0x50,
         /// <summary>Indicates an <see cref="ISwitchCaseOperation"/>.</summary>
         SwitchCase = 0x51,
-        /// <summary>Indicates different kinds of switch case clauses as defined by <see cref="CaseKind"/>.</summary>
+        /// <summary>Indicates an <see cref="ICaseClauseOperation"/>, which is further differentiated by <see cref="ICaseClauseOperation.CaseKind"/>.</summary>
         CaseClause = 0x52,
         /// <summary>Indicates an <see cref="IInterpolatedStringTextOperation"/>.</summary>
         InterpolatedStringText = 0x53,


### PR DESCRIPTION
This PR represents a few small changes to documentation around IOperation-related things.

* Fixed a typo in `BinaryOperatorKind.Equal`'s documentation. (C# operator was listed as `=` instead of `==`.)
* Modified documentation in `CaseKind` to include the interfaces associated with each kind. (Basically the same as [LoopKind](https://github.com/dotnet/roslyn/blob/70c4eaf78e1962a34f051dda2d5f2ab6c789af20/src/Compilers/Core/Portable/Operations/Loops/LoopKind.cs))
* Modified documentation for `OperationKind.Loop` and `OperationKind.CaseClause` to reference both the corresponding interface and sub-kind property.

The first change was what prompted the PR, but I figured I'd fix the other inconsistencies I remembered running into while working with `IOperation`.