### PR TITLE
make code cleanup run in-proc

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.FixAllPredefinedDiagnosticProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.FixAllPredefinedDiagnosticProvider.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CodeFixes
+{
+    internal partial class CodeFixService
+    {
+        private class FixAllPredefinedDiagnosticProvider : FixAllContext.DiagnosticProvider
+        {
+            private readonly ImmutableArray<Diagnostic> _diagnostics;
+
+            public FixAllPredefinedDiagnosticProvider(ImmutableArray<Diagnostic> diagnostics)
+            {
+                _diagnostics = diagnostics;
+            }
+
+            public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+                => Task.FromResult<IEnumerable<Diagnostic>>(_diagnostics);
+
+            public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+                => Task.FromResult<IEnumerable<Diagnostic>>(_diagnostics);
+
+            public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+                => SpecializedTasks.EmptyEnumerable<Diagnostic>();
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
                 var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 var textSpan = new TextSpan(0, syntaxTree.Length);
 
-                var fixCollection = await _codeFixServiceOpt.GetFixesAsync(document, textSpan, diagnosticId, cancellationToken).ConfigureAwait(false);
+                var fixCollection = await _codeFixServiceOpt.GetFixesInProcAsync(document, textSpan, diagnosticId, cancellationToken).ConfigureAwait(false);
                 if (fixCollection == null)
                 {
                     continue;

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
                 var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 var textSpan = new TextSpan(0, syntaxTree.Length);
 
-                var fixCollection = await _codeFixServiceOpt.GetFixesInProcAsync(document, textSpan, diagnosticId, cancellationToken).ConfigureAwait(false);
+                var fixCollection = await _codeFixServiceOpt.GetDocumentFixAllForIdInSpan(document, textSpan, diagnosticId, cancellationToken).ConfigureAwait(false);
                 if (fixCollection == null)
                 {
                     continue;

--- a/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     internal interface ICodeFixService
     {
         Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, bool includeSuppressionFixes, CancellationToken cancellationToken);
-        Task<CodeFixCollection> GetFixesInProcAsync(Document document, TextSpan textSpan, string diagnosticId, CancellationToken cancellationToken);
+        Task<CodeFixCollection> GetDocumentFixAllForIdInSpan(Document document, TextSpan textSpan, string diagnosticId, CancellationToken cancellationToken);
         CodeFixProvider GetSuppressionFixer(string language, IEnumerable<string> diagnosticIds);
         Task<FirstDiagnosticResult> GetMostSevereFixableDiagnostic(Document document, TextSpan range, CancellationToken cancellationToken);
     }

--- a/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     internal interface ICodeFixService
     {
         Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, bool includeSuppressionFixes, CancellationToken cancellationToken);
-        Task<CodeFixCollection> GetFixesAsync(Document document, TextSpan textSpan, string diagnosticId, CancellationToken cancellationToken);
+        Task<CodeFixCollection> GetFixesInProcAsync(Document document, TextSpan textSpan, string diagnosticId, CancellationToken cancellationToken);
         CodeFixProvider GetSuppressionFixer(string language, IEnumerable<string> diagnosticIds);
         Task<FirstDiagnosticResult> GetMostSevereFixableDiagnostic(Document document, TextSpan range, CancellationToken cancellationToken);
     }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return SpecializedTasks.False;
         }
 
-        public Task<IEnumerable<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, bool includeSuppressedDiagnostics = false, string diagnosticIdOpt = null, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, string diagnosticIdOpt = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
         {
             if (_map.TryGetValue(document.Project.Solution.Workspace, out var analyzer))
             {

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// this can be expensive since it is force analyzing diagnostics if it doesn't have up-to-date one yet.
         /// if diagnosticIdOpt is not null, it gets diagnostics only for this given diagnosticIdOpt value
         /// </summary>
-        Task<IEnumerable<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, bool includeSuppressedDiagnostics = false, string diagnosticIdOpt = null, CancellationToken cancellationToken = default);
+        Task<IEnumerable<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, string diagnosticIdOpt = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a list of the diagnostics that are provided by this service.

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -223,7 +223,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Return ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticDescriptor)).Empty.Add("reference", ImmutableArray.Create(Of DiagnosticDescriptor)(New DiagnosticDescriptor("CS1002", "test", "test", "test", DiagnosticSeverity.Warning, True)))
             End Function
 
-            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan, Optional includeSuppressedDiagnostics As Boolean = False, Optional diagnosticId As String = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of IEnumerable(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
+            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan, Optional diagnosticId As String = Nothing, Optional includeSuppressedDiagnostics As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As Task(Of IEnumerable(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
                 Return Task.FromResult(SpecializedCollections.EmptyEnumerable(Of DiagnosticData))
             End Function
 

--- a/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
                 Return ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticDescriptor)).Empty
             End Function
 
-            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan, Optional includeSuppressedDiagnostics As Boolean = False, Optional diagnosticId As String = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of IEnumerable(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
+            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan, Optional diagnosticId As String = Nothing, Optional includeSuppressedDiagnostics As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As Task(Of IEnumerable(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
                 Return Task.FromResult(SpecializedCollections.EmptyEnumerable(Of DiagnosticData))
             End Function
 


### PR DESCRIPTION
fixed https://github.com/dotnet/roslyn/issues/28012
<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
