### PR TITLE
fix crash where diagnostic progress reporter is created after solution crawler is started…

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/DiagnosticProgressReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/DiagnosticProgressReporter.cs
@@ -40,6 +40,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             _taskCenterService = (IVsTaskStatusCenterService)serviceProvider.GetService(typeof(SVsTaskStatusCenterService));
             _diagnosticService = diagnosticService;
 
+            _options = new TaskHandlerOptions()
+            {
+                Title = ServicesVSResources.Live_code_analysis,
+                ActionsAfterCompletion = CompletionActions.None
+            };
+
             var crawlerService = workspace.Services.GetService<ISolutionCrawlerService>();
             var reporter = crawlerService.GetProgressReporter(workspace);
 
@@ -48,12 +54,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             // no event unsubscription since it will remain alive until VS shutdown
             reporter.ProgressChanged += OnSolutionCrawlerProgressChanged;
             _diagnosticService.DiagnosticsUpdated += OnDiagnosticsUpdated;
-
-            _options = new TaskHandlerOptions()
-            {
-                Title = ServicesVSResources.Live_code_analysis,
-                ActionsAfterCompletion = CompletionActions.None
-            };
         }
 
         private void OnDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs e)


### PR DESCRIPTION
… running.

### Customer scenario

Create C# UWP app and sometimes VS show RoslynPackage load failure.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/639823?src=alerts&src-action=cta

### Workarounds, if any

No practical workaround.

### Risk

No risk

### Performance impact

No impact

### Is this a regression from a previous update?

No

### Root cause analysis

when diagnostic progress reporter is first created, it sees whether solution crawler is already running or not, and if it is running, it starts task status center, but there was a bug where some option required for task status center was assigned after it is started causing package load failure.

but this doesn't happen every time since most of the times, reporter created before solution crawler running.

### How was the bug found?

dogfooding
