### PR TITLE
Enable incremental updates of the dependency graph

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Gets the list of projects (topologically sorted) that this project directly depends on.
+        /// Gets the list of projects that this project directly depends on.
         /// </summary>
         public IImmutableSet<ProjectId> GetProjectsThatThisProjectDirectlyDependsOn(ProjectId projectId)
         {
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Gets the list of projects (topologically sorted) that directly depend on this project.
+        /// Gets the list of projects that directly depend on this project.
         /// </summary> 
         public IImmutableSet<ProjectId> GetProjectsThatDirectlyDependOnThisProject(ProjectId projectId)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -20,12 +20,12 @@ namespace Microsoft.CodeAnalysis
         // guards lazy computed data
         private readonly NonReentrantLock _dataLock = new NonReentrantLock();
 
-        // these are computed fully on demand
+        // These are computed fully on demand. null or ImmutableArray.IsDefault indicates the item needs to be realized
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _lazyReverseReferencesMap;
         private ImmutableArray<ProjectId> _lazyTopologicallySortedProjects;
         private ImmutableArray<IEnumerable<ProjectId>> _lazyDependencySets;
 
-        // these accumulate results on demand
+        // These accumulate results on demand. They are never null, but a missing key/value pair indicates it needs to be computed.
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _transitiveReferencesMap = ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty;
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _reverseTransitiveReferencesMap = ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public class ProjectDependencyGraph
     {
-        private readonly ImmutableArray<ProjectId> _projectIds;
+        private readonly ImmutableHashSet<ProjectId> _projectIds;
         private readonly ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _referencesMap;
 
         // guards lazy computed data
@@ -26,19 +26,201 @@ namespace Microsoft.CodeAnalysis
         private ImmutableArray<IEnumerable<ProjectId>> _lazyDependencySets;
 
         // These accumulate results on demand. They are never null, but a missing key/value pair indicates it needs to be computed.
-        private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _transitiveReferencesMap = ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty;
-        private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _reverseTransitiveReferencesMap = ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty;
+        private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _transitiveReferencesMap;
+        private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _reverseTransitiveReferencesMap;
 
         internal static readonly ProjectDependencyGraph Empty = new ProjectDependencyGraph(
-            ImmutableArray.Create<ProjectId>(),
+            ImmutableHashSet<ProjectId>.Empty,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty);
 
         internal ProjectDependencyGraph(
-            ImmutableArray<ProjectId> projectIds,
+            ImmutableHashSet<ProjectId> projectIds,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> referencesMap)
+            : this(
+                  projectIds,
+                  referencesMap,
+                  reverseReferencesMap: null,
+                  transitiveReferencesMap: ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
+                  reverseTransitiveReferencesMap: ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
+                  default,
+                  default)
         {
+        }
+
+        // This constructor is private to prevent other Roslyn code from producing this type with inconsistent inputs.
+        private ProjectDependencyGraph(
+            ImmutableHashSet<ProjectId> projectIds,
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> referencesMap,
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> reverseReferencesMap,
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> transitiveReferencesMap,
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> reverseTransitiveReferencesMap,
+            ImmutableArray<ProjectId> topologicallySortedProjects,
+            ImmutableArray<IEnumerable<ProjectId>> dependencySets)
+        {
+            Contract.ThrowIfNull(transitiveReferencesMap);
+            Contract.ThrowIfNull(reverseTransitiveReferencesMap);
+
             _projectIds = projectIds;
             _referencesMap = referencesMap;
+            _lazyReverseReferencesMap = reverseReferencesMap;
+            _transitiveReferencesMap = transitiveReferencesMap;
+            _reverseTransitiveReferencesMap = reverseTransitiveReferencesMap;
+            _lazyTopologicallySortedProjects = topologicallySortedProjects;
+            _lazyDependencySets = dependencySets;
+        }
+
+        internal ProjectDependencyGraph WithAdditionalProjects(IEnumerable<ProjectId> projectIds)
+        {
+            // Track the existence of some new projects. Note this call only adds new ProjectIds, but doesn't add any references. Any caller who wants to add a new project
+            // with references will first call this, and then call WithAdditionalProjectReferences to add references as well.
+            var newTopologicallySortedProjects = _lazyTopologicallySortedProjects;
+
+            if (!newTopologicallySortedProjects.IsDefault)
+            {
+                newTopologicallySortedProjects = newTopologicallySortedProjects.AddRange(projectIds);
+            }
+
+            var newDependencySets = _lazyDependencySets;
+
+            if (!newDependencySets.IsDefault)
+            {
+                var builder = newDependencySets.ToBuilder();
+
+                foreach (var projectId in projectIds)
+                {
+                    builder.Add(ImmutableArray.Create(projectId));
+                }
+
+                newDependencySets = builder.ToImmutable();
+            }
+
+            return new ProjectDependencyGraph(
+                _projectIds.Union(projectIds),
+                referencesMap: _referencesMap,
+                reverseReferencesMap: _lazyReverseReferencesMap,
+                transitiveReferencesMap: _transitiveReferencesMap,
+                reverseTransitiveReferencesMap: _reverseTransitiveReferencesMap,
+                topologicallySortedProjects: newTopologicallySortedProjects,
+                dependencySets: newDependencySets);
+        }
+
+        internal ProjectDependencyGraph WithAdditionalProjectReferences(ProjectId projectId, IReadOnlyList<ProjectId> referencedProjectIds)
+        {
+            if (!_projectIds.Contains(projectId))
+            {
+                throw new InvalidOperationException($"{nameof(projectId)} isn't being tracked by this dependency graph.");
+            }
+
+            if (referencedProjectIds.Count == 0)
+            {
+                return this;
+            }
+
+            // Step #1: recompute our references map
+            var newReferencesMap = _referencesMap;
+
+            if (newReferencesMap.TryGetValue(projectId, out var existingReferences))
+            {
+                newReferencesMap = newReferencesMap.SetItem(projectId, existingReferences.Union(referencedProjectIds));
+            }
+            else
+            {
+                newReferencesMap = newReferencesMap.SetItem(projectId, referencedProjectIds.ToImmutableHashSet());
+            }
+
+            // Step #2: compute our reverse map, if we had one previously to build off of
+            var newReverseReferencesMap = _lazyReverseReferencesMap;
+
+            if (newReverseReferencesMap != null)
+            {
+                var builder = newReverseReferencesMap.ToBuilder();
+
+                foreach (var referencedProject in referencedProjectIds)
+                {
+                    if (builder.TryGetValue(referencedProject, out var reverseReferences))
+                    {
+                        builder[referencedProject] = reverseReferences.Add(projectId);
+                    }
+                    else
+                    {
+                        builder[referencedProject] = ImmutableHashSet.Create(projectId);
+                    }
+                }
+
+                newReverseReferencesMap = builder.ToImmutable();
+            }
+
+            // Step #3: update our forward transitive map, by combining the transitive references of the new projects into the transitive references of projectId.
+            // If we didn't have transitive references computed for us, then we'll skip this because we won't be able to incrementally update what we don't have
+            var newTransitiveReferencesMap = _transitiveReferencesMap;
+
+            if (newTransitiveReferencesMap.TryGetValue(projectId, out var existingTransitiveReferences))
+            {
+                // We now will make a builder to compute the new data. If we discover that we don't know the transitive references for one of the new projects being added,
+                // then we will null this local out and remove any cached data we have for projectId instead.
+                var builder = existingTransitiveReferences.ToBuilder();
+
+                // We already have some transitive references. We'll incorporate in transitive references of the projects we all have.
+                // If any of our dependencies haven't already computed their transitive references, we'll just remove the entry on newTransitiveReferencesMap so
+                // as to compute it lazily later.
+                foreach (var referencedProjectId in referencedProjectIds)
+                {
+                    if (newTransitiveReferencesMap.TryGetValue(referencedProjectId, out var transitiveReferencesToUnion))
+                    {
+                        builder.UnionWith(transitiveReferencesToUnion);
+                    }
+                    else if (GetProjectsThatThisProjectDirectlyDependsOn(referencedProjectId).Count > 0)
+                    {
+                        // We have a problem: we know that referencedProjectId has at least one reference itself, but we don't know it's full transitive reference set. At this
+                        // point, we'll just remove it from our cache, and lazy compute it later
+                        builder = null;
+                        break;
+                    }
+                }
+
+                if (builder != null)
+                {
+                    newTransitiveReferencesMap = newTransitiveReferencesMap.SetItem(projectId, builder.ToImmutable());
+                }
+                else
+                {
+                    newTransitiveReferencesMap = newTransitiveReferencesMap.Remove(projectId);
+                }
+            }
+
+            // Step 4: update our reverse transitive references map, by including the reverse transitive references of projectId into the referenced projects
+            var newReverseTransitiveReferencesMapBuilder = _reverseTransitiveReferencesMap.ToBuilder();
+            bool reverseTransitiveReferencesKnown = newReverseTransitiveReferencesMapBuilder.TryGetValue(projectId, out var reverseTransitiveReferencesToUnion);
+
+            foreach (var referencedProjectId in referencedProjectIds)
+            {
+                if (!reverseTransitiveReferencesKnown)
+                {
+                    newReverseTransitiveReferencesMapBuilder.Remove(referencedProjectId);
+                }
+                else if (_reverseTransitiveReferencesMap.TryGetValue(referencedProjectId, out var existingReverseTransitiveReferences))
+                {
+                    newReverseTransitiveReferencesMapBuilder[referencedProjectId] = existingReverseTransitiveReferences.Union(reverseTransitiveReferencesToUnion);
+                }
+            }
+
+            // Note: rather than updating our dependency sets and topologically sorted data, we'll throw that away since incremental update is
+            // tricky, and those are rarely used.
+            return new ProjectDependencyGraph(
+                _projectIds,
+                referencesMap: newReferencesMap,
+                reverseReferencesMap: newReverseReferencesMap,
+                transitiveReferencesMap: newTransitiveReferencesMap,
+                reverseTransitiveReferencesMap: newReverseTransitiveReferencesMapBuilder.ToImmutable(),
+                topologicallySortedProjects: default,
+                dependencySets: default);
+        }
+
+        internal ProjectDependencyGraph WithProjectReferences(ProjectId projectId, IEnumerable<ProjectId> referencedProjectIds)
+        {
+            // This method we can't optimize very well: changing project references arbitrarily could invalidate pretty much anything. The only thing we can reuse is our
+            // actual map of project references for all the other projects, so we'll do that
+            return new ProjectDependencyGraph(_projectIds, _referencesMap.SetItem(projectId, referencedProjectIds.ToImmutableHashSet()));
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -471,14 +471,6 @@ namespace Microsoft.CodeAnalysis
             return project1.LanguageServices == project2.LanguageServices;
         }
 
-        public ProjectState AddProjectReference(ProjectReference projectReference)
-        {
-            Contract.Requires(!this.ProjectReferences.Contains(projectReference));
-
-            return this.With(
-                projectInfo: this.ProjectInfo.WithProjectReferences(this.ProjectReferences.ToImmutableArray().Add(projectReference)).WithVersion(this.Version.GetNewerVersion()));
-        }
-
         public ProjectState RemoveProjectReference(ProjectReference projectReference)
         {
             Contract.Requires(this.ProjectReferences.Contains(projectReference));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -401,7 +401,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public Solution AddProjectReference(ProjectId projectId, ProjectReference projectReference)
         {
-            var newState = _state.AddProjectReference(projectId, projectReference);
+            var newState = _state.AddProjectReferences(projectId, SpecializedCollections.SingletonEnumerable(projectReference));
             if (newState == _state)
             {
                 return this;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -771,35 +771,6 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Create a new solution instance with the project specified updated to include
-        /// the specified project reference.
-        /// </summary>
-        public SolutionState AddProjectReference(ProjectId projectId, ProjectReference projectReference)
-        {
-            if (projectId == null)
-            {
-                throw new ArgumentNullException(nameof(projectId));
-            }
-
-            if (projectReference == null)
-            {
-                throw new ArgumentNullException(nameof(projectReference));
-            }
-
-            CheckContainsProject(projectId);
-            CheckContainsProject(projectReference.ProjectId);
-            CheckNotContainsProjectReference(projectId, projectReference);
-            CheckNotContainsTransitiveReference(projectReference.ProjectId, projectId);
-
-            CheckNotSecondSubmissionReference(projectId, projectReference.ProjectId);
-
-            var oldProject = this.GetProjectState(projectId);
-            var newProject = oldProject.AddProjectReference(projectReference);
-
-            return this.ForkProject(newProject, withProjectReferenceChange: true);
-        }
-
-        /// <summary>
-        /// Create a new solution instance with the project specified updated to include
         /// the specified project references.
         /// </summary>
         public SolutionState AddProjectReferences(ProjectId projectId, IEnumerable<ProjectReference> projectReferences)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1516,7 +1516,7 @@ namespace Microsoft.CodeAnalysis
                     state.ProjectReferences.Where(pr => projectStates.ContainsKey(pr.ProjectId)).Select(pr => pr.ProjectId).ToImmutableHashSet()))
                     .ToImmutableDictionary();
 
-            return new ProjectDependencyGraph(projectIds.ToImmutableArray(), map);
+            return new ProjectDependencyGraph(projectIds.ToImmutableHashSet(), map);
         }
 
         private ImmutableDictionary<ProjectId, CompilationTracker> CreateCompilationTrackerMap(ProjectId projectId, ProjectDependencyGraph dependencyGraph)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -417,7 +417,9 @@ namespace Microsoft.CodeAnalysis
 
             var newProjectIds = _projectIds.ToImmutableArray().Add(projectId);
             var newStateMap = _projectIdToProjectStateMap.Add(projectId, projectState);
-            var newDependencyGraph = CreateDependencyGraph(newProjectIds, newStateMap);
+            var newDependencyGraph = _dependencyGraph
+                                        .WithAdditionalProjects(SpecializedCollections.SingletonEnumerable(projectId))
+                                        .WithAdditionalProjectReferences(projectId, projectState.ProjectReferences.Select(r => r.ProjectId).ToList());
             var newTrackerMap = CreateCompilationTrackerMap(projectId, newDependencyGraph);
             var newLinkedFilesMap = CreateLinkedFilesMapWithAddedProject(newStateMap[projectId]);
 
@@ -797,8 +799,9 @@ namespace Microsoft.CodeAnalysis
 
             var oldProject = this.GetProjectState(projectId);
             var newProject = oldProject.AddProjectReferences(projectReferences);
+            var newDependencyGraph = _dependencyGraph.WithAdditionalProjectReferences(projectId, projectReferences.Select(r => r.ProjectId).ToList());
 
-            return this.ForkProject(newProject, withProjectReferenceChange: true);
+            return this.ForkProject(newProject, newDependencyGraph: newDependencyGraph);
         }
 
         /// <summary>
@@ -823,7 +826,7 @@ namespace Microsoft.CodeAnalysis
             var oldProject = this.GetProjectState(projectId);
             var newProject = oldProject.RemoveProjectReference(projectReference);
 
-            return this.ForkProject(newProject, withProjectReferenceChange: true);
+            return this.ForkProject(newProject, newDependencyGraph: _dependencyGraph.WithProjectReferences(projectId, newProject.ProjectReferences.Select(p => p.ProjectId)));
         }
 
         /// <summary>
@@ -847,7 +850,7 @@ namespace Microsoft.CodeAnalysis
             var oldProject = this.GetProjectState(projectId);
             var newProject = oldProject.WithProjectReferences(projectReferences);
 
-            return this.ForkProject(newProject, withProjectReferenceChange: true);
+            return this.ForkProject(newProject, newDependencyGraph: _dependencyGraph.WithProjectReferences(projectId, projectReferences.Select(p => p.ProjectId)));
         }
 
         /// <summary>
@@ -1459,14 +1462,14 @@ namespace Microsoft.CodeAnalysis
         private SolutionState ForkProject(
             ProjectState newProjectState,
             CompilationTranslationAction translate = null,
-            bool withProjectReferenceChange = false,
+            ProjectDependencyGraph newDependencyGraph = null,
             ImmutableDictionary<string, ImmutableArray<DocumentId>> newLinkedFilesMap = null,
             bool forkTracker = true)
         {
             var projectId = newProjectState.Id;
 
             var newStateMap = _projectIdToProjectStateMap.SetItem(projectId, newProjectState);
-            var newDependencyGraph = withProjectReferenceChange ? CreateDependencyGraph(_projectIds, newStateMap) : _dependencyGraph;
+            newDependencyGraph = newDependencyGraph ?? _dependencyGraph;
             var newTrackerMap = CreateCompilationTrackerMap(projectId, newDependencyGraph);
             // If we have a tracker for this project, then fork it as well (along with the
             // translation action and store it in the tracker map.

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1732,24 +1732,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected void CheckProjectDoesNotHaveTransitiveProjectReference(ProjectId fromProjectId, ProjectId toProjectId)
         {
-            var transitiveReferences = GetTransitiveProjectReferences(toProjectId);
+            var transitiveReferences = this.CurrentSolution.GetProjectDependencyGraph().GetProjectsThatThisProjectTransitivelyDependsOn(toProjectId);
             if (transitiveReferences.Contains(fromProjectId))
             {
                 throw new ArgumentException(string.Format(
                     WorkspacesResources.Adding_project_reference_from_0_to_1_will_cause_a_circular_reference,
                     this.GetProjectName(fromProjectId), this.GetProjectName(toProjectId)));
             }
-        }
-
-        private ISet<ProjectId> GetTransitiveProjectReferences(ProjectId project, ISet<ProjectId> projects = null)
-        {
-            projects = projects ?? new HashSet<ProjectId>();
-            if (projects.Add(project))
-            {
-                this.CurrentSolution.GetProject(project).ProjectReferences.Do(p => GetTransitiveProjectReferences(p.ProjectId, projects));
-            }
-
-            return projects;
         }
 
         /// <summary>


### PR DESCRIPTION
This set of changes enables us to incrementally update the ProjectDependencyGraph rather than throwing it away and recomputing it each time we make any change to the topology of our solution. In the CPS case (where right now we aren't doing smarter batching right now, so each individual reference triggers a recompute), this eliminates almost two seconds of CPU time. I fully contend that's an extreme example (and yes, we will still fix the batching problem), but the hope by attacking this directly is we still make improvements where the direct batching might not be so useful. In the examples given by #25823, there may still be multiple times in a large solution where we end up adding a project references (but only a few) to a bunch of projects; even if we do one batch per project that's still not a great reason to throw this out and recompute everything again.

I strongly suggest you review a commit at a time, which will make the series of changes pretty straightforward.

Prior to the change, the state of the world was any topology change would result in us creating a new dependency graph from scratch. We did this by:

1. Walking the SolutionState to produce a new `ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>`. This rewalking alone counted for about a second of CPU time.
2. Creating the new ProjectDependencyGraph with this directly. Note, everything else was "lazy", but...
3. We would then have to create a new CompilationTracker map. This caused us to ask for reverse transitive references, causing us to realize the "lazy" reverse project reference map every time, so the laziness was worthless. This map is the reverse of the `ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>`, so every topology change was computing the full reverse one in addition to the forward one...every time.
4. We'd then actually compute the reverse transitive information in some cases.

This resulted in huge allocations, even when it didn't make sense. See @davkean's bug #25823 for a few examples.

The primary win of this change is instead of steps 1 and 3, where we recreated the direct project references and direct reverse project references every time from scratch, we just incrementally update them whenever we're adding a new reference. I suspect this is the result of most or perhaps all of the wins here. We try to also update the transitive and reverse transitive maps if we can easily do so; it's less clear to me right now if that's really helping much. In my testing right now it looks like we're occasionally getting a project reference _removal_ in my build, where we do still throw away everything.

My primary concern about this change would be whether this increases stable memory. What do I mean by that? Previously, we were actively throwing away the transitive data all the time; in practice it might have not been surviving very long. Now since we're incrementally updating it, this might actually be holding onto _more_ memory. If this becomes a concern, we could remove the "step 3" and "step 4" in the incremental add methods and just throw away the transitive maps; this would bring us to the memory usage we had before, while still leaving all the wins we get from steps 1 and step 2 which is perhaps the majority of the wins. Right now prior to this change we're churning so much memory it's just hard to say. I propose we merge this, make batching improvements, and once we've done that take a look at the total memory being consumed by this data structure and see if that's still a concern. If it is, just delete "step 3" and "step 4" in the code.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
