### PR TITLE
Enable refactorings which were unintentionally removed by 'none' severity

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseExplicitType/UseExplicitTypeRefactoringTests.cs
@@ -19,30 +19,66 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExp
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
             => new UseExplicitTypeCodeRefactoringProvider();
 
+        private readonly CodeStyleOption<bool> onWithNone = new CodeStyleOption<bool>(true, NotificationOption.None);
+        private readonly CodeStyleOption<bool> offWithNone = new CodeStyleOption<bool>(false, NotificationOption.None);
         private readonly CodeStyleOption<bool> onWithSilent = new CodeStyleOption<bool>(true, NotificationOption.Silent);
         private readonly CodeStyleOption<bool> offWithSilent = new CodeStyleOption<bool>(false, NotificationOption.Silent);
         private readonly CodeStyleOption<bool> onWithInfo = new CodeStyleOption<bool>(true, NotificationOption.Suggestion);
         private readonly CodeStyleOption<bool> offWithInfo = new CodeStyleOption<bool>(false, NotificationOption.Suggestion);
+        private readonly CodeStyleOption<bool> onWithWarning = new CodeStyleOption<bool>(true, NotificationOption.Warning);
+        private readonly CodeStyleOption<bool> offWithWarning = new CodeStyleOption<bool>(false, NotificationOption.Warning);
+        private readonly CodeStyleOption<bool> offWithError = new CodeStyleOption<bool>(false, NotificationOption.Error);
+        private readonly CodeStyleOption<bool> onWithError = new CodeStyleOption<bool>(true, NotificationOption.Error);
+
+        private IDictionary<OptionKey, object> PreferExplicitTypeWithError() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithError));
+
+        private IDictionary<OptionKey, object> PreferImplicitTypeWithError() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithError));
+
+        private IDictionary<OptionKey, object> PreferExplicitTypeWithWarning() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithWarning));
+
+        private IDictionary<OptionKey, object> PreferImplicitTypeWithWarning() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithWarning));
 
         private IDictionary<OptionKey, object> PreferExplicitTypeWithInfo() => OptionsSet(
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithInfo),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo));
 
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithSilent() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithSilent));
-
         private IDictionary<OptionKey, object> PreferImplicitTypeWithInfo() => OptionsSet(
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo));
 
+        private IDictionary<OptionKey, object> PreferExplicitTypeWithSilent() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithSilent),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithSilent),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithSilent));
+
         private IDictionary<OptionKey, object> PreferImplicitTypeWithSilent() => OptionsSet(
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithSilent),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithSilent),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithSilent));
+
+        private IDictionary<OptionKey, object> PreferExplicitTypeWithNone() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithNone));
+
+        private IDictionary<OptionKey, object> PreferImplicitTypeWithNone() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithNone));
 
         [Fact]
         public async Task TestIntLocalDeclaration()
@@ -65,9 +101,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
-            await TestInRegularAndScriptAsync(code, expected, options: PreferExplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -91,7 +125,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -106,9 +140,7 @@ class C
     }
 }";
 
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+            await TestMissingInRegularAndScriptAsync(code);
         }
 
         [Fact]
@@ -124,9 +156,7 @@ class C
 }";
 
 
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+            await TestMissingInRegularAndScriptAsync(code);
         }
 
         [Fact]
@@ -165,7 +195,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -189,7 +219,7 @@ class C : System.IDisposable
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -203,7 +233,7 @@ class var
         var[||] i = null;
     }
 }";
-            await TestMissingInRegularAndScriptAsync(code, options: PreferImplicitTypeWithSilent());
+            await TestMissingInRegularAndScriptAsync(code);
         }
 
         [Fact]
@@ -227,7 +257,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -251,7 +281,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -275,9 +305,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
-            await TestInRegularAndScriptAsync(code, expected, options: PreferExplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -292,7 +320,7 @@ class C
     }
 }";
 
-            await TestMissingInRegularAndScriptAsync(code, options: PreferImplicitTypeWithSilent());
+            await TestMissingInRegularAndScriptAsync(code);
         }
 
         [Fact, WorkItem(26923, "https://github.com/dotnet/roslyn/issues/26923")]
@@ -313,15 +341,42 @@ class Program
 }";
 
             // We never want to get offered here under any circumstances.
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+            await TestMissingInRegularAndScriptAsync(code);
         }
 
-        private Task TestMissingInRegularAndScriptAsync(string initialMarkup, IDictionary<OptionKey, object> options)
+        private async Task TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(string initialMarkup, string expectedMarkup)
         {
-            return TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: options));
+            // Enabled because the diagnostic is disabled
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferExplicitTypeWithNone());
+
+            // Enabled because the diagnostic is checking for the other direction
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferImplicitTypeWithNone());
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferImplicitTypeWithInfo());
+
+            // Disabled because the diagnostic will report it instead
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithSilent()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithInfo()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithWarning()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithError()));
+
+            // Currently this refactoring is still enabled in cases where it would cause a warning or error
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferImplicitTypeWithWarning());
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferImplicitTypeWithError());
+        }
+
+        private async Task TestMissingInRegularAndScriptAsync(string initialMarkup)
+        {
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithNone()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithNone()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithSilent()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithSilent()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithInfo()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithInfo()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithWarning()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithWarning()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithError()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithError()));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/UseImplicitType/UseImplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseImplicitType/UseImplicitTypeRefactoringTests.cs
@@ -19,10 +19,36 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExp
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
             => new UseImplicitTypeCodeRefactoringProvider();
 
+        private readonly CodeStyleOption<bool> onWithNone = new CodeStyleOption<bool>(true, NotificationOption.None);
+        private readonly CodeStyleOption<bool> offWithNone = new CodeStyleOption<bool>(false, NotificationOption.None);
         private readonly CodeStyleOption<bool> onWithSilent = new CodeStyleOption<bool>(true, NotificationOption.Silent);
         private readonly CodeStyleOption<bool> offWithSilent = new CodeStyleOption<bool>(false, NotificationOption.Silent);
         private readonly CodeStyleOption<bool> onWithInfo = new CodeStyleOption<bool>(true, NotificationOption.Suggestion);
         private readonly CodeStyleOption<bool> offWithInfo = new CodeStyleOption<bool>(false, NotificationOption.Suggestion);
+        private readonly CodeStyleOption<bool> onWithWarning = new CodeStyleOption<bool>(true, NotificationOption.Warning);
+        private readonly CodeStyleOption<bool> offWithWarning = new CodeStyleOption<bool>(false, NotificationOption.Warning);
+        private readonly CodeStyleOption<bool> offWithError = new CodeStyleOption<bool>(false, NotificationOption.Error);
+        private readonly CodeStyleOption<bool> onWithError = new CodeStyleOption<bool>(true, NotificationOption.Error);
+
+        private IDictionary<OptionKey, object> PreferExplicitTypeWithError() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithError));
+
+        private IDictionary<OptionKey, object> PreferImplicitTypeWithError() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithError));
+
+        private IDictionary<OptionKey, object> PreferExplicitTypeWithWarning() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithWarning));
+
+        private IDictionary<OptionKey, object> PreferImplicitTypeWithWarning() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithWarning));
 
         private IDictionary<OptionKey, object> PreferExplicitTypeWithInfo() => OptionsSet(
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo),
@@ -43,6 +69,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExp
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithSilent),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithSilent),
             SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithSilent));
+
+        private IDictionary<OptionKey, object> PreferExplicitTypeWithNone() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithNone));
+
+        private IDictionary<OptionKey, object> PreferImplicitTypeWithNone() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithNone));
 
         [Fact]
         public async Task TestIntLocalDeclaration()
@@ -65,10 +101,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
-            await TestInRegularAndScriptAsync(code, expected, options: PreferExplicitTypeWithSilent());
-            await TestInRegularAndScriptAsync(code, expected, options: PreferExplicitTypeWithInfo());
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -92,7 +125,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -107,10 +140,7 @@ class C
     }
 }";
 
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
+            await TestMissingInRegularAndScriptAsync(code);
         }
 
         [Fact]
@@ -126,10 +156,7 @@ class C
 }";
 
 
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
+            await TestMissingInRegularAndScriptAsync(code);
         }
 
         [Fact]
@@ -168,7 +195,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -192,7 +219,7 @@ class C : System.IDisposable
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -216,7 +243,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -240,7 +267,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -264,9 +291,7 @@ class C
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, options: PreferImplicitTypeWithSilent());
-            await TestInRegularAndScriptAsync(code, expected, options: PreferExplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact, WorkItem(26923, "https://github.com/dotnet/roslyn/issues/26923")]
@@ -287,15 +312,42 @@ class C
 }";
 
             // We never want to get offered here under any circumstances.
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithSilent());
-            await TestMissingInRegularAndScriptAsync(code, PreferImplicitTypeWithInfo());
-            await TestMissingInRegularAndScriptAsync(code, PreferExplicitTypeWithInfo());
+            await TestMissingInRegularAndScriptAsync(code);
         }
 
-        private Task TestMissingInRegularAndScriptAsync(string initialMarkup, IDictionary<OptionKey, object> options)
+        private async Task TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(string initialMarkup, string expectedMarkup)
         {
-            return TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: options));
+            // Enabled because the diagnostic is disabled
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferImplicitTypeWithNone());
+
+            // Enabled because the diagnostic is checking for the other direction
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferExplicitTypeWithNone());
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferExplicitTypeWithSilent());
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferExplicitTypeWithInfo());
+
+            // Disabled because the diagnostic will report it instead
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithSilent()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithInfo()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithWarning()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithError()));
+
+            // Currently this refactoring is still enabled in cases where it would cause a warning or error
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferExplicitTypeWithWarning());
+            await TestInRegularAndScriptAsync(initialMarkup, expectedMarkup, options: PreferExplicitTypeWithError());
+        }
+
+        private async Task TestMissingInRegularAndScriptAsync(string initialMarkup)
+        {
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithNone()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithNone()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithSilent()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithSilent()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithInfo()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithInfo()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithWarning()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithWarning()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferImplicitTypeWithError()));
+            await TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: PreferExplicitTypeWithError()));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/AbstractUseTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/AbstractUseTypeRefactoringTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitOrImplicitType
+{
+    public abstract class AbstractUseTypeRefactoringTests : AbstractCSharpCodeActionTest
+    {
+        private readonly CodeStyleOption<bool> onWithNone = new CodeStyleOption<bool>(true, NotificationOption.None);
+        private readonly CodeStyleOption<bool> offWithNone = new CodeStyleOption<bool>(false, NotificationOption.None);
+        private readonly CodeStyleOption<bool> onWithSilent = new CodeStyleOption<bool>(true, NotificationOption.Silent);
+        private readonly CodeStyleOption<bool> offWithSilent = new CodeStyleOption<bool>(false, NotificationOption.Silent);
+        private readonly CodeStyleOption<bool> onWithInfo = new CodeStyleOption<bool>(true, NotificationOption.Suggestion);
+        private readonly CodeStyleOption<bool> offWithInfo = new CodeStyleOption<bool>(false, NotificationOption.Suggestion);
+        private readonly CodeStyleOption<bool> onWithWarning = new CodeStyleOption<bool>(true, NotificationOption.Warning);
+        private readonly CodeStyleOption<bool> offWithWarning = new CodeStyleOption<bool>(false, NotificationOption.Warning);
+        private readonly CodeStyleOption<bool> offWithError = new CodeStyleOption<bool>(false, NotificationOption.Error);
+        private readonly CodeStyleOption<bool> onWithError = new CodeStyleOption<bool>(true, NotificationOption.Error);
+
+        protected IDictionary<OptionKey, object> PreferExplicitTypeWithError() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithError));
+
+        protected IDictionary<OptionKey, object> PreferImplicitTypeWithError() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithError),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithError));
+
+        protected IDictionary<OptionKey, object> PreferExplicitTypeWithWarning() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithWarning));
+
+        protected IDictionary<OptionKey, object> PreferImplicitTypeWithWarning() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithWarning),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithWarning));
+
+        protected IDictionary<OptionKey, object> PreferExplicitTypeWithInfo() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo));
+
+        protected IDictionary<OptionKey, object> PreferImplicitTypeWithInfo() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo));
+
+        protected IDictionary<OptionKey, object> PreferExplicitTypeWithSilent() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithSilent),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithSilent),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithSilent));
+
+        protected IDictionary<OptionKey, object> PreferImplicitTypeWithSilent() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithSilent),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithSilent),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithSilent));
+
+        protected IDictionary<OptionKey, object> PreferExplicitTypeWithNone() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithNone));
+
+        protected IDictionary<OptionKey, object> PreferImplicitTypeWithNone() => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithNone));
+    }
+}

--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseExplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseExplicitTypeRefactoringTests.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseExplicitType;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -14,71 +10,10 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitOrImplicitType
 {
     [Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
-    public class UseExplicitTypeRefactoringTests : AbstractCSharpCodeActionTest
+    public class UseExplicitTypeRefactoringTests : AbstractUseTypeRefactoringTests
     {
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
             => new UseExplicitTypeCodeRefactoringProvider();
-
-        private readonly CodeStyleOption<bool> onWithNone = new CodeStyleOption<bool>(true, NotificationOption.None);
-        private readonly CodeStyleOption<bool> offWithNone = new CodeStyleOption<bool>(false, NotificationOption.None);
-        private readonly CodeStyleOption<bool> onWithSilent = new CodeStyleOption<bool>(true, NotificationOption.Silent);
-        private readonly CodeStyleOption<bool> offWithSilent = new CodeStyleOption<bool>(false, NotificationOption.Silent);
-        private readonly CodeStyleOption<bool> onWithInfo = new CodeStyleOption<bool>(true, NotificationOption.Suggestion);
-        private readonly CodeStyleOption<bool> offWithInfo = new CodeStyleOption<bool>(false, NotificationOption.Suggestion);
-        private readonly CodeStyleOption<bool> onWithWarning = new CodeStyleOption<bool>(true, NotificationOption.Warning);
-        private readonly CodeStyleOption<bool> offWithWarning = new CodeStyleOption<bool>(false, NotificationOption.Warning);
-        private readonly CodeStyleOption<bool> offWithError = new CodeStyleOption<bool>(false, NotificationOption.Error);
-        private readonly CodeStyleOption<bool> onWithError = new CodeStyleOption<bool>(true, NotificationOption.Error);
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithError() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithError),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithError),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithError));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithError() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithError),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithError),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithError));
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithWarning() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithWarning),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithWarning),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithWarning));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithWarning() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithWarning),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithWarning),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithWarning));
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithInfo() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithInfo),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithInfo() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo));
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithSilent() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithSilent));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithSilent() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithSilent));
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithNone() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithNone),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithNone),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithNone));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithNone() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithNone));
 
         [Fact]
         public async Task TestIntLocalDeclaration()

--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseExplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseExplicitTypeRefactoringTests.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitType
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitOrImplicitType
 {
     [Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
     public class UseExplicitTypeRefactoringTests : AbstractCSharpCodeActionTest

--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseImplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseImplicitTypeRefactoringTests.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitType
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitOrImplicitType
 {
     [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
     public class UseImplicitTypeRefactoringTests : AbstractCSharpCodeActionTest

--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseImplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseImplicitTypeRefactoringTests.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseImplicitType;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -14,71 +10,10 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.UseExplicitOrImplicitType
 {
     [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
-    public class UseImplicitTypeRefactoringTests : AbstractCSharpCodeActionTest
+    public class UseImplicitTypeRefactoringTests : AbstractUseTypeRefactoringTests
     {
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
             => new UseImplicitTypeCodeRefactoringProvider();
-
-        private readonly CodeStyleOption<bool> onWithNone = new CodeStyleOption<bool>(true, NotificationOption.None);
-        private readonly CodeStyleOption<bool> offWithNone = new CodeStyleOption<bool>(false, NotificationOption.None);
-        private readonly CodeStyleOption<bool> onWithSilent = new CodeStyleOption<bool>(true, NotificationOption.Silent);
-        private readonly CodeStyleOption<bool> offWithSilent = new CodeStyleOption<bool>(false, NotificationOption.Silent);
-        private readonly CodeStyleOption<bool> onWithInfo = new CodeStyleOption<bool>(true, NotificationOption.Suggestion);
-        private readonly CodeStyleOption<bool> offWithInfo = new CodeStyleOption<bool>(false, NotificationOption.Suggestion);
-        private readonly CodeStyleOption<bool> onWithWarning = new CodeStyleOption<bool>(true, NotificationOption.Warning);
-        private readonly CodeStyleOption<bool> offWithWarning = new CodeStyleOption<bool>(false, NotificationOption.Warning);
-        private readonly CodeStyleOption<bool> offWithError = new CodeStyleOption<bool>(false, NotificationOption.Error);
-        private readonly CodeStyleOption<bool> onWithError = new CodeStyleOption<bool>(true, NotificationOption.Error);
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithError() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithError),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithError),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithError));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithError() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithError),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithError),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithError));
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithWarning() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithWarning),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithWarning),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithWarning));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithWarning() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithWarning),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithWarning),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithWarning));
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithInfo() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithInfo),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithInfo() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo));
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithSilent() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithSilent));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithSilent() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithSilent),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithSilent));
-
-        private IDictionary<OptionKey, object> PreferExplicitTypeWithNone() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithNone),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithNone),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithNone));
-
-        private IDictionary<OptionKey, object> PreferImplicitTypeWithNone() => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithNone));
 
         [Fact]
         public async Task TestIntLocalDeclaration()

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
@@ -23,20 +24,40 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
                 this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement),
                 this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CSharpCodeStyleOptions.NeverWithSilentEnforcement));
 
+        private IDictionary<OptionKey, object> UseExpressionBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic =>
+            OptionsSet(
+                this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.None)),
+                this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.None)));
+
         private IDictionary<OptionKey, object> UseExpressionBodyForAccessors_ExpressionBodyForProperties =>
             OptionsSet(
                 this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement),
                 this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement));
+
+        private IDictionary<OptionKey, object> UseExpressionBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic =>
+            OptionsSet(
+                this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.None)),
+                this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.None)));
 
         private IDictionary<OptionKey, object> UseBlockBodyForAccessors_ExpressionBodyForProperties =>
             OptionsSet(
                 this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CSharpCodeStyleOptions.NeverWithSilentEnforcement),
                 this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement));
 
+        private IDictionary<OptionKey, object> UseBlockBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic =>
+            OptionsSet(
+                this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.None)),
+                this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.None)));
+
         private IDictionary<OptionKey, object> UseBlockBodyForAccessors_BlockBodyForProperties =>
             OptionsSet(
                 this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CSharpCodeStyleOptions.NeverWithSilentEnforcement),
                 this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CSharpCodeStyleOptions.NeverWithSilentEnforcement));
+
+        private IDictionary<OptionKey, object> UseBlockBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic =>
+            OptionsSet(
+                this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.None)),
+                this.SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.None)));
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
         public async Task TestUpdatePropertyIfPropertyWantsBlockAndAccessorWantsExpression()
@@ -72,6 +93,46 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         }
     }
 }", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    int Goo
+    {
+        get
+        {
+            return [||]Bar();
+        }
+    }
+}",
+@"class C
+{
+    int Goo => Bar();
+}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody2()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    int Goo
+    {
+        get
+        {
+            return [||]Bar();
+        }
+    }
+}",
+@"class C
+{
+    int Goo => Bar();
+}", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
@@ -125,6 +186,36 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     int Goo { get => [||]Bar(); }
 }", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    int Goo { get => [||]Bar(); }
+}",
+
+@"class C
+{
+    int Goo => Bar();
+}", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties_DisabledDiagnostic));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody2()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    int Goo { get => [||]Bar(); }
+}",
+
+@"class C
+{
+    int Goo => Bar();
+}", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties_DisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
@@ -20,8 +21,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         private IDictionary<OptionKey, object> UseExpressionBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement);
 
+        private IDictionary<OptionKey, object> UseExpressionBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.None));
+
         private IDictionary<OptionKey, object> UseBlockBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, CSharpCodeStyleOptions.NeverWithSilentEnforcement);
+
+        private IDictionary<OptionKey, object> UseBlockBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.None));
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
         public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
@@ -34,6 +41,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         [||]Bar();
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    public C()
+    {
+        [||]Bar();
+    }
+}",
+@"class C
+{
+    public C() => Bar();
+}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
@@ -74,6 +98,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public C() => [||]Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    public C() => [||]Bar();
+}",
+@"class C
+{
+    public C()
+    {
+        Bar();
+    }
+}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
@@ -20,8 +21,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         private IDictionary<OptionKey, object> UseExpressionBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement);
 
+        private IDictionary<OptionKey, object> UseExpressionBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.None));
+
         private IDictionary<OptionKey, object> UseBlockBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, CSharpCodeStyleOptions.NeverWithSilentEnforcement);
+
+        private IDictionary<OptionKey, object> UseBlockBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.None));
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
         public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
@@ -34,6 +41,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         [||]Bar();
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    public static implicit operator bool(C c1)
+    {
+        [||]Bar();
+    }
+}",
+@"class C
+{
+    public static implicit operator bool(C c1) => Bar();
+}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
@@ -74,6 +98,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public static implicit operator bool(C c1) => [||]Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    public static implicit operator bool(C c1) => [||]Bar();
+}",
+@"class C
+{
+    public static implicit operator bool(C c1)
+    {
+        return Bar();
+    }
+}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
@@ -21,8 +22,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         private IDictionary<OptionKey, object> UseExpressionBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement);
 
+        private IDictionary<OptionKey, object> UseExpressionBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.None));
+
         private IDictionary<OptionKey, object> UseBlockBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, CSharpCodeStyleOptions.NeverWithSilentEnforcement);
+
+        private IDictionary<OptionKey, object> UseBlockBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.None));
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
         public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
@@ -38,6 +45,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         }
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    int this[int i]
+    {
+        get
+        {
+            [||]return Bar();
+        }
+    }
+}",
+@"class C
+{
+    int this[int i] => Bar();
+}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
         }
 
 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
@@ -84,6 +111,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     int this[int i] => [||]Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    int this[int i] => [||]Bar();
+}",
+@"class C
+{
+    int this[int i]
+    {
+        get
+        {
+            return Bar();
+        }
+    }
+}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
         }
 
         [WorkItem(20363, "https://github.com/dotnet/roslyn/issues/20363")]

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
@@ -20,8 +21,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         private IDictionary<OptionKey, object> UseExpressionBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement);
 
+        private IDictionary<OptionKey, object> UseExpressionBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.None));
+
         private IDictionary<OptionKey, object> UseBlockBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CSharpCodeStyleOptions.NeverWithSilentEnforcement);
+
+        private IDictionary<OptionKey, object> UseBlockBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.None));
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
         public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
@@ -34,6 +41,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         [||]Bar();
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void Goo()
+    {
+        [||]Bar();
+    }
+}",
+@"class C
+{
+    void Goo() => Bar();
+}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
@@ -74,6 +98,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     void Goo() => [||]Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void Goo() => [||]Bar();
+}",
+@"class C
+{
+    void Goo()
+    {
+        Bar();
+    }
+}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
@@ -20,8 +21,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         private IDictionary<OptionKey, object> UseExpressionBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement);
 
+        private IDictionary<OptionKey, object> UseExpressionBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.None));
+
         private IDictionary<OptionKey, object> UseBlockBody =>
             this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, CSharpCodeStyleOptions.NeverWithSilentEnforcement);
+
+        private IDictionary<OptionKey, object> UseBlockBodyDisabledDiagnostic =>
+            this.Option(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, NotificationOption.None));
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
         public async Task TestNotOfferedIfUserPrefersExpressionBodiesAndInBlockBody()
@@ -34,6 +41,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         [||]Bar();
     }
 }", parameters: new TestParameters(options: UseExpressionBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersExpressionBodiesWithoutDiagnosticAndInBlockBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    public static bool operator +(C c1, C c2)
+    {
+        [||]Bar();
+    }
+}",
+@"class C
+{
+    public static bool operator +(C c1, C c2) => Bar();
+}", parameters: new TestParameters(options: UseExpressionBodyDisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
@@ -74,6 +98,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     public static bool operator +(C c1, C c2) => [||]Bar();
 }", parameters: new TestParameters(options: UseBlockBody));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferedIfUserPrefersBlockBodiesWithoutDiagnosticAndInExpressionBody()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    public static bool operator +(C c1, C c2) => [||]Bar();
+}",
+@"class C
+{
+    public static bool operator +(C c1, C c2)
+    {
+        return Bar();
+    }
+}", parameters: new TestParameters(options: UseBlockBodyDisabledDiagnostic));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]

--- a/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitOrImplicitType/AbstractUseTypeCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitOrImplicitType/AbstractUseTypeCodeRefactoringProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseType
             }
 
             var typeStyle = AnalyzeTypeName(declaredType, semanticModel, optionSet, cancellationToken);
-            if (typeStyle.IsStylePreferred && typeStyle.Severity.WithDefaultSeverity(DiagnosticSeverity.Hidden) < ReportDiagnostic.Hidden)
+            if (typeStyle.IsStylePreferred && typeStyle.Severity != ReportDiagnostic.Suppress)
             {
                 // the analyzer would handle this.  So we do not.
                 return;


### PR DESCRIPTION
### Customer scenario

A customer creates a .editorconfig file with `none` severity for rules they do not wish to enforce. After updating to Visual Studio 2017 version 15.8 Preview 3, some manual refactorings related to these rules stop working as well. The impacted refactorings are:

* Use implicit type
* Use explicit type
* Use expression body
* Use block body

### Bugs this fixes

N/A

### Workarounds, if any

Update the .editorconfig to specify `silent` instead of `none`.

### Risk

The risk is relatively low.

### Performance impact

None relative to 15.8 Preview 2 and earlier. The refactoring is now evaluated in the same manner and locations it was prior to the change in meaning of `none` severity in .editorconfig.

### Is this a regression from a previous update?

Yes, introduced by #27220.

### Root cause analysis

Currently we test the diagnostic analyzers separately from the refactorings, even when the two are operating on the same underlying feature in code. Each set of tests assumes behavior about the other in order to test the remaining cases. #27720 caused the analyzer to no longer operate under one of these scenarios where the refactoring tests continued to assume the diagnostic would provide a code fix.

The ideal fix is implementing a new test strategy that enables multiple analyzers and/or code fixes known to operate on the same body of code, and make assertions about the combined impact from the user's perspective. These assertions would more accurately reflect the behavior of the application in production, and detect two specific situations that are currently undetected by tests:

1. Tests would fail if the analyzer stopped providing a code fix and the refactoring was not updated to offer it (and vice versa)
2. Tests would fail if the analyzer started offering a code fix and the refactoring was not updated to exclude it (and vice versa)

I have filed #28216 to improve this situation in the future.

### How was the bug found?

Dogfooding.

### Test documentation updated?

No.
