### PR TITLE
Transfer leading trivia in ChangeSignature

### DIFF
--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignature_Delegates.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignature_Delegates.cs
@@ -535,7 +535,7 @@ class C
 /// <summary>
 /// This is <see cref=""MyDelegate""/>, which has these methods:
 ///     <see cref=""MyDelegate.MyDelegate(object, IntPtr)""/>
-///     <see cref=""MyDelegate.Invoke( bool, string)""/>
+///     <see cref=""MyDelegate.Invoke(bool, string)""/>
 ///     <see cref=""MyDelegate.EndInvoke(IAsyncResult)""/>
 ///     <see cref=""MyDelegate.BeginInvoke(int, string, bool, AsyncCallback, object)""/>
 /// </summary>

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignature_Formatting.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignature_Formatting.cs
@@ -42,6 +42,72 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [WorkItem(28156, "https://github.com/dotnet/roslyn/issues/28156")]
+        public async Task ChangeSignature_Formatting_KeepTrivia()
+        {
+            var markup = @"
+class C
+{
+    void $$Method(
+        int a, int b, int c,
+        int d, int e,
+        int f)
+    {
+        Method(
+            1, 2, 3,
+            4, 5, 6);
+    }
+}";
+            var updatedSignature = new[] { 1, 2, 3, 4, 5 };
+            var expectedUpdatedCode = @"
+class C
+{
+    void Method(
+        int b, int c, int d,
+        int e, int f)
+    {
+        Method(
+            2, 3, 4,
+            5, 6);
+    }
+}";
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [WorkItem(28156, "https://github.com/dotnet/roslyn/issues/28156")]
+        public async Task ChangeSignature_Formatting_KeepTrivia_WithArgumentNames()
+        {
+            var markup = @"
+class C
+{
+    void $$Method(
+        int a, int b, int c,
+        int d, int e,
+        int f)
+    {
+        Method(
+            a: 1, b: 2, c: 3,
+            d: 4, e: 5, f: 6);
+    }
+}";
+            var updatedSignature = new[] { 1, 2, 3, 4, 5 };
+            var expectedUpdatedCode = @"
+class C
+{
+    void Method(
+        int b, int c, int d,
+        int e, int f)
+    {
+        Method(
+            b: 2, c: 3, d: 4,
+            e: 5, f: 6);
+    }
+}";
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public async Task ChangeSignature_Formatting_Method()
         {
             var markup = @"
@@ -254,6 +320,28 @@ class CustomAttribute : System.Attribute
 class CustomAttribute : System.Attribute
 {
     public CustomAttribute(int y, int x) { }
+}";
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [WorkItem(28156, "https://github.com/dotnet/roslyn/issues/28156")]
+        public async Task ChangeSignature_Formatting_Attribute_KeepTrivia()
+        {
+            var markup = @"
+[Custom(
+    1, 2)]
+class CustomAttribute : System.Attribute
+{
+    public $$CustomAttribute(int x, int y) { }
+}";
+            var updatedSignature = new[] { 1 };
+            var expectedUpdatedCode = @"
+[Custom(
+    2)]
+class CustomAttribute : System.Attribute
+{
+    public CustomAttribute(int y) { }
 }";
             await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
         }

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignature_Formatting.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignature_Formatting.cs
@@ -346,6 +346,71 @@ class CustomAttribute : System.Attribute
             await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [WorkItem(28156, "https://github.com/dotnet/roslyn/issues/28156")]
+        public async Task ChangeSignature_Formatting_Attribute_KeepTrivia_RemovingSecond()
+        {
+            var markup = @"
+[Custom(
+    1, 2)]
+class CustomAttribute : System.Attribute
+{
+    public $$CustomAttribute(int x, int y) { }
+}";
+            var updatedSignature = new[] { 0 };
+            var expectedUpdatedCode = @"
+[Custom(
+    1)]
+class CustomAttribute : System.Attribute
+{
+    public CustomAttribute(int x) { }
+}";
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [WorkItem(28156, "https://github.com/dotnet/roslyn/issues/28156")]
+        public async Task ChangeSignature_Formatting_Attribute_KeepTrivia_RemovingBoth()
+        {
+            var markup = @"
+[Custom(
+    1, 2)]
+class CustomAttribute : System.Attribute
+{
+    public $$CustomAttribute(int x, int y) { }
+}";
+            var updatedSignature = new int[] { };
+            var expectedUpdatedCode = @"
+[Custom(
+)]
+class CustomAttribute : System.Attribute
+{
+    public CustomAttribute() { }
+}";
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [WorkItem(28156, "https://github.com/dotnet/roslyn/issues/28156")]
+        public async Task ChangeSignature_Formatting_Attribute_KeepTrivia_RemovingBeforeNewlineComma()
+        {
+            var markup = @"
+[Custom(1
+    , 2, 3)]
+class CustomAttribute : System.Attribute
+{
+    public $$CustomAttribute(int x, int y, int z) { }
+}";
+            var updatedSignature = new[] { 1, 2 };
+            var expectedUpdatedCode = @"
+[Custom(2, 3)]
+class CustomAttribute : System.Attribute
+{
+    public CustomAttribute(int y, int z) { }
+}";
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+        }
+
         [WorkItem(946220, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/946220")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public async Task ChangeSignature_Formatting_LambdaAsArgument()

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
@@ -803,7 +803,7 @@ class C
 class C
 {
     /// <summary>
-    /// See <see cref=""M( string,int)""/> and <see cref=""M""/>
+    /// See <see cref=""M(string, int)""/> and <see cref=""M""/>
     /// </summary>
     void M(string y, int x)
     { }

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -406,9 +406,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             var reorderedParameters = updatedSignature.UpdatedConfiguration.ToListOfParameters();
 
             var newParameters = new List<T>();
-            int index = 0;
-            foreach (var newParam in reorderedParameters)
+            for (var index = 0; index < reorderedParameters.Count; index++)
             {
+                var newParam = reorderedParameters[index];
                 var pos = originalParameters.IndexOf(newParam);
                 var param = list[pos];
 
@@ -416,7 +416,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
                 param = TransferLeadingWhitespaceTrivia(param, list[index]);
 
                 newParameters.Add(param);
-                index++;
             }
 
             var numSeparatorsToSkip = originalParameters.Count - reorderedParameters.Count;
@@ -433,7 +432,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
             if (oldOnlyHasWhitespaceTrivia && newOnlyHasWhitespaceTrivia)
             {
-                return newArgument.WithLeadingTrivia(oldTrivia);
+                newArgument = newArgument.WithLeadingTrivia(oldTrivia);
             }
 
             return newArgument;
@@ -449,7 +448,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             var numSeparatorsToSkip = arguments.Count - newArguments.Count;
 
             // copy whitespace trivia from original position
-            var newArgumentsWithTrivia = TransferLeadingWhitespaceTrivia(newArguments.Select(a => (AttributeArgumentSyntax)(UnifiedArgumentSyntax)a), arguments);
+            var newArgumentsWithTrivia = TransferLeadingWhitespaceTrivia(
+                newArguments.Select(a => (AttributeArgumentSyntax)(UnifiedArgumentSyntax)a), arguments);
 
             return SyntaxFactory.SeparatedList(newArgumentsWithTrivia, GetSeparators(arguments, numSeparatorsToSkip));
         }
@@ -463,7 +463,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         {
             var newArguments = PermuteArguments(document, declarationSymbol, arguments.Select(a => UnifiedArgumentSyntax.Create(a)).ToList(), updatedSignature, isReducedExtensionMethod);
 
-            var newArgumentsWithTrivia = TransferLeadingWhitespaceTrivia(newArguments.Select(a => (ArgumentSyntax)(UnifiedArgumentSyntax)a), arguments); // copy whitespace trivia from original position
+            // copy whitespace trivia from original position
+            var newArgumentsWithTrivia = TransferLeadingWhitespaceTrivia(
+                newArguments.Select(a => (ArgumentSyntax)(UnifiedArgumentSyntax)a), arguments);
 
             var numSeparatorsToSkip = arguments.Count - newArguments.Count;
             return SyntaxFactory.SeparatedList(newArgumentsWithTrivia, GetSeparators(arguments, numSeparatorsToSkip));

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -406,15 +406,37 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             var reorderedParameters = updatedSignature.UpdatedConfiguration.ToListOfParameters();
 
             var newParameters = new List<T>();
+            int index = 0;
             foreach (var newParam in reorderedParameters)
             {
                 var pos = originalParameters.IndexOf(newParam);
                 var param = list[pos];
+
+                // copy whitespace trivia from original position
+                param = TransferLeadingWhitespaceTrivia(param, list[index]);
+
                 newParameters.Add(param);
+                index++;
             }
 
             var numSeparatorsToSkip = originalParameters.Count - reorderedParameters.Count;
             return SyntaxFactory.SeparatedList(newParameters, GetSeparators(list, numSeparatorsToSkip));
+        }
+
+        private static T TransferLeadingWhitespaceTrivia<T>(T newArgument, SyntaxNode oldArgument) where T : SyntaxNode
+        {
+            var oldTrivia = oldArgument.GetLeadingTrivia();
+            var oldOnlyHasWhitespaceTrivia = oldTrivia.All(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
+
+            var newTrivia = newArgument.GetLeadingTrivia();
+            var newOnlyHasWhitespaceTrivia = newTrivia.All(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
+
+            if (oldOnlyHasWhitespaceTrivia && newOnlyHasWhitespaceTrivia)
+            {
+                return newArgument.WithLeadingTrivia(oldTrivia);
+            }
+
+            return newArgument;
         }
 
         private static SeparatedSyntaxList<AttributeArgumentSyntax> PermuteAttributeArgumentList(
@@ -425,7 +447,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         {
             var newArguments = PermuteArguments(document, declarationSymbol, arguments.Select(a => UnifiedArgumentSyntax.Create(a)).ToList(), updatedSignature);
             var numSeparatorsToSkip = arguments.Count - newArguments.Count;
-            return SyntaxFactory.SeparatedList(newArguments.Select(a => (AttributeArgumentSyntax)(UnifiedArgumentSyntax)a), GetSeparators(arguments, numSeparatorsToSkip));
+
+            // copy whitespace trivia from original position
+            var newArgumentsWithTrivia = TransferLeadingWhitespaceTrivia(newArguments.Select(a => (AttributeArgumentSyntax)(UnifiedArgumentSyntax)a), arguments);
+
+            return SyntaxFactory.SeparatedList(newArgumentsWithTrivia, GetSeparators(arguments, numSeparatorsToSkip));
         }
 
         private static SeparatedSyntaxList<ArgumentSyntax> PermuteArgumentList(
@@ -436,8 +462,26 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             bool isReducedExtensionMethod = false)
         {
             var newArguments = PermuteArguments(document, declarationSymbol, arguments.Select(a => UnifiedArgumentSyntax.Create(a)).ToList(), updatedSignature, isReducedExtensionMethod);
+
+            var newArgumentsWithTrivia = TransferLeadingWhitespaceTrivia(newArguments.Select(a => (ArgumentSyntax)(UnifiedArgumentSyntax)a), arguments); // copy whitespace trivia from original position
+
             var numSeparatorsToSkip = arguments.Count - newArguments.Count;
-            return SyntaxFactory.SeparatedList(newArguments.Select(a => (ArgumentSyntax)(UnifiedArgumentSyntax)a), GetSeparators(arguments, numSeparatorsToSkip));
+            return SyntaxFactory.SeparatedList(newArgumentsWithTrivia, GetSeparators(arguments, numSeparatorsToSkip));
+        }
+
+        private static List<T> TransferLeadingWhitespaceTrivia<T, U>(IEnumerable<T> newArguments, SeparatedSyntaxList<U> oldArguments)
+            where T : SyntaxNode
+            where U : SyntaxNode
+        {
+            var result = new List<T>();
+            int index = 0;
+            foreach (var newArgument in newArguments)
+            {
+                result.Add(TransferLeadingWhitespaceTrivia(newArgument, oldArguments[index]));
+                index++;
+            }
+
+            return result;
         }
 
         private List<SyntaxTrivia> UpdateParamTagsInLeadingTrivia(CSharpSyntaxNode node, ISymbol declarationSymbol, SignatureChange updatedSignature)


### PR DESCRIPTION
### Customer scenario
Previously, ChangeSignature would produce some badly formatted results when deleting a parameter that is used as the beginning of a line. With this fix, the resulting code uses a more similar formatting to the original code.

Starting code:
![image](https://user-images.githubusercontent.com/12466233/41960339-5bff2e1e-79a4-11e8-8951-a41811dcc144.png)

Code after deleting first parameter with ChangeSignature (before fix):
![image](https://user-images.githubusercontent.com/12466233/41960313-4f4b6e8a-79a4-11e8-911d-a4d50f8e2658.png)

Code after deleting first parameter with ChangeSignature (after fix):
![image](https://user-images.githubusercontent.com/12466233/42121944-4718cc2a-7bee-11e8-9e24-c80a8ae20ae0.png)

Note: I think this fix is only valuable for C# (VB formatting is more prescriptive).

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/28156

### Workarounds, if any
You could fix the code formatting by hand after using ChangeSignature.

### Risk
### Performance impact
Low. The code is limited to ChangeSignature, and the transfer of trivia only happens for whitespace trivia.

### Is this a regression from a previous update?
No.

### How was the bug found?
While working on Roslyn codebase.