### PR TITLE
Implement FAR for GetAwaiter methods

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -55,6 +55,83 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
         <WorkItem(18963, "https://github.com/dotnet/roslyn/issues/18963")>
+        Public Async Function FindReferences_GetAwaiter() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+public class C
+{
+    public TaskAwaiter<bool> {|Definition:Get$$Awaiter|}() => Task.FromResult(true).GetAwaiter();
+
+    static async void M(C c)
+    {
+        [|await|] c;
+        [|await|] c;
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(18963, "https://github.com/dotnet/roslyn/issues/18963")>
+        Public Async Function FindReferences_GetAwaiter_VB() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Imports System.Threading.Tasks
+Imports System.Runtime.CompilerServices
+Public Class C
+    Public Function {|Definition:Get$$Awaiter|}() As TaskAwaiter(Of Boolean)
+    End Function
+
+    Shared Async Sub M(c As C)
+        [|Await|] c
+    End Sub
+End Class
+        ]]></Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(18963, "https://github.com/dotnet/roslyn/issues/18963")>
+        Public Async Function FindReferences_GetAwaiterInAnotherDocument() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+public class C
+{
+   public TaskAwaiter<bool> {|Definition:Get$$Awaiter|}() => Task.FromResult(true).GetAwaiter();
+}
+        ]]></Document>
+        <Document><![CDATA[
+class D
+{
+    static async void M(C c)
+    {
+        [|await|] c;
+        [|await|] c;
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(18963, "https://github.com/dotnet/roslyn/issues/18963")>
         Public Async Function FindReferences_Deconstruction() As Task
             Dim input =
 <Workspace>

--- a/src/EditorFeatures/Test2/Rename/CSharp/ImplicitReferenceConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/ImplicitReferenceConflictTests.vb
@@ -98,6 +98,31 @@ class C
             End Using
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameGetAwaiterCausesConflict()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document><![CDATA[
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+public class C
+{
+    public TaskAwaiter<bool> [|Get$$Awaiter|]() => Task.FromResult(true).GetAwaiter();
+
+    static async void M(C c)
+    {
+        {|awaitconflict:await|} c;
+    }
+}
+                            ]]></Document>
+                        </Project>
+                    </Workspace>, renameTo:="GetAwaiter2")
+
+                result.AssertLabeledSpansAre("awaitconflict", type:=RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
+
         <WorkItem(528966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528966")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoveNextInVBCausesConflictInForEach()

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
@@ -231,11 +231,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public IMethodSymbol GetAwaitExpressionMethod(SemanticModel semanticModel, SyntaxNode node)
+        public IMethodSymbol GetGetAwaiterMethod(SemanticModel semanticModel, SyntaxNode node)
         {
             if (node is AwaitExpressionSyntax awaitExpression)
             {
-                var builder = ArrayBuilder<IMethodSymbol>.GetInstance();
                 var info = semanticModel.GetAwaitExpressionInfo(awaitExpression);
                 return info.GetAwaiterMethod;
             }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
@@ -231,6 +231,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        public IMethodSymbol GetAwaitExpressionMethod(SemanticModel semanticModel, SyntaxNode node)
+        {
+            if (node is AwaitExpressionSyntax awaitExpression)
+            {
+                var builder = ArrayBuilder<IMethodSymbol>.GetInstance();
+                var info = semanticModel.GetAwaitExpressionInfo(awaitExpression);
+                return info.GetAwaiterMethod;
+            }
+
+            return null;
+        }
+
         public ImmutableArray<IMethodSymbol> GetDeconstructionAssignmentMethods(SemanticModel semanticModel, SyntaxNode node)
         {
             if (node is AssignmentExpressionSyntax assignment && assignment.IsDeconstruction())

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1585,6 +1585,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return node != null && (node.Parent as InvocationExpressionSyntax)?.Expression == node;
         }
 
+        public bool IsAwaitExpression(SyntaxNode node)
+        {
+            return node.IsKind(SyntaxKind.AwaitExpression);
+        }
+
         public bool IsExpressionOfAwaitExpression(SyntaxNode node)
         {
             return node != null && (node.Parent as AwaitExpressionSyntax)?.Expression == node;

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1586,9 +1586,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public bool IsAwaitExpression(SyntaxNode node)
-        {
-            return node.IsKind(SyntaxKind.AwaitExpression);
-        }
+            => node.IsKind(SyntaxKind.AwaitExpression);
 
         public bool IsExpressionOfAwaitExpression(SyntaxNode node)
         {

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -996,6 +996,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                     (renameSymbol.Kind == SymbolKind.Method &&
                         (string.Compare(renameSymbol.Name, WellKnownMemberNames.MoveNextMethodName, StringComparison.OrdinalIgnoreCase) == 0 ||
                         string.Compare(renameSymbol.Name, WellKnownMemberNames.GetEnumeratorMethodName, StringComparison.OrdinalIgnoreCase) == 0 ||
+                        string.Compare(renameSymbol.Name, WellKnownMemberNames.GetAwaiter, StringComparison.OrdinalIgnoreCase) == 0 ||
                         string.Compare(renameSymbol.Name, WellKnownMemberNames.DeconstructMethodName, StringComparison.OrdinalIgnoreCase) == 0));
 
             // TODO: handle Dispose for using statement and Add methods for collection initializers.
@@ -1013,6 +1014,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                         {
                             case SyntaxKind.ForEachKeyword:
                                 return ImmutableArray.Create(((CommonForEachStatementSyntax)token.Parent).Expression.GetLocation());
+                            case SyntaxKind.AwaitKeyword:
+                                return ImmutableArray.Create(token.GetLocation());
                         }
 
                         if (token.Parent.IsInDeconstructionLeft(out var deconstructionLeft))

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
@@ -25,7 +25,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsBaseConstructorInitializer,
                 bool containsElementAccessExpression,
                 bool containsIndexerMemberCref,
-                bool containsDeconstruction) :
+                bool containsDeconstruction,
+                bool containsAwait) :
                 this(predefinedTypes, predefinedOperators,
                      ConvertToContainingNodeFlag(
                          containsForEachStatement,
@@ -36,7 +37,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                          containsBaseConstructorInitializer,
                          containsElementAccessExpression,
                          containsIndexerMemberCref,
-                         containsDeconstruction))
+                         containsDeconstruction,
+                         containsAwait))
             {
             }
 
@@ -56,7 +58,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsBaseConstructorInitializer,
                 bool containsElementAccessExpression,
                 bool containsIndexerMemberCref,
-                bool containsDeconstruction)
+                bool containsDeconstruction,
+                bool containsAwait)
             {
                 var containingNodes = ContainingNodes.None;
 
@@ -69,6 +72,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 containingNodes = containsElementAccessExpression ? (containingNodes | ContainingNodes.ContainsElementAccessExpression) : containingNodes;
                 containingNodes = containsIndexerMemberCref ? (containingNodes | ContainingNodes.ContainsIndexerMemberCref) : containingNodes;
                 containingNodes = containsDeconstruction ? (containingNodes | ContainingNodes.ContainsDeconstruction) : containingNodes;
+                containingNodes = containsAwait ? (containingNodes | ContainingNodes.ContainsAwait) : containingNodes;
 
                 return containingNodes;
             }
@@ -84,6 +88,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             public bool ContainsDeconstruction
                 => (_containingNodes & ContainingNodes.ContainsDeconstruction) == ContainingNodes.ContainsDeconstruction;
+
+            public bool ContainsAwait
+                => (_containingNodes & ContainingNodes.ContainsAwait) == ContainingNodes.ContainsAwait;
 
             public bool ContainsLockStatement
                 => (_containingNodes & ContainingNodes.ContainsLockStatement) == ContainingNodes.ContainsLockStatement;
@@ -143,6 +150,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 ContainsElementAccessExpression = 1 << 6,
                 ContainsIndexerMemberCref = 1 << 7,
                 ContainsDeconstruction = 1 << 8,
+                ContainsAwait = 1 << 9,
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 var containsElementAccess = false;
                 var containsIndexerMemberCref = false;
                 var containsDeconstruction = false;
+                var containsAwait = false;
 
                 var predefinedTypes = (int)PredefinedType.None;
                 var predefinedOperators = (int)PredefinedOperator.None;
@@ -95,6 +96,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                             containsDeconstruction = containsDeconstruction || syntaxFacts.IsDeconstructionAssignment(node)
                                 || syntaxFacts.IsDeconstructionForEachStatement(node);
+
+                            containsAwait = containsAwait || syntaxFacts.IsAwaitExpression(node);
 
                             // We've received a number of error reports where DeclaredSymbolInfo.GetSymbolAsync() will
                             // crash because the document's syntax root doesn't contain the span of the node returned
@@ -203,7 +206,8 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                             containsBaseConstructorInitializer,
                             containsElementAccess,
                             containsIndexerMemberCref,
-                            containsDeconstruction),
+                            containsDeconstruction,
+                            containsAwait),
                     new DeclarationInfo(
                             declaredSymbolInfos.ToImmutableAndFree()));
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         public bool ContainsForEachStatement => _contextInfo.ContainsForEachStatement;
         public bool ContainsDeconstruction => _contextInfo.ContainsDeconstruction;
+        public bool ContainsAwait => _contextInfo.ContainsAwait;
         public bool ContainsLockStatement => _contextInfo.ContainsLockStatement;
         public bool ContainsUsingStatement => _contextInfo.ContainsUsingStatement;
         public bool ContainsQueryExpression => _contextInfo.ContainsQueryExpression;

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal sealed partial class SyntaxTreeIndex : IObjectWritable
     {
         private const string PersistenceName = "<SyntaxTreeIndex>";
-        private const string SerializationFormat = "11";
+        private const string SerializationFormat = "12";
 
         public readonly Checksum Checksum;
 

--- a/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         ForEachSymbols GetForEachSymbols(SemanticModel semanticModel, SyntaxNode forEachStatement);
 
-        IMethodSymbol GetAwaitExpressionMethod(SemanticModel semanticModel, SyntaxNode node);
+        IMethodSymbol GetGetAwaiterMethod(SemanticModel semanticModel, SyntaxNode node);
 
         ImmutableArray<IMethodSymbol> GetDeconstructionAssignmentMethods(SemanticModel semanticModel, SyntaxNode node);
 

--- a/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
@@ -91,6 +91,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         ForEachSymbols GetForEachSymbols(SemanticModel semanticModel, SyntaxNode forEachStatement);
 
+        IMethodSymbol GetAwaitExpressionMethod(SemanticModel semanticModel, SyntaxNode node);
+
         ImmutableArray<IMethodSymbol> GetDeconstructionAssignmentMethods(SemanticModel semanticModel, SyntaxNode node);
 
         ImmutableArray<IMethodSymbol> GetDeconstructionForEachMethods(SemanticModel semanticModel, SyntaxNode node);

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -93,6 +93,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         SyntaxNode GetExpressionOfExpressionStatement(SyntaxNode node);
 
+        bool IsAwaitExpression(SyntaxNode node);
         bool IsExpressionOfAwaitExpression(SyntaxNode node);
         SyntaxNode GetExpressionOfAwaitExpression(SyntaxNode node);
 

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -257,12 +257,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Function GetAwaitExpressionMethod(model As SemanticModel, node As SyntaxNode) As IMethodSymbol Implements ISemanticFactsService.GetAwaitExpressionMethod
+        Public Function GetGetAwaiterMethod(model As SemanticModel, node As SyntaxNode) As IMethodSymbol Implements ISemanticFactsService.GetGetAwaiterMethod
             If node.IsKind(SyntaxKind.AwaitExpression) Then
                 Dim awaitExpression = DirectCast(node, AwaitExpressionSyntax)
-                Dim builder = ArrayBuilder(Of IMethodSymbol).GetInstance()
                 Dim info = model.GetAwaitExpressionInfo(awaitExpression)
-
                 Return info.GetAwaiterMethod
             End If
 

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -7,6 +7,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -251,6 +252,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     info.CurrentProperty,
                     info.DisposeMethod,
                     info.ElementType)
+            End If
+
+            Return Nothing
+        End Function
+
+        Public Function GetAwaitExpressionMethod(model As SemanticModel, node As SyntaxNode) As IMethodSymbol Implements ISemanticFactsService.GetAwaitExpressionMethod
+            If node.IsKind(SyntaxKind.AwaitExpression) Then
+                Dim awaitExpression = DirectCast(node, AwaitExpressionSyntax)
+                Dim builder = ArrayBuilder(Of IMethodSymbol).GetInstance()
+                Dim info = model.GetAwaitExpressionInfo(awaitExpression)
+
+                Return info.GetAwaiterMethod
             End If
 
             Return Nothing

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -1521,6 +1521,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return node IsNot Nothing AndAlso TryCast(node.Parent, InvocationExpressionSyntax)?.Expression Is node
         End Function
 
+        Public Function IsAwaitExpression(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsAwaitExpression
+            Return node.IsKind(SyntaxKind.AwaitExpression)
+        End Function
+
         Public Function IsExpressionOfAwaitExpression(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsExpressionOfAwaitExpression
             Return node IsNot Nothing AndAlso TryCast(node.Parent, AwaitExpressionSyntax)?.Expression Is node
         End Function


### PR DESCRIPTION
The parts of the change:
- store information about which documents have `await` expressions into the syntax tree index (and update the `SerializationFormat` for the index),
- `AbstractReferenceFinder` and `OrdinaryMethodReferenceFinder` inspect `await` expressions when looking for references to a `GetAwaiter` method,
- `CSharpRenameConflictLanguageService` produces a conflict if you try to rename a `GetAwaiter` method that is used in an `await` expression.

### Customer scenario
Invoked FindAllReferences on a `GetAwaiter` method. You'd expect the `await` expressions that implicitly involve that method to be identified as references.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/25714

### Workarounds, if any
N/A

### Risk
### Performance impact
Low. This is following a well-established template (see [similar change](https://github.com/dotnet/roslyn/pull/22934) for FAR to handle `Deconstruct` methods).

### Is this a regression from a previous update?
No

### How was the bug found?
Reported by customer