### PR TITLE
Provide a spellchecking suggestion when someone mispells a constructor.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.CodeFixes.Spellcheck;
+using Microsoft.CodeAnalysis.CSharp.SpellCheck;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -576,6 +576,21 @@ class C
 }",
 @"class C<T> where T : unmanaged
 {
+}");
+        }
+
+        [WorkItem(1688, "https://github.com/dotnet/csharplang/issues/1688")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)]
+        public async Task TestMispelledConstructor()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class SomeClass
+{
+    public [|SomeClss|]() { }
+}",
+@"public class SomeClass
+{
+    public SomeClass() { }
 }");
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
@@ -579,9 +579,9 @@ class C
 }");
         }
 
-        [WorkItem(1688, "https://github.com/dotnet/csharplang/issues/1688")]
+        [WorkItem(28244, "https://github.com/dotnet/roslyn/issues/28244")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)]
-        public async Task TestMispelledConstructor()
+        public async Task TestMisspelledConstructor()
         {
             await TestInRegularAndScriptAsync(
 @"public class SomeClass

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
@@ -5,7 +5,7 @@ Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
-Imports Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Spellcheck
+Imports Microsoft.CodeAnalysis.VisualBasic.SpellCheck
 Imports Microsoft.CodeAnalysis.VisualBasic.Diagnostics
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Spellcheck

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -232,18 +232,16 @@ namespace Microsoft.CodeAnalysis {
                 return ResourceManager.GetString("Add_parameter_to_0", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Add parameter to &apos;{0}&apos; (and overrides/implementations).
         /// </summary>
-        internal static string Add_parameter_to_0_and_overrides_implementations
-        {
-            get
-            {
+        internal static string Add_parameter_to_0_and_overrides_implementations {
+            get {
                 return ResourceManager.GetString("Add_parameter_to_0_and_overrides_implementations", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Add parameters to &apos;{0}&apos;.
         /// </summary>
@@ -315,18 +313,16 @@ namespace Microsoft.CodeAnalysis {
                 return ResourceManager.GetString("Add_this_or_Me_qualification", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Add to &apos;{0}&apos;.
         /// </summary>
-        internal static string Add_to_0
-        {
-            get
-            {
+        internal static string Add_to_0 {
+            get {
                 return ResourceManager.GetString("Add_to_0", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Adding &apos;{0}&apos; around an active statement will prevent the debug session from continuing..
         /// </summary>
@@ -1297,6 +1293,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Fix_Name_Violation_colon_0 {
             get {
                 return ResourceManager.GetString("Fix_Name_Violation_colon_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix typo &apos;{0}&apos;.
+        /// </summary>
+        internal static string Fix_typo_0 {
+            get {
+                return ResourceManager.GetString("Fix_typo_0", resourceCulture);
             }
         }
         
@@ -2619,18 +2624,16 @@ namespace Microsoft.CodeAnalysis {
                 return ResourceManager.GetString("Re_triage_0_currently_1", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Related method signatures found in metadata will not be updated..
         /// </summary>
-        internal static string Related_method_signatures_found_in_metadata_will_not_be_updated
-        {
-            get
-            {
+        internal static string Related_method_signatures_found_in_metadata_will_not_be_updated {
+            get {
                 return ResourceManager.GetString("Related_method_signatures_found_in_metadata_will_not_be_updated", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remarks:.
         /// </summary>
@@ -3020,15 +3023,6 @@ namespace Microsoft.CodeAnalysis {
         internal static string Specified_file_not_found_colon_0 {
             get {
                 return ResourceManager.GetString("Specified_file_not_found_colon_0", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Spell check &apos;{0}&apos;.
-        /// </summary>
-        internal static string Spell_check_0 {
-            get {
-                return ResourceManager.GetString("Spell_check_0", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1088,8 +1088,8 @@ This version used in: {2}</value>
   <data name="Use_expression_body_for_properties" xml:space="preserve">
     <value>Use expression body for properties</value>
   </data>
-  <data name="Spell_check_0" xml:space="preserve">
-    <value>Spell check '{0}'</value>
+  <data name="Fix_typo_0" xml:space="preserve">
+    <value>Fix typo '{0}'</value>
   </data>
   <data name="Fully_qualify_0" xml:space="preserve">
     <value>Fully qualify '{0}'</value>

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -8,6 +8,9 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SpellCheck
@@ -17,9 +20,12 @@ namespace Microsoft.CodeAnalysis.SpellCheck
 #pragma warning restore RS1016 // Code fix providers should provide FixAll support.
         where TSimpleName : SyntaxNode
     {
+        private const int MinTokenLength = 3;
+
+        protected abstract bool IsGeneric(SyntaxToken nameToken);
         protected abstract bool IsGeneric(TSimpleName nameNode);
         protected abstract bool IsGeneric(CompletionItem completionItem);
-        protected abstract SyntaxToken CreateIdentifier(TSimpleName nameNode, string newName);
+        protected abstract SyntaxToken CreateIdentifier(SyntaxToken nameToken, string newName);
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -29,11 +35,23 @@ namespace Microsoft.CodeAnalysis.SpellCheck
 
             var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var node = syntaxRoot.FindNode(span);
-            if (node == null || node.Span != span)
+            if (node != null && node.Span == span)
             {
+                await CheckNodeAsync(context, document, node, cancellationToken).ConfigureAwait(false);
                 return;
             }
 
+            // didn't get a node that matches the span.  see if there's a token that matches.
+            var token = syntaxRoot.FindToken(span.Start);
+            if (token.RawKind != 0 && token.Span == span)
+            {
+                await CheckTokenAsync(context, document, token, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+        }
+
+        private async Task CheckNodeAsync(CodeFixContext context, Document document, SyntaxNode node, CancellationToken cancellationToken)
+        {
             SemanticModel semanticModel = null;
             foreach (var name in node.DescendantNodesAndSelf(DescendIntoChildren).OfType<TSimpleName>())
             {
@@ -44,45 +62,65 @@ namespace Microsoft.CodeAnalysis.SpellCheck
 
                 // Only bother with identifiers that are at least 3 characters long.
                 // We don't want to be too noisy as you're just starting to type something.
-                var nameText = name.GetFirstToken().ValueText;
-                if (nameText?.Length >= 3)
+                var token = name.GetFirstToken();
+                var nameText = token.ValueText;
+                if (nameText?.Length >= MinTokenLength)
                 {
                     semanticModel = semanticModel ?? await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                     var symbolInfo = semanticModel.GetSymbolInfo(name, cancellationToken);
                     if (symbolInfo.Symbol == null)
                     {
-                        await CreateSpellCheckCodeIssueAsync(context, name, nameText, cancellationToken).ConfigureAwait(false);
+                        var isGeneric = IsGeneric(name);
+                        await CreateSpellCheckCodeIssueAsync(context, token, isGeneric, cancellationToken).ConfigureAwait(false);
                     }
                 }
+            }
+        }
+
+        private async Task CheckTokenAsync(CodeFixContext context, Document document, SyntaxToken token, CancellationToken cancellationToken)
+        {
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            if (!syntaxFacts.IsWord(token))
+            {
+                return;
+            }
+
+            var nameText = token.ValueText;
+            if (nameText?.Length >= MinTokenLength)
+            {
+                var isGeneric = IsGeneric(token);
+                await CreateSpellCheckCodeIssueAsync(context, token, isGeneric, cancellationToken).ConfigureAwait(false);
             }
         }
 
         protected abstract bool ShouldSpellCheck(TSimpleName name);
         protected abstract bool DescendIntoChildren(SyntaxNode arg);
 
-        private async Task CreateSpellCheckCodeIssueAsync(CodeFixContext context, TSimpleName nameNode, string nameText, CancellationToken cancellationToken)
+        private async Task CreateSpellCheckCodeIssueAsync(
+            CodeFixContext context, SyntaxToken nameToken, bool isGeneric, CancellationToken cancellationToken)
         {
             var document = context.Document;
             var service = CompletionService.GetService(document);
 
             // Disable snippets from ever appearing in the completion items. It's
-            // very unlikely the user would ever mispell a snippet, then use spell-
+            // very unlikely the user would ever misspell a snippet, then use spell-
             // checking to fix it, then try to invoke the snippet.
             var originalOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var options = originalOptions.WithChangedOption(CompletionOptions.SnippetsBehavior, document.Project.Language, SnippetsRule.NeverInclude);
 
             var completionList = await service.GetCompletionsAsync(
-                document, nameNode.SpanStart, options: options, cancellationToken: cancellationToken).ConfigureAwait(false);
+                document, nameToken.SpanStart, options: options, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (completionList == null)
             {
                 return;
             }
 
+            var nameText = nameToken.ValueText;
             var similarityChecker = WordSimilarityChecker.Allocate(nameText, substringsAreSimilar: true);
             try
             {
                 await CheckItemsAsync(
-                    context, nameNode, nameText,
+                    context, nameToken, isGeneric,
                     completionList, similarityChecker).ConfigureAwait(false);
             }
             finally
@@ -92,13 +130,13 @@ namespace Microsoft.CodeAnalysis.SpellCheck
         }
 
         private async Task CheckItemsAsync(
-            CodeFixContext context, TSimpleName nameNode, string nameText, 
+            CodeFixContext context, SyntaxToken nameToken, bool isGeneric, 
             CompletionList completionList, WordSimilarityChecker similarityChecker)
         {
             var document = context.Document;
             var cancellationToken = context.CancellationToken;
 
-            var onlyConsiderGenerics = IsGeneric(nameNode);
+            var onlyConsiderGenerics = isGeneric;
             var results = new MultiDictionary<double, string>();
 
             foreach (var item in completionList.Items)
@@ -118,11 +156,12 @@ namespace Microsoft.CodeAnalysis.SpellCheck
                 results.Add(matchCost, insertionText);
             }
 
+            var nameText = nameToken.ValueText;
             var codeActions = results.OrderBy(kvp => kvp.Key)
                                      .SelectMany(kvp => kvp.Value.Order())
                                      .Where(t => t != nameText)
                                      .Take(3)
-                                     .Select(n => CreateCodeAction(nameNode, nameText, n, document))
+                                     .Select(n => CreateCodeAction(nameToken, nameText, n, document))
                                      .ToImmutableArrayOrEmpty<CodeAction>();
 
             if (codeActions.Length > 1)
@@ -146,18 +185,18 @@ namespace Microsoft.CodeAnalysis.SpellCheck
             return change.TextChange.NewText;
         }
 
-        private SpellCheckCodeAction CreateCodeAction(TSimpleName nameNode, string oldName, string newName, Document document)
+        private SpellCheckCodeAction CreateCodeAction(SyntaxToken nameToken, string oldName, string newName, Document document)
         {
             return new SpellCheckCodeAction(
                 string.Format(FeaturesResources.Change_0_to_1, oldName, newName),
-                c => Update(document, nameNode, newName, c),
+                c => Update(document, nameToken, newName, c),
                 equivalenceKey: newName);
         }
 
-        private async Task<Document> Update(Document document, TSimpleName nameNode, string newName, CancellationToken cancellationToken)
+        private async Task<Document> Update(Document document, SyntaxToken nameToken, string newName, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var newRoot = root.ReplaceToken(nameNode.GetFirstToken(), CreateIdentifier(nameNode, newName));
+            var newRoot = root.ReplaceToken(nameToken, CreateIdentifier(nameToken, newName));
 
             return document.WithSyntaxRoot(newRoot);
         }

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -70,8 +70,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
                     var symbolInfo = semanticModel.GetSymbolInfo(name, cancellationToken);
                     if (symbolInfo.Symbol == null)
                     {
-                        var isGeneric = IsGeneric(name);
-                        await CreateSpellCheckCodeIssueAsync(context, token, isGeneric, cancellationToken).ConfigureAwait(false);
+                        await CreateSpellCheckCodeIssueAsync(context, token, IsGeneric(name), cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -88,8 +87,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
             var nameText = token.ValueText;
             if (nameText?.Length >= MinTokenLength)
             {
-                var isGeneric = IsGeneric(token);
-                await CreateSpellCheckCodeIssueAsync(context, token, isGeneric, cancellationToken).ConfigureAwait(false);
+                await CreateSpellCheckCodeIssueAsync(context, token, IsGeneric(token), cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
                 // Wrap the spell checking actions into a single top level suggestion
                 // so as to not clutter the list.
                 context.RegisterCodeFix(new MyCodeAction(
-                    string.Format(FeaturesResources.Spell_check_0, nameText), codeActions), context.Diagnostics);
+                    string.Format(FeaturesResources.Fix_typo_0, nameText), codeActions), context.Diagnostics);
             }
             else
             {

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ Tato verze se používá zde: {2}.</target>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">Pro vlastnosti používat text výrazu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">Kontrola pravopisu {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ Diese Version wird verwendet in: {2}</target>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">Ausdruckskörper für Eigenschaften verwenden</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">Rechtschreibprüfung für "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ Esta versión se utiliza en: {2}</target>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">Usar cuerpo de expresiones para las propiedades</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">Corregir ortografía de '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ Version utilisée dans : {2}</target>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">Utiliser un corps d'expression pour les propriétés</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">Vérifier l'orthographe de '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ Questa versione è usata {2}</target>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">Usa il corpo dell'espressione per le proprietà</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">Controlla l'ortografia di '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ This version used in: {2}</source>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">プロパティに式本体を使用する</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">{0}' をスペル チェック</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ This version used in: {2}</source>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">속성에 식 본문 사용</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">{0}' 맞춤법 검사</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ Ta wersja jest używana wersja: {2}</target>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">Użyj treści wyrażenia dla właściwości</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">Sprawdź pisownię elementu „{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ Essa versão é usada no: {2}</target>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">Usar o corpo da expressão para propriedades</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">Verificar ortografia de '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ This version used in: {2}</source>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">Использовать тело выражения для свойств</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">Проверить орфографию в "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ Bu sürüm şurada kullanılır: {2}</target>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">Özellikler için ifade gövdesi kullan</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">{0}' üzerinde yazım denetimi yap</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ This version used in: {2}</source>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">使用属性的表达式主体</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">拼写检查“{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="new">Add to '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_typo_0">
+        <source>Fix typo '{0}'</source>
+        <target state="new">Fix typo '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="new">Related method signatures found in metadata will not be updated.</target>
@@ -1588,11 +1593,6 @@ This version used in: {2}</source>
       <trans-unit id="Use_expression_body_for_properties">
         <source>Use expression body for properties</source>
         <target state="translated">使用屬性的運算式主體</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Spell_check_0">
-        <source>Spell check '{0}'</source>
-        <target state="translated">拼字檢查 '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Fully_qualify_0">


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/28244
Fixes https://github.com/dotnet/roslyn/issues/24997