### PR TITLE
use correct line ending

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -25,7 +25,6 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Differencing;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
-using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
@@ -799,6 +798,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             var editorOptionsFactory = _componentModel.GetService<IEditorOptionsFactoryService>();
             var editorOptions = editorOptionsFactory.GetOptions(_containedLanguage.DataBuffer);
             var options = _workspace.Options
+                                        .WithChangedOption(FormattingOptions.NewLine, root.Language, editorOptions.GetNewLineCharacter())
                                         .WithChangedOption(FormattingOptions.UseTabs, root.Language, !editorOptions.IsConvertTabsToSpacesEnabled())
                                         .WithChangedOption(FormattingOptions.TabSize, root.Language, editorOptions.GetTabSize())
                                         .WithChangedOption(FormattingOptions.IndentationSize, root.Language, editorOptions.GetIndentSize());

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -473,7 +473,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 switch (ch)
                 {
                     case ' ':
-                        if (!TextAt(text, i - 1, ' '))
+                    case '\t':
+                        if (!TextAt(text, i - 1, ' ', '\t'))
                         {
                             start = i;
                         }
@@ -486,7 +487,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                         {
                             groups.Add(TextSpan.FromBounds(0, 0));
                         }
-                        else if (TextAt(text, i - 1, ' '))
+                        else if (TextAt(text, i - 1, ' ', '\t'))
                         {
                             groups.Add(TextSpan.FromBounds(start, i));
                         }
@@ -511,14 +512,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             return true;
         }
 
-        private bool TextAt(string text, int index, char ch)
+        private bool TextAt(string text, int index, char ch1, char ch2 = default)
         {
             if (index < 0 || text.Length <= index)
             {
                 return false;
             }
 
-            return text[index] == ch;
+            var actual = text[index];
+            if (actual == ch1)
+            {
+                return true;
+            }
+
+            if (ch2 != default && actual == ch2)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private bool TryGetSubTextChange(


### PR DESCRIPTION
### Customer scenario

user commit completion in razor on mac and code got messed up.

### Bugs this fixes

 https://devdiv.visualstudio.com/DevDiv/_workitems/edit/585147 and #28240

### Workarounds, if any

don't use tab and use windows line ending.

### Risk

Low. no code loss. 

### Performance impact

Low. no perf impacting changes

### Is this a regression from a previous update?

No

### Root cause analysis

formatter we used for razor didn't set line ending correctly (always used windows style) and didn't check tab for whitespace causing it to group strings in the wrong group (whitespace group)

### How was the bug found?

A customer from VS for Mac
