### PR TITLE
Erase nullability for unconstrained type parameters in constraints from unannotated assemblies

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -903,9 +903,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                // Treat reference types as nullable if inferring nullability.
-                declTypeOpt = declTypeOpt.AsNullableReferenceTypeIfInferLocalNullability(declarator);
-
                 if (ReferenceEquals(equalsClauseSyntax, null))
                 {
                     initializerOpt = null;
@@ -958,9 +955,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 hasErrors = true;
             }
-
-            // Treat reference types as nullable if inferring nullability.
-            declTypeOpt = declTypeOpt.AsNullableReferenceTypeIfInferLocalNullability(declarator);
 
             localSymbol.SetTypeSymbol(declTypeOpt);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3718,7 +3718,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             //if (this.State.Reachable) // PROTOTYPE(NullableReferenceTypes): Consider reachability?
             {
-                _resultType = _resultType?.WithTopLevelNonNullability();
+                _resultType = _resultType?.WithTopLevelNonNullabilityForReferenceTypes();
             }
 
             return null;

--- a/src/Compilers/CSharp/Portable/NullableReferenceFlags.cs
+++ b/src/Compilers/CSharp/Portable/NullableReferenceFlags.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         None = 0,
         //AllowNullAsNonNull = 0x1,
-        InferLocalNullability = 0x2,
+        //InferLocalNullability = 0x2,
         AllowMemberOptOut = 0x4,
         AllowAssemblyOptOut = 0x8,
         Enabled = 0x1000,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -346,11 +346,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     declType = TypeSymbolWithAnnotations.Create(typeBinder.CreateErrorType("var"));
                 }
             }
-            else
-            {
-                // Treat reference types as nullable if inferring nullability.
-                declType = declType.AsNullableReferenceTypeIfInferLocalNullability(_typeSyntax);
-            }
 
             Debug.Assert((object)declType != null);
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -578,7 +578,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 this.SetUnknownNullabilityForReferenceTypes();
         }
 
-        public TypeSymbolWithAnnotations WithTopLevelNonNullability()
+        public TypeSymbolWithAnnotations WithTopLevelNonNullabilityForReferenceTypes()
         {
             var typeSymbol = TypeSymbol;
             if (IsNullable == false || typeSymbol.IsValueType)

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // In this case we delay asking this question as long as possible.
             if (typeSymbol.TypeKind != TypeKind.TypeParameter)
             {
-                if (typeSymbol.IsReferenceType)
+                if (!typeSymbol.IsValueType)
                 {
                     return new NonLazyType(typeSymbol, isNullable: true, this.CustomModifiers);
                 }
@@ -260,23 +260,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return new LazyNullableType(compilation, this);
-        }
-
-        /// <summary>
-        /// Return nullable type if the type is a non-nullable
-        /// reference type and local nullability is inferred.
-        /// </summary>
-        public TypeSymbolWithAnnotations AsNullableReferenceTypeIfInferLocalNullability(SyntaxNode syntax)
-        {
-            if (IsReferenceType && IsNullable == false)
-            {
-                var flags = ((CSharpParseOptions)syntax.SyntaxTree.Options).GetNullableReferenceFlags();
-                if ((flags & NullableReferenceFlags.InferLocalNullability) != 0)
-                {
-                    return AsNullableReferenceType();
-                }
-            }
-            return this;
         }
 
         /// <summary>
@@ -519,7 +502,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var typeSymbol = TypeSymbol;
 
-            if (IsNullable == true && !typeSymbol.IsNullableType() && typeSymbol.IsReferenceType)
+            if (IsNullable == true && !typeSymbol.IsValueType)
             {
                 return true;
             }
@@ -598,7 +581,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public TypeSymbolWithAnnotations WithTopLevelNonNullability()
         {
             var typeSymbol = TypeSymbol;
-            if (IsNullable == false || !typeSymbol.IsReferenceType)
+            if (IsNullable == false || typeSymbol.IsValueType)
             {
                 return this;
             }
@@ -612,7 +595,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (IsNullable.HasValue)
             {
-                if (!typeSymbol.IsNullableType() && typeSymbol.IsReferenceType)
+                if (!typeSymbol.IsValueType)
                 {
                     typeSymbol = typeSymbol.SetUnknownNullabilityForReferenceTypes();
                     return new NonLazyType(typeSymbol, isNullable: null, CustomModifiers);


### PR DESCRIPTION
Nullability of unconstrained type parameters was not erased in `SetUnknownNullabilityForReferenceTypes`. That meant the constraint for `class C<T> where T : I<T> { }` from an unannotated assembly was treated as `I<T!>~` rather than `I<T~>~`.