### PR TITLE
GenerateDeconstructMethod code fixer

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateDeconstructMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateDeconstructMethodTests.cs
@@ -1,0 +1,241 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateDeconstructMethod;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateDeconstructMethod
+{
+    public class GenerateDeconstructMethodTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (null, new GenerateDeconstructMethodCodeFixProvider());
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionDeclaration_Simple()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        (int x, int y) = [|this|];
+    }
+}",
+@"using System;
+
+class Class
+{
+    private void Deconstruct(out int x, out int y)
+    {
+        throw new NotImplementedException();
+    }
+
+    void Method()
+    {
+        (int x, int y) = this;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionDeclaration_OtherDeconstructMethods()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        (int x, int y) = [|this|];
+    }
+    void Deconstruct(out int x) => throw null;
+    void Deconstruct(out int x, out int y, out int z) => throw null;
+}",
+@"using System;
+
+class Class
+{
+    void Method()
+    {
+        (int x, int y) = this;
+    }
+    void Deconstruct(out int x) => throw null;
+    void Deconstruct(out int x, out int y, out int z) => throw null;
+
+    private void Deconstruct(out int x, out int y)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionDeclaration_AlreadySuccessfull()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        (int x, int y) = [|this|];
+    }
+    void Deconstruct(out int x, out int y) => throw null;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionDeclaration_UndeterminedType()
+        {
+            await TestInRegularAndScript1Async(
+@"class Class
+{
+    void Method()
+    {
+        (var x, var y) = [|this|];
+    }
+}",
+@"using System;
+
+class Class
+{
+    private void Deconstruct(out object x, out object y)
+    {
+        throw new NotImplementedException();
+    }
+
+    void Method()
+    {
+        (var x, var y) = this;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionDeclaration_UndeterminedType2()
+        {
+            await TestInRegularAndScript1Async(
+@"class Class
+{
+    void Method()
+    {
+        var (x, y) = [|this|];
+    }
+}",
+@"using System;
+
+class Class
+{
+    private void Deconstruct(out object x, out object y)
+    {
+        throw new NotImplementedException();
+    }
+
+    void Method()
+    {
+        var (x, y) = this;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionDeclaration_BuiltinType()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        (int x, int y) = [|1|];
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionAssignment()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        int x, y;
+        (x, y) = [|this|];
+    }
+}",
+@"using System;
+
+class Class
+{
+    private void Deconstruct(out int x, out int y)
+    {
+        throw new NotImplementedException();
+    }
+
+    void Method()
+    {
+        int x, y;
+        (x, y) = this;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionAssignment_Nested()
+        {
+            // We only offer a fix for non-nested deconstruction, at the moment
+            await TestMissingInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        int x, y, z;
+        ((x, y), z) = ([|this|], 0);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionAssignment_Array()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        int x, y;
+        (x, y) = [|new[] { this }|];
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestSimpleDeconstructionForeach()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    void Method()
+    {
+        foreach ((int x, int y) in new[] { [|this|] }) { }
+    }
+}",
+@"using System;
+
+class Class
+{
+    private void Deconstruct(out int x, out int y)
+    {
+        throw new NotImplementedException();
+    }
+
+    void Method()
+    {
+        foreach ((int x, int y) in new[] { this }) { }
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateDeconstructMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateDeconstructMethodTests.cs
@@ -42,6 +42,33 @@ class Class
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionDeclaration_TypeParamters()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class<T>
+{
+    void Method<U>()
+    {
+        (T x, U y) = [|this|];
+    }
+}",
+@"using System;
+
+class Class<T>
+{
+    private void Deconstruct(out T x, out object y)
+    {
+        throw new NotImplementedException();
+    }
+
+    void Method<U>()
+    {
+        (T x, U y) = this;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public async Task TestDeconstructionDeclaration_OtherDeconstructMethods()
         {
             await TestInRegularAndScriptAsync(
@@ -234,6 +261,38 @@ class Class
     void Method()
     {
         foreach ((int x, int y) in new[] { this }) { }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestSimpleDeconstructionForeach_AnotherType()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    void Method(D d)
+    {
+        foreach ((int x, int y) in new[] { [|d|] }) { }
+    }
+}
+class D
+{
+}",
+@"using System;
+
+class Class
+{
+    void Method(D d)
+    {
+        foreach ((int x, int y) in new[] { d }) { }
+    }
+}
+class D
+{
+    internal void Deconstruct(out int x, out int y)
+    {
+        throw new NotImplementedException();
     }
 }");
         }

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateDeconstructMethod
 
             if (deconstruction is null)
             {
-                Debug.Assert(false);
+                Debug.Fail("The diagnostic can only be produced in context of a deconstruction-assignment or deconstruction-foreach");
                 return;
             }
 

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateDeconstructMethod
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.GenerateDeconstructMethod), Shared]
+    [ExtensionOrder(After = PredefinedCodeFixProviderNames.GenerateEnumMember)]
+#pragma warning disable RS1016 // Code fix providers should provide FixAll support. https://github.com/dotnet/roslyn/issues/23528
+    internal class GenerateDeconstructMethodCodeFixProvider : CodeFixProvider
+#pragma warning restore RS1016 // Code fix providers should provide FixAll support.
+    {
+        private const string CS8129 = nameof(CS8129); // No suitable Deconstruct instance or extension method was found...
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get { return ImmutableArray.Create(CS8129); }
+        }
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            // Not supported in REPL
+            if (context.Project.IsSubmission)
+            {
+                return;
+            }
+
+            var document = context.Document;
+            var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var span = context.Span;
+            var token = root.FindToken(span.Start);
+
+            var deconstruction = token.GetAncestors<SyntaxNode>()
+                .FirstOrDefault(n => n.IsKind(SyntaxKind.SimpleAssignmentExpression, SyntaxKind.ForEachVariableStatement));
+
+            if (deconstruction is null)
+            {
+                Debug.Assert(false);
+                return;
+            }
+
+            var model = await document.GetSemanticModelForNodeAsync(deconstruction, context.CancellationToken).ConfigureAwait(false);
+
+            DeconstructionInfo info;
+            ITypeSymbol type;
+            ExpressionSyntax target;
+            switch (deconstruction)
+            {
+                case ForEachVariableStatementSyntax @foreach:
+                    info = model.GetDeconstructionInfo(@foreach);
+                    type = model.GetForEachStatementInfo(@foreach).ElementType;
+                    target = @foreach.Variable;
+                    break;
+                case AssignmentExpressionSyntax assignment:
+                    info = model.GetDeconstructionInfo(assignment);
+                    type = model.GetTypeInfo(assignment.Right).Type;
+                    target = assignment.Left;
+                    break;
+                default:
+                    Debug.Assert(false);
+                    return;
+            }
+
+            if (type.Kind != SymbolKind.NamedType)
+            {
+                return;
+            }
+
+            if (info.Method != null || !info.Nested.IsEmpty)
+            {
+                // There is already a Deconstruct method, or we have a nesting situation
+                return;
+            }
+
+            var service = document.GetLanguageService<IGenerateDeconstructMemberService>();
+            var codeActions = await service.GenerateDeconstructMethodAsync(document, target, (INamedTypeSymbol)type, context.CancellationToken).ConfigureAwait(false);
+
+            if (!codeActions.IsDefaultOrEmpty)
+            {
+                context.RegisterFixes(codeActions, context.Diagnostics);
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateDeconstructMethodService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateDeconstructMethodService.cs
@@ -1,18 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Composition;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateParameterizedMember;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.LanguageServices;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
 {
@@ -31,10 +24,5 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
 
         protected override bool IsValidSymbol(ISymbol symbol, SemanticModel semanticModel)
             => CSharpCommonGenerationServiceMethods.IsValidSymbol(symbol, semanticModel);
-
-        protected override SyntaxToken MakeDeconstructToken()
-        {
-            return SyntaxFactory.Identifier(WellKnownMemberNames.DeconstructMethodName);
-        }
     }
 }

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateDeconstructMethodService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateDeconstructMethodService.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateParameterizedMember;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
+{
+    [ExportLanguageService(typeof(IGenerateDeconstructMemberService), LanguageNames.CSharp), Shared]
+    internal class CSharpGenerateDeconstructMethodService :
+        AbstractGenerateDeconstructMethodService<CSharpGenerateDeconstructMethodService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>
+    {
+        protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
+            => containingType.ContainingTypesOrSelfHasUnsafeKeyword();
+
+        protected override AbstractInvocationInfo CreateInvocationMethodInfo(SemanticDocument document, AbstractGenerateParameterizedMemberService<CSharpGenerateDeconstructMethodService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>.State state)
+            => new CSharpGenerateParameterizedMemberService<CSharpGenerateDeconstructMethodService>.InvocationExpressionInfo(document, state);
+
+        protected override bool AreSpecialOptionsActive(SemanticModel semanticModel)
+            => CSharpCommonGenerationServiceMethods.AreSpecialOptionsActive(semanticModel);
+
+        protected override bool IsValidSymbol(ISymbol symbol, SemanticModel semanticModel)
+            => CSharpCommonGenerationServiceMethods.IsValidSymbol(symbol, semanticModel);
+
+        protected override SyntaxToken MakeDeconstructToken()
+        {
+            return SyntaxFactory.Identifier(WellKnownMemberNames.DeconstructMethodName);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateDeconstructMethodService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateDeconstructMethodService.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
 {
     [ExportLanguageService(typeof(IGenerateDeconstructMemberService), LanguageNames.CSharp), Shared]
-    internal class CSharpGenerateDeconstructMethodService :
+    internal sealed class CSharpGenerateDeconstructMethodService :
         AbstractGenerateDeconstructMethodService<CSharpGenerateDeconstructMethodService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>
     {
         protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateMethodService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateMethodService.cs
@@ -17,7 +17,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
 {
     [ExportLanguageService(typeof(IGenerateParameterizedMemberService), LanguageNames.CSharp), Shared]
-    internal class CSharpGenerateMethodService :
+    internal sealed class CSharpGenerateMethodService :
         AbstractGenerateMethodService<CSharpGenerateMethodService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>
     {
         protected override bool IsExplicitInterfaceGeneration(SyntaxNode node)

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateMethodService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateMethodService.cs
@@ -17,7 +17,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
 {
     [ExportLanguageService(typeof(IGenerateParameterizedMemberService), LanguageNames.CSharp), Shared]
-    internal partial class CSharpGenerateMethodService :
+    internal class CSharpGenerateMethodService :
         AbstractGenerateMethodService<CSharpGenerateMethodService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>
     {
         protected override bool IsExplicitInterfaceGeneration(SyntaxNode node)

--- a/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string GenerateVariable = nameof(GenerateVariable);
         public const string GenerateMethod = nameof(GenerateMethod);
         public const string GenerateConversion = nameof(GenerateConversion);
+        public const string GenerateDeconstructMethod = nameof(GenerateDeconstructMethod);
         public const string GenerateType = nameof(GenerateType);
         public const string ImplementAbstractClass = nameof(ImplementAbstractClass);
         public const string ImplementInterface = nameof(ImplementInterface);

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateConversionService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateConversionService.State.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     }
                 }
 
-                return TryFinishInitializingState(service, document, cancellationToken);
+                return TryFinishInitializingStateAsync(service, document, cancellationToken);
             }
 
             private bool TryInitializeExplicitConversion(TService service, SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.State.cs
@@ -73,12 +73,12 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     refKind: RefKind.None,
                     explicitInterfaceImplementations: default,
                     name: null,
-                    typeParameters: ImmutableArray<ITypeParameterSymbol>.Empty,
+                    typeParameters: default,
                     parameters);
 
                 this.SignatureInfo = new MethodSignatureInfo(document, this, methodSymbol);
 
-                return await TryFinishInitializingState(service, document, cancellationToken).ConfigureAwait(false);
+                return await TryFinishInitializingStateAsync(service, document, cancellationToken).ConfigureAwait(false);
             }
 
             private static ImmutableArray<IParameterSymbol> TryMakeParameters(

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.State.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
+{
+    internal partial class AbstractGenerateDeconstructMethodService<TService, TSimpleNameSyntax, TExpressionSyntax, TInvocationExpressionSyntax>
+    {
+        internal new class State :
+            AbstractGenerateParameterizedMemberService<TService, TSimpleNameSyntax, TExpressionSyntax, TInvocationExpressionSyntax>.State
+        {
+            /// <summary>
+            /// Make a State instance representing the Deconstruct method we want to generate.
+            /// The method will be called "Deconstruct". It will be a member of `typeToGenerateIn`.
+            /// Its arguments will be based on `targetVariables`.
+            /// </summary>
+            public static async Task<State> GenerateDeconstructMethodStateAsync(
+                TService service,
+                SemanticDocument document,
+                SyntaxNode targetVariables,
+                INamedTypeSymbol typeToGenerateIn,
+                CancellationToken cancellationToken)
+            {
+                var state = new State();
+                if (await state.TryInitializeMethodAsync(service, document, targetVariables, typeToGenerateIn, cancellationToken).ConfigureAwait(false))
+                {
+                    return state;
+                }
+
+                return null;
+            }
+
+            private async Task<bool> TryInitializeMethodAsync(
+                TService service,
+                SemanticDocument document,
+                SyntaxNode targetVariables,
+                INamedTypeSymbol typeToGenerateIn,
+                CancellationToken cancellationToken)
+            {
+                this.TypeToGenerateIn = typeToGenerateIn;
+                this.IsStatic = false;
+                this.IdentifierToken = service.MakeDeconstructToken();
+                this.MethodGenerationKind = MethodGenerationKind.Member;
+                MethodKind = MethodKind.Ordinary;
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var semanticModel = document.SemanticModel;
+                this.ContainingType = semanticModel.GetEnclosingNamedType(targetVariables.SpanStart, cancellationToken);
+                if (this.ContainingType == null)
+                {
+                    return false;
+                }
+
+                var parameters = TryMakeParameters(semanticModel, targetVariables, cancellationToken);
+                if (parameters.IsDefault)
+                {
+                    return false;
+                }
+
+                var methodSymbol = CodeGenerationSymbolFactory.CreateMethodSymbol(
+                    attributes: ImmutableArray<AttributeData>.Empty,
+                    accessibility: default,
+                    modifiers: default,
+                    returnType: semanticModel.Compilation.GetSpecialType(SpecialType.System_Void),
+                    refKind: RefKind.None,
+                    explicitInterfaceImplementations: default,
+                    name: null,
+                    typeParameters: ImmutableArray<ITypeParameterSymbol>.Empty,
+                    parameters);
+
+                this.SignatureInfo = new MethodSignatureInfo(document, this, methodSymbol);
+
+                return await TryFinishInitializingState(service, document, cancellationToken).ConfigureAwait(false);
+            }
+
+            private static ImmutableArray<IParameterSymbol> TryMakeParameters(
+                SemanticModel semanticModel, SyntaxNode target, CancellationToken cancellationToken)
+            {
+                var targetType = semanticModel.GetTypeInfo(target).Type;
+                if (targetType?.IsTupleType != true)
+                {
+                    return default;
+                }
+
+                var tupleElements = ((INamedTypeSymbol)targetType).TupleElements;
+                var builder = ArrayBuilder<IParameterSymbol>.GetInstance(tupleElements.Length);
+                foreach (var element in tupleElements)
+                {
+                    builder.Add(CodeGenerationSymbolFactory.CreateParameterSymbol(
+                        attributes: default, RefKind.Out, isParams: false, element.Type, element.Name));
+                }
+
+                return builder.ToImmutableAndFree();
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Internal.Log;
+
+namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
+{
+    internal abstract partial class AbstractGenerateDeconstructMethodService<TService, TSimpleNameSyntax, TExpressionSyntax, TInvocationExpressionSyntax> :
+        AbstractGenerateParameterizedMemberService<TService, TSimpleNameSyntax, TExpressionSyntax, TInvocationExpressionSyntax>,
+        IGenerateDeconstructMemberService
+        where TService : AbstractGenerateDeconstructMethodService<TService, TSimpleNameSyntax, TExpressionSyntax, TInvocationExpressionSyntax>
+        where TSimpleNameSyntax : TExpressionSyntax
+        where TExpressionSyntax : SyntaxNode
+        where TInvocationExpressionSyntax : TExpressionSyntax
+    {
+        // Make a language-specific identifier token for "Deconstruct"
+        protected abstract SyntaxToken MakeDeconstructToken();
+
+        public async Task<ImmutableArray<CodeAction>> GenerateDeconstructMethodAsync(
+            Document document,
+            SyntaxNode targetVariables,
+            INamedTypeSymbol typeToGenerateIn,
+            CancellationToken cancellationToken)
+        {
+            using (Logger.LogBlock(FunctionId.Refactoring_GenerateMember_GenerateMethod, cancellationToken))
+            {
+                var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+                var state = await State.GenerateDeconstructMethodStateAsync(
+                    (TService)this, semanticDocument, targetVariables, typeToGenerateIn, cancellationToken).ConfigureAwait(false);
+
+                return state != null ? GetActions(document, state, cancellationToken) : ImmutableArray<CodeAction>.Empty;
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
     {
         public async Task<ImmutableArray<CodeAction>> GenerateDeconstructMethodAsync(
             Document document,
-            SyntaxNode targetVariables,
+            SyntaxNode leftSide,
             INamedTypeSymbol typeToGenerateIn,
             CancellationToken cancellationToken)
         {
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
                 var state = await State.GenerateDeconstructMethodStateAsync(
-                    (TService)this, semanticDocument, targetVariables, typeToGenerateIn, cancellationToken).ConfigureAwait(false);
+                    (TService)this, semanticDocument, leftSide, typeToGenerateIn, cancellationToken).ConfigureAwait(false);
 
                 return state != null ? GetActions(document, state, cancellationToken) : ImmutableArray<CodeAction>.Empty;
             }

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.cs
@@ -16,9 +16,6 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
         where TExpressionSyntax : SyntaxNode
         where TInvocationExpressionSyntax : TExpressionSyntax
     {
-        // Make a language-specific identifier token for "Deconstruct"
-        protected abstract SyntaxToken MakeDeconstructToken();
-
         public async Task<ImmutableArray<CodeAction>> GenerateDeconstructMethodAsync(
             Document document,
             SyntaxNode targetVariables,

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     }
                 }
 
-                return TryFinishInitializingState(service, document, cancellationToken);
+                return TryFinishInitializingStateAsync(service, document, cancellationToken);
             }
 
             private bool TryInitializeExplicitInterface(

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 }
             }
 
-            protected async Task<bool> TryFinishInitializingState(TService service, SemanticDocument document, CancellationToken cancellationToken)
+            protected async Task<bool> TryFinishInitializingStateAsync(TService service, SemanticDocument document, CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 this.TypeToGenerateIn = await SymbolFinder.FindSourceDefinitionAsync(this.TypeToGenerateIn, document.Project.Solution, cancellationToken).ConfigureAwait(false) as INamedTypeSymbol;

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/IGenerateDeconstructMemberService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/IGenerateDeconstructMemberService.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
+{
+    internal interface IGenerateDeconstructMemberService : ILanguageService
+    {
+        Task<ImmutableArray<CodeAction>> GenerateDeconstructMethodAsync(
+            Document document, SyntaxNode targetVariables, INamedTypeSymbol typeToGenerateIn, CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
### Customer scenario
Try to deconstruct from a type that doesn't have a `Deconstruct`. This new code fixer will generate the proper missing method.

In the case of `(int x, int y) = new Pair();`, we'll offer to generate a `void Pair.Deconstruct(out int x, out int y)` method.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/26597

### Workarounds, if any
Write the `Deconstruct` method declaration by hand.

### Risk
### Performance impact
Low. This is similar to `GenerateMethod` (and simpler) and is purely additive.

### Is this a regression from a previous update?
No.

### How was the bug found?
Feature suggestion logged as part of the deconstruction work. 