### PR TITLE
Track if a file contains a tuple expression or tuple type in our index.

### DIFF
--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1656,6 +1656,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool IsConditionalOr(SyntaxNode node)
             => node.Kind() == SyntaxKind.LogicalOrExpression;
 
+        public bool IsTupleExpression(SyntaxNode node)
+            => node.Kind() == SyntaxKind.TupleExpression;
+
+        public bool IsTupleType(SyntaxNode node)
+            => node.Kind() == SyntaxKind.TupleType;
+
         public SyntaxNode GetOperandOfPrefixUnaryExpression(SyntaxNode node)
             => ((PrefixUnaryExpressionSyntax)node).Operand;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
@@ -26,7 +26,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsElementAccessExpression,
                 bool containsIndexerMemberCref,
                 bool containsDeconstruction,
-                bool containsAwait) :
+                bool containsAwait,
+                bool containsTupleExpressionOrTupleType) :
                 this(predefinedTypes, predefinedOperators,
                      ConvertToContainingNodeFlag(
                          containsForEachStatement,
@@ -38,7 +39,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                          containsElementAccessExpression,
                          containsIndexerMemberCref,
                          containsDeconstruction,
-                         containsAwait))
+                         containsAwait,
+                         containsTupleExpressionOrTupleType))
             {
             }
 
@@ -59,20 +61,22 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsElementAccessExpression,
                 bool containsIndexerMemberCref,
                 bool containsDeconstruction,
-                bool containsAwait)
+                bool containsAwait,
+                bool containsTupleExpressionOrTupleType)
             {
                 var containingNodes = ContainingNodes.None;
 
-                containingNodes = containsForEachStatement ? (containingNodes | ContainingNodes.ContainsForEachStatement) : containingNodes;
-                containingNodes = containsLockStatement ? (containingNodes | ContainingNodes.ContainsLockStatement) : containingNodes;
-                containingNodes = containsUsingStatement ? (containingNodes | ContainingNodes.ContainsUsingStatement) : containingNodes;
-                containingNodes = containsQueryExpression ? (containingNodes | ContainingNodes.ContainsQueryExpression) : containingNodes;
-                containingNodes = containsThisConstructorInitializer ? (containingNodes | ContainingNodes.ContainsThisConstructorInitializer) : containingNodes;
-                containingNodes = containsBaseConstructorInitializer ? (containingNodes | ContainingNodes.ContainsBaseConstructorInitializer) : containingNodes;
-                containingNodes = containsElementAccessExpression ? (containingNodes | ContainingNodes.ContainsElementAccessExpression) : containingNodes;
-                containingNodes = containsIndexerMemberCref ? (containingNodes | ContainingNodes.ContainsIndexerMemberCref) : containingNodes;
-                containingNodes = containsDeconstruction ? (containingNodes | ContainingNodes.ContainsDeconstruction) : containingNodes;
-                containingNodes = containsAwait ? (containingNodes | ContainingNodes.ContainsAwait) : containingNodes;
+                containingNodes |= containsForEachStatement ? ContainingNodes.ContainsForEachStatement : 0;
+                containingNodes |= containsLockStatement ? ContainingNodes.ContainsLockStatement : 0;
+                containingNodes |= containsUsingStatement ? ContainingNodes.ContainsUsingStatement : 0;
+                containingNodes |= containsQueryExpression ? ContainingNodes.ContainsQueryExpression : 0;
+                containingNodes |= containsThisConstructorInitializer ? ContainingNodes.ContainsThisConstructorInitializer : 0;
+                containingNodes |= containsBaseConstructorInitializer ? ContainingNodes.ContainsBaseConstructorInitializer : 0;
+                containingNodes |= containsElementAccessExpression ? ContainingNodes.ContainsElementAccessExpression : 0;
+                containingNodes |= containsIndexerMemberCref ? ContainingNodes.ContainsIndexerMemberCref : 0;
+                containingNodes |= containsDeconstruction ? ContainingNodes.ContainsDeconstruction : 0;
+                containingNodes |= containsAwait ? ContainingNodes.ContainsAwait : 0;
+                containingNodes |= containsTupleExpressionOrTupleType ? ContainingNodes.ContainsTupleExpressionOrTupleType : 0;
 
                 return containingNodes;
             }
@@ -113,6 +117,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             public bool ContainsIndexerMemberCref
                 => (_containingNodes & ContainingNodes.ContainsIndexerMemberCref) == ContainingNodes.ContainsIndexerMemberCref;
 
+            public bool ContainsTupleExpressionOrTupleType
+                => (_containingNodes & ContainingNodes.ContainsTupleExpressionOrTupleType) == ContainingNodes.ContainsTupleExpressionOrTupleType;
+
             public void WriteTo(ObjectWriter writer)
             {
                 writer.WriteInt32(_predefinedTypes);
@@ -151,6 +158,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 ContainsIndexerMemberCref = 1 << 7,
                 ContainsDeconstruction = 1 << 8,
                 ContainsAwait = 1 << 9,
+                ContainsTupleExpressionOrTupleType = 1 << 10,
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -71,6 +71,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 var containsIndexerMemberCref = false;
                 var containsDeconstruction = false;
                 var containsAwait = false;
+                var containsTupleExpressionOrTupleType = false;
 
                 var predefinedTypes = (int)PredefinedType.None;
                 var predefinedOperators = (int)PredefinedOperator.None;
@@ -98,6 +99,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                                 || syntaxFacts.IsDeconstructionForEachStatement(node);
 
                             containsAwait = containsAwait || syntaxFacts.IsAwaitExpression(node);
+                            containsTupleExpressionOrTupleType = containsTupleExpressionOrTupleType ||
+                                syntaxFacts.IsTupleExpression(node) || syntaxFacts.IsTupleType(node);
 
                             // We've received a number of error reports where DeclaredSymbolInfo.GetSymbolAsync() will
                             // crash because the document's syntax root doesn't contain the span of the node returned
@@ -207,7 +210,8 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                             containsElementAccess,
                             containsIndexerMemberCref,
                             containsDeconstruction,
-                            containsAwait),
+                            containsAwait,
+                            containsTupleExpressionOrTupleType),
                     new DeclarationInfo(
                             declaredSymbolInfos.ToImmutableAndFree()));
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal sealed partial class SyntaxTreeIndex : IObjectWritable
     {
         private const string PersistenceName = "<SyntaxTreeIndex>";
-        private const string SerializationFormat = "12";
+        private const string SerializationFormat = "15";
 
         public readonly Checksum Checksum;
 

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -103,8 +103,12 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsConditionalAnd(SyntaxNode node);
         bool IsConditionalOr(SyntaxNode node);
 
+        bool IsTupleExpression(SyntaxNode node);
+        bool IsTupleType(SyntaxNode node);
+
         SyntaxNode GetOperandOfPrefixUnaryExpression(SyntaxNode node);
         SyntaxToken GetOperatorTokenOfPrefixUnaryExpression(SyntaxNode node);
+
 
         // Left side of = assignment.
         bool IsLeftSideOfAssignment(SyntaxNode node);

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -1604,6 +1604,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return node.Kind() = SyntaxKind.OrElseExpression
         End Function
 
+        Public Function IsTupleExpression(node As syntaxnode) As Boolean Implements ISyntaxFactsService.IsTupleExpression
+            Return node.kind() = SyntaxKind.TupleExpression
+        End Function
+
+        Public Function IsTupleType(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsTupleType
+            Return node.Kind() = SyntaxKind.TupleType
+        End Function
+
         Public Function GetOperandOfPrefixUnaryExpression(node As SyntaxNode) As SyntaxNode Implements ISyntaxFactsService.GetOperandOfPrefixUnaryExpression
             Return DirectCast(node, UnaryExpressionSyntax).Operand
         End Function


### PR DESCRIPTION
This will be used by the "convert tuple to struct" feature (https://github.com/dotnet/roslyn/pull/28257).  We want to track this information to so that we can limit the number of documents we need to look at when choosing "... and update matches in current project" or "... and update matches in dependent projects".

By using this index we can search for files containing tuples which also contain the names of the tuple fields.  This should help greatly limit our search space.

I made this into its own PR to help extract out bits of "convert tuple to struct" that could go in independently.