### PR TITLE
Fallback navigate to

### DIFF
--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -26,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             private readonly INavigateToCallback _callback;
             private readonly string _searchPattern;
             private readonly bool _searchCurrentDocument;
-            private readonly ISet<string> _kinds;
+            private readonly IImmutableSet<string> _kinds;
             private readonly Document _currentDocument;
             private readonly ProgressTracker _progress;
             private readonly IAsynchronousOperationListener _asyncListener;
@@ -39,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 INavigateToCallback callback,
                 string searchPattern,
                 bool searchCurrentDocument,
-                ISet<string> kinds,
+                IImmutableSet<string> kinds,
                 CancellationToken cancellationToken)
             {
                 _solution = solution;
@@ -215,14 +214,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                     _navigateToSearchService = navigateToSearchService;
                 }
 
-                public IImmutableSet<string> KindsProvided => ImmutableHashSet<string>.Empty;
+                public IImmutableSet<string> KindsProvided => ImmutableHashSet.Create<string>(StringComparer.Ordinal);
 
                 public bool CanFilter => false;
 
-                public Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken)
+                public Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
                     => _navigateToSearchService.SearchDocumentAsync(document, searchPattern, cancellationToken);
 
-                public Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken)
+                public Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
                     => _navigateToSearchService.SearchProjectAsync(project, searchPattern, cancellationToken);
             }
         }

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -128,27 +128,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 }
             }
 
-            private static INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate TryGetNavigateToSearchService(Project project)
-            {
-                var service = project.LanguageServices.GetService<INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate>();
-                if (service != null)
-                {
-                    return service;
-                }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0612 // Type or member is obsolete
-                var legacyService = project.LanguageServices.GetService<INavigateToSearchService>();
-                if (legacyService != null)
-                {
-                    return new ShimNavigateToSearchService(legacyService);
-                }
-#pragma warning restore CS0612 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
-
-                return null;
-            }
-
             private void ReportMatchResult(Project project, INavigateToSearchResult result)
             {
                 var matchedSpans = result.NameMatchSpans.SelectAsArray(t => t.ToSpan());
@@ -202,27 +181,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                     default:
                         return languageName;
                 }
-            }
-
-            [Obsolete]
-            private class ShimNavigateToSearchService : INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate
-            {
-                private readonly INavigateToSearchService _navigateToSearchService;
-
-                public ShimNavigateToSearchService(INavigateToSearchService navigateToSearchService)
-                {
-                    _navigateToSearchService = navigateToSearchService;
-                }
-
-                public IImmutableSet<string> KindsProvided => ImmutableHashSet.Create<string>(StringComparer.Ordinal);
-
-                public bool CanFilter => false;
-
-                public Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
-                    => _navigateToSearchService.SearchDocumentAsync(document, searchPattern, cancellationToken);
-
-                public Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
-                    => _navigateToSearchService.SearchProjectAsync(project, searchPattern, cancellationToken);
             }
         }
     }

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -43,11 +43,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 var result = ImmutableHashSet.Create<string>(StringComparer.Ordinal);
                 foreach (var project in _workspace.CurrentSolution.Projects)
                 {
-                    var navigateToSearchService = project.LanguageServices.GetService<INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate>();
+                    var navigateToSearchService = TryGetNavigateToSearchService(project);
                     if (navigateToSearchService != null)
                     {
                         result = result.Union(navigateToSearchService.KindsProvided);
-                        continue;
                     }
                 }
 
@@ -61,27 +60,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             {
                 foreach (var project in _workspace.CurrentSolution.Projects)
                 {
-                    var navigateToSearchService = project.LanguageServices.GetService<INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate>();
-                    if (navigateToSearchService != null)
+                    var navigateToSearchService = TryGetNavigateToSearchService(project);
+                    if (navigateToSearchService is null)
                     {
-                        if (!navigateToSearchService.CanFilter)
-                        {
-                            return false;
-                        }
-
+                        // If we reach here, it means the current project does not support Navigate To, which is
+                        // functionally equivalent to supporting filtering.
                         continue;
                     }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-                    var legacyNavigateToSearchService = project.LanguageServices.GetService<INavigateToSearchService>();
-                    if (legacyNavigateToSearchService != null)
+                    if (!navigateToSearchService.CanFilter)
                     {
                         return false;
                     }
-#pragma warning restore CS0618 // Type or member is obsolete
-
-                    // If we reach here, it means the current project does not support Navigate To, which is
-                    // functionally equivalent to supporting filtering.
                 }
 
                 // All projects either support filtering or do not support Navigate To at all

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.NavigateTo.Interfaces;
@@ -31,17 +32,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             _displayFactory = new NavigateToItemDisplayFactory();
         }
 
-        public ISet<string> KindsProvided
+        ISet<string> INavigateToItemProvider2.KindsProvided => KindsProvided;
+
+        public ImmutableHashSet<string> KindsProvided
         {
             get
             {
-                var result = new HashSet<string>(StringComparer.Ordinal);
+                var result = ImmutableHashSet.Create<string>(StringComparer.Ordinal);
                 foreach (var project in _workspace.CurrentSolution.Projects)
                 {
                     var navigateToSearchService = project.LanguageServices.GetService<INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate>();
                     if (navigateToSearchService != null)
                     {
-                        result.UnionWith(navigateToSearchService.KindsProvided);
+                        result = result.Union(navigateToSearchService.KindsProvided);
                         continue;
                     }
                 }
@@ -125,10 +128,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
 
         public void StartSearch(INavigateToCallback callback, string searchValue, INavigateToFilterParameters filter)
         {
-            StartSearch(callback, searchValue, filter.Kinds);
+            StartSearch(callback, searchValue, filter.Kinds.ToImmutableHashSet(StringComparer.Ordinal));
         }
 
-        private void StartSearch(INavigateToCallback callback, string searchValue, ISet<string> kinds)
+        private void StartSearch(INavigateToCallback callback, string searchValue, IImmutableSet<string> kinds)
         {
             this.StopSearch();
 

--- a/src/Features/CSharp/Portable/NavigateTo/CSharpNavigateToSearchService.cs
+++ b/src/Features/CSharp/Portable/NavigateTo/CSharpNavigateToSearchService.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.NavigateTo;
 
 namespace Microsoft.CodeAnalysis.CSharp.NavigateTo
 {
-    [ExportLanguageService(typeof(INavigateToSearchService), LanguageNames.CSharp), Shared]
+    [ExportLanguageService(typeof(INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate), LanguageNames.CSharp), Shared]
     internal class CSharpNavigateToSearchService : AbstractNavigateToSearchService
     {
     }

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -23,21 +23,21 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             new ConditionalWeakTable<Project, Tuple<string, ImmutableArray<SearchResult>>>();
 
         public static Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInCurrentProcessAsync(
-            Project project, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken)
+            Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             return FindSearchResultsAsync(
                 project, searchDocument: null, pattern: searchPattern, kinds, cancellationToken: cancellationToken);
         }
 
         public static Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentInCurrentProcessAsync(
-            Document document, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken)
+            Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             return FindSearchResultsAsync(
                 document.Project, document, searchPattern, kinds, cancellationToken);
         }
 
         private static async Task<ImmutableArray<INavigateToSearchResult>> FindSearchResultsAsync(
-            Project project, Document searchDocument, string pattern, ISet<string> kinds, CancellationToken cancellationToken)
+            Project project, Document searchDocument, string pattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             // If the user created a dotted pattern then we'll grab the last part of the name
             var (patternName, patternContainerOpt) = PatternMatcher.GetNameAndContainer(pattern);

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
@@ -12,25 +13,25 @@ namespace Microsoft.CodeAnalysis.NavigateTo
     internal abstract partial class AbstractNavigateToSearchService
     {
         private async Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentInRemoteProcessAsync(
-            RemoteHostClient client, Document document, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken)
+            RemoteHostClient client, Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             var solution = document.Project.Solution;
 
             var serializableResults = await client.TryRunCodeAnalysisRemoteAsync<IList<SerializableNavigateToSearchResult>>(
                 solution, nameof(IRemoteNavigateToSearchService.SearchDocumentAsync),
-                new object[] { document.Id, searchPattern, kinds }, cancellationToken).ConfigureAwait(false);
+                new object[] { document.Id, searchPattern, kinds.ToArray() }, cancellationToken).ConfigureAwait(false);
 
             return serializableResults.SelectAsArray(r => r.Rehydrate(solution));
         }
 
         private async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInRemoteProcessAsync(
-            RemoteHostClient client, Project project, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken)
+            RemoteHostClient client, Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             var solution = project.Solution;
 
             var serializableResults = await client.TryRunCodeAnalysisRemoteAsync<IList<SerializableNavigateToSearchResult>>(
                 solution, nameof(IRemoteNavigateToSearchService.SearchProjectAsync),
-                new object[] { project.Id, searchPattern, kinds }, cancellationToken).ConfigureAwait(false);
+                new object[] { project.Id, searchPattern, kinds.ToArray() }, cancellationToken).ConfigureAwait(false);
 
             return serializableResults.SelectAsArray(r => r.Rehydrate(solution));
         }

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         public bool CanFilter => true;
 
         public async Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(
-            Document document, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken)
+            Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             var client = await TryGetRemoteHostClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
             if (client == null)
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         }
 
         public async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(
-            Project project, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken)
+            Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             var client = await TryGetRemoteHostClientAsync(project, cancellationToken).ConfigureAwait(false);
             if (client == null)

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
@@ -7,8 +7,24 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
 {
-    internal abstract partial class AbstractNavigateToSearchService : INavigateToSearchService
+    internal abstract partial class AbstractNavigateToSearchService : INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate
     {
+        public IImmutableSet<string> KindsProvided { get; } = ImmutableHashSet.Create(
+            NavigateToItemKind.Class,
+            NavigateToItemKind.Constant,
+            NavigateToItemKind.Delegate,
+            NavigateToItemKind.Enum,
+            NavigateToItemKind.EnumItem,
+            NavigateToItemKind.Event,
+            NavigateToItemKind.Field,
+            NavigateToItemKind.Interface,
+            NavigateToItemKind.Method,
+            NavigateToItemKind.Module,
+            NavigateToItemKind.Property,
+            NavigateToItemKind.Structure);
+
+        public bool CanFilter => true;
+
         public async Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(
             Document document, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,7 +27,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             get;
         }
 
-        Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken);
-        Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken);
+        Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
+        Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -8,8 +9,25 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
 {
+    [Obsolete("Use " + nameof(INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate) + " instead.")]
     internal interface INavigateToSearchService : ILanguageService
     {
+        Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, CancellationToken cancellationToken);
+        Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, CancellationToken cancellationToken);
+    }
+
+    internal interface INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate : ILanguageService
+    {
+        IImmutableSet<string> KindsProvided
+        {
+            get;
+        }
+
+        bool CanFilter
+        {
+            get;
+        }
+
         Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken);
         Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, ISet<string> kinds, CancellationToken cancellationToken);
     }

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, CancellationToken cancellationToken);
     }
 
+    // This will be renamed to replace INavigateToSearchService as part of https://github.com/dotnet/roslyn/issues/28343
     internal interface INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate : ILanguageService
     {
         IImmutableSet<string> KindsProvided

--- a/src/Features/VisualBasic/Portable/NavigateTo/VisualBasicNavigateToSearchService.vb
+++ b/src/Features/VisualBasic/Portable/NavigateTo/VisualBasicNavigateToSearchService.vb
@@ -5,7 +5,7 @@ Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.NavigateTo
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.NavigateTo
-    <ExportLanguageService(GetType(INavigateToSearchService), LanguageNames.VisualBasic), [Shared]>
+    <ExportLanguageService(GetType(INavigateToSearchService_RemoveInterfaceAboveAndRenameThisAfterInternalsVisibleToUsersUpdate), LanguageNames.VisualBasic), [Shared]>
     Friend Class VisualBasicNavigateToSearchService
         Inherits AbstractNavigateToSearchService
     End Class


### PR DESCRIPTION
### Customer scenario

In the latest 15.8 Preview 4 internal builds, Navigate To does not work for TypeScript or F#.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/644180

### Workarounds, if any

None.

### Risk

Medium risk. The safest option for release would be reverting the original change, but we would lose the substantial (clearly user visible) performance benefit it provided for Go To File.

### Performance impact

This change enumerates the projects in a `Solution` to determine the supported Navigate To kinds each time the feature is used. However, this is not expected to result in substantial overhead compared to the underlying navigation operation.

### Is this a regression from a previous update?

Yes

### Root cause analysis

TypeScript and F# support Navigate To by implementing `INavigateToSearchService` (only available via IVTs and thus not under the protection of our public API surface change review process), but there is no test coverage for this feature in either language in either the dotnet/roslyn PR builds or the DDRITs used during the RI process.

### How was the bug found?

Dogfooding

### Test documentation updated?

No
