### PR TITLE
Allow the build script to find prerelease versions of Visual Studio

### DIFF
--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -353,7 +353,7 @@ function Test-SupportedVisualStudioVersion([string]$version) {
 # meets our minimal requirements for the Roslyn repo.
 function Get-VisualStudioDirAndId() {
     $vswhere = Join-Path (Ensure-BasicTool "vswhere") "tools\vswhere.exe"
-    $output = Exec-Command $vswhere "-requires Microsoft.Component.MSBuild -format json" | Out-String
+    $output = Exec-Command $vswhere "-prerelease -requires Microsoft.Component.MSBuild -format json" | Out-String
     $j = ConvertFrom-Json $output
     foreach ($obj in $j) { 
 

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -367,6 +367,11 @@ function Get-VisualStudioDirAndId() {
                 Write-Output $obj.instanceId
                 return
             }
+            else {
+                Write-Host "Ignored unsupported installation $name"
+                Write-Host "  Path: $($obj.installationPath)"
+                Write-Host "  ID: $($obj.instanceId)"
+            }
         }
         else {
             Write-Host "Unrecognized installationName format $name"


### PR DESCRIPTION
Fixes #28278