### PR TITLE
In region analysis, recover gracefully from zero-width nodes.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int startLocation = firstInRegion.Syntax.SpanStart;
                 int endLocation = lastInRegion.Syntax.Span.End;
                 int length = endLocation - startLocation;
-                Debug.Assert(length > 0, "last comes before first");
+                Debug.Assert(length >= 0, "last comes before first");
                 this.RegionSpan = new TextSpan(startLocation, length);
             }
 


### PR DESCRIPTION
Fixes #26028

This fixes a crash in debug builds caused by a slightly too aggressive assertion.

@dotnet/roslyn-compiler Please review this smallest possible (1 character) bug fix. I am hoping to get this into 15.8.
