### PR TITLE
Use default constant value for synthesized local reference for LockTa…

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ILockStatement.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ILockStatement.cs
@@ -452,7 +452,7 @@ Block[B0] - Entry
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                       IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: lockTaken) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'source1 ?? source2')
-                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsImplicit) (Syntax: 'source1 ?? source2')
+                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, IsImplicit) (Syntax: 'source1 ?? source2')
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
 
@@ -498,7 +498,7 @@ Block[B0] - Entry
             Predecessors (0)
             Statements (0)
             Jump if False (Regular) to Block[B9]
-                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsImplicit) (Syntax: 'source1 ?? source2')
+                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, IsImplicit) (Syntax: 'source1 ?? source2')
 
             Next (Regular) Block[B8]
         Block[B8] - Block
@@ -674,7 +674,7 @@ Block[B0] - Entry
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                       IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: lockTaken) (OperationKind.Argument, Type: null, IsInvalid, IsImplicit) (Syntax: 'input1')
-                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsInvalid, IsImplicit) (Syntax: 'input1')
+                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'input1')
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
 
@@ -696,7 +696,7 @@ Block[B0] - Entry
             Predecessors (0)
             Statements (0)
             Jump if False (Regular) to Block[B5]
-                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsInvalid, IsImplicit) (Syntax: 'input1')
+                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'input1')
 
             Next (Regular) Block[B4]
         Block[B4] - Block
@@ -784,7 +784,7 @@ Block[B0] - Entry
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                       IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: lockTaken) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'null')
-                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsImplicit) (Syntax: 'null')
+                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, IsImplicit) (Syntax: 'null')
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
 
@@ -806,7 +806,7 @@ Block[B0] - Entry
             Predecessors (0)
             Statements (0)
             Jump if False (Regular) to Block[B5]
-                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsImplicit) (Syntax: 'null')
+                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, IsImplicit) (Syntax: 'null')
 
             Next (Regular) Block[B4]
         Block[B4] - Block
@@ -982,7 +982,7 @@ Block[B0] - Entry
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                       IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: lockTaken) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'input')
-                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsImplicit) (Syntax: 'input')
+                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, IsImplicit) (Syntax: 'input')
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
 
@@ -1004,7 +1004,7 @@ Block[B0] - Entry
             Predecessors (0)
             Statements (0)
             Jump if False (Regular) to Block[B5]
-                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsImplicit) (Syntax: 'input')
+                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, IsImplicit) (Syntax: 'input')
 
             Next (Regular) Block[B4]
         Block[B4] - Block

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -3755,7 +3755,7 @@ oneMoreTime:
             {
                 // Monitor.Enter($lock, ref $lockTaken);
                 lockTaken = new LocalReferenceExpression(baseLockStatement.LockTakenSymbol, isDeclaration: true, semanticModel: null, lockedValue.Syntax,
-                                                         baseLockStatement.LockTakenSymbol.Type, constantValue: null, isImplicit: true);
+                                                         baseLockStatement.LockTakenSymbol.Type, constantValue: default, isImplicit: true);
                 AddStatement(new InvocationExpression(enterMethod, instance: null, isVirtual: false,
                                                       ImmutableArray.Create<IArgumentOperation>(
                                                                 new ArgumentOperation(lockedValue,
@@ -3795,7 +3795,7 @@ oneMoreTime:
             {
                 // if ($lockTaken)
                 IOperation condition = new LocalReferenceExpression(baseLockStatement.LockTakenSymbol, isDeclaration: false, semanticModel: null, lockedValue.Syntax,
-                                                                    baseLockStatement.LockTakenSymbol.Type, constantValue: null, isImplicit: true);
+                                                                    baseLockStatement.LockTakenSymbol.Type, constantValue: default, isImplicit: true);
                 condition = Operation.SetParentOperation(condition, null);
                 LinkBlocks(CurrentBasicBlock, condition, jumpIfTrue: false, RegularBranch(endOfFinally));
                 _currentBasicBlock = null;

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -25,6 +25,9 @@ namespace Microsoft.CodeAnalysis
 
         protected Operation(OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
         {
+            // Constant value cannot be "null" for non-nullable value type operations.
+            Debug.Assert(type?.IsValueType != true || ITypeSymbolHelpers.IsNullableType(type) || !constantValue.HasValue || constantValue.Value != null);
+
 #if DEBUG
             if (semanticModel != null)
             {

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_ILockStatement.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_ILockStatement.vb
@@ -414,7 +414,7 @@ Block[B0] - Entry
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                       IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: lockTaken) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'Nothing')
-                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                        ILocalReferenceOperation:  (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Boolean, IsImplicit) (Syntax: 'Nothing')
                         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
 
@@ -436,7 +436,7 @@ Block[B0] - Entry
             Predecessors (0)
             Statements (0)
             Jump if False (Regular) to Block[B5]
-                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, Constant: null, IsImplicit) (Syntax: 'Nothing')
+                ILocalReferenceOperation:  (OperationKind.LocalReference, Type: System.Boolean, IsImplicit) (Syntax: 'Nothing')
 
             Next (Regular) Block[B4]
         Block[B4] - Block


### PR DESCRIPTION
…ken variable in CFG

Fixes #28301

<details><summary>Ask Mode template</summary>

### Customer scenario

When an analyzer using the new ControlFlowGraph compiler APIs tries to request and analyze a flow graph for source code containing a `lock` statement, we return a corrupt graph. This can cause analsysis to fail in various ways (throws exception(s), fires assert(s), produce incorrect analysis result, etc.). In fact, attempting to move the features/dataflow branch on https://github.com/dotnet/roslyn-analyzers to the latest Microsoft.CodeAnalysis NuGet package is causing all the lock related tests to fail with asserts.

### Bugs this fixes

Fixes #28301

### Workarounds, if any

All CFG based analyzers have to explicitly identify and handle such corrupt cases.

### Risk

Low. This only affects analyzers based on new CFG APIs, which need to be executed under an experimental feature flag. The fix is also pretty trivial.

### Performance impact

None

### Is this a regression from a previous update?

No, this is a new public API.

### Root cause analysis

Missed it while reviewing the tests.

### How was the bug found?

Attempting to move roslyn-analyzers repo to latest Microsoft.CodeAnalysis NuGet pacakge

### Test documentation updated?

N/A

</details>