### PR TITLE
Updating the OptimizationData to 2.9.0-beta7-63018-03-01

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -152,7 +152,7 @@
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62506-02</MicrosoftDiaSymReaderPdb2PdbVersion>
     <RestSharpVersion>105.2.3</RestSharpVersion>
     <RoslynBuildUtilVersion>0.9.8-beta</RoslynBuildUtilVersion>
-    <RoslynDependenciesOptimizationDataVersion>2.8.0-alpha1-20180601-withsci</RoslynDependenciesOptimizationDataVersion>
+    <RoslynDependenciesOptimizationDataVersion>2.9.0-beta7-63018-03-01</RoslynDependenciesOptimizationDataVersion>
     <RoslynToolsMicrosoftLocateVSVersion>0.2.4-beta</RoslynToolsMicrosoftLocateVSVersion>
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.4.0-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
     <RoslynToolsMSBuildVersion>0.5.0-alpha</RoslynToolsMSBuildVersion>


### PR DESCRIPTION
### Customer scenario

An additional assembly is loaded into memory (aka *the worst thing that can ever happen*)

### Bugs this fixes

[internal VSTS Bug](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/631775)

### Workarounds, if any

None, the new code is part of a compatibility path required to preserve some user code style settings during the 15.8 upgrade process, so addressing the assembly code by removing the new code path has a high risk of frustrating users.

### Risk

We already know about the increase in VM size and have gotten an exception

### Performance impact

reduced JIT time by 17%

### Is this a regression from a previous update?

Yes

### Root cause analysis

Introduced with https://github.com/dotnet/roslyn/pull/26165.  XDocument assemblies are now loaded because they are not properly NGEN'd

### How was the bug found?

RPS testing
