### PR TITLE
Add telemetry for code cleanup

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -8,6 +8,11 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Extensions;
+<<<<<<< HEAD
+=======
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Options;
+>>>>>>> Add telemetry for infobar selections
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -53,14 +58,24 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                               kind: InfoBarUI.UIKind.Button,
                               () =>
                               {
+                                  Logger.Log(FunctionId.CodeCleanupInfobar_ConfigNow);
                                   optionPageService.ShowFormattingOptionPage();
                               }),
                 new InfoBarUI(EditorFeaturesResources.Do_not_show_this_message_again,
                               kind: InfoBarUI.UIKind.Button,
                               () =>
                               {
+<<<<<<< HEAD
                                   workspace.Options = workspace.Options.WithChangedOption(
                                       CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain, document.Project.Language, value: true);
+=======
+                                  Logger.Log(FunctionId.CodeCleanupInfobar_DoNotShow);
+                                  var optionService = document.Project.Solution.Workspace.Services.GetService<IOptionService>();
+                                  var oldOptions = optionService.GetOptions();
+                                  var newOptions = oldOptions.WithChangedOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain,
+                                      document.Project.Language, true);
+                                  optionService.SetOptions(newOptions);
+>>>>>>> Add telemetry for infobar selections
                               }));
         }
 

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -8,11 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Extensions;
-<<<<<<< HEAD
-=======
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
->>>>>>> Add telemetry for infobar selections
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -58,24 +55,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                               kind: InfoBarUI.UIKind.Button,
                               () =>
                               {
-                                  Logger.Log(FunctionId.CodeCleanupInfobar_ConfigNow);
+                                  Logger.Log(FunctionId.CodeCleanupInfobar_ConfigureNow, KeyValueLogMessage.NoProperty);
                                   optionPageService.ShowFormattingOptionPage();
                               }),
                 new InfoBarUI(EditorFeaturesResources.Do_not_show_this_message_again,
                               kind: InfoBarUI.UIKind.Button,
                               () =>
                               {
-<<<<<<< HEAD
+                                  Logger.Log(FunctionId.CodeCleanupInfobar_DoNotShow, KeyValueLogMessage.NoProperty);
                                   workspace.Options = workspace.Options.WithChangedOption(
                                       CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain, document.Project.Language, value: true);
-=======
-                                  Logger.Log(FunctionId.CodeCleanupInfobar_DoNotShow);
-                                  var optionService = document.Project.Solution.Workspace.Services.GetService<IOptionService>();
-                                  var oldOptions = optionService.GetOptions();
-                                  var newOptions = oldOptions.WithChangedOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain,
-                                      document.Project.Language, true);
-                                  optionService.SetOptions(newOptions);
->>>>>>> Add telemetry for infobar selections
                               }));
         }
 
@@ -92,6 +81,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                 return false;
             }
 
+            var cancellationToken = context.OperationContext.UserCancellationToken;
+            var docOptions = document.GetOptionsAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+
             context.OperationContext.TakeOwnership();
             _waitIndicator.Wait(
                 EditorFeaturesResources.Formatting_document,
@@ -99,9 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                 allowCancel: true,
                 showProgress: true,
                 c =>
-                {
-                    var cancellationToken = context.OperationContext.UserCancellationToken;
-
+                { 
                     using (var transaction = new CaretPreservingEditTransaction(
                         EditorFeaturesResources.Formatting, args.TextView, _undoHistoryRegistry, _editorOperationsFactoryService))
                     {

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -94,22 +94,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                     var docOptions = document.GetOptionsAsync(c.CancellationToken).WaitAndGetResult(c.CancellationToken);
 
                     using (Logger.LogBlock(FunctionId.FormatDocument, CodeCleanupLogMessage.Create(docOptions), c.CancellationToken))
+                    using (var transaction = new CaretPreservingEditTransaction(
+                        EditorFeaturesResources.Formatting, args.TextView, _undoHistoryRegistry, _editorOperationsFactoryService))
                     {
-                        using (var transaction = new CaretPreservingEditTransaction(
-                            EditorFeaturesResources.Formatting, args.TextView, _undoHistoryRegistry, _editorOperationsFactoryService))
+                        var codeCleanupService = document.GetLanguageService<ICodeCleanupService>();
+                        if (codeCleanupService == null)
                         {
-                            var codeCleanupService = document.GetLanguageService<ICodeCleanupService>();
-                            if (codeCleanupService == null)
-                            {
-                                Format(args.TextView, document, selectionOpt: null, c.CancellationToken);
-                            }
-                            else
-                            {
-                                CodeCleanupOrFormat(args, document, c.ProgressTracker, c.CancellationToken);
-                            }
-
-                            transaction.Complete();
+                            Format(args.TextView, document, selectionOpt: null, c.CancellationToken);
                         }
+                        else
+                        {
+                            CodeCleanupOrFormat(args, document, c.ProgressTracker, c.CancellationToken);
+                        }
+
+                        transaction.Complete();
                     }
                 });
 

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
         private void ShowGoldBarForCodeCleanupConfigurationIfNeeded(Document document)
         {
             AssertIsForeground();
+            Logger.Log(FunctionId.CodeCleanupInfobar_BarDisplayed, KeyValueLogMessage.NoProperty);
 
             var workspace = document.Project.Solution.Workspace;
 

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -92,21 +92,24 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                 allowCancel: true,
                 showProgress: true,
                 c =>
-                { 
-                    using (var transaction = new CaretPreservingEditTransaction(
-                        EditorFeaturesResources.Formatting, args.TextView, _undoHistoryRegistry, _editorOperationsFactoryService))
+                {
+                    using (Logger.LogBlock(FunctionId.FormatDocument, CodeCleanupLogMessage.Create(docOptions), cancellationToken))
                     {
-                        var codeCleanupService = document.GetLanguageService<ICodeCleanupService>();
-                        if (codeCleanupService == null)
+                        using (var transaction = new CaretPreservingEditTransaction(
+                            EditorFeaturesResources.Formatting, args.TextView, _undoHistoryRegistry, _editorOperationsFactoryService))
                         {
-                            Format(args.TextView, document, selectionOpt: null, cancellationToken);
-                        }
-                        else
-                        {
-                            CodeCleanupOrFormat(args, document, c.ProgressTracker, cancellationToken);
-                        }
+                            var codeCleanupService = document.GetLanguageService<ICodeCleanupService>();
+                            if (codeCleanupService == null)
+                            {
+                                Format(args.TextView, document, selectionOpt: null, cancellationToken);
+                            }
+                            else
+                            {
+                                CodeCleanupOrFormat(args, document, c.ProgressTracker, cancellationToken);
+                            }
 
-                        transaction.Complete();
+                            transaction.Complete();
+                        }
                     }
                 });
 
@@ -147,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
         }
 
         private async Task<ImmutableArray<TextChange>> GetCodeCleanupAndFormatChangesAsync(
-            Document document, ICodeCleanupService codeCleanupService, 
+            Document document, ICodeCleanupService codeCleanupService,
             IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
             var newDoc = await codeCleanupService.CleanupAsync(

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.CSharp.RemoveUnusedVariable;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.OrganizeImports;
 using Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -188,6 +188,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
 
                 // Mark this option as being completed.
                 progressTracker.ItemCompleted();
+
+                using (Logger.LogBlock(FunctionId.CodeCleanup_Format, cancellationToken))
+                {
+                    var result = await Formatter.FormatAsync(document).ConfigureAwait(false);
+                    progressTracker.ItemCompleted();
+                    return result;
+                }
+
             }
 
             return document;

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.RemoveUnusedVariable;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.OrganizeImports;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -119,8 +120,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
 
             if (_codeFixServiceOpt != null)
             {
-                document = await ApplyCodeFixesAsync(
-                    document, docOptions, progressTracker, cancellationToken).ConfigureAwait(false);
+                Logger.Log(FunctionId.Rename_InlineSession_Session, CodeCleanupLogMessage.Create(docOptions));
+                document = await ApplyCodeFixesAsync(document, docOptions, cancellationToken).ConfigureAwait(false);
             }
 
             // do the remove usings after code fix, as code fix might remove some code which can results in unused usings.

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.RemoveUnusedVariable;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.OrganizeImports;
 using Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -188,10 +188,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
 
                 // Mark this option as being completed.
                 progressTracker.ItemCompleted();
-
-                var result = await Formatter.FormatAsync(document).ConfigureAwait(false);
-                progressTracker.ItemCompleted();
-                return result;
             }
 
             return document;
@@ -205,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
                 using (Logger.LogBlock(FunctionId.CodeCleanup_ApplyCodeFixesAsync, diagnosticId, cancellationToken))
                 {
                     document = await ApplyCodeFixesForSpecificDiagnosticId(
-                    document, diagnosticId, cancellationToken).ConfigureAwait(false);
+                        document, diagnosticId, cancellationToken).ConfigureAwait(false);
                 }
             }
 

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -180,22 +180,21 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
 
             foreach (var (description, diagnosticIds) in enabledOptions)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                progressTracker.Description = description;
-                document = await ApplyCodeFixesForSpecificDiagnosticIds(
-                    document, diagnosticIds, cancellationToken).ConfigureAwait(false);
-
-                // Mark this option as being completed.
-                progressTracker.ItemCompleted();
-
                 using (Logger.LogBlock(FunctionId.CodeCleanup_Format, cancellationToken))
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    progressTracker.Description = description;
+                    document = await ApplyCodeFixesForSpecificDiagnosticIds(
+                        document, diagnosticIds, cancellationToken).ConfigureAwait(false);
+
+                    // Mark this option as being completed.
+                    progressTracker.ItemCompleted();
+
                     var result = await Formatter.FormatAsync(document).ConfigureAwait(false);
                     progressTracker.ItemCompleted();
                     return result;
                 }
-
             }
 
             return document;

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -140,7 +140,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
                 progressTracker.ItemCompleted();
                 return result;
             }
-
         }
 
         private async Task<Document> RemoveSortUsingsAsync(

--- a/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/Features/CSharp/Portable/CodeCleanup/CSharpCodeCleanupService.cs
@@ -180,21 +180,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
 
             foreach (var (description, diagnosticIds) in enabledOptions)
             {
-                using (Logger.LogBlock(FunctionId.CodeCleanup_Format, cancellationToken))
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
-                    progressTracker.Description = description;
-                    document = await ApplyCodeFixesForSpecificDiagnosticIds(
-                        document, diagnosticIds, cancellationToken).ConfigureAwait(false);
+                progressTracker.Description = description;
+                document = await ApplyCodeFixesForSpecificDiagnosticIds(
+                    document, diagnosticIds, cancellationToken).ConfigureAwait(false);
 
-                    // Mark this option as being completed.
-                    progressTracker.ItemCompleted();
+                // Mark this option as being completed.
+                progressTracker.ItemCompleted();
 
-                    var result = await Formatter.FormatAsync(document).ConfigureAwait(false);
-                    progressTracker.ItemCompleted();
-                    return result;
-                }
+                var result = await Formatter.FormatAsync(document).ConfigureAwait(false);
+                progressTracker.ItemCompleted();
+                return result;
             }
 
             return document;
@@ -205,8 +202,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
         {
             foreach (var diagnosticId in diagnosticIds)
             {
-                document = await ApplyCodeFixesForSpecificDiagnosticId(
+                using (Logger.LogBlock(FunctionId.CodeCleanup_ApplyCodeFixesAsync, diagnosticId, cancellationToken))
+                {
+                    document = await ApplyCodeFixesForSpecificDiagnosticId(
                     document, diagnosticId, cancellationToken).ConfigureAwait(false);
+                }
             }
 
             return document;

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
@@ -7,41 +7,25 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
 {
     internal static class CodeCleanupLogMessage
     {
-        private const string AreCodeCleanupRulesConfigured= nameof(AreCodeCleanupRulesConfigured);
-        private const string AddAccessibilityModifiers= nameof(AddAccessibilityModifiers);
-        private const string AddRemoveBracesForSingleLineControlStatements= nameof(AddRemoveBracesForSingleLineControlStatements);
-        private const string ApplyExpressionBlockBodyPreferences= nameof(ApplyExpressionBlockBodyPreferences);
-        private const string ApplyLanguageFrameworkTypePreferences= nameof(ApplyLanguageFrameworkTypePreferences);
-        private const string ApplyImplicitExplicitTypePreferences= nameof(ApplyImplicitExplicitTypePreferences);
-        private const string ApplyInlineOutVariablePreferences= nameof(ApplyInlineOutVariablePreferences);
-        private const string ApplyObjectCollectionInitializationPreferences= nameof(ApplyObjectCollectionInitializationPreferences);
-        private const string ApplyThisQualificationPreferences= nameof(ApplyThisQualificationPreferences);
-        private const string MakePrivateFieldReadonlyWhenPossible= nameof(MakePrivateFieldReadonlyWhenPossible);
-        private const string RemoveUnnecessaryCasts= nameof(RemoveUnnecessaryCasts);
-        private const string RemoveUnusedImports= nameof(RemoveUnnecessaryImports);
-        private const string RemoveUnusedVariables= nameof(RemoveUnusedVariables);
-        private const string SortAccessibilityModifiers= nameof(SortAccessibilityModifiers);
-        private const string SortImports = nameof(SortImports);
-
         public static KeyValueLogMessage Create(DocumentOptionSet docOptions)
         {
             return KeyValueLogMessage.Create(LogType.UserAction, m =>
             {
-                m[AreCodeCleanupRulesConfigured] = docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured);
-                m[AddAccessibilityModifiers] = docOptions.GetOption(CodeCleanupOptions.AddAccessibilityModifiers);
-                m[AddRemoveBracesForSingleLineControlStatements] = docOptions.GetOption(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements);
-                m[ApplyExpressionBlockBodyPreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences);
-                m[ApplyLanguageFrameworkTypePreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences);
-                m[ApplyImplicitExplicitTypePreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences);
-                m[ApplyInlineOutVariablePreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyInlineOutVariablePreferences);
-                m[ApplyObjectCollectionInitializationPreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences);
-                m[ApplyThisQualificationPreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyThisQualificationPreferences);
-                m[MakePrivateFieldReadonlyWhenPossible] = docOptions.GetOption(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible);
-                m[RemoveUnnecessaryCasts] = docOptions.GetOption(CodeCleanupOptions.RemoveUnnecessaryCasts);
-                m[RemoveUnusedImports] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedImports);
-                m[RemoveUnusedVariables] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedVariables);
-                m[SortAccessibilityModifiers] = docOptions.GetOption(CodeCleanupOptions.SortAccessibilityModifiers);
-                m[SortImports] = docOptions.GetOption(CodeCleanupOptions.SortImports);
+                m["AreCodeCleanupRulesConfigured"] = docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured);
+                m["AddAccessibilityModifiers"] = docOptions.GetOption(CodeCleanupOptions.AddAccessibilityModifiers);
+                m["AddRemoveBracesForSingleLineControlStatements"] = docOptions.GetOption(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements);
+                m["ApplyExpressionBlockBodyPreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences);
+                m["ApplyLanguageFrameworkTypePreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences);
+                m["ApplyImplicitExplicitTypePreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences);
+                m["ApplyInlineOutVariablePreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyInlineOutVariablePreferences);
+                m["ApplyObjectCollectionInitializationPreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences);
+                m["ApplyThisQualificationPreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyThisQualificationPreferences);
+                m["MakePrivateFieldReadonlyWhenPossible"] = docOptions.GetOption(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible);
+                m["RemoveUnnecessaryCasts"] = docOptions.GetOption(CodeCleanupOptions.RemoveUnnecessaryCasts);
+                m["RemoveUnusedImports"] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedImports);
+                m["RemoveUnusedVariables"] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedVariables);
+                m["SortAccessibilityModifiers"] = docOptions.GetOption(CodeCleanupOptions.SortAccessibilityModifiers);
+                m["SortImports"] = docOptions.GetOption(CodeCleanupOptions.SortImports);
                 });
         }
     }

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.CodeCleanup
+{
+    internal static class CodeCleanupLogMessage
+    {
+        private const string AreCodeCleanupRulesConfigured= nameof(AreCodeCleanupRulesConfigured);
+        private const string AddAccessibilityModifiers= nameof(AddAccessibilityModifiers);
+        private const string AddRemoveBracesForSingleLineControlStatements= nameof(AddRemoveBracesForSingleLineControlStatements);
+        private const string ApplyExpressionBlockBodyPreferences= nameof(ApplyExpressionBlockBodyPreferences);
+        private const string ApplyLanguageFrameworkTypePreferences= nameof(ApplyLanguageFrameworkTypePreferences);
+        private const string ApplyImplicitExplicitTypePreferences= nameof(ApplyImplicitExplicitTypePreferences);
+        private const string ApplyInlineOutVariablePreferences= nameof(ApplyInlineOutVariablePreferences);
+        private const string ApplyObjectCollectionInitializationPreferences= nameof(ApplyObjectCollectionInitializationPreferences);
+        private const string ApplyThisQualificationPreferences= nameof(ApplyThisQualificationPreferences);
+        private const string MakePrivateFieldReadonlyWhenPossible= nameof(MakePrivateFieldReadonlyWhenPossible);
+        private const string RemoveUnnecessaryCasts= nameof(RemoveUnnecessaryCasts);
+        private const string RemoveUnusedImports= nameof(RemoveUnnecessaryImports);
+        private const string RemoveUnusedVariables= nameof(RemoveUnusedVariables);
+        private const string SortAccessibilityModifiers= nameof(SortAccessibilityModifiers);
+        private const string SortImports = nameof(SortImports);
+
+        public static KeyValueLogMessage Create(DocumentOptionSet docOptions)
+        {
+            return KeyValueLogMessage.Create(LogType.UserAction, m =>
+            {
+                m[AreCodeCleanupRulesConfigured] = docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured);
+                m[AddAccessibilityModifiers] = docOptions.GetOption(CodeCleanupOptions.AddAccessibilityModifiers);
+                m[AddRemoveBracesForSingleLineControlStatements] = docOptions.GetOption(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements);
+                m[ApplyExpressionBlockBodyPreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences);
+                m[ApplyLanguageFrameworkTypePreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences);
+                m[ApplyImplicitExplicitTypePreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences);
+                m[ApplyInlineOutVariablePreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyInlineOutVariablePreferences);
+                m[ApplyObjectCollectionInitializationPreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences);
+                m[ApplyThisQualificationPreferences] = docOptions.GetOption(CodeCleanupOptions.ApplyThisQualificationPreferences);
+                m[MakePrivateFieldReadonlyWhenPossible] = docOptions.GetOption(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible);
+                m[RemoveUnnecessaryCasts] = docOptions.GetOption(CodeCleanupOptions.RemoveUnnecessaryCasts);
+                m[RemoveUnusedImports] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedImports);
+                m[RemoveUnusedVariables] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedVariables);
+                m[SortAccessibilityModifiers] = docOptions.GetOption(CodeCleanupOptions.SortAccessibilityModifiers);
+                m[SortImports] = docOptions.GetOption(CodeCleanupOptions.SortImports);
+                });
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
@@ -11,21 +11,23 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
         {
             return KeyValueLogMessage.Create(LogType.UserAction, m =>
             {
-                m[nameof(CodeCleanupOptions.AreCodeCleanupRulesConfigured)] = docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured);
-                m[nameof(CodeCleanupOptions.AddAccessibilityModifiers)] = docOptions.GetOption(CodeCleanupOptions.AddAccessibilityModifiers);
+                m[nameof(CodeCleanupOptions.CodeCleanupInfoBarShown)] = docOptions.GetOption(CodeCleanupOptions.CodeCleanupInfoBarShown);
+                m[nameof(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain)] = docOptions.GetOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain);
+                m[nameof(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting)] = docOptions.GetOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting);
+                m[nameof(CodeCleanupOptions.RemoveUnusedImports)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedImports);
+                m[nameof(CodeCleanupOptions.SortImports)] = docOptions.GetOption(CodeCleanupOptions.SortImports);
                 m[nameof(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements)] = docOptions.GetOption(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements);
+                m[nameof(CodeCleanupOptions.AddAccessibilityModifiers)] = docOptions.GetOption(CodeCleanupOptions.AddAccessibilityModifiers);
+                m[nameof(CodeCleanupOptions.SortAccessibilityModifiers)] = docOptions.GetOption(CodeCleanupOptions.SortAccessibilityModifiers);
                 m[nameof(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences);
-                m[nameof(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences);
                 m[nameof(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences);
                 m[nameof(CodeCleanupOptions.ApplyInlineOutVariablePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyInlineOutVariablePreferences);
+                m[nameof(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences);
                 m[nameof(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences);
                 m[nameof(CodeCleanupOptions.ApplyThisQualificationPreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyThisQualificationPreferences);
                 m[nameof(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible)] = docOptions.GetOption(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible);
                 m[nameof(CodeCleanupOptions.RemoveUnnecessaryCasts)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnnecessaryCasts);
-                m[nameof(CodeCleanupOptions.RemoveUnusedImports)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedImports);
                 m[nameof(CodeCleanupOptions.RemoveUnusedVariables)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedVariables);
-                m[nameof(CodeCleanupOptions.SortAccessibilityModifiers)] = docOptions.GetOption(CodeCleanupOptions.SortAccessibilityModifiers);
-                m[nameof(CodeCleanupOptions.SortImports)] = docOptions.GetOption(CodeCleanupOptions.SortImports);
                 });
         }
     }

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
@@ -11,7 +11,6 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
         {
             return KeyValueLogMessage.Create(LogType.UserAction, m =>
             {
-                m[nameof(CodeCleanupOptions.CodeCleanupInfoBarShown)] = docOptions.GetOption(CodeCleanupOptions.CodeCleanupInfoBarShown);
                 m[nameof(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain)] = docOptions.GetOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain);
                 m[nameof(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting)] = docOptions.GetOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting);
                 m[nameof(CodeCleanupOptions.RemoveUnusedImports)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedImports);

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
@@ -11,21 +11,21 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
         {
             return KeyValueLogMessage.Create(LogType.UserAction, m =>
             {
-                m["AreCodeCleanupRulesConfigured"] = docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured);
-                m["AddAccessibilityModifiers"] = docOptions.GetOption(CodeCleanupOptions.AddAccessibilityModifiers);
-                m["AddRemoveBracesForSingleLineControlStatements"] = docOptions.GetOption(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements);
-                m["ApplyExpressionBlockBodyPreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences);
-                m["ApplyLanguageFrameworkTypePreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences);
-                m["ApplyImplicitExplicitTypePreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences);
-                m["ApplyInlineOutVariablePreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyInlineOutVariablePreferences);
-                m["ApplyObjectCollectionInitializationPreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences);
-                m["ApplyThisQualificationPreferences"] = docOptions.GetOption(CodeCleanupOptions.ApplyThisQualificationPreferences);
-                m["MakePrivateFieldReadonlyWhenPossible"] = docOptions.GetOption(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible);
-                m["RemoveUnnecessaryCasts"] = docOptions.GetOption(CodeCleanupOptions.RemoveUnnecessaryCasts);
-                m["RemoveUnusedImports"] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedImports);
-                m["RemoveUnusedVariables"] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedVariables);
-                m["SortAccessibilityModifiers"] = docOptions.GetOption(CodeCleanupOptions.SortAccessibilityModifiers);
-                m["SortImports"] = docOptions.GetOption(CodeCleanupOptions.SortImports);
+                m[nameof(CodeCleanupOptions.AreCodeCleanupRulesConfigured)] = docOptions.GetOption(CodeCleanupOptions.AreCodeCleanupRulesConfigured);
+                m[nameof(CodeCleanupOptions.AddAccessibilityModifiers)] = docOptions.GetOption(CodeCleanupOptions.AddAccessibilityModifiers);
+                m[nameof(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements)] = docOptions.GetOption(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements);
+                m[nameof(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences);
+                m[nameof(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences);
+                m[nameof(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences);
+                m[nameof(CodeCleanupOptions.ApplyInlineOutVariablePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyInlineOutVariablePreferences);
+                m[nameof(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences);
+                m[nameof(CodeCleanupOptions.ApplyThisQualificationPreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyThisQualificationPreferences);
+                m[nameof(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible)] = docOptions.GetOption(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible);
+                m[nameof(CodeCleanupOptions.RemoveUnnecessaryCasts)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnnecessaryCasts);
+                m[nameof(CodeCleanupOptions.RemoveUnusedImports)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedImports);
+                m[nameof(CodeCleanupOptions.RemoveUnusedVariables)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedVariables);
+                m[nameof(CodeCleanupOptions.SortAccessibilityModifiers)] = docOptions.GetOption(CodeCleanupOptions.SortAccessibilityModifiers);
+                m[nameof(CodeCleanupOptions.SortImports)] = docOptions.GetOption(CodeCleanupOptions.SortImports);
                 });
         }
     }

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
@@ -11,23 +11,11 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
         {
             return KeyValueLogMessage.Create(LogType.UserAction, m =>
             {
-                m[nameof(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain)] = docOptions.GetOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain);
-                m[nameof(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting)] = docOptions.GetOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting);
-                m[nameof(CodeCleanupOptions.RemoveUnusedImports)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedImports);
-                m[nameof(CodeCleanupOptions.SortImports)] = docOptions.GetOption(CodeCleanupOptions.SortImports);
-                m[nameof(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements)] = docOptions.GetOption(CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements);
-                m[nameof(CodeCleanupOptions.AddAccessibilityModifiers)] = docOptions.GetOption(CodeCleanupOptions.AddAccessibilityModifiers);
-                m[nameof(CodeCleanupOptions.SortAccessibilityModifiers)] = docOptions.GetOption(CodeCleanupOptions.SortAccessibilityModifiers);
-                m[nameof(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyExpressionBlockBodyPreferences);
-                m[nameof(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyImplicitExplicitTypePreferences);
-                m[nameof(CodeCleanupOptions.ApplyInlineOutVariablePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyInlineOutVariablePreferences);
-                m[nameof(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyLanguageFrameworkTypePreferences);
-                m[nameof(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences);
-                m[nameof(CodeCleanupOptions.ApplyThisQualificationPreferences)] = docOptions.GetOption(CodeCleanupOptions.ApplyThisQualificationPreferences);
-                m[nameof(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible)] = docOptions.GetOption(CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible);
-                m[nameof(CodeCleanupOptions.RemoveUnnecessaryCasts)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnnecessaryCasts);
-                m[nameof(CodeCleanupOptions.RemoveUnusedVariables)] = docOptions.GetOption(CodeCleanupOptions.RemoveUnusedVariables);
-                });
+                foreach (var option in CodeCleanupOptionsProvider.SingletonOptions)
+                {
+                    m[option.Name] = docOptions.GetOption((PerLanguageOption<bool>)option, LanguageNames.CSharp);
+                }
+            });
         }
     }
 }

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupOptions.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupOptions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
     [ExportOptionProvider, Shared]
     internal class CodeCleanupOptionsProvider : IOptionProvider
     {
-        public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
+        public static ImmutableArray<IOption> SingletonOptions { get; } = ImmutableArray.Create<IOption>(
             CodeCleanupOptions.CodeCleanupInfoBarShown,
             CodeCleanupOptions.AddAccessibilityModifiers,
             CodeCleanupOptions.AddRemoveBracesForSingleLineControlStatements,
@@ -92,11 +92,15 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             CodeCleanupOptions.ApplyObjectCollectionInitializationPreferences,
             CodeCleanupOptions.ApplyThisQualificationPreferences,
             CodeCleanupOptions.MakePrivateFieldReadonlyWhenPossible,
+            CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain,
+            CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting,
             CodeCleanupOptions.RemoveUnnecessaryCasts,
             CodeCleanupOptions.RemoveUnusedImports,
             CodeCleanupOptions.RemoveUnusedVariables,
             CodeCleanupOptions.SortAccessibilityModifiers,
             CodeCleanupOptions.SortImports
         );
+
+        public ImmutableArray<IOption> Options { get; } = SingletonOptions;
     }
 }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -419,6 +419,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         SymbolFinder_Project_Pattern_FindSourceDeclarationsAsync,
         Intellisense_Completion_Commit,
 
+        CodeCleanupInfobar_BarDisplayed,
         CodeCleanupInfobar_ConfigureNow,
         CodeCleanupInfobar_DoNotShow,
 

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -418,5 +418,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         SymbolFinder_Solution_Pattern_FindSourceDeclarationsAsync,
         SymbolFinder_Project_Pattern_FindSourceDeclarationsAsync,
         Intellisense_Completion_Commit,
+
+        CodeCleanupInfobar_ConfigNow,
+        CodeCleanupInfobar_DoNotShow
     }
 }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -423,6 +423,10 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         CodeCleanupInfobar_ConfigureNow,
         CodeCleanupInfobar_DoNotShow,
 
-        FormatDocument
+        FormatDocument,
+        CodeCleanup_ApplyCodeFixesAsync,
+        CodeCleanup_RemoveUnusedImports,
+        CodeCleanup_SortImports,
+        CodeCleanup_Format
     }
 }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -419,7 +419,9 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         SymbolFinder_Project_Pattern_FindSourceDeclarationsAsync,
         Intellisense_Completion_Commit,
 
-        CodeCleanupInfobar_ConfigNow,
-        CodeCleanupInfobar_DoNotShow
+        CodeCleanupInfobar_ConfigureNow,
+        CodeCleanupInfobar_DoNotShow,
+
+        FormatDocument
     }
 }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         CodeCleanupInfobar_BarDisplayed,
         CodeCleanupInfobar_ConfigureNow,
-        CodeCleanupInfobar_DoNotShow,
+        CodeCleanupInfobar_NeverShowCodeCleanupInfoBarAgain,
 
         FormatDocument,
         CodeCleanup_ApplyCodeFixesAsync,


### PR DESCRIPTION
Adding telemetry for Code Cleanup

- [x] infobar displayed
- [x] button on infobar clicked
- [x] Tools|Options settings when Format Document is run
- [x] running time for Code Cleanup

 Bugs this fixes
#28337 

<details><summary>Ask Mode template</summary>

### Customer scenario
When a customer formats a document, an infobar is displayed asking if they want to configure Code Cleanup or never show this infobar again.  This PR adds telemetry on when the infobar is show, what option the user chooses on this infobar, and what Code Cleanup options were set at the time of running Format Document.

### Bugs this fixes
#28337

### Workarounds, if any
n/a

### Risk
Low.  No feature code has been changed, just added logging.

### Performance impact
Very low or negligible

### Is this a regression from a previous update?
No, telemetry was not previously added

### Root cause analysis
n/a

### How was the bug found?
n/a