### PR TITLE
Turn on loc check for dev15.8.x

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -238,9 +238,10 @@ commitPullList.each { isPr ->
 
 // Loc status check
 commitPullList.each { isPr ->
-  // Only add the check to PR builds for now. At some point we'll change this check
-  // to instead look for particular branch names.
-  if (isPr) {
+  // Add the check for PR builds, and dev15.8.x/dev15.8.x-vs-deps builds.
+  if (isPr
+      || branchName == "dev15.8.x"
+      || branchName == "dev15.8.x-vs-deps") {
     def jobName = Utilities.getFullJobName(projectName, "windows_loc_status", isPr)
     def myJob = job(jobName) {
       description('Check for untranslated resources')
@@ -249,8 +250,8 @@ commitPullList.each { isPr ->
       }
     }
 
-    // For now we'll only run this when explicitly asked.
-    def triggerPhraseOnly = true
+    // Run it automatically on CI builds but only when requested on PR builds.
+    def triggerPhraseOnly = isPr
     def triggerPhraseExtra = "loc"
     Utilities.setMachineAffinity(myJob, 'Windows_NT', windowsUnitTestMachine)
     addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)


### PR DESCRIPTION
Infrastructure-only change.

Turn on the `windows_loc_status` check for the dev15.8.x and
dev15.8.x-vs-deps branches for CI builds. For PR builds it will continue
to show only when requested.

It is expected that it will fail in these branches until we have our
final loc passes.
