### PR TITLE
Fix VB snippet tests race condition

### DIFF
--- a/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
@@ -14,6 +14,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Composition
 Imports Microsoft.VisualStudio.Editor
+Imports Microsoft.VisualStudio.Language.Intellisense
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Text
@@ -29,7 +30,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
         Inherits AbstractCommandHandlerTestState
 
         Public Sub New(workspaceElement As XElement, languageName As String, startActiveSession As Boolean, extraParts As IEnumerable(Of Type), Optional workspaceKind As String = Nothing)
-            MyBase.New(workspaceElement, extraParts:=CreatePartCatalog(extraParts), workspaceKind:=workspaceKind)
+            ' Remove the default completion presenters to prevent them from conflicting with the test one
+            ' that we are adding.
+            MyBase.New(workspaceElement, extraParts:=CreatePartCatalog(extraParts), workspaceKind:=workspaceKind, excludedTypes:={GetType(IIntelliSensePresenter(Of ICompletionPresenterSession, ICompletionSession))})
 
             Workspace.Options = Workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.Snippets, True)
 


### PR DESCRIPTION
The VB snippet tests are using a custom completion presenter but did not
remove the deafult one, nor did it specify any ordering. Hence imports
which took an enumerable of completion sources essentially raced on
whether they got the test completion soucre or the default one. The fix
is to remove the default one for these tests.

