### PR TITLE
Enable incremental updates of the dependency graph

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -23,6 +23,10 @@ namespace Microsoft.CodeAnalysis
         // These are computed fully on demand. null or ImmutableArray.IsDefault indicates the item needs to be realized
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _lazyReverseReferencesMap;
         private ImmutableArray<ProjectId> _lazyTopologicallySortedProjects;
+        
+        // This is not typed ImmutableArray<ImmutableArray<...>> because GetDependencySets() wants to return
+        // an IEnumerable<IEnumerable<...>>, and ImmutableArray<ImmutableArray<...>> can't be converted
+        // to an IEnumerable<IEnumerable<...>> without a bunch of boxing.
         private ImmutableArray<IEnumerable<ProjectId>> _lazyDependencySets;
 
         // These accumulate results on demand. They are never null, but a missing key/value pair indicates it needs to be computed.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -110,10 +110,7 @@ namespace Microsoft.CodeAnalysis
 
         internal ProjectDependencyGraph WithAdditionalProjectReferences(ProjectId projectId, IReadOnlyList<ProjectId> referencedProjectIds)
         {
-            if (!_projectIds.Contains(projectId))
-            {
-                throw new InvalidOperationException($"{nameof(projectId)} isn't being tracked by this dependency graph.");
-            }
+            Contract.ThrowIfFalse(_projectIds.Contains(projectId));
 
             if (referencedProjectIds.Count == 0)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -295,6 +295,8 @@ namespace Microsoft.CodeAnalysis
 
         internal ProjectDependencyGraph WithProjectReferences(ProjectId projectId, IEnumerable<ProjectId> referencedProjectIds)
         {
+            Contract.ThrowIfFalse(_projectIds.Contains(projectId));
+
             // This method we can't optimize very well: changing project references arbitrarily could invalidate pretty much anything. The only thing we can reuse is our
             // actual map of project references for all the other projects, so we'll do that
             return new ProjectDependencyGraph(_projectIds, _referencesMap.SetItem(projectId, referencedProjectIds.ToImmutableHashSet()));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Gets the list of projects (topologically sorted) that this project directly depends on.
+        /// Gets the list of projects that this project directly depends on.
         /// </summary>
         public IImmutableSet<ProjectId> GetProjectsThatThisProjectDirectlyDependsOn(ProjectId projectId)
         {
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Gets the list of projects (topologically sorted) that directly depend on this project.
+        /// Gets the list of projects that directly depend on this project.
         /// </summary> 
         public IImmutableSet<ProjectId> GetProjectsThatDirectlyDependOnThisProject(ProjectId projectId)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -20,12 +20,12 @@ namespace Microsoft.CodeAnalysis
         // guards lazy computed data
         private readonly NonReentrantLock _dataLock = new NonReentrantLock();
 
-        // these are computed fully on demand
+        // These are computed fully on demand. null or ImmutableArray.IsDefault indicates the item needs to be realized
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _lazyReverseReferencesMap;
         private ImmutableArray<ProjectId> _lazyTopologicallySortedProjects;
         private ImmutableArray<IEnumerable<ProjectId>> _lazyDependencySets;
 
-        // these accumulate results on demand
+        // These accumulate results on demand. They are never null, but a missing key/value pair indicates it needs to be computed.
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _transitiveReferencesMap = ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty;
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _reverseTransitiveReferencesMap = ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public class ProjectDependencyGraph
     {
-        private readonly ImmutableArray<ProjectId> _projectIds;
+        private readonly ImmutableHashSet<ProjectId> _projectIds;
         private readonly ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _referencesMap;
 
         // guards lazy computed data
@@ -26,19 +26,272 @@ namespace Microsoft.CodeAnalysis
         private ImmutableArray<IEnumerable<ProjectId>> _lazyDependencySets;
 
         // These accumulate results on demand. They are never null, but a missing key/value pair indicates it needs to be computed.
-        private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _transitiveReferencesMap = ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty;
-        private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _reverseTransitiveReferencesMap = ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty;
+        private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _transitiveReferencesMap;
+        private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _reverseTransitiveReferencesMap;
 
         internal static readonly ProjectDependencyGraph Empty = new ProjectDependencyGraph(
-            ImmutableArray.Create<ProjectId>(),
+            ImmutableHashSet<ProjectId>.Empty,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty);
 
         internal ProjectDependencyGraph(
-            ImmutableArray<ProjectId> projectIds,
+            ImmutableHashSet<ProjectId> projectIds,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> referencesMap)
+            : this(
+                  projectIds,
+                  referencesMap,
+                  reverseReferencesMap: null,
+                  transitiveReferencesMap: ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
+                  reverseTransitiveReferencesMap: ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
+                  default,
+                  default)
         {
+        }
+
+        // This constructor is private to prevent other Roslyn code from producing this type with inconsistent inputs.
+        private ProjectDependencyGraph(
+            ImmutableHashSet<ProjectId> projectIds,
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> referencesMap,
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> reverseReferencesMap,
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> transitiveReferencesMap,
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> reverseTransitiveReferencesMap,
+            ImmutableArray<ProjectId> topologicallySortedProjects,
+            ImmutableArray<IEnumerable<ProjectId>> dependencySets)
+        {
+            Contract.ThrowIfNull(transitiveReferencesMap);
+            Contract.ThrowIfNull(reverseTransitiveReferencesMap);
+
             _projectIds = projectIds;
             _referencesMap = referencesMap;
+            _lazyReverseReferencesMap = reverseReferencesMap;
+            _transitiveReferencesMap = transitiveReferencesMap;
+            _reverseTransitiveReferencesMap = reverseTransitiveReferencesMap;
+            _lazyTopologicallySortedProjects = topologicallySortedProjects;
+            _lazyDependencySets = dependencySets;
+        }
+
+        internal ProjectDependencyGraph WithAdditionalProjects(IEnumerable<ProjectId> projectIds)
+        {
+            // Track the existence of some new projects. Note this call only adds new ProjectIds, but doesn't add any references. Any caller who wants to add a new project
+            // with references will first call this, and then call WithAdditionalProjectReferences to add references as well.
+            var newTopologicallySortedProjects = _lazyTopologicallySortedProjects;
+
+            if (!newTopologicallySortedProjects.IsDefault)
+            {
+                newTopologicallySortedProjects = newTopologicallySortedProjects.AddRange(projectIds);
+            }
+
+            var newDependencySets = _lazyDependencySets;
+
+            if (!newDependencySets.IsDefault)
+            {
+                var builder = newDependencySets.ToBuilder();
+
+                foreach (var projectId in projectIds)
+                {
+                    builder.Add(ImmutableArray.Create(projectId));
+                }
+
+                newDependencySets = builder.ToImmutable();
+            }
+
+            return new ProjectDependencyGraph(
+                _projectIds.Union(projectIds),
+                referencesMap: _referencesMap,
+                reverseReferencesMap: _lazyReverseReferencesMap,
+                transitiveReferencesMap: _transitiveReferencesMap,
+                reverseTransitiveReferencesMap: _reverseTransitiveReferencesMap,
+                topologicallySortedProjects: newTopologicallySortedProjects,
+                dependencySets: newDependencySets);
+        }
+
+        internal ProjectDependencyGraph WithAdditionalProjectReferences(ProjectId projectId, IReadOnlyList<ProjectId> referencedProjectIds)
+        {
+            if (!_projectIds.Contains(projectId))
+            {
+                throw new InvalidOperationException($"{nameof(projectId)} isn't being tracked by this dependency graph.");
+            }
+
+            if (referencedProjectIds.Count == 0)
+            {
+                return this;
+            }
+
+            var newReferencesMap = ComputeNewReferencesMapForAdditionalProjectReferences(_referencesMap, projectId, referencedProjectIds);
+
+            var newReverseReferencesMap =
+                _lazyReverseReferencesMap != null
+                    ? ComputeNewReverseReferencesMapForAdditionalProjectReferences(_lazyReverseReferencesMap, projectId, referencedProjectIds)
+                    : null;
+
+            var newTransitiveReferencesMap = ComputeNewTransitiveReferencesMapForAdditionalProjectReferences(_transitiveReferencesMap, projectId, referencedProjectIds);
+
+            var newReverseTransitiveReferencesMap = ComputeNewReverseTransitiveReferencesMapForAdditionalProjectReferences(_reverseTransitiveReferencesMap, projectId, referencedProjectIds);
+
+            // Note: rather than updating our dependency sets and topologically sorted data, we'll throw that away since incremental update is
+            // tricky, and those are rarely used.
+            return new ProjectDependencyGraph(
+                _projectIds,
+                referencesMap: newReferencesMap,
+                reverseReferencesMap: newReverseReferencesMap,
+                transitiveReferencesMap: newTransitiveReferencesMap,
+                reverseTransitiveReferencesMap: newReverseTransitiveReferencesMap,
+                topologicallySortedProjects: default,
+                dependencySets: default);
+        }
+
+        /// <summary>
+        /// Computes a new <see cref="_referencesMap"/> for the addition of additional project references.
+        /// </summary>
+        private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewReferencesMapForAdditionalProjectReferences(
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingReferencesMap,
+            ProjectId projectId,
+            IReadOnlyList<ProjectId> referencedProjectIds)
+        {
+            if (existingReferencesMap.TryGetValue(projectId, out var existingReferences))
+            {
+                return existingReferencesMap.SetItem(projectId, existingReferences.Union(referencedProjectIds));
+            }
+            else
+            {
+                return existingReferencesMap.SetItem(projectId, referencedProjectIds.ToImmutableHashSet());
+            }
+        }
+
+        /// <summary>
+        /// Computes a new <see cref="_lazyReverseReferencesMap"/> for the addition of additional project references. Must be called on a non-null
+        /// map.
+        /// </summary>
+        private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewReverseReferencesMapForAdditionalProjectReferences(
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingReverseReferencesMap,
+            ProjectId projectId,
+            IReadOnlyList<ProjectId> referencedProjectIds)
+        {
+            var builder = existingReverseReferencesMap.ToBuilder();
+
+            foreach (var referencedProject in referencedProjectIds)
+            {
+                if (builder.TryGetValue(referencedProject, out var reverseReferences))
+                {
+                    builder[referencedProject] = reverseReferences.Add(projectId);
+                }
+                else
+                {
+                    builder[referencedProject] = ImmutableHashSet.Create(projectId);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        /// <summary>
+        /// Computes a new <see cref="_transitiveReferencesMap"/> for the addition of additional project references. 
+        /// </summary>
+        private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewTransitiveReferencesMapForAdditionalProjectReferences(
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingTransitiveReferencesMap,
+            ProjectId projectId,
+            IReadOnlyList<ProjectId> referencedProjectIds)
+        {
+            // To update our forward transitive map, we need to add referencedProjectIds (and their transitive dependencies) to the transitive references
+            // of projects. First, let's just compute the new set of transitive references. It's possible while doing so we'll discover that we don't
+            // know the transitive project references for one of our new references. In that case, we'll use null as a sentinel to mean "we don't know" and
+            // we propogate the not-knowingness. But let's not worry about that yet. First, let's just get the new transitive reference set.
+            var newTransitiveReferences = new HashSet<ProjectId>(referencedProjectIds);
+
+            foreach (var referencedProjectId in referencedProjectIds)
+            {
+                if (existingTransitiveReferencesMap.TryGetValue(referencedProjectId, out var additionalTransitiveReferences))
+                {
+                    newTransitiveReferences.UnionWith(additionalTransitiveReferences);
+                }
+                else
+                {
+                    newTransitiveReferences = null;
+                    break;
+                }
+            }
+
+            // We'll now loop through each entry in our existing cache and compute updates. We'll accumulate them into this builder.
+            var builder = existingTransitiveReferencesMap.ToBuilder();
+
+            foreach (var projectIdToUpdate in existingTransitiveReferencesMap.Keys)
+            {
+                existingTransitiveReferencesMap.TryGetValue(projectIdToUpdate, out var existingTransitiveReferences);
+
+                // The projects who need to have their caches updated are projectIdToUpdate (since we're obviously updating it!)
+                // and also anything that depended on us.
+                if (projectIdToUpdate == projectId || existingTransitiveReferences?.Contains(projectId) == true)
+                {
+                    // This needs an update. If we know what to include in, we'll union it with the existing ones. Otherwise, we don't know
+                    // and we'll remove any data from the cache.
+                    if (newTransitiveReferences != null && existingTransitiveReferences != null)
+                    {
+                        builder[projectIdToUpdate] = existingTransitiveReferences.Union(newTransitiveReferences);
+                    }
+                    else
+                    {
+                        // Either we don't know the full set of the new references being added, or don't know the existing set projectIdToUpdate.
+                        // In this case, just remove it
+                        builder.Remove(projectIdToUpdate);
+                    }
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        /// <summary>
+        /// Computes a new <see cref="_reverseTransitiveReferencesMap"/> for the addition of new projects.
+        /// </summary>
+        private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewReverseTransitiveReferencesMapForAdditionalProjectReferences(
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingReverseTransitiveReferencesMap,
+            ProjectId projectId,
+            IReadOnlyList<ProjectId> referencedProjectIds)
+        {
+            // To update the reverse transitive map, we need to add the existing reverse transitive references of projectId to any of referencedProjectIds,
+            // and anything else with a reverse dependency on them. If we don't already know our reverse transitive references, then we'll have to instead remove
+            // the cache entries instead of update them. We'll fetch this from the map, and use "null" to indicate the "we don't know and should remove the cache entry"
+            // instead
+            existingReverseTransitiveReferencesMap.TryGetValue(projectId, out var newReverseTranstiveReferences);
+
+            if (newReverseTranstiveReferences != null)
+            {
+                newReverseTranstiveReferences = newReverseTranstiveReferences.Add(projectId);
+            }
+
+            // We'll now loop through each entry in our existing cache and compute updates. We'll accumulate them into this builder.
+            var builder = existingReverseTransitiveReferencesMap.ToBuilder();
+
+            foreach (var projectIdToUpdate in existingReverseTransitiveReferencesMap.Keys)
+            {
+                existingReverseTransitiveReferencesMap.TryGetValue(projectIdToUpdate, out var existingReverseTransitiveReferences);
+
+                // The projects who need to have their caches updated are projectIdToUpdate (since we're obviously updating it!)
+                // and also anything that depended on us.
+                if (referencedProjectIds.Contains(projectIdToUpdate) || existingReverseTransitiveReferences?.Overlaps(referencedProjectIds) == true)
+                {
+                    // This needs an update. If we know what to include in, we'll union it with the existing ones. Otherwise, we don't know
+                    // and we'll remove any data from the cache.
+                    if (newReverseTranstiveReferences != null && existingReverseTransitiveReferences != null)
+                    {
+                        builder[projectIdToUpdate] = existingReverseTransitiveReferences.Union(newReverseTranstiveReferences);
+                    }
+                    else
+                    {
+                        // Either we don't know the full set of the new references being added, or don't know the existing set projectIdToUpdate.
+                        // In this case, just remove it
+                        builder.Remove(projectIdToUpdate);
+                    }
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        internal ProjectDependencyGraph WithProjectReferences(ProjectId projectId, IEnumerable<ProjectId> referencedProjectIds)
+        {
+            // This method we can't optimize very well: changing project references arbitrarily could invalidate pretty much anything. The only thing we can reuse is our
+            // actual map of project references for all the other projects, so we'll do that
+            return new ProjectDependencyGraph(_projectIds, _referencesMap.SetItem(projectId, referencedProjectIds.ToImmutableHashSet()));
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -471,14 +471,6 @@ namespace Microsoft.CodeAnalysis
             return project1.LanguageServices == project2.LanguageServices;
         }
 
-        public ProjectState AddProjectReference(ProjectReference projectReference)
-        {
-            Debug.Assert(!this.ProjectReferences.Contains(projectReference));
-
-            return this.With(
-                projectInfo: this.ProjectInfo.WithProjectReferences(this.ProjectReferences.ToImmutableArray().Add(projectReference)).WithVersion(this.Version.GetNewerVersion()));
-        }
-
         public ProjectState RemoveProjectReference(ProjectReference projectReference)
         {
             Debug.Assert(this.ProjectReferences.Contains(projectReference));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -401,7 +401,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public Solution AddProjectReference(ProjectId projectId, ProjectReference projectReference)
         {
-            var newState = _state.AddProjectReference(projectId, projectReference);
+            var newState = _state.AddProjectReferences(projectId, SpecializedCollections.SingletonEnumerable(projectReference));
             if (newState == _state)
             {
                 return this;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1537,7 +1537,7 @@ namespace Microsoft.CodeAnalysis
                     state.ProjectReferences.Where(pr => projectStates.ContainsKey(pr.ProjectId)).Select(pr => pr.ProjectId).ToImmutableHashSet()))
                     .ToImmutableDictionary();
 
-            return new ProjectDependencyGraph(projectIds.ToImmutableArray(), map);
+            return new ProjectDependencyGraph(projectIds.ToImmutableHashSet(), map);
         }
 
         private ImmutableDictionary<ProjectId, CompilationTracker> CreateCompilationTrackerMap(ProjectId projectId, ProjectDependencyGraph dependencyGraph)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -804,35 +804,6 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Create a new solution instance with the project specified updated to include
-        /// the specified project reference.
-        /// </summary>
-        public SolutionState AddProjectReference(ProjectId projectId, ProjectReference projectReference)
-        {
-            if (projectId == null)
-            {
-                throw new ArgumentNullException(nameof(projectId));
-            }
-
-            if (projectReference == null)
-            {
-                throw new ArgumentNullException(nameof(projectReference));
-            }
-
-            CheckContainsProject(projectId);
-            CheckContainsProject(projectReference.ProjectId);
-            CheckNotContainsProjectReference(projectId, projectReference);
-            CheckNotContainsTransitiveReference(projectReference.ProjectId, projectId);
-
-            CheckNotSecondSubmissionReference(projectId, projectReference.ProjectId);
-
-            var oldProject = this.GetProjectState(projectId);
-            var newProject = oldProject.AddProjectReference(projectReference);
-
-            return this.ForkProject(newProject, withProjectReferenceChange: true);
-        }
-
-        /// <summary>
-        /// Create a new solution instance with the project specified updated to include
         /// the specified project references.
         /// </summary>
         public SolutionState AddProjectReferences(ProjectId projectId, IEnumerable<ProjectReference> projectReferences)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1723,24 +1723,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected void CheckProjectDoesNotHaveTransitiveProjectReference(ProjectId fromProjectId, ProjectId toProjectId)
         {
-            var transitiveReferences = GetTransitiveProjectReferences(toProjectId);
+            var transitiveReferences = this.CurrentSolution.GetProjectDependencyGraph().GetProjectsThatThisProjectTransitivelyDependsOn(toProjectId);
             if (transitiveReferences.Contains(fromProjectId))
             {
                 throw new ArgumentException(string.Format(
                     WorkspacesResources.Adding_project_reference_from_0_to_1_will_cause_a_circular_reference,
                     this.GetProjectName(fromProjectId), this.GetProjectName(toProjectId)));
             }
-        }
-
-        private ISet<ProjectId> GetTransitiveProjectReferences(ProjectId project, ISet<ProjectId> projects = null)
-        {
-            projects = projects ?? new HashSet<ProjectId>();
-            if (projects.Add(project))
-            {
-                this.CurrentSolution.GetProject(project).ProjectReferences.Do(p => GetTransitiveProjectReferences(p.ProjectId, projects));
-            }
-
-            return projects;
         }
 
         /// <summary>

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
@@ -152,6 +152,27 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestTransitiveReferencesIncrementalUpdateInMiddleLongerChain()
+        {
+            // We are going to create a solution with the references:
+            //
+            // A -> B -> C   D -> E -> F
+            //
+            // but we will add the C-> D link last, to verify that when we add the C to D link we update the references of A. This is similar
+            // to the previous test but with a longer chain.
+
+            var solution = CreateSolutionFromReferenceMap("A:B B:C C D:E E:F F");
+            VerifyTransitiveReferences(solution, "A", new string[] { "B", "C" });
+            VerifyTransitiveReferences(solution, "B", new string[] { "C" });
+            VerifyTransitiveReferences(solution, "D", new string[] { "E", "F" });
+            VerifyTransitiveReferences(solution, "E", new string[] { "F" });
+
+            solution = AddProjectReferences(solution, "C", new string[] { "D" });
+
+            VerifyTransitiveReferences(solution, "A", new string[] { "B", "C", "D", "E", "F" });
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestTransitiveReferencesIncrementalUpdateWithReferencesAlreadyTransitivelyIncluded()
         {
             // We are going to create a solution with the references:

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
@@ -122,12 +122,6 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
 
         #region Helpers
 
-        private ProjectDependencyGraph CreateGraph(string projectReferences)
-        {
-            var solution = CreateSolutionFromReferenceMap(projectReferences);
-            return solution.GetProjectDependencyGraph();
-        }
-
         private Solution CreateSolutionFromReferenceMap(string projectReferences)
         {
             Solution solution = CreateSolution();

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
         {
             Solution solution = CreateSolution();
 
-            var references = new Dictionary<string, List<string>>();
+            var references = new Dictionary<string, IEnumerable<string>>();
             var projects = new Dictionary<string, ProjectId>();
 
             var projectDefinitions = projectReferences.Split(' ');
@@ -147,16 +147,7 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
                 string projectName = projectDefinitionParts[0];
                 if (referencedProjectNames != null)
                 {
-                    foreach (var referencedProjectName in referencedProjectNames)
-                    {
-                        if (!references.TryGetValue(projectName, out var bucket))
-                        {
-                            bucket = new List<string>();
-                            references.Add(projectName, bucket);
-                        }
-
-                        bucket.Add(referencedProjectName);
-                    }
+                    references.Add(projectName, referencedProjectNames);
                 }
 
                 ProjectId projectId = AddProject(ref solution, projectName);

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
@@ -130,7 +130,6 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
             var projects = new Dictionary<string, ProjectId>();
 
             var projectDefinitions = projectReferences.Split(' ');
-            int index = 0;
             foreach (var projectDefinition in projectDefinitions)
             {
                 var projectDefinitionParts = projectDefinition.Split(':');
@@ -160,8 +159,7 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
                     }
                 }
 
-                ProjectId projectId = AddProject(ref solution, index, projectName);
-                index++;
+                ProjectId projectId = AddProject(ref solution, projectName);
                 projects.Add(projectName, projectId);
             }
 
@@ -173,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
             return solution;
         }
 
-        private static ProjectId AddProject(ref Solution solution, int index, string projectName)
+        private static ProjectId AddProject(ref Solution solution, string projectName)
         {
             ProjectId projectId = ProjectId.CreateNewId(debugName: projectName);
             solution = solution.AddProject(ProjectInfo.Create(projectId, VersionStamp.Create(), projectName, projectName, LanguageNames.CSharp, projectName));

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
         #region GetTopologicallySortedProjects
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void ProjectDependencyGraph_GetTopologicallySortedProjects()
+        public void TestGetTopologicallySortedProjects()
         {
             VerifyTopologicalSort("A", "A");
             VerifyTopologicalSort("A B", "AB", "BA");
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         [WorkItem(542438, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542438")]
-        public void ProjectDependencyGraph_GetDependencySets()
+        public void TestGetDependencySets()
         {
             VerifyDependencySets("A B:A C:A D E:D F:D", "ABC DEF");
             VerifyDependencySets("A B:A,C C", "ABC");
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
         #region GetProjectsThatThisProjectTransitivelyDependsOn
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void ProjectDependencyGraph_GetProjectsThatThisProjectTransitivelyDependsOn()
+        public void TestGetProjectsThatThisProjectTransitivelyDependsOn()
         {
             VerifyTransitiveReferences(CreateSolutionFromReferenceMap("A"), "A", new string[] { });
             VerifyTransitiveReferences(CreateSolutionFromReferenceMap("B:A A"), "B", new string[] { "A" });
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
         #region GetProjectsThatTransitivelyDependOnThisProject
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void ProjectDependencyGraph_GetProjectsThatTransitivelyDependOnThisProject()
+        public void TestGetProjectsThatTransitivelyDependOnThisProject()
         {
             VerifyReverseTransitiveReferences(CreateSolutionFromReferenceMap("A"), "A", new string[] { });
             VerifyReverseTransitiveReferences(CreateSolutionFromReferenceMap("B:A A"), "A", new string[] { "B" });

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
@@ -70,15 +70,14 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void ProjectDependencyGraph_GetProjectsThatThisProjectTransitivelyDependsOn()
         {
-            VerifyTransitiveReferences("A", "A", new string[] { });
-            VerifyTransitiveReferences("B:A A", "B", new string[] { "A" });
-            VerifyTransitiveReferences("C:B B:A A", "C", new string[] { "B", "A" });
-            VerifyTransitiveReferences("C:B B:A A", "A", new string[] { });
+            VerifyTransitiveReferences(CreateSolutionFromReferenceMap("A"), "A", new string[] { });
+            VerifyTransitiveReferences(CreateSolutionFromReferenceMap("B:A A"), "B", new string[] { "A" });
+            VerifyTransitiveReferences(CreateSolutionFromReferenceMap("C:B B:A A"), "C", new string[] { "B", "A" });
+            VerifyTransitiveReferences(CreateSolutionFromReferenceMap("C:B B:A A"), "A", new string[] { });
         }
 
-        private void VerifyTransitiveReferences(string projectReferences, string project, string[] expectedResults)
+        private void VerifyTransitiveReferences(Solution solution, string project, string[] expectedResults)
         {
-            Solution solution = CreateSolutionFromReferenceMap(projectReferences);
             var projectDependencyGraph = solution.GetProjectDependencyGraph();
             var projectId = solution.GetProjectsByName(project).Single().Id;
             var projectIds = projectDependencyGraph.GetProjectsThatThisProjectTransitivelyDependsOn(projectId);
@@ -97,16 +96,15 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void ProjectDependencyGraph_GetProjectsThatTransitivelyDependOnThisProject()
         {
-            VerifyReverseTransitiveReferences("A", "A", new string[] { });
-            VerifyReverseTransitiveReferences("B:A A", "A", new string[] { "B" });
-            VerifyReverseTransitiveReferences("C:B B:A A", "A", new string[] { "B", "C" });
-            VerifyReverseTransitiveReferences("C:B B:A A", "C", new string[] { });
-            VerifyReverseTransitiveReferences("D:C,B B:A C A", "A", new string[] { "D", "B" });
+            VerifyReverseTransitiveReferences(CreateSolutionFromReferenceMap("A"), "A", new string[] { });
+            VerifyReverseTransitiveReferences(CreateSolutionFromReferenceMap("B:A A"), "A", new string[] { "B" });
+            VerifyReverseTransitiveReferences(CreateSolutionFromReferenceMap("C:B B:A A"), "A", new string[] { "B", "C" });
+            VerifyReverseTransitiveReferences(CreateSolutionFromReferenceMap("C:B B:A A"), "C", new string[] { });
+            VerifyReverseTransitiveReferences(CreateSolutionFromReferenceMap("D:C,B B:A C A"), "A", new string[] { "D", "B" });
         }
 
-        private void VerifyReverseTransitiveReferences(string projectReferences, string project, string[] expectedResults)
+        private void VerifyReverseTransitiveReferences(Solution solution, string project, string[] expectedResults)
         {
-            Solution solution = CreateSolutionFromReferenceMap(projectReferences);
             var projectDependencyGraph = solution.GetProjectDependencyGraph();
             var projectId = solution.GetProjectsByName(project).Single().Id;
             var projectIds = projectDependencyGraph.GetProjectsThatTransitivelyDependOnThisProject(projectId);

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
@@ -254,6 +254,25 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
             VerifyTransitiveReferences(solution, "A", new string[] { "B" });
         }
 
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestTransitiveReferencesWithMultipleReferences()
+        {
+            // We are going to create a solution with the references:
+            //
+            // A    B -> C    D -> E
+            //
+            // and then add A referencing B and D in one call, to make sure that works.
+
+            var solution = CreateSolutionFromReferenceMap("A B:C C D:E E");
+            VerifyTransitiveReferences(solution, "A", new string[] { });
+
+            solution = AddProjectReferences(solution, "A", new string[] { "B", "D" });
+
+            VerifyDirectReferences(solution, "A", new string[] { "B", "D" });
+            VerifyTransitiveReferences(solution, "A", new string[] { "B", "C", "D", "E" });
+        }
+
         private void VerifyDirectReferences(Solution solution, string project, string[] expectedResults)
         {
             var projectDependencyGraph = solution.GetProjectDependencyGraph();


### PR DESCRIPTION
This set of changes enables us to incrementally update the ProjectDependencyGraph rather than throwing it away and recomputing it each time we make any change to the topology of our solution. In the CPS case (where right now we aren't doing smarter batching right now, so each individual reference triggers a recompute), this eliminates almost two seconds of CPU time. I fully contend that's an extreme example (and yes, we will still fix the batching problem), but the hope by attacking this directly is we still make improvements where the direct batching might not be so useful. In the examples given by #25823, there may still be multiple times in a large solution where we end up adding a project references (but only a few) to a bunch of projects; even if we do one batch per project that's still not a great reason to throw this out and recompute everything again.

I strongly suggest you review a commit at a time, which will make the series of changes pretty straightforward.

Prior to the change, the state of the world was any topology change would result in us creating a new dependency graph from scratch. We did this by:

1. Walking the SolutionState to produce a new `ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>`. This rewalking alone counted for about a second of CPU time.
2. Creating the new ProjectDependencyGraph with this directly. Note, everything else was "lazy", but...
3. We would then have to create a new CompilationTracker map. This caused us to ask for reverse transitive references, causing us to realize the "lazy" reverse project reference map every time, so the laziness was worthless. This map is the reverse of the `ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>`, so every topology change was computing the full reverse one in addition to the forward one...every time.
4. We'd then actually compute the reverse transitive information in some cases.

This resulted in huge allocations, even when it didn't make sense. See @davkean's bug #25823 for a few examples.

The primary win of this change is instead of steps 1 and 3, where we recreated the direct project references and direct reverse project references every time from scratch, we just incrementally update them whenever we're adding a new reference. I suspect this is the result of most or perhaps all of the wins here. We try to also update the transitive and reverse transitive maps if we can easily do so; it's less clear to me right now if that's really helping much. In my testing right now it looks like we're occasionally getting a project reference _removal_ in my build, where we do still throw away everything.

My primary concern about this change would be whether this increases stable memory. What do I mean by that? Previously, we were actively throwing away the transitive data all the time; in practice it might have not been surviving very long. Now since we're incrementally updating it, this might actually be holding onto _more_ memory. If this becomes a concern, we could just throw away the transitive maps; this would bring us to the memory usage we had before, while still leaving all the wins we get from the direct map updates. Right now prior to this change we're churning so much memory it's just hard to say.

(Fixes #25823.)