### PR TITLE
Update SwixBuild to 1.0.422

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -18,7 +18,7 @@
     <LibGit2SharpVersion>0.22.0</LibGit2SharpVersion>
     <MicroBuildCoreVersion>0.2.0</MicroBuildCoreVersion>
     <MicroBuildCoreSentinelVersion>1.0.0</MicroBuildCoreSentinelVersion>
-    <MicroBuildPluginsSwixBuildVersion>1.0.295</MicroBuildPluginsSwixBuildVersion>
+    <MicroBuildPluginsSwixBuildVersion>1.0.422</MicroBuildPluginsSwixBuildVersion>
     <MicrosoftAzureKeyVaultVersion>2.0.6</MicrosoftAzureKeyVaultVersion>
     <MicrosoftBuildVersion>15.1.0-preview-000458-02</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>15.1.0-preview-000458-02</MicrosoftBuildFrameworkVersion>


### PR DESCRIPTION
This version includes now required `signers` entry to Willow package manifest.

### Customer scenario

VS now requires each payload has signer information with `subjectName` attached.

### Bugs this fixes

[VSO 642948](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/Acquisition%20Foundation/_workitems/edit/642948)

### Workarounds, if any

### Risk

### Performance impact

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

### Test documentation updated?
