### PR TITLE
Fix discard symbol for declaration pattern

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1967,7 +1967,7 @@ namespace Microsoft.CodeAnalysis.Operations
             ISymbol variable = boundDeclarationPattern.Variable;
             if (variable == null && boundDeclarationPattern.VariableAccess.Kind == BoundKind.DiscardExpression)
             {
-                variable = (IDiscardSymbol)(((BoundDiscardExpression)boundDeclarationPattern.VariableAccess).ExpressionSymbol);
+                variable = ((BoundDiscardExpression)boundDeclarationPattern.VariableAccess).ExpressionSymbol;
             }
 
             SyntaxNode syntax = boundDeclarationPattern.Syntax;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1965,6 +1965,11 @@ namespace Microsoft.CodeAnalysis.Operations
         private IDeclarationPatternOperation CreateBoundDeclarationPatternOperation(BoundDeclarationPattern boundDeclarationPattern)
         {
             ISymbol variable = boundDeclarationPattern.Variable;
+            if (variable == null && boundDeclarationPattern.VariableAccess.Kind == BoundKind.DiscardExpression)
+            {
+                variable = (IDiscardSymbol)(((BoundDiscardExpression)boundDeclarationPattern.VariableAccess).ExpressionSymbol);
+            }
+
             SyntaxNode syntax = boundDeclarationPattern.Syntax;
             ITypeSymbol type = null;
             Optional<object> constantValue = default(Optional<object>);


### PR DESCRIPTION


### Customer scenario

Get control flow graph for this code:

```csharp
class C
{
    static void M(object o)
    /*<bind>*/
    {
        if (o is var _)
        {
            return;
        }
    }/*</bind>*/
}
```

### Issue this fixes

#27086

### Workarounds, if any
none

### Risk
low

### Performance impact
low, very small change

### Is this a regression from a previous update?
no

### Root cause analysis


### Test documentation updated?
n/a
