### PR TITLE
Update project files to not references C# or VB.

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -79,13 +79,11 @@
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Desktop\Workspaces.Desktop.csproj" />
-    <ProjectReference Include="..\..\..\Workspaces\CSharp\Portable\CSharpWorkspace.csproj" />
     <ProjectReference Include="..\..\..\EditorFeatures\Core\EditorFeatures.csproj" />
     <ProjectReference Include="..\..\..\EditorFeatures\Core.Wpf\EditorFeatures.Wpf.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Workspaces.csproj" />
     <ProjectReference Include="..\..\..\Features\Core\Portable\Features.csproj" />
     <ProjectReference Include="..\..\..\EditorFeatures\Text\TextEditorFeatures.csproj" />
-    <ProjectReference Include="..\..\..\Workspaces\VisualBasic\Portable\BasicWorkspace.vbproj" />
   </ItemGroup>
   <ItemGroup Label="File References">
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
+++ b/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
@@ -4,12 +4,10 @@
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Desktop\Workspaces.Desktop.csproj" />
-    <ProjectReference Include="..\..\..\Workspaces\CSharp\Portable\CSharpWorkspace.csproj" />
     <ProjectReference Include="..\..\..\EditorFeatures\Core\EditorFeatures.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Workspaces.csproj" />
     <ProjectReference Include="..\..\..\Features\Core\Portable\Features.csproj" />
     <ProjectReference Include="..\..\..\EditorFeatures\Text\TextEditorFeatures.csproj" />
-    <ProjectReference Include="..\..\..\Workspaces\VisualBasic\Portable\BasicWorkspace.vbproj" />
     <ProjectReference Include="..\Def\ServicesVisualStudio.csproj" />
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/28468

Tagging @jasonmalinowski 

~~Note: this doesn't work for me locally because whne i clean and try to build the project now i get:~~

```
8>------ Build started: Project: ServicesVisualStudio, Configuration: Debug Any CPU ------
8>CSC : error CS0006: Metadata file 'C:\GitHub\roslyn-internal\roslyn\Binaries\Debug\Dlls\CSharpCodeAnalysis\Microsoft.CodeAnalysis.CSharp.dll' could not be found
8>CSC : error CS0006: Metadata file 'C:\GitHub\roslyn-internal\roslyn\Binaries\Debug\Dlls\BasicCodeAnalysis\Microsoft.CodeAnalysis.VisualBasic.dll' could not be found
```

~~But i can't figure out why ServicesVisualStudio thinks it needs these dlls...~~

Update.  This builds fine after a ```restore```.