### PR TITLE
Return Completion.Empty when the service is null

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Completion/Presentation/CustomCommitCompletion.cs
+++ b/src/EditorFeatures/Core.Wpf/Completion/Presentation/CustomCommitCompletion.cs
@@ -57,7 +57,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
         public Task<CompletionDescription> GetDescriptionAsync(CancellationToken cancellationToken)
         {
             var service = CompletionService.GetService(this.CompletionItem.Document);
-            return service?.GetDescriptionAsync(this.CompletionItem.Document, this.CompletionItem, cancellationToken);
+            return service == null ?
+                Task.FromResult(CompletionDescription.Empty) :
+                service.GetDescriptionAsync(this.CompletionItem.Document, this.CompletionItem, cancellationToken);
         }
 
         public string GetDescription_TestingOnly()


### PR DESCRIPTION
### Customer scenario

Scrolling too far up on completion window in suggestion mode throws NullReferenceException.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/23890

### Workarounds, if any

None.

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

Dogfooding.

### Test documentation updated?
