### PR TITLE
Add support to save current tools options into an .editorconfig file

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -9,5 +9,6 @@
     <add key="enabled" value="false" />
   </packageRestore>
   <packageSources>
-    <clear /></packageSources>
+    <clear />
+  </packageSources>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -9,6 +9,5 @@
     <add key="enabled" value="false" />
   </packageRestore>
   <packageSources>
-    <clear />
-  </packageSources>
+    <clear /></packageSources>
 </configuration>

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -26,9 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
         internal static void GetCurrentEditorConfigOptionsCSharp(OptionSet optionSet, StringBuilder editorconfig)
         {
             editorconfig.AppendLine();
-            editorconfig.AppendLine("###############################");
-            editorconfig.AppendLine("# C# Coding Conventions       #");
-            editorconfig.AppendLine("###############################");
+            editorconfig.AppendLine("# C# Coding Conventions");
 
             editorconfig.AppendLine("# var preferences");
             // csharp_style_var_for_built_in_types
@@ -86,9 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInlinedVariableDeclaration, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("###############################");
-            editorconfig.AppendLine("# C# Formatting Rules         #");
-            editorconfig.AppendLine("###############################");
+            editorconfig.AppendLine("# C# Formatting Rules");
             editorconfig.AppendLine("# New line preferences");
             // csharp_new_line_before_open_brace
             CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(optionSet, editorconfig);

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             editorconfig.AppendLine();
             editorconfig.AppendLine("# C# Coding Conventions");
 
-            editorconfig.AppendLine("# var preferences");
+            editorconfig.AppendLine("# " + CSharpVSResources.var_preferences_colon);
             // csharp_style_var_for_built_in_types
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, editorconfig);
             // csharp_style_var_when_type_is_apparent
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeWherePossible, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Expression-bodied members");
+            editorconfig.AppendLine("# Expression-bodied members:");
             // csharp_style_expression_bodied_methods
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedMethods, editorconfig);
             // csharp_style_expression_bodied_constructors
@@ -58,26 +58,26 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Pattern matching preferences");
+            editorconfig.AppendLine("# Pattern matching preferences:");
             // csharp_style_pattern_matching_over_is_with_cast_check
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck, editorconfig);
             // csharp_style_pattern_matching_over_as_with_null_check
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Null-checking preferences");
+            editorconfig.AppendLine("# Null-checking preferences:");
             // csharp_style_throw_expression
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferThrowExpression, editorconfig);
             // csharp_style_conditional_delegate_call
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferConditionalDelegateCall, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Modifier preferences");
+            editorconfig.AppendLine("# Modifier preferences:");
             // csharp_preferred_modifier_order
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferredModifierOrder, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Expression-level preferences");
+            editorconfig.AppendLine("# Expression-level preferences:");
             // csharp_prefer_braces
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferBraces, editorconfig);
             // csharp_style_deconstructed_variable_declaration
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 
             editorconfig.AppendLine();
             editorconfig.AppendLine("# C# Formatting Rules");
-            editorconfig.AppendLine("# New line preferences");
+            editorconfig.AppendLine("# New line preferences:");
             // csharp_new_line_before_open_brace
             CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(optionSet, editorconfig);
             // csharp_new_line_before_else
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.NewLineForClausesInQuery, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Indentation preferences");
+            editorconfig.AppendLine("# Indentation preferences:");
             // csharp_indent_case_contents
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.IndentSwitchCaseSection, editorconfig);
             // chsarp_indent_switch_labels
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.LabelPositioning, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Space preferences");
+            editorconfig.AppendLine("# Space preferences:");
             // csharp_space_after_cast
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceAfterCast, editorconfig);
             // csharp_space_after_keywords_in_control_flow_statements
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceBetweenEmptyMethodCallParentheses, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Wrapping preferences");
+            editorconfig.AppendLine("# Wrapping preferences:");
             // csharp_preserve_single_line_statements
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine, editorconfig);
             // csharp_preserve_single_line_blocks
@@ -151,18 +151,18 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 
         private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<bool> option, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<bool>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<bool>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
 
-                editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForElse).ToString().ToLower());
+                editorconfig.AppendLine(optionSet.GetOption(option).ToString().ToLower());
             }
         }
 
         private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<CodeStyleOption<bool>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<bool>>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 
         private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<bool>> option, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<CodeStyleOption<bool>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<bool>>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -186,7 +186,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 
         private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<string>> option, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<CodeStyleOption<string>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<string>>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -198,7 +198,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 
         private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<ExpressionBodyPreference>> option, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -208,16 +208,24 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                 {
                     editorconfig.AppendLine("false" + ":" + curSetting.Notification.ToString().ToLower());
                 }
-                else
+                else if (curSetting.Value == ExpressionBodyPreference.WhenPossible)
                 {
                     editorconfig.AppendLine("true" + ":" + curSetting.Notification.ToString().ToLower());
+                }
+                else if (curSetting.Value == ExpressionBodyPreference.WhenOnSingleLine)
+                {
+                    editorconfig.AppendLine("when_on_single_line" + ":" + curSetting.Notification.ToString().ToLower());
+                }
+                else
+                {
+                    throw new NotSupportedException();
                 }
             }
         }
 
         private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<LabelPositionOptions> option, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<LabelPositionOptions>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<LabelPositionOptions>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -230,16 +238,20 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                 {
                     editorconfig.AppendLine("one_less_than_current");
                 }
-                else
+                else if (curSetting == LabelPositionOptions.NoIndent)
                 {
                     editorconfig.AppendLine("no_change");
+                }
+                else
+                {
+                    throw new NotSupportedException();
                 }
             }
         }
 
         private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<BinaryOperatorSpacingOptions> option, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<BinaryOperatorSpacingOptions>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<BinaryOperatorSpacingOptions>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -252,16 +264,20 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                 {
                     editorconfig.AppendLine("none");
                 }
-                else
+                else if (curSetting == BinaryOperatorSpacingOptions.Ignore)
                 {
                     editorconfig.AppendLine("ignore");
+                }
+                else
+                {
+                    throw new NotSupportedException();
                 }
             }
         }
 
         private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<bool>)CSharpFormattingOptions.SpaceWithinOtherParentheses.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = CSharpFormattingOptions.SpaceWithinOtherParentheses.StorageLocations.OfType<EditorConfigStorageLocation<bool>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -312,7 +328,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 
         private static void CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<bool>)CSharpFormattingOptions.NewLinesForBracesInAccessors.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = CSharpFormattingOptions.NewLinesForBracesInAccessors.StorageLocations.OfType<EditorConfigStorageLocation<bool>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
     {
         protected override AbstractOptionPageControl CreateOptionPage(IServiceProvider serviceProvider)
         {
-            return new GridOptionPreviewControl(serviceProvider, (o, s) => new StyleViewModel(o, s), GetCurrentEditorConfigOptionsString);
+            return new GridOptionPreviewControl(serviceProvider, (o, s) => new StyleViewModel(o, s), GetCurrentEditorConfigOptionsString, LanguageNames.CSharp);
         }
 
         internal static string GetCurrentEditorConfigOptionsString(OptionSet optionSet)
@@ -54,22 +54,22 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             editorconfig.AppendLine();
             // this. preferences
             editorconfig.AppendLine("# this. preferences");
-            editorconfig.Append("dotnet_style_qualification_for_field = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyFieldAccess));
-            editorconfig.Append("dotnet_style_qualification_for_property = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess));
-            editorconfig.Append("dotnet_style_qualification_for_method = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyMethodAccess));
-            editorconfig.Append("dotnet_style_qualification_for_event = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess));
+            // dotnet_style_qualification_for_field
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyFieldAccess, editorconfig);
+            // dotnet_style_qualification_for_property
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess, editorconfig);
+            // dotnet_style_qualification_for_method
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyMethodAccess, editorconfig);
+            // dotnet_style_qualification_for_event
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyEventAccess, editorconfig);
 
             editorconfig.AppendLine();
             // Language keywords vs. BCL types preferences
             editorconfig.AppendLine("# Language keywords vs BCL types preferences");
-            editorconfig.Append("dotnet_style_predefined_type_for_locals_parameters_members = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration));
-            editorconfig.Append("dotnet_style_predefined_type_for_member_access = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess));
+            // dotnet_style_predefined_type_for_locals_parameters_members
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, editorconfig);
+            // dotnet_style_predefined_type_for_member_access
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, editorconfig);
 
             editorconfig.AppendLine();
             // Parentheses preferences
@@ -88,34 +88,34 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             editorconfig.AppendLine("# Modifier preferences");
             editorconfig.Append("dotnet_style_require_accessibility_modifiers = ");
             editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RequireAccessibilityModifiers));
-            editorconfig.Append("dotnet_style_readonly_field = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferReadonly));
+            // dotnet_style_readonly_field
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferReadonly, editorconfig);
 
             editorconfig.AppendLine();
             // Expression-level preferences
             editorconfig.AppendLine("# Expression-level preferences");
-            editorconfig.Append("dotnet_style_object_initializer = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferObjectInitializer));
-            editorconfig.Append("dotnet_style_collection_initializer = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCollectionInitializer));
-            editorconfig.Append("dotnet_style_explicit_tuple_names = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferExplicitTupleNames));
-            editorconfig.Append("dotnet_style_null_propagation = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferNullPropagation));
-            editorconfig.Append("dotnet_style_coalesce_expression = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCoalesceExpression));
-            editorconfig.Append("dotnet_style_prefer_is_null_check_over_reference_equality_method = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIsNullCheckOverReferenceEqualityMethod));
-            editorconfig.Append("dotnet_prefer_inferred_tuple_names = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredTupleNames));
-            editorconfig.Append("dotnet_prefer_inferred_anonymous_type_member_names = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredAnonymousTypeMemberNames));
-            editorconfig.Append("dotnet_style_prefer_auto_properties = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferAutoProperties));
-            editorconfig.Append("dotnet_style_prefer_conditional_expression_over_assignment = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverAssignment));
-            editorconfig.Append("dotnet_style_prefer_conditional_expression_over_return = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverReturn));
+            // dotnet_style_object_initializer
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferObjectInitializer, editorconfig);
+            // dotnet_style_collection_initializer
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCollectionInitializer, editorconfig);
+            // dotnet_style_explicit_tuple_names
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferExplicitTupleNames, editorconfig);
+            // dotnet_style_null_propagation
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferNullPropagation, editorconfig);
+            // dotnet_style_coalesce_expression
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCoalesceExpression, editorconfig);
+            // dotnet_style_prefer_is_null_check_over_reference_equality_method
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIsNullCheckOverReferenceEqualityMethod, editorconfig);
+            // dotnet_prefer_inferred_tuple_names
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredTupleNames, editorconfig);
+            // dotnet_prefer_inferred_anonymous_type_member_names
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredAnonymousTypeMemberNames, editorconfig);
+            // dotnet_style_prefer_auto_properties
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferAutoProperties, editorconfig);
+            // dotnet_style_prefer_conditional_expression_over_assignment
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverAssignment, editorconfig);
+            // dotnet_style_prefer_conditional_expression_over_return
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverReturn, editorconfig);
 
             editorconfig.AppendLine();
             // C# Coding Conventions
@@ -159,8 +159,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             editorconfig.AppendLine();
             // Null-checking preferences
             editorconfig.AppendLine("# Null-checking preferences");
-            editorconfig.Append("csharp_style_throw_expression = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferThrowExpression));
+            // csharp_style_throw_expression
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferThrowExpression, editorconfig);
             editorconfig.Append("csharp_style_conditional_delegate_call = ");
             editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferConditionalDelegateCall));
 
@@ -175,14 +175,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             editorconfig.AppendLine("# Expression-level preferences");
             editorconfig.Append("csharp_prefer_braces = ");
             editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferBraces));
-            editorconfig.Append("csharp_style_deconstructed_variable_declaration = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferDeconstructedVariableDeclaration));
+            // csharp_style_deconstructed_variable_declaration
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferDeconstructedVariableDeclaration, editorconfig);
             editorconfig.Append("csharp_prefer_simple_default_expression = ");
             editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferSimpleDefaultExpression));
             editorconfig.Append("csharp_style_pattern_local_over_anonymous_function = ");
             editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferLocalOverAnonymousFunction));
-            editorconfig.Append("csharp_style_inlined_variable_declaration = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInlinedVariableDeclaration));
+            // csharp_style_inlined_variable_declaration
+            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInlinedVariableDeclaration, editorconfig);
 
             editorconfig.AppendLine();
             // C# Formatting Rules
@@ -433,11 +433,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             return editorconfig;
         }
 
-        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option)
+        private static void DotNetCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option, StringBuilder editorconfig)
         {
+            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<bool>>) option.StorageLocations[0]).KeyName);
+            editorconfig.Append(" = ");
+
             var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
-            var editorconfig = curSetting.Value + ":" + curSetting.Notification;
-            return editorconfig.ToLower();
+            editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
         }
 
         private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<bool>> option)

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -19,243 +20,234 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
     {
         protected override AbstractOptionPageControl CreateOptionPage(IServiceProvider serviceProvider)
         {
-            return new GridOptionPreviewControl(serviceProvider, (o, s) => new StyleViewModel(o, s), GetCurrentEditorConfigOptionsString, LanguageNames.CSharp);
+            return new GridOptionPreviewControl(serviceProvider, (o, s) => new StyleViewModel(o, s), GetCurrentEditorConfigOptionsCSharp, LanguageNames.CSharp);
         }
 
-        internal static string GetCurrentEditorConfigOptionsString(OptionSet optionSet)
+        internal static void GetCurrentEditorConfigOptionsCSharp(OptionSet optionSet, StringBuilder editorconfig)
         {
-            var editorconfig = new StringBuilder();
-            // Core EditorConfig Options
-            editorconfig.AppendLine("###############################");
-            editorconfig.AppendLine("# Core EditorConfig Options   #");
-            editorconfig.AppendLine("###############################");
-            editorconfig.AppendLine("# You can uncomment the next line if this is your top-most .editorconfig file.");
-            editorconfig.AppendLine("# root = true");
-
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# C# files");
-            editorconfig.AppendLine("[*.cs]");
-            editorconfig.Append("indent_style = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, FormattingOptions.UseTabs));
-            editorconfig.Append("indent_size = ");
-            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.IndentationSize, LanguageNames.CSharp).ToString());
-            editorconfig.Append("insert_final_newline = ");
-            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.InsertFinalNewLine).ToString().ToLower());
-
-            editorconfig.AppendLine();
-            // .NET Coding Conventions
-            editorconfig.AppendLine("###############################");
-            editorconfig.AppendLine("# .NET Coding Conventions     #");
-            editorconfig.AppendLine("###############################");
-            editorconfig.AppendLine("# Organize usings");
-            editorconfig.Append("dotnet_sort_system_directives_first = ");
-            editorconfig.AppendLine(optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp).ToString().ToLower());
-
-            editorconfig.AppendLine();
-            // this. preferences
-            editorconfig.AppendLine("# this. preferences");
-            // dotnet_style_qualification_for_field
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyFieldAccess, editorconfig);
-            // dotnet_style_qualification_for_property
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess, editorconfig);
-            // dotnet_style_qualification_for_method
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyMethodAccess, editorconfig);
-            // dotnet_style_qualification_for_event
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyEventAccess, editorconfig);
-
-            editorconfig.AppendLine();
-            // Language keywords vs. BCL types preferences
-            editorconfig.AppendLine("# Language keywords vs BCL types preferences");
-            // dotnet_style_predefined_type_for_locals_parameters_members
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, editorconfig);
-            // dotnet_style_predefined_type_for_member_access
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, editorconfig);
-
-            editorconfig.AppendLine();
-            // Parentheses preferences
-            editorconfig.AppendLine("# Parentheses preferences");
-            editorconfig.Append("dotnet_style_parentheses_in_arithmetic_binary_operators = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.ArithmeticBinaryParentheses));
-            editorconfig.Append("dotnet_style_parentheses_in_relational_binary_operators = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RelationalBinaryParentheses));
-            editorconfig.Append("dotnet_style_parentheses_in_other_binary_operators = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.OtherBinaryParentheses));
-            editorconfig.Append("dotnet_style_parentheses_in_other_operators = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.OtherParentheses));
-
-            editorconfig.AppendLine();
-            // Modifier preferences
-            editorconfig.AppendLine("# Modifier preferences");
-            editorconfig.Append("dotnet_style_require_accessibility_modifiers = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RequireAccessibilityModifiers));
-            // dotnet_style_readonly_field
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferReadonly, editorconfig);
-
-            editorconfig.AppendLine();
-            // Expression-level preferences
-            editorconfig.AppendLine("# Expression-level preferences");
-            // dotnet_style_object_initializer
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferObjectInitializer, editorconfig);
-            // dotnet_style_collection_initializer
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCollectionInitializer, editorconfig);
-            // dotnet_style_explicit_tuple_names
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferExplicitTupleNames, editorconfig);
-            // dotnet_style_null_propagation
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferNullPropagation, editorconfig);
-            // dotnet_style_coalesce_expression
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCoalesceExpression, editorconfig);
-            // dotnet_style_prefer_is_null_check_over_reference_equality_method
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIsNullCheckOverReferenceEqualityMethod, editorconfig);
-            // dotnet_prefer_inferred_tuple_names
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredTupleNames, editorconfig);
-            // dotnet_prefer_inferred_anonymous_type_member_names
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredAnonymousTypeMemberNames, editorconfig);
-            // dotnet_style_prefer_auto_properties
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferAutoProperties, editorconfig);
-            // dotnet_style_prefer_conditional_expression_over_assignment
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverAssignment, editorconfig);
-            // dotnet_style_prefer_conditional_expression_over_return
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverReturn, editorconfig);
-
-            editorconfig.AppendLine();
-            // C# Coding Conventions
             editorconfig.AppendLine("###############################");
             editorconfig.AppendLine("# C# Coding Conventions       #");
             editorconfig.AppendLine("###############################");
 
-            // Var preferences
             editorconfig.AppendLine("# var preferences");
-            editorconfig.Append("csharp_style_var_for_built_in_types = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes));
-            editorconfig.Append("csharp_style_var_when_type_is_apparent = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeWhereApparent));
-            editorconfig.Append("csharp_style_var_elsewhere = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeWherePossible));
+            // csharp_style_var_for_built_in_types
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, editorconfig);
+            // csharp_style_var_when_type_is_apparent
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, editorconfig);
+            // csharp_style_var_elsewhere
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeWherePossible, editorconfig);
 
             editorconfig.AppendLine();
-            // Expression-bodied members
             editorconfig.AppendLine("# Expression-bodied members");
-            editorconfig.Append("csharp_style_expression_bodied_methods = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedMethods));
-            editorconfig.Append("csharp_style_expression_bodied_constructors = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedConstructors));
-            editorconfig.Append("csharp_style_expression_bodied_operators = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedOperators));
-            editorconfig.Append("csharp_style_expression_bodied_properties = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedProperties));
-            editorconfig.Append("csharp_style_expression_bodied_indexers = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedIndexers));
-            editorconfig.Append("csharp_style_expression_bodied_accessors = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedAccessors));
+            // csharp_style_expression_bodied_methods
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedMethods, editorconfig);
+            // csharp_style_expression_bodied_constructors
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, editorconfig);
+            // csharp_style_expression_bodied_operators
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedOperators, editorconfig);
+            // csharp_style_expression_bodied_properties
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedProperties, editorconfig);
+            // csharp_style_expression_bodied_indexers
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, editorconfig);
+            // csharp_style_expression_bodied_accessors
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, editorconfig);
 
             editorconfig.AppendLine();
-            // Pattern matching preferences
             editorconfig.AppendLine("# Pattern matching preferences");
-            editorconfig.Append("csharp_style_pattern_matching_over_is_with_cast_check = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck));
-            editorconfig.Append("csharp_style_pattern_matching_over_as_with_null_check = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck));
+            // csharp_style_pattern_matching_over_is_with_cast_check
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck, editorconfig);
+            // csharp_style_pattern_matching_over_as_with_null_check
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck, editorconfig);
 
             editorconfig.AppendLine();
-            // Null-checking preferences
             editorconfig.AppendLine("# Null-checking preferences");
             // csharp_style_throw_expression
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferThrowExpression, editorconfig);
-            editorconfig.Append("csharp_style_conditional_delegate_call = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferConditionalDelegateCall));
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferThrowExpression, editorconfig);
+            // csharp_style_conditional_delegate_call
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferConditionalDelegateCall, editorconfig);
 
             editorconfig.AppendLine();
-            // Modifier preferences
             editorconfig.AppendLine("# Modifier preferences");
-            editorconfig.Append("csharp_preferred_modifier_order = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferredModifierOrder));
+            // csharp_preferred_modifier_order
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferredModifierOrder, editorconfig);
 
             editorconfig.AppendLine();
-            // Expression-level preferences
             editorconfig.AppendLine("# Expression-level preferences");
-            editorconfig.Append("csharp_prefer_braces = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferBraces));
+            // csharp_prefer_braces
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferBraces, editorconfig);
             // csharp_style_deconstructed_variable_declaration
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferDeconstructedVariableDeclaration, editorconfig);
-            editorconfig.Append("csharp_prefer_simple_default_expression = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferSimpleDefaultExpression));
-            editorconfig.Append("csharp_style_pattern_local_over_anonymous_function = ");
-            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferLocalOverAnonymousFunction));
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferDeconstructedVariableDeclaration, editorconfig);
+            // csharp_prefer_simple_default_expression
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferSimpleDefaultExpression, editorconfig);
+            // csharp_style_pattern_local_over_anonymous_function
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferLocalOverAnonymousFunction, editorconfig);
             // csharp_style_inlined_variable_declaration
-            DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInlinedVariableDeclaration, editorconfig);
+            CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInlinedVariableDeclaration, editorconfig);
 
             editorconfig.AppendLine();
-            // C# Formatting Rules
             editorconfig.AppendLine("###############################");
             editorconfig.AppendLine("# C# Formatting Rules         #");
             editorconfig.AppendLine("###############################");
-
-            editorconfig.AppendLine();
-            // New line preferences
             editorconfig.AppendLine("# New line preferences");
-            editorconfig.Append("csharp_new_line_before_open_brace = ");
-            editorconfig.AppendLine(CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(optionSet));
-            editorconfig.Append("csharp_new_line_before_else = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForElse).ToString().ToLower());
-            editorconfig.Append("csharp_new_line_before_catch = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForCatch).ToString().ToLower());
-            editorconfig.Append("csharp_new_line_before_finally = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForFinally).ToString().ToLower());
-            editorconfig.Append("csharp_new_line_before_members_in_object_initializers = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForMembersInObjectInit).ToString().ToLower());
-            editorconfig.Append("csharp_new_line_before_members_in_anonymous_types = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForMembersInAnonymousTypes).ToString().ToLower());
-            editorconfig.Append("csharp_new_line_between_query_expression_clauses = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForClausesInQuery).ToString().ToLower());
+            // csharp_new_line_before_open_brace
+            CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(optionSet, editorconfig);
+            // csharp_new_line_before_else
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.NewLineForElse, editorconfig);
+            // csharp_new_line_before_catch
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.NewLineForCatch, editorconfig);
+            // csharp_new_line_before_finally
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.NewLineForFinally, editorconfig);
+            // csharp_new_line_before_members_in_object_initializers
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.NewLineForMembersInObjectInit, editorconfig);
+            // csharp_new_line_before_members_in_anonymous_types
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.NewLineForMembersInAnonymousTypes, editorconfig);
+            // csharp_new_line_between_query_expression_clauses
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.NewLineForClausesInQuery, editorconfig);
 
             editorconfig.AppendLine();
-            // Indentation preferences
             editorconfig.AppendLine("# Indentation preferences");
-            editorconfig.Append("csharp_indent_case_contents = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.IndentSwitchCaseSection).ToString().ToLower());
-            editorconfig.Append("csharp_indent_labels = ");
-            editorconfig.AppendLine(CSharpLabelPositioning_GenerateEditorconfig(optionSet.GetOption(CSharpFormattingOptions.LabelPositioning)));
+            // csharp_indent_case_contents
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.IndentSwitchCaseSection, editorconfig);
+            // chsarp_indent_switch_labels
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.IndentSwitchSection, editorconfig);
+            // csharp_indent_labels
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.LabelPositioning, editorconfig);
 
             editorconfig.AppendLine();
-            // Space preferences
             editorconfig.AppendLine("# Space preferences");
-            editorconfig.Append("csharp_space_after_cast = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceAfterCast).ToString().ToLower());
-            editorconfig.Append("csharp_space_after_keywords_in_control_flow_statements = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceAfterControlFlowStatementKeyword).ToString().ToLower());
-            editorconfig.Append("csharp_space_between_method_call_parameter_list_parentheses = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceWithinMethodCallParentheses).ToString().ToLower());
-            editorconfig.Append("csharp_space_between_method_declaration_parameter_list_parentheses = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceWithinMethodDeclarationParenthesis).ToString().ToLower());
-            editorconfig.Append("csharp_space_between_parentheses = ");
-            CSharpSpaceBetweenParentheses_GenerateEditorconfig(optionSet, editorconfig);
-            editorconfig.AppendLine();
-            editorconfig.Append("csharp_space_before_colon_in_inheritance_clause = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceBeforeColonInBaseTypeDeclaration).ToString().ToLower());
-            editorconfig.Append("csharp_space_after_colon_in_inheritance_clause = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceAfterColonInBaseTypeDeclaration).ToString().ToLower());
-            editorconfig.Append("csharp_space_around_binary_operators = ");
-            editorconfig.AppendLine(CSharpSpacingAroundBinaryOperator_GenerateEditorconfig(optionSet.GetOption(CSharpFormattingOptions.SpacingAroundBinaryOperator)));
-            editorconfig.Append("csharp_space_between_method_declaration_empty_parameter_list_parentheses = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceBetweenEmptyMethodDeclarationParentheses).ToString().ToLower());
-            editorconfig.Append("csharp_space_between_method_call_name_and_opening_parenthesis = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceAfterMethodCallName).ToString().ToLower());
-            editorconfig.Append("csharp_space_between_method_call_empty_parameter_list_parentheses = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceBetweenEmptyMethodCallParentheses).ToString().ToLower());
+            // csharp_space_after_cast
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceAfterCast, editorconfig);
+            // csharp_space_after_keywords_in_control_flow_statements
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceAfterControlFlowStatementKeyword, editorconfig);
+            // csharp_space_between_method_call_parameter_list_parentheses
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceWithinMethodCallParentheses, editorconfig);
+            // csharp_space_between_method_declaration_parameter_list_parentheses
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceWithinMethodDeclarationParenthesis, editorconfig);
+            // csharp_space_between_parentheses
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, editorconfig);
+            // csharp_space_before_colon_in_inheritance_clause
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceBeforeColonInBaseTypeDeclaration, editorconfig);
+            // csharp_space_after_colon_in_inheritance_clause
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceAfterColonInBaseTypeDeclaration, editorconfig);
+            // csharp_space_around_binary_operators
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpacingAroundBinaryOperator, editorconfig);
+            // csharp_space_between_method_declaration_empty_parameter_list_parentheses
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceBetweenEmptyMethodDeclarationParentheses, editorconfig);
+            // csharp_space_between_method_call_name_and_opening_parenthesis
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceAfterMethodCallName, editorconfig);
+            // csharp_space_between_method_call_empty_parameter_list_parentheses
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceBetweenEmptyMethodCallParentheses, editorconfig);
 
             editorconfig.AppendLine();
-            // Wrapping preferences
             editorconfig.AppendLine("# Wrapping preferences");
-            editorconfig.Append("csharp_preserve_single_line_statements = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine).ToString().ToLower());
-            editorconfig.Append("csharp_preserve_single_line_blocks = ");
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.WrappingPreserveSingleLine).ToString().ToLower());
-
-            return editorconfig.ToString();
+            // csharp_preserve_single_line_statements
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine, editorconfig);
+            // csharp_preserve_single_line_blocks
+            CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.WrappingPreserveSingleLine, editorconfig);
         }
 
-        private static void CSharpSpaceBetweenParentheses_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
+        private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<bool> option, StringBuilder editorconfig)
         {
+            editorconfig.Append(((EditorConfigStorageLocation<bool>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+
+            editorconfig.Append(" = ");
+
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForElse).ToString().ToLower());
+        }
+
+        private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option, StringBuilder editorconfig)
+        {
+            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<bool>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+
+            editorconfig.Append(" = ");
+
+            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
+            editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+        }
+
+        private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<bool>> option, StringBuilder editorconfig)
+        {
+            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<bool>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+
+            editorconfig.Append(" = ");
+
+            var curSetting = optionSet.GetOption(option);
+            editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+        }
+
+        private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<string>> option, StringBuilder editorconfig)
+        {
+            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<string>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+            editorconfig.Append(" = ");
+
+            var curSetting = optionSet.GetOption(option);
+            editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+        }
+
+        private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<ExpressionBodyPreference>> option, StringBuilder editorconfig)
+        {
+            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+
+            editorconfig.Append(" = ");
+
+            var curSetting = optionSet.GetOption(option);
+            if (curSetting.Value == ExpressionBodyPreference.Never)
+            {
+                editorconfig.AppendLine("false" + ":" + curSetting.Notification.ToString().ToLower());
+            }
+            else
+            {
+                editorconfig.AppendLine("true" + ":" + curSetting.Notification.ToString().ToLower());
+            }
+        }
+
+        private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<LabelPositionOptions> option, StringBuilder editorconfig)
+        {
+            editorconfig.Append(((EditorConfigStorageLocation<LabelPositionOptions>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+
+            editorconfig.Append(" = ");
+
+            var curSetting = optionSet.GetOption(option);
+            if (curSetting == LabelPositionOptions.LeftMost)
+            {
+                editorconfig.AppendLine("flush_left");
+            }
+            else if (curSetting == LabelPositionOptions.OneLess)
+            {
+                editorconfig.AppendLine("one_less_than_current");
+            }
+            else
+            {
+                editorconfig.AppendLine("no_change");
+            }
+        }
+
+        private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<BinaryOperatorSpacingOptions> option, StringBuilder editorconfig)
+        {
+            editorconfig.Append(((EditorConfigStorageLocation<BinaryOperatorSpacingOptions>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+            editorconfig.Append(" = ");
+
+            var curSetting = optionSet.GetOption(option);
+            if (curSetting == BinaryOperatorSpacingOptions.Single)
+            {
+                editorconfig.AppendLine("before_and_after");
+            }
+            else if (curSetting == BinaryOperatorSpacingOptions.Remove)
+            {
+                editorconfig.AppendLine("none");
+            }
+            else
+            {
+                editorconfig.AppendLine("ignore");
+            }
+        }
+
+        private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
+        {
+            editorconfig.Append(((EditorConfigStorageLocation<bool>)CSharpFormattingOptions.SpaceWithinOtherParentheses.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+            editorconfig.Append(" = ");
+
             var firstRule = true;
             if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinOtherParentheses))
             {
@@ -291,12 +283,19 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 
             if (firstRule)
             {
-                editorconfig.Append("false");
+                editorconfig.AppendLine("false");
+            }
+            else
+            {
+                editorconfig.AppendLine();
             }
         }
 
-        private static string CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(OptionSet optionSet)
+        private static void CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
         {
+            editorconfig.Append(((EditorConfigStorageLocation<bool>)CSharpFormattingOptions.NewLinesForBracesInAccessors.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);;
+            editorconfig.Append(" = ");
+
             const int totalRules = 9;
             var rulesApplied = 0;
             var ruleString = new StringBuilder();
@@ -388,134 +387,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 
             if (rulesApplied == totalRules)
             {
-                return "all";
+                editorconfig.AppendLine("all");
             }
             else if (rulesApplied == 0)
             {
-                return "none";
+                editorconfig.AppendLine("none");
             }
             else
             {
-                return ruleString.ToString();
-            }
-        }
-
-        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<bool> option)
-        {
-            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
-            if (curSetting)
-            {
-                return "tab";
-            }
-            else
-            {
-                return "space";
-            }
-        }
-
-        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<AccessibilityModifiersRequired>> option)
-        {
-            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
-            var editorconfig = "";
-            if (curSetting.Value == AccessibilityModifiersRequired.ForNonInterfaceMembers)
-            {
-                editorconfig += "for_non_interface_members:" + curSetting.Notification.ToString().ToLower();
-            }
-            else if (curSetting.Value == AccessibilityModifiersRequired.OmitIfDefault)
-            {
-                editorconfig += "omit_if_default:" + curSetting.Notification.ToString().ToLower();
-            }
-            else
-            {
-                editorconfig += (curSetting.Value + ":" + curSetting.Notification).ToLower();
-            }
-
-            return editorconfig;
-        }
-
-        private static void DotNetCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option, StringBuilder editorconfig)
-        {
-            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<bool>>) option.StorageLocations[0]).KeyName);
-            editorconfig.Append(" = ");
-
-            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
-            editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
-        }
-
-        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<bool>> option)
-        {
-            var curSetting = optionSet.GetOption(option);
-            var editorconfig = curSetting.Value + ":" + curSetting.Notification;
-            return editorconfig.ToLower();
-        }
-        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<string>> option)
-        {
-            var curSetting = optionSet.GetOption(option);
-            var editorconfig = curSetting.Value + ":" + curSetting.Notification;
-            return editorconfig.ToLower();
-        }
-
-        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<ExpressionBodyPreference>> option)
-        {
-            var curSetting = optionSet.GetOption(option);
-            var editorconfig = "";
-            if (curSetting.Value == ExpressionBodyPreference.Never)
-            {
-                editorconfig = "false" + ":" + curSetting.Notification.ToString().ToLower();
-            }
-            else
-            {
-                editorconfig = "true" + ":" + curSetting.Notification.ToString().ToLower();
-            }
-
-            return editorconfig;
-        }
-        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<ParenthesesPreference>> option)
-        {
-            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
-            var editorconfig = "";
-            if (curSetting.Value == ParenthesesPreference.AlwaysForClarity)
-            {
-                editorconfig += "always_for_clarity:" + curSetting.Notification.ToString().ToLower();
-            }
-            else
-            {
-                editorconfig += "never_if_unnecessary:" + curSetting.Notification.ToString().ToLower();
-            }
-
-            return editorconfig;
-        }
-
-
-        private static string CSharpLabelPositioning_GenerateEditorconfig(LabelPositionOptions option)
-        {
-            if (option == LabelPositionOptions.LeftMost)
-            {
-                return "flush_left";
-            }
-            else if (option == LabelPositionOptions.OneLess)
-            {
-                return "one_less_than_current";
-            }
-            else
-            {
-                return "no_change";
-            }
-        }
-
-        private static string CSharpSpacingAroundBinaryOperator_GenerateEditorconfig(BinaryOperatorSpacingOptions option)
-        {
-            if (option == BinaryOperatorSpacingOptions.Single)
-            {
-                return "before_and_after";
-            }
-            else if (option == BinaryOperatorSpacingOptions.Remove)
-            {
-                return "none";
-            }
-            else
-            {
-                return "ignore";
+                editorconfig.AppendLine(ruleString.ToString());
             }
         }
     }

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -2,6 +2,14 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Options;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
@@ -11,7 +19,502 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
     {
         protected override AbstractOptionPageControl CreateOptionPage(IServiceProvider serviceProvider)
         {
-            return new GridOptionPreviewControl(serviceProvider, (o, s) => new StyleViewModel(o, s));
+            return new GridOptionPreviewControl(serviceProvider, (o, s) => new StyleViewModel(o, s), GetCurrentEditorConfigOptionsString);
+        }
+
+        internal static string GetCurrentEditorConfigOptionsString(OptionSet optionSet)
+        {
+            var editorconfig = new StringBuilder();
+            // Core EditorConfig Options
+            editorconfig.AppendLine("###############################");
+            editorconfig.AppendLine("# Core EditorConfig Options   #");
+            editorconfig.AppendLine("###############################");
+            editorconfig.AppendLine("# You can uncomment the next line if this is your top-most .editorconfig file.");
+            editorconfig.AppendLine("# root = true");
+
+            editorconfig.AppendLine();
+            editorconfig.AppendLine("# C# files");
+            editorconfig.AppendLine("[*.cs]");
+            editorconfig.Append("indent_style = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, FormattingOptions.UseTabs));
+            editorconfig.Append("indent_size = ");
+            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.IndentationSize, LanguageNames.CSharp).ToString());
+            editorconfig.Append("insert_final_newline = ");
+            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.InsertFinalNewLine).ToString().ToLower());
+
+            editorconfig.AppendLine();
+            // .NET Coding Conventions
+            editorconfig.AppendLine("###############################");
+            editorconfig.AppendLine("# .NET Coding Conventions     #");
+            editorconfig.AppendLine("###############################");
+            editorconfig.AppendLine("# Organize usings");
+            editorconfig.Append("dotnet_sort_system_directives_first = ");
+            editorconfig.AppendLine(optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp).ToString().ToLower());
+
+            editorconfig.AppendLine();
+            // this. preferences
+            editorconfig.AppendLine("# this. preferences");
+            editorconfig.Append("dotnet_style_qualification_for_field = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyFieldAccess));
+            editorconfig.Append("dotnet_style_qualification_for_property = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess));
+            editorconfig.Append("dotnet_style_qualification_for_method = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyMethodAccess));
+            editorconfig.Append("dotnet_style_qualification_for_event = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess));
+
+            editorconfig.AppendLine();
+            // Language keywords vs. BCL types preferences
+            editorconfig.AppendLine("# Language keywords vs BCL types preferences");
+            editorconfig.Append("dotnet_style_predefined_type_for_locals_parameters_members = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration));
+            editorconfig.Append("dotnet_style_predefined_type_for_member_access = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess));
+
+            editorconfig.AppendLine();
+            // Parentheses preferences
+            editorconfig.AppendLine("# Parentheses preferences");
+            editorconfig.Append("dotnet_style_parentheses_in_arithmetic_binary_operators = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.ArithmeticBinaryParentheses));
+            editorconfig.Append("dotnet_style_parentheses_in_relational_binary_operators = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RelationalBinaryParentheses));
+            editorconfig.Append("dotnet_style_parentheses_in_other_binary_operators = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.OtherBinaryParentheses));
+            editorconfig.Append("dotnet_style_parentheses_in_other_operators = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.OtherParentheses));
+
+            editorconfig.AppendLine();
+            // Modifier preferences
+            editorconfig.AppendLine("# Modifier preferences");
+            editorconfig.Append("dotnet_style_require_accessibility_modifiers = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RequireAccessibilityModifiers));
+            editorconfig.Append("dotnet_style_readonly_field = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferReadonly));
+
+            editorconfig.AppendLine();
+            // Expression-level preferences
+            editorconfig.AppendLine("# Expression-level preferences");
+            editorconfig.Append("dotnet_style_object_initializer = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferObjectInitializer));
+            editorconfig.Append("dotnet_style_collection_initializer = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCollectionInitializer));
+            editorconfig.Append("dotnet_style_explicit_tuple_names = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferExplicitTupleNames));
+            editorconfig.Append("dotnet_style_null_propagation = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferNullPropagation));
+            editorconfig.Append("dotnet_style_coalesce_expression = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCoalesceExpression));
+            editorconfig.Append("dotnet_style_prefer_is_null_check_over_reference_equality_method = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIsNullCheckOverReferenceEqualityMethod));
+            editorconfig.Append("dotnet_prefer_inferred_tuple_names = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredTupleNames));
+            editorconfig.Append("dotnet_prefer_inferred_anonymous_type_member_names = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredAnonymousTypeMemberNames));
+            editorconfig.Append("dotnet_style_prefer_auto_properties = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferAutoProperties));
+            editorconfig.Append("dotnet_style_prefer_conditional_expression_over_assignment = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverAssignment));
+            editorconfig.Append("dotnet_style_prefer_conditional_expression_over_return = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverReturn));
+
+            editorconfig.AppendLine();
+            // C# Coding Conventions
+            editorconfig.AppendLine("###############################");
+            editorconfig.AppendLine("# C# Coding Conventions       #");
+            editorconfig.AppendLine("###############################");
+
+            // Var preferences
+            editorconfig.AppendLine("# var preferences");
+            editorconfig.Append("csharp_style_var_for_built_in_types = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes));
+            editorconfig.Append("csharp_style_var_when_type_is_apparent = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeWhereApparent));
+            editorconfig.Append("csharp_style_var_elsewhere = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeWherePossible));
+
+            editorconfig.AppendLine();
+            // Expression-bodied members
+            editorconfig.AppendLine("# Expression-bodied members");
+            editorconfig.Append("csharp_style_expression_bodied_methods = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedMethods));
+            editorconfig.Append("csharp_style_expression_bodied_constructors = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedConstructors));
+            editorconfig.Append("csharp_style_expression_bodied_operators = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedOperators));
+            editorconfig.Append("csharp_style_expression_bodied_properties = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedProperties));
+            editorconfig.Append("csharp_style_expression_bodied_indexers = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedIndexers));
+            editorconfig.Append("csharp_style_expression_bodied_accessors = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedAccessors));
+
+            editorconfig.AppendLine();
+            // Pattern matching preferences
+            editorconfig.AppendLine("# Pattern matching preferences");
+            editorconfig.Append("csharp_style_pattern_matching_over_is_with_cast_check = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck));
+            editorconfig.Append("csharp_style_pattern_matching_over_as_with_null_check = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck));
+
+            editorconfig.AppendLine();
+            // Null-checking preferences
+            editorconfig.AppendLine("# Null-checking preferences");
+            editorconfig.Append("csharp_style_throw_expression = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferThrowExpression));
+            editorconfig.Append("csharp_style_conditional_delegate_call = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferConditionalDelegateCall));
+
+            editorconfig.AppendLine();
+            // Modifier preferences
+            editorconfig.AppendLine("# Modifier preferences");
+            editorconfig.Append("csharp_preferred_modifier_order = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferredModifierOrder));
+
+            editorconfig.AppendLine();
+            // Expression-level preferences
+            editorconfig.AppendLine("# Expression-level preferences");
+            editorconfig.Append("csharp_prefer_braces = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferBraces));
+            editorconfig.Append("csharp_style_deconstructed_variable_declaration = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferDeconstructedVariableDeclaration));
+            editorconfig.Append("csharp_prefer_simple_default_expression = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferSimpleDefaultExpression));
+            editorconfig.Append("csharp_style_pattern_local_over_anonymous_function = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferLocalOverAnonymousFunction));
+            editorconfig.Append("csharp_style_inlined_variable_declaration = ");
+            editorconfig.AppendLine(CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInlinedVariableDeclaration));
+
+            editorconfig.AppendLine();
+            // C# Formatting Rules
+            editorconfig.AppendLine("###############################");
+            editorconfig.AppendLine("# C# Formatting Rules         #");
+            editorconfig.AppendLine("###############################");
+
+            editorconfig.AppendLine();
+            // New line preferences
+            editorconfig.AppendLine("# New line preferences");
+            editorconfig.Append("csharp_new_line_before_open_brace = ");
+            editorconfig.AppendLine(CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(optionSet));
+            editorconfig.Append("csharp_new_line_before_else = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForElse).ToString().ToLower());
+            editorconfig.Append("csharp_new_line_before_catch = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForCatch).ToString().ToLower());
+            editorconfig.Append("csharp_new_line_before_finally = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForFinally).ToString().ToLower());
+            editorconfig.Append("csharp_new_line_before_members_in_object_initializers = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForMembersInObjectInit).ToString().ToLower());
+            editorconfig.Append("csharp_new_line_before_members_in_anonymous_types = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForMembersInAnonymousTypes).ToString().ToLower());
+            editorconfig.Append("csharp_new_line_between_query_expression_clauses = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForClausesInQuery).ToString().ToLower());
+
+            editorconfig.AppendLine();
+            // Indentation preferences
+            editorconfig.AppendLine("# Indentation preferences");
+            editorconfig.Append("csharp_indent_case_contents = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.IndentSwitchCaseSection).ToString().ToLower());
+            editorconfig.Append("csharp_indent_labels = ");
+            editorconfig.AppendLine(CSharpLabelPositioning_GenerateEditorconfig(optionSet.GetOption(CSharpFormattingOptions.LabelPositioning)));
+
+            editorconfig.AppendLine();
+            // Space preferences
+            editorconfig.AppendLine("# Space preferences");
+            editorconfig.Append("csharp_space_after_cast = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceAfterCast).ToString().ToLower());
+            editorconfig.Append("csharp_space_after_keywords_in_control_flow_statements = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceAfterControlFlowStatementKeyword).ToString().ToLower());
+            editorconfig.Append("csharp_space_between_method_call_parameter_list_parentheses = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceWithinMethodCallParentheses).ToString().ToLower());
+            editorconfig.Append("csharp_space_between_method_declaration_parameter_list_parentheses = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceWithinMethodDeclarationParenthesis).ToString().ToLower());
+            editorconfig.Append("csharp_space_between_parentheses = ");
+            CSharpSpaceBetweenParentheses_GenerateEditorconfig(optionSet, editorconfig);
+            editorconfig.AppendLine();
+            editorconfig.Append("csharp_space_before_colon_in_inheritance_clause = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceBeforeColonInBaseTypeDeclaration).ToString().ToLower());
+            editorconfig.Append("csharp_space_after_colon_in_inheritance_clause = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceAfterColonInBaseTypeDeclaration).ToString().ToLower());
+            editorconfig.Append("csharp_space_around_binary_operators = ");
+            editorconfig.AppendLine(CSharpSpacingAroundBinaryOperator_GenerateEditorconfig(optionSet.GetOption(CSharpFormattingOptions.SpacingAroundBinaryOperator)));
+            editorconfig.Append("csharp_space_between_method_declaration_empty_parameter_list_parentheses = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceBetweenEmptyMethodDeclarationParentheses).ToString().ToLower());
+            editorconfig.Append("csharp_space_between_method_call_name_and_opening_parenthesis = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceAfterMethodCallName).ToString().ToLower());
+            editorconfig.Append("csharp_space_between_method_call_empty_parameter_list_parentheses = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.SpaceBetweenEmptyMethodCallParentheses).ToString().ToLower());
+
+            editorconfig.AppendLine();
+            // Wrapping preferences
+            editorconfig.AppendLine("# Wrapping preferences");
+            editorconfig.Append("csharp_preserve_single_line_statements = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine).ToString().ToLower());
+            editorconfig.Append("csharp_preserve_single_line_blocks = ");
+            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.WrappingPreserveSingleLine).ToString().ToLower());
+
+            return editorconfig.ToString();
+        }
+
+        private static void CSharpSpaceBetweenParentheses_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
+        {
+            var firstRule = true;
+            if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinOtherParentheses))
+            {
+                editorconfig.Append("control_flow_statements");
+                firstRule = false;
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinExpressionParentheses))
+            {
+                if (firstRule)
+                {
+                    firstRule = false;
+                }
+                else
+                {
+                    editorconfig.Append(",");
+                }
+
+                editorconfig.Append("expressions");
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinCastParentheses))
+            {
+                if (firstRule)
+                {
+                    firstRule = false;
+                }
+                else
+                {
+                    editorconfig.Append(",");
+                }
+
+                editorconfig.Append("type_casts");
+            }
+
+            if (firstRule)
+            {
+                editorconfig.Append("false");
+            }
+        }
+
+        private static string CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(OptionSet optionSet)
+        {
+            const int totalRules = 9;
+            var rulesApplied = 0;
+            var ruleString = new StringBuilder();
+            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAccessors))
+            {
+                ++rulesApplied;
+                ruleString.Append("accessors");
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods))
+            {
+                if (ruleString.Length != 0)
+                {
+                    ruleString.Append(",");
+                }
+
+                ++rulesApplied;
+                ruleString.Append("anonymous_methods");
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAnonymousTypes))
+            {
+                if (ruleString.Length != 0)
+                {
+                    ruleString.Append(",");
+                }
+
+                ++rulesApplied;
+                ruleString.Append("anonymous_types");
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInControlBlocks))
+            {
+                if (ruleString.Length != 0)
+                {
+                    ruleString.Append(",");
+                }
+
+                ++rulesApplied;
+                ruleString.Append("control_blocks");
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInLambdaExpressionBody))
+            {
+                if (ruleString.Length != 0)
+                {
+                    ruleString.Append(",");
+                }
+
+                ++rulesApplied;
+                ruleString.Append("lambdas");
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
+            {
+                if (ruleString.Length != 0)
+                {
+                    ruleString.Append(",");
+                }
+
+                ++rulesApplied;
+                ruleString.Append("methods");
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInObjectCollectionArrayInitializers))
+            {
+                if (ruleString.Length != 0)
+                {
+                    ruleString.Append(",");
+                }
+
+                ++rulesApplied;
+                ruleString.Append("object_collection");
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInProperties))
+            {
+                if (ruleString.Length != 0)
+                {
+                    ruleString.Append(",");
+                }
+
+                ++rulesApplied;
+                ruleString.Append("properties");
+            }
+            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInTypes))
+            {
+                if (ruleString.Length != 0)
+                {
+                    ruleString.Append(",");
+                }
+
+                ++rulesApplied;
+                ruleString.Append("types");
+            }
+
+            if (rulesApplied == totalRules)
+            {
+                return "all";
+            }
+            else if (rulesApplied == 0)
+            {
+                return "none";
+            }
+            else
+            {
+                return ruleString.ToString();
+            }
+        }
+
+        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<bool> option)
+        {
+            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
+            if (curSetting)
+            {
+                return "tab";
+            }
+            else
+            {
+                return "space";
+            }
+        }
+
+        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<AccessibilityModifiersRequired>> option)
+        {
+            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
+            var editorconfig = "";
+            if (curSetting.Value == AccessibilityModifiersRequired.ForNonInterfaceMembers)
+            {
+                editorconfig += "for_non_interface_members:" + curSetting.Notification.ToString().ToLower();
+            }
+            else if (curSetting.Value == AccessibilityModifiersRequired.OmitIfDefault)
+            {
+                editorconfig += "omit_if_default:" + curSetting.Notification.ToString().ToLower();
+            }
+            else
+            {
+                editorconfig += (curSetting.Value + ":" + curSetting.Notification).ToLower();
+            }
+
+            return editorconfig;
+        }
+
+        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option)
+        {
+            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
+            var editorconfig = curSetting.Value + ":" + curSetting.Notification;
+            return editorconfig.ToLower();
+        }
+
+        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<bool>> option)
+        {
+            var curSetting = optionSet.GetOption(option);
+            var editorconfig = curSetting.Value + ":" + curSetting.Notification;
+            return editorconfig.ToLower();
+        }
+        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<string>> option)
+        {
+            var curSetting = optionSet.GetOption(option);
+            var editorconfig = curSetting.Value + ":" + curSetting.Notification;
+            return editorconfig.ToLower();
+        }
+
+        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<ExpressionBodyPreference>> option)
+        {
+            var curSetting = optionSet.GetOption(option);
+            var editorconfig = "";
+            if (curSetting.Value == ExpressionBodyPreference.Never)
+            {
+                editorconfig = "false" + ":" + curSetting.Notification.ToString().ToLower();
+            }
+            else
+            {
+                editorconfig = "true" + ":" + curSetting.Notification.ToString().ToLower();
+            }
+
+            return editorconfig;
+        }
+        private static string CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<ParenthesesPreference>> option)
+        {
+            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
+            var editorconfig = "";
+            if (curSetting.Value == ParenthesesPreference.AlwaysForClarity)
+            {
+                editorconfig += "always_for_clarity:" + curSetting.Notification.ToString().ToLower();
+            }
+            else
+            {
+                editorconfig += "never_if_unnecessary:" + curSetting.Notification.ToString().ToLower();
+            }
+
+            return editorconfig;
+        }
+
+
+        private static string CSharpLabelPositioning_GenerateEditorconfig(LabelPositionOptions option)
+        {
+            if (option == LabelPositionOptions.LeftMost)
+            {
+                return "flush_left";
+            }
+            else if (option == LabelPositionOptions.OneLess)
+            {
+                return "one_less_than_current";
+            }
+            else
+            {
+                return "no_change";
+            }
+        }
+
+        private static string CSharpSpacingAroundBinaryOperator_GenerateEditorconfig(BinaryOperatorSpacingOptions option)
+        {
+            if (option == BinaryOperatorSpacingOptions.Single)
+            {
+                return "before_and_after";
+            }
+            else if (option == BinaryOperatorSpacingOptions.Remove)
+            {
+                return "none";
+            }
+            else
+            {
+                return "ignore";
+            }
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             GridOptionPreviewControl.Generate_Editorconfig(optionSet, language, editorconfig, GetCurrentEditorConfigOptionsCSharp);
         }
 
-            internal static void GetCurrentEditorConfigOptionsCSharp(OptionSet optionSet, StringBuilder editorconfig)
+        private static void GetCurrentEditorConfigOptionsCSharp(OptionSet optionSet, StringBuilder editorconfig)
         {
             editorconfig.AppendLine();
             editorconfig.AppendLine("# C# Coding Conventions");

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -8,8 +8,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Options;
 

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -156,7 +157,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             {
                 editorconfig.Append(element.KeyName + " = ");
 
-                editorconfig.AppendLine(optionSet.GetOption(option).ToString().ToLower());
+                editorconfig.AppendLine(optionSet.GetOption(option).ToString().ToLowerInvariant());
             }
         }
 
@@ -168,7 +169,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                 editorconfig.Append(element.KeyName + " = ");
 
                 var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
-                editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+                editorconfig.AppendLine(curSetting.Value.ToString().ToLowerInvariant() + ":" + curSetting.Notification.ToString().ToLowerInvariant());
             }
         }
 
@@ -180,7 +181,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                 editorconfig.Append(element.KeyName + " = ");
 
                 var curSetting = optionSet.GetOption(option);
-                editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+                editorconfig.AppendLine(curSetting.Value.ToString().ToLowerInvariant() + ":" + curSetting.Notification.ToString().ToLowerInvariant());
             }
         }
 
@@ -192,7 +193,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                 editorconfig.Append(element.KeyName + " = ");
 
                 var curSetting = optionSet.GetOption(option);
-                editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+                editorconfig.AppendLine(curSetting.Value.ToString().ToLowerInvariant() + ":" + curSetting.Notification.ToString().ToLowerInvariant());
             }
         }
 
@@ -206,15 +207,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                 var curSetting = optionSet.GetOption(option);
                 if (curSetting.Value == ExpressionBodyPreference.Never)
                 {
-                    editorconfig.AppendLine("false" + ":" + curSetting.Notification.ToString().ToLower());
+                    editorconfig.AppendLine("false" + ":" + curSetting.Notification.ToString().ToLowerInvariant());
                 }
                 else if (curSetting.Value == ExpressionBodyPreference.WhenPossible)
                 {
-                    editorconfig.AppendLine("true" + ":" + curSetting.Notification.ToString().ToLower());
+                    editorconfig.AppendLine("true" + ":" + curSetting.Notification.ToString().ToLowerInvariant());
                 }
                 else if (curSetting.Value == ExpressionBodyPreference.WhenOnSingleLine)
                 {
-                    editorconfig.AppendLine("when_on_single_line" + ":" + curSetting.Notification.ToString().ToLower());
+                    editorconfig.AppendLine("when_on_single_line" + ":" + curSetting.Notification.ToString().ToLowerInvariant());
                 }
                 else
                 {

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -23,7 +23,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             return new GridOptionPreviewControl(serviceProvider, (o, s) => new StyleViewModel(o, s), GetCurrentEditorConfigOptionsCSharp, LanguageNames.CSharp);
         }
 
-        internal static void GetCurrentEditorConfigOptionsCSharp(OptionSet optionSet, StringBuilder editorconfig)
+        internal static void Generate_Editorconfig(
+            OptionSet optionSet,
+            string language,
+            StringBuilder editorconfig)
+        {
+            GridOptionPreviewControl.Generate_Editorconfig(optionSet, language, editorconfig, GetCurrentEditorConfigOptionsCSharp);
+        }
+
+            internal static void GetCurrentEditorConfigOptionsCSharp(OptionSet optionSet, StringBuilder editorconfig)
         {
             editorconfig.AppendLine();
             editorconfig.AppendLine("# C# Coding Conventions");
@@ -145,253 +153,272 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 
         private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<bool> option, StringBuilder editorconfig)
         {
-            editorconfig.Append(((EditorConfigStorageLocation<bool>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+            var element = (EditorConfigStorageLocation<bool>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            if (element != null)
+            {
+                editorconfig.Append(element.KeyName + " = ");
 
-            editorconfig.Append(" = ");
-
-            editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForElse).ToString().ToLower());
+                editorconfig.AppendLine(optionSet.GetOption(CSharpFormattingOptions.NewLineForElse).ToString().ToLower());
+            }
         }
 
         private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option, StringBuilder editorconfig)
         {
-            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<bool>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+            var element = (EditorConfigStorageLocation<CodeStyleOption<bool>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            if (element != null)
+            {
+                editorconfig.Append(element.KeyName + " = ");
 
-            editorconfig.Append(" = ");
-
-            var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
-            editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+                var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
+                editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+            }
         }
 
         private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<bool>> option, StringBuilder editorconfig)
         {
-            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<bool>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
+            var element = (EditorConfigStorageLocation<CodeStyleOption<bool>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            if (element != null)
+            {
+                editorconfig.Append(element.KeyName + " = ");
 
-            editorconfig.Append(" = ");
-
-            var curSetting = optionSet.GetOption(option);
-            editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+                var curSetting = optionSet.GetOption(option);
+                editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+            }
         }
 
         private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<string>> option, StringBuilder editorconfig)
         {
-            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<string>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
-            editorconfig.Append(" = ");
+            var element = (EditorConfigStorageLocation<CodeStyleOption<string>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            if (element != null)
+            {
+                editorconfig.Append(element.KeyName + " = ");
 
-            var curSetting = optionSet.GetOption(option);
-            editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+                var curSetting = optionSet.GetOption(option);
+                editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+            }
         }
 
         private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<ExpressionBodyPreference>> option, StringBuilder editorconfig)
         {
-            editorconfig.Append(((EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
-
-            editorconfig.Append(" = ");
-
-            var curSetting = optionSet.GetOption(option);
-            if (curSetting.Value == ExpressionBodyPreference.Never)
+            var element = (EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            if (element != null)
             {
-                editorconfig.AppendLine("false" + ":" + curSetting.Notification.ToString().ToLower());
-            }
-            else
-            {
-                editorconfig.AppendLine("true" + ":" + curSetting.Notification.ToString().ToLower());
+                editorconfig.Append(element.KeyName + " = ");
+
+                var curSetting = optionSet.GetOption(option);
+                if (curSetting.Value == ExpressionBodyPreference.Never)
+                {
+                    editorconfig.AppendLine("false" + ":" + curSetting.Notification.ToString().ToLower());
+                }
+                else
+                {
+                    editorconfig.AppendLine("true" + ":" + curSetting.Notification.ToString().ToLower());
+                }
             }
         }
 
         private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<LabelPositionOptions> option, StringBuilder editorconfig)
         {
-            editorconfig.Append(((EditorConfigStorageLocation<LabelPositionOptions>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
-
-            editorconfig.Append(" = ");
-
-            var curSetting = optionSet.GetOption(option);
-            if (curSetting == LabelPositionOptions.LeftMost)
+            var element = (EditorConfigStorageLocation<LabelPositionOptions>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            if (element != null)
             {
-                editorconfig.AppendLine("flush_left");
-            }
-            else if (curSetting == LabelPositionOptions.OneLess)
-            {
-                editorconfig.AppendLine("one_less_than_current");
-            }
-            else
-            {
-                editorconfig.AppendLine("no_change");
+                editorconfig.Append(element.KeyName + " = ");
+                var curSetting = optionSet.GetOption(option);
+                if (curSetting == LabelPositionOptions.LeftMost)
+                {
+                    editorconfig.AppendLine("flush_left");
+                }
+                else if (curSetting == LabelPositionOptions.OneLess)
+                {
+                    editorconfig.AppendLine("one_less_than_current");
+                }
+                else
+                {
+                    editorconfig.AppendLine("no_change");
+                }
             }
         }
 
         private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<BinaryOperatorSpacingOptions> option, StringBuilder editorconfig)
         {
-            editorconfig.Append(((EditorConfigStorageLocation<BinaryOperatorSpacingOptions>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
-            editorconfig.Append(" = ");
-
-            var curSetting = optionSet.GetOption(option);
-            if (curSetting == BinaryOperatorSpacingOptions.Single)
+            var element = (EditorConfigStorageLocation<BinaryOperatorSpacingOptions>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            if (element != null)
             {
-                editorconfig.AppendLine("before_and_after");
-            }
-            else if (curSetting == BinaryOperatorSpacingOptions.Remove)
-            {
-                editorconfig.AppendLine("none");
-            }
-            else
-            {
-                editorconfig.AppendLine("ignore");
+                editorconfig.Append(element.KeyName + " = ");
+                var curSetting = optionSet.GetOption(option);
+                if (curSetting == BinaryOperatorSpacingOptions.Single)
+                {
+                    editorconfig.AppendLine("before_and_after");
+                }
+                else if (curSetting == BinaryOperatorSpacingOptions.Remove)
+                {
+                    editorconfig.AppendLine("none");
+                }
+                else
+                {
+                    editorconfig.AppendLine("ignore");
+                }
             }
         }
 
         private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
         {
-            editorconfig.Append(((EditorConfigStorageLocation<bool>)CSharpFormattingOptions.SpaceWithinOtherParentheses.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);
-            editorconfig.Append(" = ");
+            var element = (EditorConfigStorageLocation<bool>)CSharpFormattingOptions.SpaceWithinOtherParentheses.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            if (element != null)
+            {
+                editorconfig.Append(element.KeyName + " = ");
 
-            var firstRule = true;
-            if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinOtherParentheses))
-            {
-                editorconfig.Append("control_flow_statements");
-                firstRule = false;
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinExpressionParentheses))
-            {
+                var firstRule = true;
+                if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinOtherParentheses))
+                {
+                    editorconfig.Append("control_flow_statements");
+                    firstRule = false;
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinExpressionParentheses))
+                {
+                    if (firstRule)
+                    {
+                        firstRule = false;
+                    }
+                    else
+                    {
+                        editorconfig.Append(",");
+                    }
+
+                    editorconfig.Append("expressions");
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinCastParentheses))
+                {
+                    if (firstRule)
+                    {
+                        firstRule = false;
+                    }
+                    else
+                    {
+                        editorconfig.Append(",");
+                    }
+
+                    editorconfig.Append("type_casts");
+                }
+
                 if (firstRule)
                 {
-                    firstRule = false;
+                    editorconfig.AppendLine("false");
                 }
                 else
                 {
-                    editorconfig.Append(",");
+                    editorconfig.AppendLine();
                 }
-
-                editorconfig.Append("expressions");
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinCastParentheses))
-            {
-                if (firstRule)
-                {
-                    firstRule = false;
-                }
-                else
-                {
-                    editorconfig.Append(",");
-                }
-
-                editorconfig.Append("type_casts");
-            }
-
-            if (firstRule)
-            {
-                editorconfig.AppendLine("false");
-            }
-            else
-            {
-                editorconfig.AppendLine();
             }
         }
 
         private static void CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
         {
-            editorconfig.Append(((EditorConfigStorageLocation<bool>)CSharpFormattingOptions.NewLinesForBracesInAccessors.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault()).KeyName);;
-            editorconfig.Append(" = ");
-
-            const int totalRules = 9;
-            var rulesApplied = 0;
-            var ruleString = new StringBuilder();
-            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAccessors))
+            var element = (EditorConfigStorageLocation<bool>)CSharpFormattingOptions.NewLinesForBracesInAccessors.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            if (element != null)
             {
-                ++rulesApplied;
-                ruleString.Append("accessors");
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods))
-            {
-                if (ruleString.Length != 0)
+                editorconfig.Append(element.KeyName + " = ");
+                const int totalRules = 9;
+                var rulesApplied = 0;
+                var ruleString = new StringBuilder();
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAccessors))
                 {
-                    ruleString.Append(",");
+                    ++rulesApplied;
+                    ruleString.Append("accessors");
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods))
+                {
+                    if (ruleString.Length != 0)
+                    {
+                        ruleString.Append(",");
+                    }
+
+                    ++rulesApplied;
+                    ruleString.Append("anonymous_methods");
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAnonymousTypes))
+                {
+                    if (ruleString.Length != 0)
+                    {
+                        ruleString.Append(",");
+                    }
+
+                    ++rulesApplied;
+                    ruleString.Append("anonymous_types");
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInControlBlocks))
+                {
+                    if (ruleString.Length != 0)
+                    {
+                        ruleString.Append(",");
+                    }
+
+                    ++rulesApplied;
+                    ruleString.Append("control_blocks");
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInLambdaExpressionBody))
+                {
+                    if (ruleString.Length != 0)
+                    {
+                        ruleString.Append(",");
+                    }
+
+                    ++rulesApplied;
+                    ruleString.Append("lambdas");
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
+                {
+                    if (ruleString.Length != 0)
+                    {
+                        ruleString.Append(",");
+                    }
+
+                    ++rulesApplied;
+                    ruleString.Append("methods");
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInObjectCollectionArrayInitializers))
+                {
+                    if (ruleString.Length != 0)
+                    {
+                        ruleString.Append(",");
+                    }
+
+                    ++rulesApplied;
+                    ruleString.Append("object_collection");
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInProperties))
+                {
+                    if (ruleString.Length != 0)
+                    {
+                        ruleString.Append(",");
+                    }
+
+                    ++rulesApplied;
+                    ruleString.Append("properties");
+                }
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInTypes))
+                {
+                    if (ruleString.Length != 0)
+                    {
+                        ruleString.Append(",");
+                    }
+
+                    ++rulesApplied;
+                    ruleString.Append("types");
                 }
 
-                ++rulesApplied;
-                ruleString.Append("anonymous_methods");
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAnonymousTypes))
-            {
-                if (ruleString.Length != 0)
+                if (rulesApplied == totalRules)
                 {
-                    ruleString.Append(",");
+                    editorconfig.AppendLine("all");
                 }
-
-                ++rulesApplied;
-                ruleString.Append("anonymous_types");
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInControlBlocks))
-            {
-                if (ruleString.Length != 0)
+                else if (rulesApplied == 0)
                 {
-                    ruleString.Append(",");
+                    editorconfig.AppendLine("none");
                 }
-
-                ++rulesApplied;
-                ruleString.Append("control_blocks");
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInLambdaExpressionBody))
-            {
-                if (ruleString.Length != 0)
+                else
                 {
-                    ruleString.Append(",");
+                    editorconfig.AppendLine(ruleString.ToString());
                 }
-
-                ++rulesApplied;
-                ruleString.Append("lambdas");
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
-            {
-                if (ruleString.Length != 0)
-                {
-                    ruleString.Append(",");
-                }
-
-                ++rulesApplied;
-                ruleString.Append("methods");
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInObjectCollectionArrayInitializers))
-            {
-                if (ruleString.Length != 0)
-                {
-                    ruleString.Append(",");
-                }
-
-                ++rulesApplied;
-                ruleString.Append("object_collection");
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInProperties))
-            {
-                if (ruleString.Length != 0)
-                {
-                    ruleString.Append(",");
-                }
-
-                ++rulesApplied;
-                ruleString.Append("properties");
-            }
-            if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInTypes))
-            {
-                if (ruleString.Length != 0)
-                {
-                    ruleString.Append(",");
-                }
-
-                ++rulesApplied;
-                ruleString.Append("types");
-            }
-
-            if (rulesApplied == totalRules)
-            {
-                editorconfig.AppendLine("all");
-            }
-            else if (rulesApplied == 0)
-            {
-                editorconfig.AppendLine("none");
-            }
-            else
-            {
-                editorconfig.AppendLine(ruleString.ToString());
             }
         }
     }

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -35,12 +35,12 @@
             <converters:MarginConverter x:Key="MarginConverter" />
         </Grid.Resources>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" MinHeight="74.857" />
-            <RowDefinition Height="115*" />
-            <RowDefinition Height="4.571" />
-            <RowDefinition Height="84*" />
+            <RowDefinition Height="Auto" MinHeight="75" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="5" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock TextWrapping="Wrap" Margin="0,0,0.286,4.857">
+        <TextBlock TextWrapping="Wrap">
             <Run Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeader}"/>
             <Run Text=" "/>
             <Hyperlink RequestNavigate="LearnMoreHyperlink_RequestNavigate" NavigateUri="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreUri}">
@@ -50,7 +50,6 @@
         <DataGrid
             x:Uid="CodeStyleContent"
             x:Name="CodeStyleMembers"
-            Margin="0,0.143,0.286,1.286"
             ItemsSource="{Binding CodeStyleItems, Mode=OneWay}"
             AutoGenerateColumns="False"
             CanUserReorderColumns="False"
@@ -176,9 +175,9 @@
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
-        <GridSplitter Grid.Row="3" HorizontalAlignment="Stretch" Margin="0,28.143,0.286,6.857"/>
-        <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1" Margin="0,0.143,0.286,-0.143">
-            <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False" Margin="-0.143,-1.143,-0.429,-0.571"></ContentControl>
+        <GridSplitter Grid.Row="3" HorizontalAlignment="Stretch" Margin="0,28,0,7"/>
+        <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1">
+            <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False"></ContentControl>
         </Border>
         <Button Content="Generate .editorconfig file from settings" HorizontalAlignment="Left" Margin="20,40,0,0" VerticalAlignment="Top" Width="235" Height="25" Click="Generate_Save_Editorconfig" />
     </Grid>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -180,6 +180,6 @@
         <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1" Margin="0,0.143,0.286,-0.143">
             <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False" Margin="-0.143,-1.143,-0.429,-0.571"></ContentControl>
         </Border>
-        <Button Content="Generate .editorconfig file from settings" HorizontalAlignment="Left" Margin="20,40,0,0" VerticalAlignment="Top" Width="235" Height="25" Click="Generate_Editorconfig" />
+        <Button Content="Generate .editorconfig file from settings" HorizontalAlignment="Left" Margin="20,40,0,0" VerticalAlignment="Top" Width="235" Height="25" Click="Generate_Save_Editorconfig" />
     </Grid>
 </options:AbstractOptionPageControl>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -35,12 +35,12 @@
             <converters:MarginConverter x:Key="MarginConverter" />
         </Grid.Resources>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="5" />
-            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" MinHeight="74.857" />
+            <RowDefinition Height="115*" />
+            <RowDefinition Height="4.571" />
+            <RowDefinition Height="84*" />
         </Grid.RowDefinitions>
-        <TextBlock TextWrapping="Wrap">
+        <TextBlock TextWrapping="Wrap" Margin="0,0,0.286,4.857">
             <Run Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeader}"/>
             <Run Text=" "/>
             <Hyperlink RequestNavigate="LearnMoreHyperlink_RequestNavigate" NavigateUri="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreUri}">
@@ -48,10 +48,9 @@
             </Hyperlink>
         </TextBlock>
         <DataGrid
-            Grid.Row="1"
             x:Uid="CodeStyleContent"
             x:Name="CodeStyleMembers"
-            Margin="0,5,0,0"
+            Margin="0,0.143,0.286,1.286"
             ItemsSource="{Binding CodeStyleItems, Mode=OneWay}"
             AutoGenerateColumns="False"
             CanUserReorderColumns="False"
@@ -70,7 +69,7 @@
             HorizontalAlignment="Stretch"
             Style="{StaticResource ResourceKey=DataGridStyle}"
             SelectionChanged="Options_SelectionChanged"
-            PreviewKeyDown="Options_PreviewKeyDown">
+            PreviewKeyDown="Options_PreviewKeyDown" Grid.Row="1">
             <DataGrid.Resources>
                 <Style x:Key="GroupHeaderStyle" TargetType="{x:Type GroupItem}">
                     <Setter Property="Template">
@@ -177,9 +176,10 @@
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
-        <GridSplitter Grid.Row="2" HorizontalAlignment="Stretch"></GridSplitter>
-        <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1">
-            <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False"></ContentControl>
+        <GridSplitter Grid.Row="3" HorizontalAlignment="Stretch" Margin="0,28.143,0.286,6.857"/>
+        <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1" Margin="0,0.143,0.286,-0.143">
+            <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False" Margin="-0.143,-1.143,-0.429,-0.571"></ContentControl>
         </Border>
+        <Button Content="Generate .editorconfig file from settings" HorizontalAlignment="Left" Margin="20,40,0,0" VerticalAlignment="Top" Width="235" Height="25" Click="Generate_Editorconfig" />
     </Grid>
 </options:AbstractOptionPageControl>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -47,6 +47,7 @@
                 <TextBlock Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreText}"/>
             </Hyperlink>
         </TextBlock>
+        <Button Content="Generate .editorconfig file from settings" HorizontalAlignment="Left" Margin="20,35,0,0" VerticalAlignment="Center" Padding="5" Click="Generate_Save_Editorconfig" />
         <DataGrid
             x:Uid="CodeStyleContent"
             x:Name="CodeStyleMembers"
@@ -175,10 +176,9 @@
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
-        <GridSplitter Grid.Row="3" HorizontalAlignment="Stretch" Margin="0,28,0,7"/>
+        <GridSplitter Grid.Row="2" HorizontalAlignment="Stretch"></GridSplitter>
         <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1">
             <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False"></ContentControl>
         </Border>
-        <Button Content="Generate .editorconfig file from settings" HorizontalAlignment="Left" Margin="20,40,0,0" VerticalAlignment="Top" Width="235" Height="25" Click="Generate_Save_Editorconfig" />
     </Grid>
 </options:AbstractOptionPageControl>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -141,10 +141,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         internal static void GenerateEditorconfig_CoreSettings(OptionSet optionSet, string language, StringBuilder editorconfig)
         {
             // Core EditorConfig Options
-            editorconfig.AppendLine("###############################");
-            editorconfig.AppendLine("# Core EditorConfig Options   #");
-            editorconfig.AppendLine("###############################");
-            editorconfig.AppendLine("# You can uncomment the next line if this is your top-most .editorconfig file.");
+            editorconfig.AppendLine("# Core EditorConfig Options");
+            editorconfig.AppendLine("# Uncomment the line below if you don’t want to inherit parent .editorconfig settings or if this is your solution directory.");
             editorconfig.AppendLine("# root = true");
 
             editorconfig.AppendLine();
@@ -199,10 +197,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         internal static void GenerateEditorconfig_DotNetSettings(OptionSet optionSet, string language, StringBuilder editorconfig)
         {
             editorconfig.AppendLine();
-            editorconfig.AppendLine("###############################");
-            editorconfig.AppendLine("# .NET Coding Conventions     #");
-            editorconfig.AppendLine("###############################");
-
+            editorconfig.AppendLine("# .NET Coding Conventions");
+  
             editorconfig.AppendLine("# Organize usings");
             // dotnet_sort_system_directives_first
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, GenerationOptions.PlaceSystemNamespaceFirst, language, editorconfig);
@@ -215,6 +211,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             {
                 editorconfig.AppendLine("# Me. preferences");
             }
+
             // dotnet_style_qualification_for_field
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyFieldAccess, language, editorconfig);
             // dotnet_style_qualification_for_property

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -146,7 +146,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         private static void GenerateEditorconfig_CoreSettings(OptionSet optionSet, string language, StringBuilder editorconfig)
         {
-            // Core EditorConfig Options
             editorconfig.AppendLine("# Core EditorConfig Options");
             editorconfig.AppendLine("# Comment the line below if you want to inherit parent .editorconfig settings.");
             editorconfig.AppendLine("root = true");

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -172,7 +172,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         private static void CoreCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<bool> option, string language, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<bool>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<bool>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -187,9 +187,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 }
             }
         }
+
         private static void CoreCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<int> option, string language, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<int>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<int>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -199,7 +200,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         private static void CoreCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<bool> option, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<bool>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<bool>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -212,17 +213,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             editorconfig.AppendLine();
             editorconfig.AppendLine("# .NET Coding Conventions");
   
-            editorconfig.AppendLine("# Organize usings");
+            editorconfig.AppendLine("# Organize usings:");
             // dotnet_sort_system_directives_first
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, GenerationOptions.PlaceSystemNamespaceFirst, language, editorconfig);
 
             editorconfig.AppendLine();
             if (language == LanguageNames.CSharp)
             {
-                editorconfig.AppendLine("# this. preferences");
-            } else if (language == LanguageNames.VisualBasic)
+                editorconfig.AppendLine("# this. preferences:");
+            }
+            else if (language == LanguageNames.VisualBasic)
             {
-                editorconfig.AppendLine("# Me. preferences");
+                editorconfig.AppendLine("# Me. preferences:");
             }
 
             // dotnet_style_qualification_for_field
@@ -235,14 +237,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyEventAccess, language, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Language keywords vs BCL types preferences");
+            editorconfig.AppendLine("# Language keywords vs BCL types preferences:");
             // dotnet_style_predefined_type_for_locals_parameters_members
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, language, editorconfig);
             // dotnet_style_predefined_type_for_member_access
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, language, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Parentheses preferences");
+            editorconfig.AppendLine("# " + ServicesVSResources.Parentheses_preferences_colon);
             // dotnet_style_parentheses_in_arithmetic_binary_operators
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.ArithmeticBinaryParentheses, language, editorconfig);
             // dotnet_style_parentheses_in_relational_binary_operators
@@ -253,14 +255,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.OtherParentheses, language, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Modifier preferences");
+            editorconfig.AppendLine("# Modifier preferences:");
             // dotnet_style_require_accessibility_modifiers
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RequireAccessibilityModifiers, language, editorconfig);
             // dotnet_style_readonly_field
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferReadonly, language, editorconfig);
 
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# Expression-level preferences");
+            editorconfig.AppendLine("# Expression-level preferences:");
             // dotnet_style_object_initializer
             DotNetCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferObjectInitializer, language, editorconfig);
             // dotnet_style_collection_initializer
@@ -286,7 +288,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         }
         private static void DotNetCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<bool> option, string language, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<bool>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<bool>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -296,7 +298,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         private static void DotNetCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option, string language, StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<CodeStyleOption<bool>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<bool>>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -312,7 +314,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             string language,
             StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<CodeStyleOption<ParenthesesPreference>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<ParenthesesPreference>>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -322,9 +324,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 {
                     editorconfig.AppendLine("always_for_clarity:" + curSetting.Notification.ToString().ToLower());
                 }
-                else
+                else if (curSetting.Value == ParenthesesPreference.NeverIfUnnecessary)
                 {
                     editorconfig.AppendLine("never_if_unnecessary:" + curSetting.Notification.ToString().ToLower());
+                }
+                else
+                {
+                    throw new NotSupportedException();
                 }
             }
         }
@@ -335,7 +341,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             string language,
             StringBuilder editorconfig)
         {
-            var element = (EditorConfigStorageLocation<CodeStyleOption<AccessibilityModifiersRequired>>)option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<AccessibilityModifiersRequired>>>().FirstOrDefault();
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
@@ -349,9 +355,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 {
                     editorconfig.AppendLine("omit_if_default:" + curSetting.Notification.ToString().ToLower());
                 }
+                else if (curSetting.Value == AccessibilityModifiersRequired.Always || curSetting.Value == AccessibilityModifiersRequired.Never)
+                {
+                    editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+                }
                 else
                 {
-                    editorconfig.AppendLine(curSetting.Value + ":" + curSetting.Notification.ToString().ToLower());
+                    throw new NotSupportedException();
                 }
             }
         }

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
-                editorconfig.AppendLine(optionSet.GetOption(option).ToString().ToLower());
+                editorconfig.AppendLine(optionSet.GetOption(option).ToString().ToLowerInvariant());
             }
         }
 
@@ -292,7 +292,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             if (element != null)
             {
                 editorconfig.Append(element.KeyName + " = ");
-                editorconfig.AppendLine(optionSet.GetOption(option, language).ToString().ToLower());
+                editorconfig.AppendLine(optionSet.GetOption(option, language).ToString().ToLowerInvariant());
             }
         }
 
@@ -304,7 +304,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 editorconfig.Append(element.KeyName + " = ");
 
                 var curSetting = optionSet.GetOption(option, language);
-                editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+                editorconfig.AppendLine(curSetting.Value.ToString().ToLowerInvariant() + ":" + curSetting.Notification.ToString().ToLowerInvariant());
             }
         }
 
@@ -322,11 +322,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 var curSetting = optionSet.GetOption(option, language);
                 if (curSetting.Value == ParenthesesPreference.AlwaysForClarity)
                 {
-                    editorconfig.AppendLine("always_for_clarity:" + curSetting.Notification.ToString().ToLower());
+                    editorconfig.AppendLine("always_for_clarity:" + curSetting.Notification.ToString().ToLowerInvariant());
                 }
                 else if (curSetting.Value == ParenthesesPreference.NeverIfUnnecessary)
                 {
-                    editorconfig.AppendLine("never_if_unnecessary:" + curSetting.Notification.ToString().ToLower());
+                    editorconfig.AppendLine("never_if_unnecessary:" + curSetting.Notification.ToString().ToLowerInvariant());
                 }
                 else
                 {
@@ -349,15 +349,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 var curSetting = optionSet.GetOption(option, language);
                 if (curSetting.Value == AccessibilityModifiersRequired.ForNonInterfaceMembers)
                 {
-                    editorconfig.AppendLine("for_non_interface_members:" + curSetting.Notification.ToString().ToLower());
+                    editorconfig.AppendLine("for_non_interface_members:" + curSetting.Notification.ToString().ToLowerInvariant());
                 }
                 else if (curSetting.Value == AccessibilityModifiersRequired.OmitIfDefault)
                 {
-                    editorconfig.AppendLine("omit_if_default:" + curSetting.Notification.ToString().ToLower());
+                    editorconfig.AppendLine("omit_if_default:" + curSetting.Notification.ToString().ToLowerInvariant());
                 }
                 else if (curSetting.Value == AccessibilityModifiersRequired.Always || curSetting.Value == AccessibilityModifiersRequired.Never)
                 {
-                    editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + curSetting.Notification.ToString().ToLower());
+                    editorconfig.AppendLine(curSetting.Value.ToString().ToLowerInvariant() + ":" + curSetting.Notification.ToString().ToLowerInvariant());
                 }
                 else
                 {

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         private readonly IServiceProvider _serviceProvider;
         private readonly Func<OptionSet, IServiceProvider, AbstractOptionPreviewViewModel> _createViewModel;
         private readonly Func<OptionSet, string> _getCurrentEditorConfigOptionsString;
+        private readonly string _language;
 
         public static readonly Uri CodeStylePageHeaderLearnMoreUri = new Uri(UseEditorConfigUrl);
         public static string CodeStylePageHeader => ServicesVSResources.Code_style_header_use_editor_config;
@@ -29,7 +30,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         internal GridOptionPreviewControl(IServiceProvider serviceProvider,
             Func<OptionSet, IServiceProvider,
             AbstractOptionPreviewViewModel> createViewModel,
-            Func<OptionSet, string> getCurrentEditorConfigOptionsString)
+            Func<OptionSet, string> getCurrentEditorConfigOptionsString,
+            string language)
             : base(serviceProvider)
         {
             InitializeComponent();
@@ -37,6 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             _serviceProvider = serviceProvider;
             _createViewModel = createViewModel;
             _getCurrentEditorConfigOptionsString = getCurrentEditorConfigOptionsString;
+            _language = language;
         }
 
         private void LearnMoreHyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
@@ -1,0 +1,272 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeStyle
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
+    <[UseExportProvider]>
+    Public Class EditorConfigGeneratorTestsCSharp
+        Inherits TestBase
+
+        <WpfFact>
+        Public Sub TestEditorConfigGeneratorDefault()
+            Using workspace = TestWorkspace.CreateCSharp("")
+                Dim expectedText = "###############################
+# Core EditorConfig Options   #
+###############################
+# You can uncomment the next line if this is your top-most .editorconfig file.
+# root = true
+
+# C# files
+[*.cs]
+indent_style = space
+indent_size = 4
+insert_final_newline = false
+
+###############################
+# .NET Coding Conventions     #
+###############################
+# Organize usings
+dotnet_sort_system_directives_first = true
+
+# this. preferences
+dotnet_style_qualification_for_field = false:none
+dotnet_style_qualification_for_property = false:none
+dotnet_style_qualification_for_method = false:none
+dotnet_style_qualification_for_event = false:none
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:none
+dotnet_style_predefined_type_for_member_access = true:none
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
+dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_prefer_inferred_tuple_names = true:suggestion
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:none
+dotnet_style_prefer_conditional_expression_over_assignment = true:none
+dotnet_style_prefer_conditional_expression_over_return = true:none
+
+###############################
+# C# Coding Conventions       #
+###############################
+# var preferences
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:none
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:none
+
+# Expression-level preferences
+csharp_prefer_braces = true:none
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+###############################
+# C# Formatting Rules         #
+###############################
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_labels = one_less_than_current
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+"
+                Dim actualText = CSharp.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsString(workspace.Options)
+                Assert.Equal(expectedText, actualText)
+            End Using
+        End Sub
+
+
+        <WpfFact>
+        Public Sub TestEditorConfigGeneratorToggleOptions()
+            Using workspace = TestWorkspace.CreateCSharp("")
+                Dim changedOptions = workspace.Options.WithChangedOption(New OptionKey(CodeStyleOptions.PreferExplicitTupleNames, LanguageNames.CSharp),
+                                                                         New CodeStyleOption(Of Boolean)(False, NotificationOption.[Error]))
+                Dim expectedText = "###############################
+# Core EditorConfig Options   #
+###############################
+# You can uncomment the next line if this is your top-most .editorconfig file.
+# root = true
+
+# C# files
+[*.cs]
+indent_style = space
+indent_size = 4
+insert_final_newline = false
+
+###############################
+# .NET Coding Conventions     #
+###############################
+# Organize usings
+dotnet_sort_system_directives_first = true
+
+# this. preferences
+dotnet_style_qualification_for_field = false:none
+dotnet_style_qualification_for_property = false:none
+dotnet_style_qualification_for_method = false:none
+dotnet_style_qualification_for_event = false:none
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:none
+dotnet_style_predefined_type_for_member_access = true:none
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
+dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = false:error
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_prefer_inferred_tuple_names = true:suggestion
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:none
+dotnet_style_prefer_conditional_expression_over_assignment = true:none
+dotnet_style_prefer_conditional_expression_over_return = true:none
+
+###############################
+# C# Coding Conventions       #
+###############################
+# var preferences
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:none
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:none
+
+# Expression-level preferences
+csharp_prefer_braces = true:none
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+###############################
+# C# Formatting Rules         #
+###############################
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_labels = one_less_than_current
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+"
+                Dim actualText = CSharp.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsString(changedOptions)
+                Assert.Equal(expectedText, actualText)
+            End Using
+        End Sub
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
@@ -16,10 +16,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
         <WpfFact>
         Public Sub TestEditorConfigGeneratorDefault()
             Using workspace = TestWorkspace.CreateCSharp("")
-                Dim expectedText = "###############################
-# Core EditorConfig Options   #
-###############################
-# You can uncomment the next line if this is your top-most .editorconfig file.
+                Dim expectedText = "# Core EditorConfig Options
+# Uncomment the line below if you don’t want to inherit parent .editorconfig settings or if this is your solution directory.
 # root = true
 
 # C# files
@@ -28,9 +26,7 @@ indent_style = space
 indent_size = 4
 insert_final_newline = false
 
-###############################
-# .NET Coding Conventions     #
-###############################
+# .NET Coding Conventions
 # Organize usings
 dotnet_sort_system_directives_first = true
 
@@ -67,9 +63,7 @@ dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
 
-###############################
-# C# Coding Conventions       #
-###############################
+# C# Coding Conventions
 # var preferences
 csharp_style_var_for_built_in_types = false:none
 csharp_style_var_when_type_is_apparent = false:none
@@ -101,9 +95,7 @@ csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 
-###############################
-# C# Formatting Rules         #
-###############################
+# C# Formatting Rules
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
@@ -149,10 +141,8 @@ csharp_preserve_single_line_blocks = true
             Using workspace = TestWorkspace.CreateCSharp("")
                 Dim changedOptions = workspace.Options.WithChangedOption(New OptionKey(CodeStyleOptions.PreferExplicitTupleNames, LanguageNames.CSharp),
                                                                          New CodeStyleOption(Of Boolean)(False, NotificationOption.[Error]))
-                Dim expectedText = "###############################
-# Core EditorConfig Options   #
-###############################
-# You can uncomment the next line if this is your top-most .editorconfig file.
+                Dim expectedText = "# Core EditorConfig Options
+# Uncomment the line below if you don’t want to inherit parent .editorconfig settings or if this is your solution directory.
 # root = true
 
 # C# files
@@ -161,9 +151,7 @@ indent_style = space
 indent_size = 4
 insert_final_newline = false
 
-###############################
-# .NET Coding Conventions     #
-###############################
+# .NET Coding Conventions
 # Organize usings
 dotnet_sort_system_directives_first = true
 
@@ -200,9 +188,7 @@ dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
 
-###############################
-# C# Coding Conventions       #
-###############################
+# C# Coding Conventions
 # var preferences
 csharp_style_var_for_built_in_types = false:none
 csharp_style_var_when_type_is_apparent = false:none
@@ -234,9 +220,7 @@ csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 
-###############################
-# C# Formatting Rules         #
-###############################
+# C# Formatting Rules
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
@@ -17,8 +17,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
         Public Sub TestEditorConfigGeneratorDefault()
             Using workspace = TestWorkspace.CreateCSharp("")
                 Dim expectedText = "# Core EditorConfig Options
-# Uncomment the line below if you don’t want to inherit parent .editorconfig settings or if this is your solution directory.
-# root = true
+# Comment the line below if you want to inherit parent .editorconfig settings.
+root = true
 
 # C# files
 [*.cs]
@@ -128,13 +128,10 @@ csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 "
                 Dim actualText = New StringBuilder()
-                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_CoreSettings(workspace.Options, LanguageNames.CSharp, actualText)
-                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_DotNetSettings(workspace.Options, LanguageNames.CSharp, actualText)
-                CSharp.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsCSharp(workspace.Options, actualText)
+                CSharp.Options.Formatting.CodeStylePage.Generate_Editorconfig(workspace.Options, LanguageNames.CSharp, actualText)
                 Assert.Equal(expectedText, actualText.ToString())
             End Using
         End Sub
-
 
         <WpfFact>
         Public Sub TestEditorConfigGeneratorToggleOptions()
@@ -142,8 +139,8 @@ csharp_preserve_single_line_blocks = true
                 Dim changedOptions = workspace.Options.WithChangedOption(New OptionKey(CodeStyleOptions.PreferExplicitTupleNames, LanguageNames.CSharp),
                                                                          New CodeStyleOption(Of Boolean)(False, NotificationOption.[Error]))
                 Dim expectedText = "# Core EditorConfig Options
-# Uncomment the line below if you don’t want to inherit parent .editorconfig settings or if this is your solution directory.
-# root = true
+# Comment the line below if you want to inherit parent .editorconfig settings.
+root = true
 
 # C# files
 [*.cs]
@@ -253,9 +250,7 @@ csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 "
                 Dim actualText = New StringBuilder()
-                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_CoreSettings(changedOptions, LanguageNames.CSharp, actualText)
-                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_DotNetSettings(changedOptions, LanguageNames.CSharp, actualText)
-                CSharp.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsCSharp(changedOptions, actualText)
+                CSharp.Options.Formatting.CodeStylePage.Generate_Editorconfig(changedOptions, LanguageNames.CSharp, actualText)
                 Assert.Equal(expectedText, actualText.ToString())
             End Using
         End Sub

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Text
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeStyle
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -60,8 +61,8 @@ dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_prefer_inferred_tuple_names = true:suggestion
-dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
@@ -103,7 +104,6 @@ csharp_style_inlined_variable_declaration = true:suggestion
 ###############################
 # C# Formatting Rules         #
 ###############################
-
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
@@ -115,27 +115,31 @@ csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
 csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 
 # Space preferences
-csharp_space_after_cast = false
+csharp_space_after_cast = true
 csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = true
+csharp_space_between_method_declaration_parameter_list_parentheses = true
 csharp_space_between_parentheses = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = true
+csharp_space_between_method_call_name_and_opening_parenthesis = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = true
 
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 "
-                Dim actualText = CSharp.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsString(workspace.Options)
-                Assert.Equal(expectedText, actualText)
+                Dim actualText = New StringBuilder()
+                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_CoreSettings(workspace.Options, LanguageNames.CSharp, actualText)
+                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_DotNetSettings(workspace.Options, LanguageNames.CSharp, actualText)
+                CSharp.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsCSharp(workspace.Options, actualText)
+                Assert.Equal(expectedText, actualText.ToString())
             End Using
         End Sub
 
@@ -190,8 +194,8 @@ dotnet_style_explicit_tuple_names = false:error
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_prefer_inferred_tuple_names = true:suggestion
-dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
@@ -233,7 +237,6 @@ csharp_style_inlined_variable_declaration = true:suggestion
 ###############################
 # C# Formatting Rules         #
 ###############################
-
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
@@ -245,27 +248,31 @@ csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
 csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 
 # Space preferences
-csharp_space_after_cast = false
+csharp_space_after_cast = true
 csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = true
+csharp_space_between_method_declaration_parameter_list_parentheses = true
 csharp_space_between_parentheses = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = true
+csharp_space_between_method_call_name_and_opening_parenthesis = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = true
 
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 "
-                Dim actualText = CSharp.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsString(changedOptions)
-                Assert.Equal(expectedText, actualText)
+                Dim actualText = New StringBuilder()
+                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_CoreSettings(changedOptions, LanguageNames.CSharp, actualText)
+                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_DotNetSettings(changedOptions, LanguageNames.CSharp, actualText)
+                CSharp.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsCSharp(changedOptions, actualText)
+                Assert.Equal(expectedText, actualText.ToString())
             End Using
         End Sub
     End Class

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
@@ -27,30 +27,30 @@ indent_size = 4
 insert_final_newline = false
 
 # .NET Coding Conventions
-# Organize usings
+# Organize usings:
 dotnet_sort_system_directives_first = true
 
-# this. preferences
+# this. preferences:
 dotnet_style_qualification_for_field = false:none
 dotnet_style_qualification_for_property = false:none
 dotnet_style_qualification_for_method = false:none
 dotnet_style_qualification_for_event = false:none
 
-# Language keywords vs BCL types preferences
+# Language keywords vs BCL types preferences:
 dotnet_style_predefined_type_for_locals_parameters_members = true:none
 dotnet_style_predefined_type_for_member_access = true:none
 
-# Parentheses preferences
+# Parentheses preferences:
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
 
-# Modifier preferences
+# Modifier preferences:
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
 dotnet_style_readonly_field = true:suggestion
 
-# Expression-level preferences
+# Expression-level preferences:
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
@@ -64,12 +64,12 @@ dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
 
 # C# Coding Conventions
-# var preferences
+# 'var' preferences:
 csharp_style_var_for_built_in_types = false:none
 csharp_style_var_when_type_is_apparent = false:none
 csharp_style_var_elsewhere = false:none
 
-# Expression-bodied members
+# Expression-bodied members:
 csharp_style_expression_bodied_methods = false:none
 csharp_style_expression_bodied_constructors = false:none
 csharp_style_expression_bodied_operators = false:none
@@ -77,18 +77,18 @@ csharp_style_expression_bodied_properties = true:none
 csharp_style_expression_bodied_indexers = true:none
 csharp_style_expression_bodied_accessors = true:none
 
-# Pattern matching preferences
+# Pattern matching preferences:
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
 csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 
-# Null-checking preferences
+# Null-checking preferences:
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
-# Modifier preferences
+# Modifier preferences:
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:none
 
-# Expression-level preferences
+# Expression-level preferences:
 csharp_prefer_braces = true:none
 csharp_style_deconstructed_variable_declaration = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
@@ -96,7 +96,7 @@ csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 
 # C# Formatting Rules
-# New line preferences
+# New line preferences:
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -105,25 +105,25 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-# Indentation preferences
+# Indentation preferences:
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 
-# Space preferences
-csharp_space_after_cast = true
+# Space preferences:
+csharp_space_after_cast = false
 csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_between_method_call_parameter_list_parentheses = true
-csharp_space_between_method_declaration_parameter_list_parentheses = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = true
-csharp_space_between_method_call_name_and_opening_parenthesis = true
-csharp_space_between_method_call_empty_parameter_list_parentheses = true
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
 
-# Wrapping preferences
+# Wrapping preferences:
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 "
@@ -149,30 +149,30 @@ indent_size = 4
 insert_final_newline = false
 
 # .NET Coding Conventions
-# Organize usings
+# Organize usings:
 dotnet_sort_system_directives_first = true
 
-# this. preferences
+# this. preferences:
 dotnet_style_qualification_for_field = false:none
 dotnet_style_qualification_for_property = false:none
 dotnet_style_qualification_for_method = false:none
 dotnet_style_qualification_for_event = false:none
 
-# Language keywords vs BCL types preferences
+# Language keywords vs BCL types preferences:
 dotnet_style_predefined_type_for_locals_parameters_members = true:none
 dotnet_style_predefined_type_for_member_access = true:none
 
-# Parentheses preferences
+# Parentheses preferences:
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
 
-# Modifier preferences
+# Modifier preferences:
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
 dotnet_style_readonly_field = true:suggestion
 
-# Expression-level preferences
+# Expression-level preferences:
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
 dotnet_style_explicit_tuple_names = false:error
@@ -186,12 +186,12 @@ dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
 
 # C# Coding Conventions
-# var preferences
+# 'var' preferences:
 csharp_style_var_for_built_in_types = false:none
 csharp_style_var_when_type_is_apparent = false:none
 csharp_style_var_elsewhere = false:none
 
-# Expression-bodied members
+# Expression-bodied members:
 csharp_style_expression_bodied_methods = false:none
 csharp_style_expression_bodied_constructors = false:none
 csharp_style_expression_bodied_operators = false:none
@@ -199,18 +199,18 @@ csharp_style_expression_bodied_properties = true:none
 csharp_style_expression_bodied_indexers = true:none
 csharp_style_expression_bodied_accessors = true:none
 
-# Pattern matching preferences
+# Pattern matching preferences:
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
 csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 
-# Null-checking preferences
+# Null-checking preferences:
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
-# Modifier preferences
+# Modifier preferences:
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:none
 
-# Expression-level preferences
+# Expression-level preferences:
 csharp_prefer_braces = true:none
 csharp_style_deconstructed_variable_declaration = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
@@ -218,7 +218,7 @@ csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 
 # C# Formatting Rules
-# New line preferences
+# New line preferences:
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -227,25 +227,25 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-# Indentation preferences
+# Indentation preferences:
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 
-# Space preferences
-csharp_space_after_cast = true
+# Space preferences:
+csharp_space_after_cast = false
 csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_between_method_call_parameter_list_parentheses = true
-csharp_space_between_method_declaration_parameter_list_parentheses = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = true
-csharp_space_between_method_call_name_and_opening_parenthesis = true
-csharp_space_between_method_call_empty_parameter_list_parentheses = true
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
 
-# Wrapping preferences
+# Wrapping preferences:
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 "

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
@@ -27,30 +27,30 @@ indent_size = 4
 insert_final_newline = false
 
 # .NET Coding Conventions
-# Organize usings
+# Organize usings:
 dotnet_sort_system_directives_first = true
 
-# Me. preferences
+# Me. preferences:
 dotnet_style_qualification_for_field = false:none
 dotnet_style_qualification_for_property = false:none
 dotnet_style_qualification_for_method = false:none
 dotnet_style_qualification_for_event = false:none
 
-# Language keywords vs BCL types preferences
+# Language keywords vs BCL types preferences:
 dotnet_style_predefined_type_for_locals_parameters_members = true:none
 dotnet_style_predefined_type_for_member_access = true:none
 
-# Parentheses preferences
+# Parentheses preferences:
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
 
-# Modifier preferences
+# Modifier preferences:
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
 dotnet_style_readonly_field = true:suggestion
 
-# Expression-level preferences
+# Expression-level preferences:
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
@@ -64,7 +64,7 @@ dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
 
 # VB Coding Conventions
-# Modifier preferences
+# Modifier preferences:
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
 "
                 Dim actualText = New StringBuilder()
@@ -89,30 +89,30 @@ indent_size = 4
 insert_final_newline = false
 
 # .NET Coding Conventions
-# Organize usings
+# Organize usings:
 dotnet_sort_system_directives_first = true
 
-# Me. preferences
+# Me. preferences:
 dotnet_style_qualification_for_field = false:none
 dotnet_style_qualification_for_property = false:none
 dotnet_style_qualification_for_method = false:none
 dotnet_style_qualification_for_event = false:none
 
-# Language keywords vs BCL types preferences
+# Language keywords vs BCL types preferences:
 dotnet_style_predefined_type_for_locals_parameters_members = true:none
 dotnet_style_predefined_type_for_member_access = true:none
 
-# Parentheses preferences
+# Parentheses preferences:
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
 
-# Modifier preferences
+# Modifier preferences:
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
 dotnet_style_readonly_field = true:suggestion
 
-# Expression-level preferences
+# Expression-level preferences:
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
 dotnet_style_explicit_tuple_names = false:error
@@ -126,7 +126,7 @@ dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
 
 # VB Coding Conventions
-# Modifier preferences
+# Modifier preferences:
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
 "
                 Dim actualText = New StringBuilder()

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
@@ -17,8 +17,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
         Public Sub TestEditorConfigGeneratorDefault()
             Using workspace = TestWorkspace.CreateVisualBasic("")
                 Dim expectedText = "# Core EditorConfig Options
-# Uncomment the line below if you don’t want to inherit parent .editorconfig settings or if this is your solution directory.
-# root = true
+# Comment the line below if you want to inherit parent .editorconfig settings.
+root = true
 
 # Basic files
 [*.vb]
@@ -68,9 +68,7 @@ dotnet_style_prefer_conditional_expression_over_return = true:none
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
 "
                 Dim actualText = New StringBuilder()
-                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_CoreSettings(workspace.Options, LanguageNames.VisualBasic, actualText)
-                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_DotNetSettings(workspace.Options, LanguageNames.VisualBasic, actualText)
-                VisualBasic.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsVB(workspace.Options, actualText)
+                VisualBasic.Options.Formatting.CodeStylePage.Generate_Editorconfig(workspace.Options, LanguageNames.VisualBasic, actualText)
                 Assert.Equal(expectedText, actualText.ToString())
             End Using
         End Sub
@@ -81,8 +79,8 @@ visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public
                 Dim changedOptions = workspace.Options.WithChangedOption(New OptionKey(CodeStyleOptions.PreferExplicitTupleNames, LanguageNames.VisualBasic),
                                                                          New CodeStyleOption(Of Boolean)(False, NotificationOption.[Error]))
                 Dim expectedText = "# Core EditorConfig Options
-# Uncomment the line below if you don’t want to inherit parent .editorconfig settings or if this is your solution directory.
-# root = true
+# Comment the line below if you want to inherit parent .editorconfig settings.
+root = true
 
 # Basic files
 [*.vb]
@@ -132,10 +130,7 @@ dotnet_style_prefer_conditional_expression_over_return = true:none
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
 "
                 Dim actualText = New StringBuilder()
-                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_CoreSettings(changedOptions, LanguageNames.VisualBasic, actualText)
-                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_DotNetSettings(changedOptions, LanguageNames.VisualBasic, actualText)
-                VisualBasic.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsVB(changedOptions, actualText)
-                Dim Test = actualText.ToString()
+                VisualBasic.Options.Formatting.CodeStylePage.Generate_Editorconfig(changedOptions, LanguageNames.VisualBasic, actualText)
                 Assert.Equal(expectedText, actualText.ToString())
             End Using
         End Sub

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
@@ -1,0 +1,145 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeStyle
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
+    <[UseExportProvider]>
+    Public Class EditorConfigGeneratorTestsVB
+        Inherits TestBase
+
+        <WpfFact>
+        Public Sub TestEditorConfigGeneratorDefault()
+            Using workspace = TestWorkspace.CreateVisualBasic("")
+                Dim expectedText = "###############################
+# Core EditorConfig Options   #
+###############################
+# You can uncomment the next line if this is your top-most .editorconfig file.
+# root = true
+
+# Basic files
+[*.vb]
+indent_style = space
+indent_size = 4
+insert_final_newline = false
+
+###############################
+# .NET Coding Conventions     #
+###############################
+# Organize usings
+dotnet_sort_system_directives_first = true
+
+# this. preferences
+dotnet_style_qualification_for_field = false:none
+dotnet_style_qualification_for_property = false:none
+dotnet_style_qualification_for_method = false:none
+dotnet_style_qualification_for_event = false:none
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:none
+dotnet_style_predefined_type_for_member_access = true:none
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
+dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_prefer_inferred_tuple_names = true:suggestion
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:none
+dotnet_style_prefer_conditional_expression_over_assignment = true:none
+dotnet_style_prefer_conditional_expression_over_return = true:none
+
+###############################
+# VB Coding Conventions       #
+###############################
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
+"
+                Dim actualText = VisualBasic.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsString(workspace.Options)
+                Assert.Equal(expectedText, actualText)
+            End Using
+        End Sub
+
+        <WpfFact>
+        Public Sub TestEditorConfigGeneratorToggleOptions()
+            Using workspace = TestWorkspace.CreateVisualBasic("")
+                Dim changedOptions = workspace.Options.WithChangedOption(New OptionKey(CodeStyleOptions.PreferExplicitTupleNames, LanguageNames.VisualBasic),
+                                                                         New CodeStyleOption(Of Boolean)(False, NotificationOption.[Error]))
+                Dim expectedText = "###############################
+# Core EditorConfig Options   #
+###############################
+# You can uncomment the next line if this is your top-most .editorconfig file.
+# root = true
+
+# Basic files
+[*.vb]
+indent_style = space
+indent_size = 4
+insert_final_newline = false
+
+###############################
+# .NET Coding Conventions     #
+###############################
+# Organize usings
+dotnet_sort_system_directives_first = true
+
+# this. preferences
+dotnet_style_qualification_for_field = false:none
+dotnet_style_qualification_for_property = false:none
+dotnet_style_qualification_for_method = false:none
+dotnet_style_qualification_for_event = false:none
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:none
+dotnet_style_predefined_type_for_member_access = true:none
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
+dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = false:error
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_prefer_inferred_tuple_names = true:suggestion
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:none
+dotnet_style_prefer_conditional_expression_over_assignment = true:none
+dotnet_style_prefer_conditional_expression_over_return = true:none
+
+###############################
+# VB Coding Conventions       #
+###############################
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
+"
+                Dim actualText = VisualBasic.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsString(changedOptions)
+                Assert.Equal(expectedText, actualText)
+            End Using
+        End Sub
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
@@ -16,10 +16,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
         <WpfFact>
         Public Sub TestEditorConfigGeneratorDefault()
             Using workspace = TestWorkspace.CreateVisualBasic("")
-                Dim expectedText = "###############################
-# Core EditorConfig Options   #
-###############################
-# You can uncomment the next line if this is your top-most .editorconfig file.
+                Dim expectedText = "# Core EditorConfig Options
+# Uncomment the line below if you don’t want to inherit parent .editorconfig settings or if this is your solution directory.
 # root = true
 
 # Basic files
@@ -28,9 +26,7 @@ indent_style = space
 indent_size = 4
 insert_final_newline = false
 
-###############################
-# .NET Coding Conventions     #
-###############################
+# .NET Coding Conventions
 # Organize usings
 dotnet_sort_system_directives_first = true
 
@@ -67,9 +63,7 @@ dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
 
-###############################
-# VB Coding Conventions       #
-###############################
+# VB Coding Conventions
 # Modifier preferences
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
 "
@@ -86,10 +80,8 @@ visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public
             Using workspace = TestWorkspace.CreateVisualBasic("")
                 Dim changedOptions = workspace.Options.WithChangedOption(New OptionKey(CodeStyleOptions.PreferExplicitTupleNames, LanguageNames.VisualBasic),
                                                                          New CodeStyleOption(Of Boolean)(False, NotificationOption.[Error]))
-                Dim expectedText = "###############################
-# Core EditorConfig Options   #
-###############################
-# You can uncomment the next line if this is your top-most .editorconfig file.
+                Dim expectedText = "# Core EditorConfig Options
+# Uncomment the line below if you don’t want to inherit parent .editorconfig settings or if this is your solution directory.
 # root = true
 
 # Basic files
@@ -98,9 +90,7 @@ indent_style = space
 indent_size = 4
 insert_final_newline = false
 
-###############################
-# .NET Coding Conventions     #
-###############################
+# .NET Coding Conventions
 # Organize usings
 dotnet_sort_system_directives_first = true
 
@@ -137,9 +127,7 @@ dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
 
-###############################
-# VB Coding Conventions       #
-###############################
+# VB Coding Conventions
 # Modifier preferences
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
 "

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Text
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeStyle
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -33,7 +34,7 @@ insert_final_newline = false
 # Organize usings
 dotnet_sort_system_directives_first = true
 
-# this. preferences
+# Me. preferences
 dotnet_style_qualification_for_field = false:none
 dotnet_style_qualification_for_property = false:none
 dotnet_style_qualification_for_method = false:none
@@ -60,8 +61,8 @@ dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_prefer_inferred_tuple_names = true:suggestion
-dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
@@ -69,10 +70,14 @@ dotnet_style_prefer_conditional_expression_over_return = true:none
 ###############################
 # VB Coding Conventions       #
 ###############################
+# Modifier preferences
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
 "
-                Dim actualText = VisualBasic.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsString(workspace.Options)
-                Assert.Equal(expectedText, actualText)
+                Dim actualText = New StringBuilder()
+                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_CoreSettings(workspace.Options, LanguageNames.VisualBasic, actualText)
+                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_DotNetSettings(workspace.Options, LanguageNames.VisualBasic, actualText)
+                VisualBasic.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsVB(workspace.Options, actualText)
+                Assert.Equal(expectedText, actualText.ToString())
             End Using
         End Sub
 
@@ -99,7 +104,7 @@ insert_final_newline = false
 # Organize usings
 dotnet_sort_system_directives_first = true
 
-# this. preferences
+# Me. preferences
 dotnet_style_qualification_for_field = false:none
 dotnet_style_qualification_for_property = false:none
 dotnet_style_qualification_for_method = false:none
@@ -126,8 +131,8 @@ dotnet_style_explicit_tuple_names = false:error
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_prefer_inferred_tuple_names = true:suggestion
-dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:none
 dotnet_style_prefer_conditional_expression_over_return = true:none
@@ -135,10 +140,15 @@ dotnet_style_prefer_conditional_expression_over_return = true:none
 ###############################
 # VB Coding Conventions       #
 ###############################
+# Modifier preferences
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
 "
-                Dim actualText = VisualBasic.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsString(changedOptions)
-                Assert.Equal(expectedText, actualText)
+                Dim actualText = New StringBuilder()
+                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_CoreSettings(changedOptions, LanguageNames.VisualBasic, actualText)
+                Implementation.Options.GridOptionPreviewControl.GenerateEditorconfig_DotNetSettings(changedOptions, LanguageNames.VisualBasic, actualText)
+                VisualBasic.Options.Formatting.CodeStylePage.GetCurrentEditorConfigOptionsVB(changedOptions, actualText)
+                Dim Test = actualText.ToString()
+                Assert.Equal(expectedText, actualText.ToString())
             End Using
         End Sub
     End Class

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -3,15 +3,13 @@
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.ErrorReporting
-Imports Microsoft.CodeAnalysis.Options
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 Imports Microsoft.VisualStudio.LanguageServices.Implementation
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ObjectBrowser
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
+Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.Interop
 Imports Microsoft.VisualStudio.Shell

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
             GridOptionPreviewControl.Generate_Editorconfig(optionSet, language, editorconfig, AddressOf GetCurrentEditorConfigOptionsVB)
         End Sub
 
-        Friend Shared Sub GetCurrentEditorConfigOptionsVB(ByVal optionSet As OptionSet, ByVal editorconfig As StringBuilder)
+        Private Shared Sub GetCurrentEditorConfigOptionsVB(ByVal optionSet As OptionSet, ByVal editorconfig As StringBuilder)
             editorconfig.AppendLine()
             editorconfig.AppendLine("# VB Coding Conventions")
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -1,16 +1,171 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Runtime.InteropServices
+Imports System.Text
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeStyle
+Imports Microsoft.CodeAnalysis.Editing
+Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.VisualBasic.CodeStyle
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Options
-Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
-Namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
+Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
     <Guid(Guids.VisualBasicOptionPageCodeStyleIdString)>
     Friend Class CodeStylePage
         Inherits AbstractOptionPage
 
         Protected Overrides Function CreateOptionPage(serviceProvider As IServiceProvider) As AbstractOptionPageControl
-            Return New GridOptionPreviewControl(serviceProvider, Function(o, s) New StyleViewModel(o, s))
+            Return New GridOptionPreviewControl(serviceProvider, Function(o, s) New StyleViewModel(o, s), AddressOf GetCurrentEditorConfigOptionsString)
+        End Function
+
+        Friend Shared Function GetCurrentEditorConfigOptionsString(ByVal optionSet As OptionSet) As String
+            Dim editorconfig = New StringBuilder()
+
+            ' Core EditorConfig Options
+            editorconfig.AppendLine("###############################")
+            editorconfig.AppendLine("# Core EditorConfig Options   #")
+            editorconfig.AppendLine("###############################")
+            editorconfig.AppendLine("# You can uncomment the next line if this is your top-most .editorconfig file.")
+            editorconfig.AppendLine("# root = true")
+            editorconfig.AppendLine()
+            editorconfig.AppendLine("# Basic files")
+            editorconfig.AppendLine("[*.vb]")
+            editorconfig.Append("indent_style = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, FormattingOptions.UseTabs))
+            editorconfig.Append("indent_size = ")
+            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.IndentationSize, "csharp").ToString())
+            editorconfig.Append("insert_final_newline = ")
+            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.InsertFinalNewLine).ToString().ToLower())
+
+            editorconfig.AppendLine()
+            ' .NET Coding Conventions
+            editorconfig.AppendLine("###############################")
+            editorconfig.AppendLine("# .NET Coding Conventions     #")
+            editorconfig.AppendLine("###############################")
+            editorconfig.AppendLine("# Organize usings")
+            editorconfig.Append("dotnet_sort_system_directives_first = ")
+            editorconfig.AppendLine(optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, "csharp").ToString().ToLower())
+
+            editorconfig.AppendLine()
+            ' this. preferences
+            editorconfig.AppendLine("# this. preferences")
+            editorconfig.Append("dotnet_style_qualification_for_field = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyFieldAccess))
+            editorconfig.Append("dotnet_style_qualification_for_property = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess))
+            editorconfig.Append("dotnet_style_qualification_for_method = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyMethodAccess))
+            editorconfig.Append("dotnet_style_qualification_for_event = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess))
+
+            editorconfig.AppendLine()
+            ' Language keywords vs. BCL types preferences
+            editorconfig.AppendLine("# Language keywords vs BCL types preferences")
+            editorconfig.Append("dotnet_style_predefined_type_for_locals_parameters_members = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration))
+            editorconfig.Append("dotnet_style_predefined_type_for_member_access = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess))
+            editorconfig.AppendLine()
+
+            ' Parentheses preferences
+            editorconfig.AppendLine("# Parentheses preferences")
+            editorconfig.Append("dotnet_style_parentheses_in_arithmetic_binary_operators = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.ArithmeticBinaryParentheses))
+            editorconfig.Append("dotnet_style_parentheses_in_relational_binary_operators = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RelationalBinaryParentheses))
+            editorconfig.Append("dotnet_style_parentheses_in_other_binary_operators = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.OtherBinaryParentheses))
+            editorconfig.Append("dotnet_style_parentheses_in_other_operators = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.OtherParentheses))
+
+            editorconfig.AppendLine()
+            ' Modifier preferences
+            editorconfig.AppendLine("# Modifier preferences")
+            editorconfig.Append("dotnet_style_require_accessibility_modifiers = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RequireAccessibilityModifiers))
+            editorconfig.Append("dotnet_style_readonly_field = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferReadonly))
+
+            editorconfig.AppendLine()
+            ' Expression-level preferences
+            editorconfig.AppendLine("# Expression-level preferences")
+            editorconfig.Append("dotnet_style_object_initializer = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferObjectInitializer))
+            editorconfig.Append("dotnet_style_collection_initializer = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCollectionInitializer))
+            editorconfig.Append("dotnet_style_explicit_tuple_names = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferExplicitTupleNames))
+            editorconfig.Append("dotnet_style_null_propagation = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferNullPropagation))
+            editorconfig.Append("dotnet_style_coalesce_expression = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCoalesceExpression))
+            editorconfig.Append("dotnet_style_prefer_is_null_check_over_reference_equality_method = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIsNullCheckOverReferenceEqualityMethod))
+            editorconfig.Append("dotnet_prefer_inferred_tuple_names = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredTupleNames))
+            editorconfig.Append("dotnet_prefer_inferred_anonymous_type_member_names = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredAnonymousTypeMemberNames))
+            editorconfig.Append("dotnet_style_prefer_auto_properties = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferAutoProperties))
+            editorconfig.Append("dotnet_style_prefer_conditional_expression_over_assignment = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverAssignment))
+            editorconfig.Append("dotnet_style_prefer_conditional_expression_over_return = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverReturn))
+
+            editorconfig.AppendLine()
+            ' VB Coding Conventions
+            editorconfig.AppendLine("###############################")
+            editorconfig.AppendLine("# VB Coding Conventions       #")
+            editorconfig.AppendLine("###############################")
+            editorconfig.Append("visual_basic_preferred_modifier_order = ")
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, VisualBasicCodeStyleOptions.PreferredModifierOrder))
+
+            Return editorconfig.ToString()
+        End Function
+
+        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(optionSet As OptionSet, [option] As [Option](Of CodeStyleOption(Of String))) As String
+            Dim curSetting = optionSet.GetOption([option])
+            Return curSetting.Value + ":" + curSetting.Notification.ToString().ToLower()
+        End Function
+
+        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As PerLanguageOption(Of Boolean)) As String
+            Dim curSetting = optionSet.GetOption([option], LanguageNames.VisualBasic)
+            If curSetting Then
+                Return "tab"
+            Else
+                Return "space"
+            End If
+        End Function
+
+        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As PerLanguageOption(Of CodeStyleOption(Of AccessibilityModifiersRequired))) As String
+            Dim curSetting = optionSet.GetOption([option], LanguageNames.VisualBasic)
+            Dim editorconfig = ""
+            If curSetting.Value = AccessibilityModifiersRequired.ForNonInterfaceMembers Then
+                editorconfig += "for_non_interface_members:" & curSetting.Notification.ToString().ToLower()
+            ElseIf curSetting.Value = AccessibilityModifiersRequired.OmitIfDefault Then
+                editorconfig += "omit_if_default:" & curSetting.Notification.ToString().ToLower()
+            Else
+                editorconfig += (curSetting.Value & ":" + curSetting.Notification.ToString()).ToLower()
+            End If
+            Return editorconfig
+        End Function
+
+        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As PerLanguageOption(Of CodeStyleOption(Of Boolean))) As String
+            Dim curSetting = optionSet.GetOption([option], LanguageNames.VisualBasic)
+            Dim editorconfig = curSetting.Value & ":" + curSetting.Notification.ToString()
+            Return editorconfig.ToLower()
+        End Function
+
+        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As PerLanguageOption(Of CodeStyleOption(Of ParenthesesPreference))) As String
+            Dim curSetting = optionSet.GetOption([option], LanguageNames.VisualBasic)
+            Dim editorconfig = ""
+            If curSetting.Value = ParenthesesPreference.AlwaysForClarity Then
+                editorconfig += "always_for_clarity:" & curSetting.Notification.ToString().ToLower()
+            Else
+                editorconfig += "never_if_unnecessary:" & curSetting.Notification.ToString().ToLower()
+            End If
+            Return editorconfig
         End Function
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -4,8 +4,6 @@ Imports System.Runtime.InteropServices
 Imports System.Text
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeStyle
-Imports Microsoft.CodeAnalysis.Editing
-Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeStyle
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Options

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -21,9 +21,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
 
         Friend Shared Sub GetCurrentEditorConfigOptionsVB(ByVal optionSet As OptionSet, ByVal editorconfig As StringBuilder)
             editorconfig.AppendLine()
-            editorconfig.AppendLine("###############################")
-            editorconfig.AppendLine("# VB Coding Conventions       #")
-            editorconfig.AppendLine("###############################")
+            editorconfig.AppendLine("# VB Coding Conventions")
 
             editorconfig.AppendLine("# Modifier preferences")
             ' visual_basic_preferred_modifier_order

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -16,156 +16,26 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
         Inherits AbstractOptionPage
 
         Protected Overrides Function CreateOptionPage(serviceProvider As IServiceProvider) As AbstractOptionPageControl
-            Return New GridOptionPreviewControl(serviceProvider, Function(o, s) New StyleViewModel(o, s), AddressOf GetCurrentEditorConfigOptionsString, LanguageNames.VisualBasic)
+            Return New GridOptionPreviewControl(serviceProvider, Function(o, s) New StyleViewModel(o, s), AddressOf GetCurrentEditorConfigOptionsVB, LanguageNames.VisualBasic)
         End Function
 
-        Friend Shared Function GetCurrentEditorConfigOptionsString(ByVal optionSet As OptionSet) As String
-            Dim editorconfig = New StringBuilder()
-
-            ' Core EditorConfig Options
-            editorconfig.AppendLine("###############################")
-            editorconfig.AppendLine("# Core EditorConfig Options   #")
-            editorconfig.AppendLine("###############################")
-            editorconfig.AppendLine("# You can uncomment the next line if this is your top-most .editorconfig file.")
-            editorconfig.AppendLine("# root = true")
+        Friend Shared Sub GetCurrentEditorConfigOptionsVB(ByVal optionSet As OptionSet, ByVal editorconfig As StringBuilder)
             editorconfig.AppendLine()
-            editorconfig.AppendLine("# Basic files")
-            editorconfig.AppendLine("[*.vb]")
-            editorconfig.Append("indent_style = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, FormattingOptions.UseTabs))
-            editorconfig.Append("indent_size = ")
-            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.IndentationSize, LanguageNames.VisualBasic).ToString())
-            editorconfig.Append("insert_final_newline = ")
-            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.InsertFinalNewLine).ToString().ToLower())
-
-            editorconfig.AppendLine()
-            ' .NET Coding Conventions
-            editorconfig.AppendLine("###############################")
-            editorconfig.AppendLine("# .NET Coding Conventions     #")
-            editorconfig.AppendLine("###############################")
-            editorconfig.AppendLine("# Organize usings")
-            editorconfig.Append("dotnet_sort_system_directives_first = ")
-            editorconfig.AppendLine(optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.VisualBasic).ToString().ToLower())
-
-            editorconfig.AppendLine()
-            ' this. preferences
-            editorconfig.AppendLine("# Me. preferences")
-            editorconfig.Append("dotnet_style_qualification_for_field = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyFieldAccess))
-            editorconfig.Append("dotnet_style_qualification_for_property = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess))
-            editorconfig.Append("dotnet_style_qualification_for_method = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyMethodAccess))
-            editorconfig.Append("dotnet_style_qualification_for_event = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyEventAccess))
-
-            editorconfig.AppendLine()
-            ' Language keywords vs. BCL types preferences
-            editorconfig.AppendLine("# Language keywords vs BCL types preferences")
-            editorconfig.Append("dotnet_style_predefined_type_for_locals_parameters_members = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration))
-            editorconfig.Append("dotnet_style_predefined_type_for_member_access = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess))
-            editorconfig.AppendLine()
-
-            ' Parentheses preferences
-            editorconfig.AppendLine("# Parentheses preferences")
-            editorconfig.Append("dotnet_style_parentheses_in_arithmetic_binary_operators = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.ArithmeticBinaryParentheses))
-            editorconfig.Append("dotnet_style_parentheses_in_relational_binary_operators = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RelationalBinaryParentheses))
-            editorconfig.Append("dotnet_style_parentheses_in_other_binary_operators = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.OtherBinaryParentheses))
-            editorconfig.Append("dotnet_style_parentheses_in_other_operators = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.OtherParentheses))
-
-            editorconfig.AppendLine()
-            ' Modifier preferences
-            editorconfig.AppendLine("# Modifier preferences")
-            editorconfig.Append("dotnet_style_require_accessibility_modifiers = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.RequireAccessibilityModifiers))
-            editorconfig.Append("dotnet_style_readonly_field = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferReadonly))
-
-            editorconfig.AppendLine()
-            ' Expression-level preferences
-            editorconfig.AppendLine("# Expression-level preferences")
-            editorconfig.Append("dotnet_style_object_initializer = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferObjectInitializer))
-            editorconfig.Append("dotnet_style_collection_initializer = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCollectionInitializer))
-            editorconfig.Append("dotnet_style_explicit_tuple_names = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferExplicitTupleNames))
-            editorconfig.Append("dotnet_style_null_propagation = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferNullPropagation))
-            editorconfig.Append("dotnet_style_coalesce_expression = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferCoalesceExpression))
-            editorconfig.Append("dotnet_style_prefer_is_null_check_over_reference_equality_method = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferIsNullCheckOverReferenceEqualityMethod))
-            editorconfig.Append("dotnet_prefer_inferred_tuple_names = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredTupleNames))
-            editorconfig.Append("dotnet_prefer_inferred_anonymous_type_member_names = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInferredAnonymousTypeMemberNames))
-            editorconfig.Append("dotnet_style_prefer_auto_properties = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferAutoProperties))
-            editorconfig.Append("dotnet_style_prefer_conditional_expression_over_assignment = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverAssignment))
-            editorconfig.Append("dotnet_style_prefer_conditional_expression_over_return = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferConditionalExpressionOverReturn))
-
-            editorconfig.AppendLine()
-            ' VB Coding Conventions
             editorconfig.AppendLine("###############################")
             editorconfig.AppendLine("# VB Coding Conventions       #")
             editorconfig.AppendLine("###############################")
-            editorconfig.Append("visual_basic_preferred_modifier_order = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, VisualBasicCodeStyleOptions.PreferredModifierOrder))
 
-            Return editorconfig.ToString()
-        End Function
+            editorconfig.AppendLine("# Modifier preferences")
+            ' visual_basic_preferred_modifier_order
+            VBCodeStyleOptions_GenerateEditorconfig(optionSet, VisualBasicCodeStyleOptions.PreferredModifierOrder, editorconfig)
+        End Sub
 
-        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(optionSet As OptionSet, [option] As [Option](Of CodeStyleOption(Of String))) As String
+        Private Shared Sub VBCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As [Option](Of CodeStyleOption(Of String)), ByVal editorconfig As StringBuilder)
+            editorconfig.Append((CType([option].StorageLocations.OfType(Of IEditorConfigStorageLocation).SingleOrDefault(), EditorConfigStorageLocation(Of CodeStyleOption(Of String)))).KeyName)
+            editorconfig.Append(" = ")
+
             Dim curSetting = optionSet.GetOption([option])
-            Return curSetting.Value + ":" + curSetting.Notification.ToString().ToLower()
-        End Function
-
-        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As PerLanguageOption(Of Boolean)) As String
-            Dim curSetting = optionSet.GetOption([option], LanguageNames.VisualBasic)
-            If curSetting Then
-                Return "tab"
-            Else
-                Return "space"
-            End If
-        End Function
-
-        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As PerLanguageOption(Of CodeStyleOption(Of AccessibilityModifiersRequired))) As String
-            Dim curSetting = optionSet.GetOption([option], LanguageNames.VisualBasic)
-            Dim editorconfig = ""
-            If curSetting.Value = AccessibilityModifiersRequired.ForNonInterfaceMembers Then
-                editorconfig += "for_non_interface_members:" & curSetting.Notification.ToString().ToLower()
-            ElseIf curSetting.Value = AccessibilityModifiersRequired.OmitIfDefault Then
-                editorconfig += "omit_if_default:" & curSetting.Notification.ToString().ToLower()
-            Else
-                editorconfig += (curSetting.Value & ":" + curSetting.Notification.ToString()).ToLower()
-            End If
-            Return editorconfig
-        End Function
-
-        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As PerLanguageOption(Of CodeStyleOption(Of Boolean))) As String
-            Dim curSetting = optionSet.GetOption([option], LanguageNames.VisualBasic)
-            Dim editorconfig = curSetting.Value & ":" + curSetting.Notification.ToString()
-            Return editorconfig.ToLower()
-        End Function
-
-        Private Shared Function BasicCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As PerLanguageOption(Of CodeStyleOption(Of ParenthesesPreference))) As String
-            Dim curSetting = optionSet.GetOption([option], LanguageNames.VisualBasic)
-            Dim editorconfig = ""
-            If curSetting.Value = ParenthesesPreference.AlwaysForClarity Then
-                editorconfig += "always_for_clarity:" & curSetting.Notification.ToString().ToLower()
-            Else
-                editorconfig += "never_if_unnecessary:" & curSetting.Notification.ToString().ToLower()
-            End If
-            Return editorconfig
-        End Function
+            editorconfig.AppendLine(curSetting.Value + ":" + curSetting.Notification.ToString().ToLower())
+        End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -25,13 +25,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
             editorconfig.AppendLine()
             editorconfig.AppendLine("# VB Coding Conventions")
 
-            editorconfig.AppendLine("# Modifier preferences")
+            editorconfig.AppendLine("# Modifier preferences:")
             ' visual_basic_preferred_modifier_order
             VBCodeStyleOptions_GenerateEditorconfig(optionSet, VisualBasicCodeStyleOptions.PreferredModifierOrder, editorconfig)
         End Sub
 
         Private Shared Sub VBCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As [Option](Of CodeStyleOption(Of String)), ByVal editorconfig As StringBuilder)
-            Dim element = CType([option].StorageLocations.OfType(Of IEditorConfigStorageLocation)().SingleOrDefault(), EditorConfigStorageLocation(Of CodeStyleOption(Of String)))
+            Dim element = [option].StorageLocations.OfType(Of EditorConfigStorageLocation(Of CodeStyleOption(Of String)))().FirstOrDefault()
             If element IsNot Nothing Then
                 editorconfig.Append(element.KeyName & " = ")
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -19,6 +19,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
             Return New GridOptionPreviewControl(serviceProvider, Function(o, s) New StyleViewModel(o, s), AddressOf GetCurrentEditorConfigOptionsVB, LanguageNames.VisualBasic)
         End Function
 
+        Friend Shared Sub Generate_Editorconfig(ByVal optionSet As OptionSet, ByVal language As String, ByVal editorconfig As StringBuilder)
+            GridOptionPreviewControl.Generate_Editorconfig(optionSet, language, editorconfig, AddressOf GetCurrentEditorConfigOptionsVB)
+        End Sub
+
         Friend Shared Sub GetCurrentEditorConfigOptionsVB(ByVal optionSet As OptionSet, ByVal editorconfig As StringBuilder)
             editorconfig.AppendLine()
             editorconfig.AppendLine("# VB Coding Conventions")
@@ -29,11 +33,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
         End Sub
 
         Private Shared Sub VBCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As [Option](Of CodeStyleOption(Of String)), ByVal editorconfig As StringBuilder)
-            editorconfig.Append((CType([option].StorageLocations.OfType(Of IEditorConfigStorageLocation).SingleOrDefault(), EditorConfigStorageLocation(Of CodeStyleOption(Of String)))).KeyName)
-            editorconfig.Append(" = ")
+            Dim element = CType([option].StorageLocations.OfType(Of IEditorConfigStorageLocation)().SingleOrDefault(), EditorConfigStorageLocation(Of CodeStyleOption(Of String)))
+            If element IsNot Nothing Then
+                editorconfig.Append(element.KeyName & " = ")
 
-            Dim curSetting = optionSet.GetOption([option])
-            editorconfig.AppendLine(curSetting.Value + ":" + curSetting.Notification.ToString().ToLower())
+                Dim curSetting = optionSet.GetOption([option])
+                editorconfig.AppendLine(curSetting.Value + ":" + curSetting.Notification.ToString().ToLower())
+            End If
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
                 editorconfig.Append(element.KeyName & " = ")
 
                 Dim curSetting = optionSet.GetOption([option])
-                editorconfig.AppendLine(curSetting.Value + ":" + curSetting.Notification.ToString().ToLower())
+                editorconfig.AppendLine(curSetting.Value + ":" + curSetting.Notification.ToString().ToLowerInvariant())
             End If
         End Sub
     End Class

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
         Inherits AbstractOptionPage
 
         Protected Overrides Function CreateOptionPage(serviceProvider As IServiceProvider) As AbstractOptionPageControl
-            Return New GridOptionPreviewControl(serviceProvider, Function(o, s) New StyleViewModel(o, s), AddressOf GetCurrentEditorConfigOptionsString)
+            Return New GridOptionPreviewControl(serviceProvider, Function(o, s) New StyleViewModel(o, s), AddressOf GetCurrentEditorConfigOptionsString, LanguageNames.VisualBasic)
         End Function
 
         Friend Shared Function GetCurrentEditorConfigOptionsString(ByVal optionSet As OptionSet) As String
@@ -34,7 +34,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
             editorconfig.Append("indent_style = ")
             editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, FormattingOptions.UseTabs))
             editorconfig.Append("indent_size = ")
-            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.IndentationSize, "csharp").ToString())
+            editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.IndentationSize, LanguageNames.VisualBasic).ToString())
             editorconfig.Append("insert_final_newline = ")
             editorconfig.AppendLine(optionSet.GetOption(FormattingOptions.InsertFinalNewLine).ToString().ToLower())
 
@@ -45,11 +45,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
             editorconfig.AppendLine("###############################")
             editorconfig.AppendLine("# Organize usings")
             editorconfig.Append("dotnet_sort_system_directives_first = ")
-            editorconfig.AppendLine(optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, "csharp").ToString().ToLower())
+            editorconfig.AppendLine(optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.VisualBasic).ToString().ToLower())
 
             editorconfig.AppendLine()
             ' this. preferences
-            editorconfig.AppendLine("# this. preferences")
+            editorconfig.AppendLine("# Me. preferences")
             editorconfig.Append("dotnet_style_qualification_for_field = ")
             editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyFieldAccess))
             editorconfig.Append("dotnet_style_qualification_for_property = ")
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
             editorconfig.Append("dotnet_style_qualification_for_method = ")
             editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyMethodAccess))
             editorconfig.Append("dotnet_style_qualification_for_event = ")
-            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyPropertyAccess))
+            editorconfig.AppendLine(BasicCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.QualifyEventAccess))
 
             editorconfig.AppendLine()
             ' Language keywords vs. BCL types preferences


### PR DESCRIPTION
Adding option to generate .editorconfig file from user's existing Tools->Options settings. This feature currently only applies to C# and VB.
![editorconfigui](https://user-images.githubusercontent.com/16968319/42603787-1f910746-8524-11e8-865a-b47e2120335d.png)
The above is the edited UI. Users can click the "Generate .editorconfig file from settings" button, which will open up the File Explorer. Users are then prompted to select the destination to which to save the generated .editorconfig file. 
