### PR TITLE
Don't ensure we have a FileChangeTracker until we actually read the file

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
@@ -34,16 +34,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             private readonly VisualStudioMetadataReferenceManager _provider;
             private readonly Lazy<DateTime> _timestamp;
             private Exception _error;
+            private FileChangeTracker _fileChangeTrackerOpt;
 
-            internal Snapshot(VisualStudioMetadataReferenceManager provider, MetadataReferenceProperties properties, string fullPath)
+            internal Snapshot(VisualStudioMetadataReferenceManager provider, MetadataReferenceProperties properties, string fullPath, FileChangeTracker fileChangeTrackerOpt)
                 : base(properties, fullPath)
             {
                 Contract.Requires(Properties.Kind == MetadataImageKind.Assembly);
                 _provider = provider;
+                _fileChangeTrackerOpt = fileChangeTrackerOpt;
 
                 _timestamp = new Lazy<DateTime>(() => {
                     try
                     {
+                        _fileChangeTrackerOpt?.EnsureSubscription();
+
                         return FileUtilities.GetFileTimeStamp(this.FilePath);
                     }
                     catch (IOException e)
@@ -98,7 +102,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             protected override PortableExecutableReference WithPropertiesImpl(MetadataReferenceProperties properties)
             {
-                return new Snapshot(_provider, properties, this.FilePath);
+                return new Snapshot(_provider, properties, this.FilePath, _fileChangeTrackerOpt);
             }
 
             private string GetDebuggerDisplay()

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
@@ -55,8 +55,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     UpdateSnapshot();
                 }
 
-                // make sure we have file notification subscribed
-                _fileChangeTracker.EnsureSubscription();
                 return _currentSnapshot;
             }
         }
@@ -74,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public void UpdateSnapshot()
         {
-            _currentSnapshot = new Snapshot(_provider, Properties, this.FilePath);
+            _currentSnapshot = new Snapshot(_provider, Properties, this.FilePath, _fileChangeTracker);
         }
 
         private string GetDebuggerDisplay()

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public PortableExecutableReference CreateMetadataReferenceSnapshot(string filePath, MetadataReferenceProperties properties)
         {
-            return new VisualStudioMetadataReference.Snapshot(this, properties, filePath);
+            return new VisualStudioMetadataReference.Snapshot(this, properties, filePath, fileChangeTrackerOpt: null);
         }
 
         public VisualStudioMetadataReference CreateMetadataReference(string filePath, MetadataReferenceProperties properties)


### PR DESCRIPTION
This .EnsureSubscription() was very premature.

<details><summary>Ask Mode template</summary>

### Customer scenario

User opens a large solution that's using CPS. We do work on the UI thread (including disk I/O) that simply doesn't need to be there. This is also doing work in csproj.dll/msvbprj.dll projects, but there's a good chance we've already done the subscription asynchronously and so we don't care.

### Bugs this fixes

No bug directly for this one at this time, observed as part of larger solution load work.

### Workarounds, if any

Buy a really, really fast computer.

### Risk

Very low -- code change is straightforward.

### Performance impact

Should shave off 5.5 seconds from the UI thread when loading a CPS-based Roslyn.sln, as well as IO.

### Is this a regression from a previous update?

Nope.

### Root cause analysis

We are subscribing to a file watcher synchronously when we can defer that until the background thread later. It seems we don't see this cost in non-CPS because we defer the call to VisualStudioMetadataReference.CurrentSnapshot until a bit later, at which point we might have already done the work in a background thread.

### How was the bug found?

Examining perf traces.

</details>
