### PR TITLE
Remove SymbolWithAnnotations base class

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal bool IsAlias => Symbol?.Kind == SymbolKind.Alias;
             internal Symbol SymbolOrType => Symbol ?? Type?.TypeSymbol;
             internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => (NamespaceOrTypeSymbol)SymbolOrType;
-            internal bool IsDefault => Symbol is null && Type is null;
+            internal bool IsDefault => _symbolOrTypeSymbolWithAnnotations is null;
 
             internal static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateNonNull(bool nonNullTypes, Symbol symbol)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -9,17 +9,17 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         internal struct NamespaceOrTypeOrAliasSymbolWithAnnotations
         {
-            internal readonly TypeSymbolWithAnnotations Type;
-            internal readonly Symbol Symbol;
+            private readonly object _symbolOrTypeSymbolWithAnnotations;
 
-            private NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type, Symbol symbol)
+            private NamespaceOrTypeOrAliasSymbolWithAnnotations(object symbolOrTypeSymbolWithAnnotations)
             {
-                Debug.Assert((type is null) || (symbol is null));
-                Debug.Assert(!(symbol is TypeSymbol));
-                Type = type;
-                Symbol = symbol;
+                Debug.Assert(symbolOrTypeSymbolWithAnnotations != null);
+                Debug.Assert(!(symbolOrTypeSymbolWithAnnotations is TypeSymbol));
+                _symbolOrTypeSymbolWithAnnotations = symbolOrTypeSymbolWithAnnotations;
             }
 
+            internal TypeSymbolWithAnnotations Type => _symbolOrTypeSymbolWithAnnotations as TypeSymbolWithAnnotations;
+            internal Symbol Symbol => _symbolOrTypeSymbolWithAnnotations as Symbol;
             internal bool IsType => !(Type is null);
             internal bool IsAlias => Symbol?.Kind == SymbolKind.Alias;
             internal Symbol SymbolOrType => Symbol ?? Type?.TypeSymbol;
@@ -35,14 +35,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var type = symbol as TypeSymbol;
                 if (type is null)
                 {
-                    return new NamespaceOrTypeOrAliasSymbolWithAnnotations(null, symbol);
+                    return new NamespaceOrTypeOrAliasSymbolWithAnnotations(symbol);
                 }
-                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.CreateNonNull(nonNullTypes, type), null);
+                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.CreateNonNull(nonNullTypes, type));
             }
 
             public static implicit operator NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type)
             {
-                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(type, null);
+                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(type);
             }
 
             public static explicit operator TypeSymbolWithAnnotations(NamespaceOrTypeOrAliasSymbolWithAnnotations type)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal bool IsType => !(Type is null);
             internal bool IsAlias => Symbol?.Kind == SymbolKind.Alias;
             internal Symbol SymbolOrType => Symbol ?? Type?.TypeSymbol;
-            internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => (NamespaceOrTypeSymbol)SymbolOrType;
+            internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => SymbolOrType as NamespaceOrTypeSymbol;
             internal bool IsDefault => _symbolOrTypeSymbolWithAnnotations is null;
 
             internal static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateNonNull(bool nonNullTypes, Symbol symbol)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -44,11 +44,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return new NamespaceOrTypeOrAliasSymbolWithAnnotations(type);
             }
-
-            public static explicit operator TypeSymbolWithAnnotations(NamespaceOrTypeOrAliasSymbolWithAnnotations type)
-            {
-                return type.Type;
-            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -19,11 +19,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             internal TypeSymbolWithAnnotations Type => _symbolOrTypeSymbolWithAnnotations as TypeSymbolWithAnnotations;
-            internal Symbol Symbol => _symbolOrTypeSymbolWithAnnotations as Symbol;
+            internal Symbol Symbol => _symbolOrTypeSymbolWithAnnotations as Symbol ?? Type?.TypeSymbol;
             internal bool IsType => !(Type is null);
-            internal bool IsAlias => Symbol?.Kind == SymbolKind.Alias;
-            internal Symbol SymbolOrType => Symbol ?? Type?.TypeSymbol;
-            internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => SymbolOrType as NamespaceOrTypeSymbol;
+            internal bool IsAlias => (_symbolOrTypeSymbolWithAnnotations as Symbol)?.Kind == SymbolKind.Alias;
+            internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => Symbol as NamespaceOrTypeSymbol;
             internal bool IsDefault => _symbolOrTypeSymbolWithAnnotations is null;
 
             internal static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateNonNull(bool nonNullTypes, Symbol symbol)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class Binder
+    {
+        internal struct NamespaceOrTypeOrAliasSymbolWithAnnotations
+        {
+            internal readonly TypeSymbolWithAnnotations Type;
+            internal readonly Symbol Symbol;
+
+            private NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type, Symbol symbol)
+            {
+                Debug.Assert((type is null) || (symbol is null));
+                Debug.Assert(!(symbol is TypeSymbol));
+                Type = type;
+                Symbol = symbol;
+            }
+
+            internal bool IsType => !(Type is null);
+            internal bool IsAlias => Symbol?.Kind == SymbolKind.Alias;
+            internal Symbol SymbolOrType => Symbol ?? Type?.TypeSymbol;
+            internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => (NamespaceOrTypeSymbol)SymbolOrType;
+            internal bool IsDefault => Symbol is null && Type is null;
+
+            internal static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateNonNull(bool nonNullTypes, Symbol symbol)
+            {
+                if (symbol is null)
+                {
+                    return default;
+                }
+                var type = symbol as TypeSymbol;
+                if (type is null)
+                {
+                    return new NamespaceOrTypeOrAliasSymbolWithAnnotations(null, symbol);
+                }
+                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.CreateNonNull(nonNullTypes, type), null);
+            }
+
+            public static implicit operator NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type)
+            {
+                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(type, null);
+            }
+
+            public static explicit operator TypeSymbolWithAnnotations(NamespaceOrTypeOrAliasSymbolWithAnnotations type)
+            {
+                return type.Type;
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1769,7 +1769,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression BindNamespaceOrType(ExpressionSyntax node, DiagnosticBag diagnostics)
         {
             var symbol = this.BindNamespaceOrTypeOrAliasSymbol(node, diagnostics, null, false);
-            return CreateBoundNamespaceOrTypeExpression(node, symbol.Symbol);
+            return CreateBoundNamespaceOrTypeExpression(node, symbol.SymbolOrType);
         }
 
         public BoundExpression BindNamespaceAlias(IdentifierNameSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1769,7 +1769,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression BindNamespaceOrType(ExpressionSyntax node, DiagnosticBag diagnostics)
         {
             var symbol = this.BindNamespaceOrTypeOrAliasSymbol(node, diagnostics, null, false);
-            return CreateBoundNamespaceOrTypeExpression(node, symbol.SymbolOrType);
+            return CreateBoundNamespaceOrTypeExpression(node, symbol.Symbol);
         }
 
         public BoundExpression BindNamespaceAlias(IdentifierNameSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var symbol = BindTypeOrAliasOrVarKeyword(syntax, diagnostics, out isVar);
             Debug.Assert(isVar == symbol.IsDefault);
-            return isVar ? null : (TypeSymbolWithAnnotations)UnwrapAlias(symbol, diagnostics, syntax);
+            return isVar ? null : UnwrapAlias(symbol, diagnostics, syntax).Type;
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var symbol = BindTypeOrAliasOrUnmanagedKeyword(syntax, diagnostics, out isUnmanaged);
             Debug.Assert(isUnmanaged == symbol.IsDefault);
-            return isUnmanaged ? null : (TypeSymbolWithAnnotations)UnwrapAlias(symbol, diagnostics, syntax);
+            return isUnmanaged ? null : UnwrapAlias(symbol, diagnostics, syntax).Type;
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return (TypeSymbolWithAnnotations)UnwrapAlias(symbol, out alias, diagnostics, syntax);
+                return UnwrapAlias(symbol, out alias, diagnostics, syntax).Type;
             }
         }
 
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal TypeSymbolWithAnnotations BindType(ExpressionSyntax syntax, DiagnosticBag diagnostics, ConsList<Symbol> basesBeingResolved = null)
         {
             var symbol = BindTypeOrAlias(syntax, diagnostics, basesBeingResolved);
-            return (TypeSymbolWithAnnotations)UnwrapAlias(symbol, diagnostics, syntax, basesBeingResolved);
+            return UnwrapAlias(symbol, diagnostics, syntax, basesBeingResolved).Type;
         }
 
         // Binds the given expression syntax as Type.
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal TypeSymbolWithAnnotations BindType(ExpressionSyntax syntax, DiagnosticBag diagnostics, out AliasSymbol alias, ConsList<Symbol> basesBeingResolved = null)
         {
             var symbol = BindTypeOrAlias(syntax, diagnostics, basesBeingResolved);
-            return (TypeSymbolWithAnnotations)UnwrapAlias(symbol, out alias, diagnostics, syntax, basesBeingResolved);
+            return UnwrapAlias(symbol, out alias, diagnostics, syntax, basesBeingResolved).Type;
         }
 
         // Binds the given expression syntax as Type or an Alias to Type
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // Obsolete alias targets are reported in UnwrapAlias, but if it was a type (not an
                     // alias to a type) we report the obsolete type here.
-                    ((TypeSymbolWithAnnotations)symbol).ReportDiagnosticsIfObsolete(this, syntax, diagnostics);
+                    symbol.Type.ReportDiagnosticsIfObsolete(this, syntax, diagnostics);
                 }
 
                 return symbol;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -15,51 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class Binder
     {
-        internal struct NamespaceOrTypeOrAliasSymbolWithAnnotations
-        {
-            internal static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateNonNull(bool nonNullTypes, Symbol symbol)
-            {
-                if (symbol is null)
-                {
-                    return default;
-                }
-                var type = symbol as TypeSymbol;
-                if (type is null)
-                {
-                    return new NamespaceOrTypeOrAliasSymbolWithAnnotations(null, symbol);
-                }
-                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.CreateNonNull(nonNullTypes, type), null);
-            }
-
-            internal readonly TypeSymbolWithAnnotations Type;
-            internal readonly Symbol Symbol;
-
-            internal bool IsType => !(Type is null);
-            internal bool IsAlias => Symbol?.Kind == SymbolKind.Alias;
-            internal Symbol SymbolOrType => Symbol ?? Type?.TypeSymbol;
-            internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => (NamespaceOrTypeSymbol)SymbolOrType;
-
-            internal bool IsDefault => Symbol is null && Type is null;
-
-            private NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type, Symbol symbol)
-            {
-                Debug.Assert((type is null) || (symbol is null));
-                Debug.Assert(!(symbol is TypeSymbol));
-                Type = type;
-                Symbol = symbol;
-            }
-
-            public static implicit operator NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type)
-            {
-                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(type, null);
-            }
-
-            public static explicit operator TypeSymbolWithAnnotations(NamespaceOrTypeOrAliasSymbolWithAnnotations type)
-            {
-                return type.Type;
-            }
-        }
-
         /// <summary>
         /// Binds the type for the syntax taking into account possibility of "var" type.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         continue;
                     }
 
-                    var errorTypeName = _fixedResults[i].Name;
+                    var errorTypeName = _fixedResults[i].TypeSymbol.Name;
                     if (errorTypeName != null)
                     {
                         continue;
@@ -584,7 +584,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Example:
             //      if   "(a: 1, b: "qq")" is passed as   (T, U) arg
             //      then T becomes int and U becomes string
-            if (target.Kind != SymbolKind.NamedType)
+            if (target.TypeSymbol.Kind != SymbolKind.NamedType)
             {
                 // tuples can only match to tuples or tuple underlying types.
                 return false;

--- a/src/Compilers/CSharp/Portable/Errors/LazyObsoleteDiagnosticInfo.cs
+++ b/src/Compilers/CSharp/Portable/Errors/LazyObsoleteDiagnosticInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // A symbol's Obsoleteness may not have been calculated yet if the symbol is coming
                 // from a different compilation's source. In that case, force completion of attributes.
-                var symbol = (_symbolOrSymbolWithAnnotations as Symbol) ?? ((SymbolWithAnnotations)_symbolOrSymbolWithAnnotations).Symbol;
+                var symbol = (_symbolOrSymbolWithAnnotations as Symbol) ?? ((TypeSymbolWithAnnotations)_symbolOrSymbolWithAnnotations).TypeSymbol;
                 symbol.ForceCompleteObsoleteAttribute();
 
                 var kind = ObsoleteAttributeHelpers.GetObsoleteDiagnosticKind(symbol, _containingSymbol, forceComplete: true);

--- a/src/Compilers/CSharp/Portable/Errors/LazyObsoleteDiagnosticInfo.cs
+++ b/src/Compilers/CSharp/Portable/Errors/LazyObsoleteDiagnosticInfo.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal LazyObsoleteDiagnosticInfo(object symbol, Symbol containingSymbol, BinderFlags binderFlags)
             : base(CSharp.MessageProvider.Instance, (int)ErrorCode.Unknown)
         {
+            Debug.Assert(symbol is Symbol || symbol is TypeSymbolWithAnnotations);
             _symbolOrSymbolWithAnnotations = symbol;
             _containingSymbol = containingSymbol;
             _binderFlags = binderFlags;

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -49,6 +49,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable;
         }
 
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator ==(Symbol x, TypeSymbolWithAnnotations y)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator !=(Symbol x, TypeSymbolWithAnnotations y)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator ==(TypeSymbolWithAnnotations x, Symbol y)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator !=(TypeSymbolWithAnnotations x, Symbol y)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
         internal static readonly SymbolDisplayFormat DebuggerDisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -12,16 +12,14 @@ using Microsoft.CodeAnalysis.PooledObjects;
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
-    /// A simple class that combines a single symbol with annotations
+    /// A simple class that combines a single type symbol with annotations
     /// </summary>
-    internal abstract class SymbolWithAnnotations 
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+    internal abstract class TypeSymbolWithAnnotations : IFormattable
     {
-        public abstract Symbol Symbol { get; }
-
-        public sealed override string ToString() => Symbol.ToString();
-        public virtual string ToDisplayString(SymbolDisplayFormat format = null) => Symbol.ToDisplayString(format);
-        public string Name => Symbol.Name;
-        public SymbolKind Kind => Symbol.Kind;
+        public sealed override string ToString() => TypeSymbol.ToString();
+        public string Name => TypeSymbol.Name;
+        public SymbolKind Kind => TypeSymbol.Kind;
 
 #pragma warning disable CS0809
         [Obsolete("Unsupported", error: true)]
@@ -40,139 +38,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         [Obsolete("Unsupported", error: true)]
-        public static bool operator == (SymbolWithAnnotations x, SymbolWithAnnotations y)
+        public static bool operator ==(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
         {
             throw ExceptionUtilities.Unreachable;
         }
 
         [Obsolete("Unsupported", error: true)]
-        public static bool operator !=(SymbolWithAnnotations x, SymbolWithAnnotations y)
+        public static bool operator !=(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
         {
             throw ExceptionUtilities.Unreachable;
         }
 
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator ==(Symbol x, SymbolWithAnnotations y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator !=(Symbol x, SymbolWithAnnotations y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator ==(SymbolWithAnnotations x, Symbol y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator !=(SymbolWithAnnotations x, Symbol y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-    }
-
-    internal abstract class NamespaceOrTypeOrAliasSymbolWithAnnotations : SymbolWithAnnotations
-    {
-        [Obsolete("Unsupported", error: true)]
-        public new bool Equals(object other)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public new int GetHashCode()
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        public static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateNonNull(bool nonNullTypes, Symbol symbol)
-        {
-            if (symbol is null)
-            {
-                return null;
-            }
-
-            switch (symbol.Kind)
-            {
-                case SymbolKind.Namespace:
-                    return new NamespaceSymbolWithAnnotations((NamespaceSymbol)symbol);
-                case SymbolKind.Alias:
-                    return new AliasSymbolWithAnnotations((AliasSymbol)symbol);
-                default:
-                    return TypeSymbolWithAnnotations.CreateNonNull(nonNullTypes, (TypeSymbol)symbol);
-            }
-        }
-
-        public abstract bool IsAlias { get; }
-        public abstract bool IsNamespace { get; }
-        public abstract bool IsType { get; }
-    }
-
-    internal sealed class AliasSymbolWithAnnotations : NamespaceOrTypeOrAliasSymbolWithAnnotations
-    {
-        private readonly AliasSymbol _aliasSymbol;
-
-        public AliasSymbolWithAnnotations(AliasSymbol aliasSymbol)
-        {
-            Debug.Assert((object)aliasSymbol != null);
-            _aliasSymbol = aliasSymbol;
-        }
-
-        public sealed override Symbol Symbol => _aliasSymbol;
-        public AliasSymbol AliasSymbol => _aliasSymbol;
-
-        public override bool IsAlias => true;
-        public override bool IsNamespace => false;
-        public override bool IsType => false;
-    }
-
-    internal abstract class NamespaceOrTypeSymbolWithAnnotations : NamespaceOrTypeOrAliasSymbolWithAnnotations
-    {
-        public abstract NamespaceOrTypeSymbol NamespaceOrTypeSymbol { get; }
-
-        public static NamespaceOrTypeSymbolWithAnnotations CreateNonNull(bool nonNullTypes, NamespaceOrTypeSymbol symbol)
-        {
-            switch (symbol.Kind)
-            {
-                case SymbolKind.Namespace:
-                    return new NamespaceSymbolWithAnnotations((NamespaceSymbol)symbol);
-                default:
-                    return TypeSymbolWithAnnotations.CreateNonNull(nonNullTypes, (TypeSymbol)symbol);
-            }
-        }
-
-        public override bool IsAlias => false;
-    }
-
-    internal sealed class NamespaceSymbolWithAnnotations : NamespaceOrTypeSymbolWithAnnotations
-    {
-        private readonly NamespaceSymbol _namespaceSymbol;
-
-        public NamespaceSymbolWithAnnotations(NamespaceSymbol namespaceSymbol)
-        {
-            Debug.Assert((object)namespaceSymbol != null);
-            _namespaceSymbol = namespaceSymbol;
-        }
-
-        public sealed override Symbol Symbol => _namespaceSymbol;
-        public NamespaceSymbol NamespaceSymbol => _namespaceSymbol;
-        public sealed override NamespaceOrTypeSymbol NamespaceOrTypeSymbol => _namespaceSymbol;
-
-        public override bool IsNamespace => true;
-        public override bool IsType => false;
-    }
-
-    /// <summary>
-    /// A simple class that combines a single type symbol with annotations
-    /// </summary>
-    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-    internal abstract class TypeSymbolWithAnnotations : NamespaceOrTypeSymbolWithAnnotations, IFormattable
-    {
         internal static readonly SymbolDisplayFormat DebuggerDisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
@@ -271,12 +147,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public abstract TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers);
 
-        public sealed override Symbol Symbol => TypeSymbol;
-        public sealed override NamespaceOrTypeSymbol NamespaceOrTypeSymbol => TypeSymbol;
-
-        public override bool IsNamespace => false;
-        public override bool IsType => true;
-
         public abstract TypeSymbol TypeSymbol { get; }
         public virtual TypeSymbol NullableUnderlyingTypeOrSelf => TypeSymbol.StrippedType();
 
@@ -322,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal abstract bool GetIsReferenceType(ConsList<TypeParameterSymbol> inProgress);
         internal abstract bool GetIsValueType(ConsList<TypeParameterSymbol> inProgress);
 
-        public abstract override string ToDisplayString(SymbolDisplayFormat format = null);
+        public abstract string ToDisplayString(SymbolDisplayFormat format = null);
         internal string GetDebuggerDisplay() => ToDisplayString(DebuggerDisplayFormat);
 
         // PROTOTYPE(NullableReferenceTypes): Remove IFormattable implementation

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
@@ -752,9 +752,9 @@ class C1<T>
 
     internal abstract class SymbolChecker
     {
-        public void CheckSymbols(SymbolWithAnnotations a, SymbolWithAnnotations b, bool recurse)
+        public void CheckSymbols(TypeSymbolWithAnnotations a, TypeSymbolWithAnnotations b, bool recurse)
         {
-            CheckSymbols(a.Symbol, b.Symbol, recurse);
+            CheckSymbols(a.TypeSymbol, b.TypeSymbol, recurse);
         }
 
         public void CheckSymbols(Symbol a, Symbol b, bool recurse)

--- a/src/Compilers/Test/Utilities/CSharp/SymbolUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/SymbolUtilities.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return CodeAnalysis.Test.Extensions.SymbolExtensions.ToTestDisplayString(symbol);
         }
 
-        public static string ToTestDisplayString(this SymbolWithAnnotations symbol, bool includeNonNullable = false)
+        public static string ToTestDisplayString(this TypeSymbolWithAnnotations symbol, bool includeNonNullable = false)
         {
             var format = SymbolDisplayFormat.TestFormat;
             if (includeNonNullable)


### PR DESCRIPTION
The base class `SymbolWithAnnotations` was only used for intermediate results in binding. A dedicated `struct` has been created for that purpose, and `TypeSymbolWithAnnotations` is now an `abstract` class that derives from `object` directly.