### PR TITLE
Share file watchers for metadata references

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
@@ -74,6 +74,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             _fileChangeTracker.Dispose();
             _fileChangeTracker.UpdatedOnDisk -= OnUpdatedOnDisk;
+
+            _provider.StopTrackingSharedMetadataReference(this);
         }
 
         private void UpdateSnapshot()

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
@@ -8,6 +8,11 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
+    /// <summary>
+    /// Holds a <see cref="Snapshot" /> that represents an individual metadata reference at a certain point in time. A <see cref="Snapshot"/>
+    /// is what is actually passed to the compiler as a <see cref="MetadataReference"/>. This type monitors the file for changes and provides new
+    /// <see cref="Snapshot"/>s if needed.
+    /// </summary>
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     internal sealed partial class VisualStudioMetadataReference : IDisposable
     {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -86,9 +86,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return new VisualStudioMetadataReference.Snapshot(this, properties, filePath, fileChangeTrackerOpt: null);
         }
 
-        public VisualStudioMetadataReference CreateMetadataReference(string filePath, MetadataReferenceProperties properties)
+        public ReferenceCountedDisposable<VisualStudioMetadataReference> CreateMetadataReference(string filePath, MetadataReferenceProperties properties)
         {
-            return new VisualStudioMetadataReference(this, filePath, properties);
+            return new ReferenceCountedDisposable<VisualStudioMetadataReference>(new VisualStudioMetadataReference(this, filePath, properties));
         }
 
         public void ClearCache()


### PR DESCRIPTION
Under the covers, we were already reusing the actual metadata, but not sharing VisualStudioMetadataReference meant that each project would create it's own copies of file watchers for all metadata references. These were (hopefully) being consolidated by the Visual Studio file watching service, but the overhead of doing so was still much larger than not doing it in the first place.

<details><summary>Ask Mode template</summary>

### Customer scenario

Opening a large solution isn't as fast as we'd like it to be.

### Bugs this fixes

[bug needs to be filed if needed]

### Workarounds, if any

None, other than make your solution smaller.

### Risk

Moderate: generally changes how the lifetime of some objects are. Change is mechanical though and uses established patterns in the codebase.

### Performance impact

Improved! Because of #28475, we were no longer eagerly subscribing to file watchers, but in the Roslyn.sln case we were still calling AdviseFileChanges 18,000 times on the background thread. Although the file change service in VS would be sharing those, that's still a non-trivial amount of time we're occupying in a single-threaded service that other things need during load as well. By reducing our load we're removing work happening on that background thread, allowing other work to get done first. This also means we're reusing timestamp reading, which was causing lots of disk I/O (or at least CPU time) as well.

### Is this a regression from a previous update?

Nope.

### Root cause analysis

Always been designed this way.

### How was the bug found?

Perf trace analysis.

</details>
