### PR TITLE
Bind NonNullTypes for types

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -340,13 +340,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.DeconstructionVariablePendingInference:
                     {
                         var pending = (DeconstructionVariablePendingInference)expression;
-                        return pending.SetInferredType(type, this, diagnostics);
+                        // PROTOTYPE(NullableReferenceTypes): this TypeSymbolWithAnnotations has bad annotation and context
+                        return pending.SetInferredType(TypeSymbolWithAnnotations.Create(type), this, diagnostics);
                     }
                 case BoundKind.DiscardExpression:
                     {
                         var pending = (BoundDiscardExpression)expression;
                         Debug.Assert((object)pending.Type == null);
-                        return pending.SetInferredType(type);
+                        // PROTOTYPE(NullableReferenceTypes): this TypeSymbolWithAnnotations has bad annotation and context
+                        return pending.SetInferredType(TypeSymbolWithAnnotations.Create(type));
                     }
                 default:
                     throw ExceptionUtilities.UnexpectedValue(expression.Kind);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -340,15 +340,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.DeconstructionVariablePendingInference:
                     {
                         var pending = (DeconstructionVariablePendingInference)expression;
-                        // PROTOTYPE(NullableReferenceTypes): this TypeSymbolWithAnnotations has bad annotation and context
-                        return pending.SetInferredType(TypeSymbolWithAnnotations.Create(type), this, diagnostics);
+                        return pending.SetInferredType(TypeSymbolWithAnnotations.Create(NonNullTypesContext, type), this, diagnostics);
                     }
                 case BoundKind.DiscardExpression:
                     {
                         var pending = (BoundDiscardExpression)expression;
                         Debug.Assert((object)pending.Type == null);
-                        // PROTOTYPE(NullableReferenceTypes): this TypeSymbolWithAnnotations has bad annotation and context
-                        return pending.SetInferredType(TypeSymbolWithAnnotations.Create(type));
+                        return pending.SetInferredType(TypeSymbolWithAnnotations.Create(NonNullTypesContext, type));
                     }
                 default:
                     throw ExceptionUtilities.UnexpectedValue(expression.Kind);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2538,7 +2538,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!kind.IsIdentity || argument.Kind == BoundKind.TupleLiteral)
                 {
-                    TypeSymbol type = GetCorrespondingParameterType(ref result, parameters, arg);
+                    TypeSymbolWithAnnotations type = GetCorrespondingParameterType(ref result, parameters, arg);
 
                     // NOTE: for some reason, dev10 doesn't report this for indexer accesses.
                     if (!methodResult.Member.IsIndexer() && !argument.HasAnyErrors && type.IsUnsafe())
@@ -2548,35 +2548,35 @@ namespace Microsoft.CodeAnalysis.CSharp
                         //CONSIDER: Return a bad expression so that HasErrors is true?
                     }
 
-                    arguments[arg] = CreateConversion(argument.Syntax, argument, kind, isCast: false, conversionGroupOpt: null, type, diagnostics);
+                    arguments[arg] = CreateConversion(argument.Syntax, argument, kind, isCast: false, conversionGroupOpt: null, type.TypeSymbol, diagnostics);
                 }
                 else if (argument.Kind == BoundKind.OutVariablePendingInference)
                 {
-                    TypeSymbol parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
+                    TypeSymbolWithAnnotations parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
                     arguments[arg] = ((OutVariablePendingInference)argument).SetInferredType(parameterType, diagnostics);
                 }
                 else if (argument.Kind == BoundKind.OutDeconstructVarPendingInference)
                 {
-                    TypeSymbol parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
+                    TypeSymbolWithAnnotations parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
                     arguments[arg] = ((OutDeconstructVarPendingInference)argument).SetInferredType(parameterType, this, success: true);
                 }
                 else if (argument.Kind == BoundKind.DiscardExpression && !argument.HasExpressionType())
                 {
-                    TypeSymbol parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
+                    TypeSymbolWithAnnotations parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
                     Debug.Assert((object)parameterType != null);
                     arguments[arg] = ((BoundDiscardExpression)argument).SetInferredType(parameterType);
                 }
             }
         }
 
-        private TypeSymbol GetCorrespondingParameterType(ref MemberAnalysisResult result, ImmutableArray<ParameterSymbol> parameters, int arg)
+        private TypeSymbolWithAnnotations GetCorrespondingParameterType(ref MemberAnalysisResult result, ImmutableArray<ParameterSymbol> parameters, int arg)
         {
             int paramNum = result.ParameterFromArgument(arg);
-            var type = parameters[paramNum].Type.TypeSymbol;
+            var type = parameters[paramNum].Type;
 
             if (paramNum == parameters.Length - 1 && result.Kind == MemberResolutionKind.ApplicableInExpandedForm)
             {
-                type = ((ArrayTypeSymbol)type).ElementType.TypeSymbol;
+                type = ((ArrayTypeSymbol)type.TypeSymbol).ElementType;
             }
 
             return type;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1405,7 +1405,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                                 else
                                 {
-                                    newArguments[i] = ((OutVariablePendingInference)argument).SetInferredType(candidateType, null);
+                                    // PROTOTYPE(NullableReferenceTypes): this TypeSymbolWithAnnotations has bad annotation and context
+                                    newArguments[i] = ((OutVariablePendingInference)argument).SetInferredType(TypeSymbolWithAnnotations.Create(candidateType), null);
                                 }
                             }
                             else if (argument.Kind == BoundKind.DiscardExpression)
@@ -1416,7 +1417,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                                 else
                                 {
-                                    newArguments[i] = ((BoundDiscardExpression)argument).SetInferredType(candidateType);
+                                    // PROTOTYPE(NullableReferenceTypes): this TypeSymbolWithAnnotations has bad annotation and context
+                                    newArguments[i] = ((BoundDiscardExpression)argument).SetInferredType(TypeSymbolWithAnnotations.Create(candidateType));
                                 }
                             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1353,7 +1353,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics.Add(ErrorCode.ERR_VoidAssignment, op1.Syntax.Location);
             }
 
-            return op1.SetInferredType(inferredType);
+            // PROTOTYPE(NullableReferenceTypes): this TypeSymbolWithAnnotations has bad annotation and context
+            return op1.SetInferredType(TypeSymbolWithAnnotations.Create(inferredType));
         }
 
         private BoundAssignmentOperator BindAssignment(

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
@@ -7,10 +7,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class BoundDiscardExpression
     {
-        public BoundExpression SetInferredType(TypeSymbol type)
+        public BoundExpression SetInferredType(TypeSymbolWithAnnotations type)
         {
             Debug.Assert((object)Type == null && (object)type != null);
-            return this.Update(type);
+            // PROTOTYPE(NullableReferenceTypes): we're dropping the annotation
+            return this.Update(type.TypeSymbol);
         }
 
         public BoundDiscardExpression FailInference(Binder binder, DiagnosticBag diagnosticsOpt)

--- a/src/Compilers/CSharp/Portable/BoundTree/OutDeconstructVarPendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutDeconstructVarPendingInference.cs
@@ -9,18 +9,18 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public BoundDeconstructValuePlaceholder Placeholder;
 
-        public BoundDeconstructValuePlaceholder SetInferredType(TypeSymbol type, Binder binder, bool success)
+        public BoundDeconstructValuePlaceholder SetInferredType(TypeSymbolWithAnnotations type, Binder binder, bool success)
         {
             Debug.Assert(Placeholder is null);
 
             // The val escape scope for this placeholder won't be used, so defaulting to narrowest scope
-            Placeholder = new BoundDeconstructValuePlaceholder(this.Syntax, binder.LocalScopeDepth, type, hasErrors: this.HasErrors || !success);
+            Placeholder = new BoundDeconstructValuePlaceholder(this.Syntax, binder.LocalScopeDepth, type.TypeSymbol, hasErrors: this.HasErrors || !success);
             return Placeholder;
         }
 
         public BoundDeconstructValuePlaceholder FailInference(Binder binder)
         {
-            return SetInferredType(binder.CreateErrorType(), binder, success: false);
+            return SetInferredType(TypeSymbolWithAnnotations.CreateUnannotated(binder.NonNullTypesContext, binder.CreateErrorType()), binder, success: false);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -336,10 +336,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                 if (symbol.IsSZArray)
                 {
-                    return ArrayTypeSymbol.CreateSZArray(_otherAssembly, symbol.ElementType.Update(otherElementType, otherModifiers));
+                    return ArrayTypeSymbol.CreateSZArray(_otherAssembly, symbol.ElementType.WithTypeAndModifiers(otherElementType, otherModifiers));
                 }
 
-                return ArrayTypeSymbol.CreateMDArray(_otherAssembly, symbol.ElementType.Update(otherElementType, otherModifiers), symbol.Rank, symbol.Sizes, symbol.LowerBounds);
+                return ArrayTypeSymbol.CreateMDArray(_otherAssembly, symbol.ElementType.WithTypeAndModifiers(otherElementType, otherModifiers), symbol.Rank, symbol.Sizes, symbol.LowerBounds);
             }
 
             public override Symbol VisitEvent(EventSymbol symbol)
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                                                                                     newType = t.TypeSymbol;
                                                                                 }
 
-                                                                                return t.Update(newType, v.VisitCustomModifiers(t.CustomModifiers));
+                                                                                return t.WithTypeAndModifiers(newType, v.VisitCustomModifiers(t.CustomModifiers));
                                                                             }, this);
 
                     if (translationFailed)
@@ -554,7 +554,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     return null;
                 }
                 var otherModifiers = VisitCustomModifiers(symbol.PointedAtType.CustomModifiers);
-                return new PointerTypeSymbol(symbol.PointedAtType.Update(otherPointedAtType, otherModifiers));
+                return new PointerTypeSymbol(symbol.PointedAtType.WithTypeAndModifiers(otherPointedAtType, otherModifiers));
             }
 
             public override Symbol VisitProperty(PropertySymbol symbol)
@@ -884,10 +884,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                 if (symbol.IsSZArray)
                 {
-                    return ArrayTypeSymbol.CreateSZArray(symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly, symbol.ElementType.Update(translatedElementType, translatedModifiers));
+                    return ArrayTypeSymbol.CreateSZArray(symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly, symbol.ElementType.WithTypeAndModifiers(translatedElementType, translatedModifiers));
                 }
 
-                return ArrayTypeSymbol.CreateMDArray(symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly, symbol.ElementType.Update(translatedElementType, translatedModifiers), symbol.Rank, symbol.Sizes, symbol.LowerBounds);
+                return ArrayTypeSymbol.CreateMDArray(symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly, symbol.ElementType.WithTypeAndModifiers(translatedElementType, translatedModifiers), symbol.Rank, symbol.Sizes, symbol.LowerBounds);
             }
 
             public override Symbol VisitDynamicType(DynamicTypeSymbol symbol)
@@ -907,7 +907,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 if ((object)originalDef != type)
                 {
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                    var translatedTypeArguments = type.GetAllTypeArguments(ref useSiteDiagnostics).SelectAsArray((t, v) => t.Update((TypeSymbol)v.Visit(t.TypeSymbol), 
+                    var translatedTypeArguments = type.GetAllTypeArguments(ref useSiteDiagnostics).SelectAsArray((t, v) => t.WithTypeAndModifiers((TypeSymbol)v.Visit(t.TypeSymbol), 
                                                                                                                                                   v.VisitCustomModifiers(t.CustomModifiers)), 
                                                                                                                  this);
 
@@ -930,7 +930,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             {
                 var translatedPointedAtType = (TypeSymbol)this.Visit(symbol.PointedAtType.TypeSymbol);
                 var translatedModifiers = VisitCustomModifiers(symbol.PointedAtType.CustomModifiers);
-                return new PointerTypeSymbol(symbol.PointedAtType.Update(translatedPointedAtType, translatedModifiers));
+                return new PointerTypeSymbol(symbol.PointedAtType.WithTypeAndModifiers(translatedPointedAtType, translatedModifiers));
             }
 
             public override Symbol VisitTypeParameter(TypeParameterSymbol symbol)

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var visitedTypeArgs = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(typeArgs.Length);
             foreach (var typeArg in typeArgs)
             {
-                visitedTypeArgs.Add(typeArg.Update(VisitType(typeArg.TypeSymbol), typeArg.CustomModifiers));
+                visitedTypeArgs.Add(typeArg.WithTypeAndModifiers(VisitType(typeArg.TypeSymbol), typeArg.CustomModifiers));
             }
 
             return newMethod.Construct(visitedTypeArgs.ToImmutableAndFree());

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 typeSymbol.Accept(visitor);
 
-                if (includeNonNullability && !typeSymbol.IsNullableType() && type.IsAnnotated)
+                if (includeNullability && !typeSymbol.IsNullableType() && type.IsAnnotated)
                 {
                     AddPunctuation(SyntaxKind.QuestionToken);
                 }
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 AddArrayRank(arrayType);
 
-                if (includeNonNullability && !ReferenceEquals(isNullable, null) && !isNullable.IsNullableType() && isNullable.IsAnnotated)
+                if (includeNullability && !ReferenceEquals(isNullable, null) && !isNullable.IsNullableType() && isNullable.IsAnnotated)
                 {
                     AddPunctuation(SyntaxKind.QuestionToken);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -125,6 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
             }
 
+            // PROTOTYPE(NullableReferenceTypes): we're dropping annotation and context
             return TypeSymbolWithAnnotations.Create(result, isNullableIfReferenceType: null);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/DynamicTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/DynamicTypeDecoder.cs
@@ -301,7 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
 
                 // Note, modifiers are not involved, this is behavior of the native compiler.
-                transformedTypeArgsBuilder.Add(typeArg.Update(transformedTypeArg, typeArg.CustomModifiers));
+                transformedTypeArgsBuilder.Add(typeArg.WithTypeAndModifiers(transformedTypeArg, typeArg.CustomModifiers));
                 anyTransformed |= transformedTypeArg != typeArg.TypeSymbol;
             }
 
@@ -333,8 +333,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return transformedElementType == arrayType.ElementType.TypeSymbol ?
                 arrayType :
                 arrayType.IsSZArray ?
-                    ArrayTypeSymbol.CreateSZArray(_containingAssembly, arrayType.ElementType.Update(transformedElementType, arrayType.ElementType.CustomModifiers)) :
-                    ArrayTypeSymbol.CreateMDArray(_containingAssembly, arrayType.ElementType.Update(transformedElementType, arrayType.ElementType.CustomModifiers), arrayType.Rank, arrayType.Sizes, arrayType.LowerBounds);
+                    ArrayTypeSymbol.CreateSZArray(_containingAssembly, arrayType.ElementType.WithTypeAndModifiers(transformedElementType, arrayType.ElementType.CustomModifiers)) :
+                    ArrayTypeSymbol.CreateMDArray(_containingAssembly, arrayType.ElementType.WithTypeAndModifiers(transformedElementType, arrayType.ElementType.CustomModifiers), arrayType.Rank, arrayType.Sizes, arrayType.LowerBounds);
         }
 
         private PointerTypeSymbol TransformPointerType(PointerTypeSymbol pointerType)
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             return transformedPointedAtType == pointerType.PointedAtType.TypeSymbol ?
                 pointerType :
-                new PointerTypeSymbol(pointerType.PointedAtType.Update(transformedPointedAtType, pointerType.PointedAtType.CustomModifiers));
+                new PointerTypeSymbol(pointerType.PointedAtType.WithTypeAndModifiers(transformedPointedAtType, pointerType.PointedAtType.CustomModifiers));
         }
 
         private bool HasFlag => _index < _dynamicTransformFlags.Length || !_checkLength;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -41,20 +41,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return metadataType;
         }
 
-        internal static TypeSymbolWithAnnotations TransformOrEraseNullability(
-            TypeSymbolWithAnnotations metadataType,
-            EntityHandle targetSymbolToken,
-            PEModuleSymbol containingModule)
-        {
-            if (containingModule.UtilizesNullableReferenceTypes)
-            {
-                return NullableTypeDecoder.TransformType(metadataType, targetSymbolToken, containingModule);
-            }
-            return metadataType.SetUnknownNullabilityForReferenceTypes();
-        }
-
         // PROTOTYPE(NullableReferenceTypes): external annotations should be removed or fully designed/productized
-        internal static TypeSymbolWithAnnotations TransformOrEraseNullability(
+        internal static TypeSymbolWithAnnotations TransformType(
             TypeSymbolWithAnnotations metadataType,
             EntityHandle targetSymbolToken,
             PEModuleSymbol containingModule,
@@ -62,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             if (extraAnnotations.IsDefault)
             {
-                return NullableTypeDecoder.TransformOrEraseNullability(metadataType, targetSymbolToken, containingModule);
+                return NullableTypeDecoder.TransformType(metadataType, targetSymbolToken, containingModule);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             else
             {
                 // PROTOTYPE(NullableReferenceTypes): Extra annotations always win (even if we're loading a modern assembly)
-                return NullableTypeDecoder.TransformType(metadataType, extraAnnotations);
+                return NullableTypeDecoder.TransformType(metadataType, extraAnnotations).WithNonNullTypesContext(NonNullTypesTrueContext.Instance);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 const int targetSymbolCustomModifierCount = 0;
                 var typeSymbol = DynamicTypeDecoder.TransformType(originalEventType, targetSymbolCustomModifierCount, handle, moduleSymbol);
 
-                // We start without annotations
+                // We start without annotation (they will be decoded below)
                 var type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: containingType, typeSymbol);
 
                 // Decode nullable before tuple types to avoid converting between

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                 if (eventType.IsNil)
                 {
-                    _eventType = TypeSymbolWithAnnotations.Create(new UnsupportedMetadataTypeSymbol(mrEx));
+                    _eventType = TypeSymbolWithAnnotations.CreateUnannotated(containingType, new UnsupportedMetadataTypeSymbol(mrEx));
                 }
             }
 
@@ -96,10 +96,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                 const int targetSymbolCustomModifierCount = 0;
                 var typeSymbol = DynamicTypeDecoder.TransformType(originalEventType, targetSymbolCustomModifierCount, handle, moduleSymbol);
-                var type = TypeSymbolWithAnnotations.Create(typeSymbol);
+
+                // We start without annotations
+                var type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: containingType, typeSymbol);
+
                 // Decode nullable before tuple types to avoid converting between
                 // NamedTypeSymbol and TupleTypeSymbol unnecessarily.
-                type = NullableTypeDecoder.TransformOrEraseNullability(type, handle, moduleSymbol);
+                type = NullableTypeDecoder.TransformType(type, handle, moduleSymbol);
                 type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, handle, moduleSymbol);
                 _eventType = type;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 typeSymbol = DynamicTypeDecoder.TransformType(typeSymbol, customModifiersArray.Length, _handle, moduleSymbol);
 
                 // We start without annotations
-                var type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: _containingType, typeSymbol, customModifiersArray);
+                var type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, typeSymbol, customModifiersArray);
 
                 // Decode nullable before tuple types to avoid converting between
                 // NamedTypeSymbol and TupleTypeSymbol unnecessarily.

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -213,12 +213,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                 typeSymbol = DynamicTypeDecoder.TransformType(typeSymbol, customModifiersArray.Length, _handle, moduleSymbol);
 
-                TypeSymbolWithAnnotations type = TypeSymbolWithAnnotations.Create(typeSymbol, customModifiersArray);
+                // We start without annotations
+                var type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: _containingType, typeSymbol, customModifiersArray);
+
                 // Decode nullable before tuple types to avoid converting between
                 // NamedTypeSymbol and TupleTypeSymbol unnecessarily.
                 // PROTOTYPE(NullableReferenceTypes): Avoid setting IsNullable in TypeSymbolWithAnnotations.Create
                 // only to undo that in TransformOrEraseNullability. Same comment applies to other uses of TransformOrEraseNullability.
-                type = NullableTypeDecoder.TransformOrEraseNullability(type, _handle, moduleSymbol);
+                type = NullableTypeDecoder.TransformType(type, _handle, moduleSymbol);
                 type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, _handle, moduleSymbol);
 
                 _lazyIsVolatile = isVolatile;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         TypeSymbol typeSymbol = tokenDecoder.GetTypeOfToken(interfaceHandle);
 
                         typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, interfaceImpl, moduleSymbol);
-                        typeSymbol = NullableTypeDecoder.TransformType(TypeSymbolWithAnnotations.Create(typeSymbol), interfaceImpl, moduleSymbol).TypeSymbol;
+                        typeSymbol = NullableTypeDecoder.TransformType(TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, typeSymbol), interfaceImpl, moduleSymbol).TypeSymbol;
 
                         var namedTypeSymbol = typeSymbol as NamedTypeSymbol ?? new UnsupportedMetadataTypeSymbol(); // interface list contains a bad type
                         symbols.Add(namedTypeSymbol);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -447,7 +447,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 var declaredBase = _lazyDeclaredBaseTypeWithoutNullability;
                 if ((object)declaredBase != null)
                 {
-                    declaredBase = (NamedTypeSymbol)NullableTypeDecoder.TransformOrEraseNullability(TypeSymbolWithAnnotations.Create(declaredBase), _handle, ContainingPEModule).TypeSymbol;
+                    declaredBase = (NamedTypeSymbol)NullableTypeDecoder.TransformType(
+                        TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, declaredBase), _handle, ContainingPEModule).TypeSymbol;
                 }
                 Interlocked.CompareExchange(ref _lazyDeclaredBaseTypeWithNullability, declaredBase, ErrorTypeSymbol.UnknownResultType);
             }
@@ -510,7 +511,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         TypeSymbol typeSymbol = tokenDecoder.GetTypeOfToken(interfaceHandle);
 
                         typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, interfaceImpl, moduleSymbol);
-                        typeSymbol = NullableTypeDecoder.TransformOrEraseNullability(TypeSymbolWithAnnotations.Create(typeSymbol), interfaceImpl, moduleSymbol).TypeSymbol;
+                        typeSymbol = NullableTypeDecoder.TransformType(TypeSymbolWithAnnotations.Create(typeSymbol), interfaceImpl, moduleSymbol).TypeSymbol;
 
                         var namedTypeSymbol = typeSymbol as NamedTypeSymbol ?? new UnsupportedMetadataTypeSymbol(); // interface list contains a bad type
                         symbols.Add(namedTypeSymbol);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             bool isReturn,
             out bool isBad)
         {
-            // We start without annotations
+            // We start without annotation (they will be decoded below)
             var typeWithModifiers = TypeSymbolWithAnnotations.CreateUnannotated(containingSymbol, type, CSharpCustomModifier.Convert(customModifiers));
 
             PEParameterSymbol parameter = customModifiers.IsDefaultOrEmpty && refCustomModifiers.IsDefaultOrEmpty

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                 // CONSIDER: Can we make parameter type computation lazy?
                 var typeSymbol = DynamicTypeDecoder.TransformType(type.TypeSymbol, countOfCustomModifiers, handle, moduleSymbol, refKind);
-                type = type.Update(typeSymbol, type.CustomModifiers);
+                type = type.WithTypeAndModifiers(typeSymbol, type.CustomModifiers);
                 // Decode nullable before tuple types to avoid converting between
                 // NamedTypeSymbol and TupleTypeSymbol unnecessarily.
                 type = NullableTypeDecoder.TransformType(type, handle, moduleSymbol, extraAnnotations);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -289,7 +289,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             else
             {
                 // PROTOTYPE(NullableReferenceTypes): Extra annotations always win (even if we're loading a modern assembly)
-                return NullableTypeDecoder.TransformType(type, externalNullableAnnotations);
+                // We currently don't have a mechanism for external annotations to affect the NonNullType context, so
+                // any external annotation is taken to imply a `[NonNullTypes(true)]` context
+                return NullableTypeDecoder.TransformType(type, externalNullableAnnotations).WithNonNullTypesContext(NonNullTypesTrueContext.Instance);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 type = type.Update(typeSymbol, type.CustomModifiers);
                 // Decode nullable before tuple types to avoid converting between
                 // NamedTypeSymbol and TupleTypeSymbol unnecessarily.
-                type = NullableTypeDecoder.TransformOrEraseNullability(type, handle, moduleSymbol, extraAnnotations);
+                type = NullableTypeDecoder.TransformType(type, handle, moduleSymbol, extraAnnotations);
                 type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, handle, moduleSymbol);
             }
 
@@ -284,7 +284,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             if (externalNullableAnnotations.IsDefault)
             {
-                return type.SetUnknownNullabilityForReferenceTypesIfNecessary(module);
+                return type;
             }
             else
             {
@@ -315,7 +315,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             bool isReturn,
             out bool isBad)
         {
-            var typeWithModifiers = TypeSymbolWithAnnotations.Create(type, CSharpCustomModifier.Convert(customModifiers));
+            // We start without annotations
+            var typeWithModifiers = TypeSymbolWithAnnotations.CreateUnannotated(containingSymbol, type, CSharpCustomModifier.Convert(customModifiers));
+
             PEParameterSymbol parameter = customModifiers.IsDefaultOrEmpty && refCustomModifiers.IsDefaultOrEmpty
                 ? new PEParameterSymbol(moduleSymbol, containingSymbol, ordinal, isByRef, typeWithModifiers, extraAnnotations, handle, 0, out isBad)
                 : new PEParameterSymbolWithCustomModifiers(moduleSymbol, containingSymbol, ordinal, isByRef, refCustomModifiers, typeWithModifiers, extraAnnotations, handle, out isBad);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // Dynamify object type if necessary
             originalPropertyType = originalPropertyType.AsDynamicIfNoPia(_containingType);
 
-            // We start without annotations
+            // We start without annotation (they will be decoded below)
             var propertyType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, originalPropertyType, typeCustomModifiers);
 
             // Decode nullable before tuple types to avoid converting between

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -166,10 +166,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // Dynamify object type if necessary
             originalPropertyType = originalPropertyType.AsDynamicIfNoPia(_containingType);
 
-            var propertyType = TypeSymbolWithAnnotations.Create(originalPropertyType, typeCustomModifiers);
+            // We start without annotations
+            var propertyType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, originalPropertyType, typeCustomModifiers);
+
             // Decode nullable before tuple types to avoid converting between
             // NamedTypeSymbol and TupleTypeSymbol unnecessarily.
-            propertyType = NullableTypeDecoder.TransformOrEraseNullability(propertyType, handle, moduleSymbol);
+            propertyType = NullableTypeDecoder.TransformType(propertyType, handle, moduleSymbol);
             propertyType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(propertyType, handle, moduleSymbol);
 
             _propertyType = propertyType;

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -864,7 +864,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// parameters in the type.</param>
         public NamedTypeSymbol Construct(params TypeSymbol[] typeArguments)
         {
-            return ConstructWithoutModifiers(typeArguments.AsImmutableOrNull(), false);
+            return ConstructWithoutModifiers(typeArguments.AsImmutableOrNull(), false, nonNullTypesContext: null);
+        }
+
+        /// <summary>
+        /// Returns a constructed type given its type arguments.
+        /// </summary>
+        /// <param name="nonNullTypesContext">This context indicates how to interprete un-annotated types.</param>
+        /// <param name="typeArguments">The immediate type arguments to be replaced for type
+        /// parameters in the type.</param>
+        public NamedTypeSymbol Construct(INonNullTypesContext nonNullTypesContext, params TypeSymbol[] typeArguments)
+        {
+            return ConstructWithoutModifiers(typeArguments.AsImmutableOrNull(), false, nonNullTypesContext);
         }
 
         /// <summary>
@@ -874,7 +885,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// parameters in the type.</param>
         public NamedTypeSymbol Construct(ImmutableArray<TypeSymbol> typeArguments)
         {
-            return ConstructWithoutModifiers(typeArguments, false);
+            // PROTOTYPE(NullableReferenceTypes): We should fix the callers to pass an explicit context.
+            return ConstructWithoutModifiers(typeArguments, false, nonNullTypesContext: null);
         }
 
         /// <summary>
@@ -883,7 +895,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="typeArguments"></param>
         public NamedTypeSymbol Construct(IEnumerable<TypeSymbol> typeArguments)
         {
-            return ConstructWithoutModifiers(typeArguments.AsImmutableOrNull(), false);
+            // PROTOTYPE(NullableReferenceTypes): We should fix the callers to pass an explicit context.
+            return ConstructWithoutModifiers(typeArguments.AsImmutableOrNull(), false, nonNullTypesContext: null);
         }
 
         /// <summary>
@@ -913,7 +926,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsErrorType = type => (object)type != null && type.IsErrorType();
 
-        private NamedTypeSymbol ConstructWithoutModifiers(ImmutableArray<TypeSymbol> typeArguments, bool unbound)
+        private NamedTypeSymbol ConstructWithoutModifiers(ImmutableArray<TypeSymbol> typeArguments, bool unbound, INonNullTypesContext nonNullTypesContext)
         {
             ImmutableArray<TypeSymbolWithAnnotations> modifiedArguments;
 
@@ -930,7 +943,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var builder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(typeArguments.Length);
                 foreach (TypeSymbol t in typeArguments)
                 {
-                    builder.Add((object)t == null ? null : TypeSymbolWithAnnotations.Create(t));
+                    builder.Add((object)t == null ? null : TypeSymbolWithAnnotations.Create(nonNullTypesContext, t));
                 }
 
                 modifiedArguments = builder.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -870,7 +870,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Returns a constructed type given its type arguments.
         /// </summary>
-        /// <param name="nonNullTypesContext">This context indicates how to interprete un-annotated types.</param>
+        /// <param name="nonNullTypesContext">This context indicates how to interpret un-annotated types.</param>
         /// <param name="typeArguments">The immediate type arguments to be replaced for type
         /// parameters in the type.</param>
         public NamedTypeSymbol Construct(INonNullTypesContext nonNullTypesContext, params TypeSymbol[] typeArguments)

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
                 if (modifiersHaveChanged || underlyingType.TypeSymbol != newTypeSymbol)
                 {
-                    return underlyingType.Update(newTypeSymbol, newModifiers);
+                    return underlyingType.WithTypeAndModifiers(newTypeSymbol, newModifiers);
                 }
 
                 return underlyingType;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -103,9 +103,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames)); // Same custom modifiers as source type.
             Debug.Assert(resultType.Equals(destinationType,
-               TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds)); // Same object/dynamic and tuple names as destination type.
-               // PROTOTYPE(NullableReferenceTypes): We want to check nullability, but that would pull on NonNullTypes too early (ie. cause cycles).
-               //TypeCompareKind.CompareNullableModifiersForReferenceTypes)); // Same nullability as destination type.
+                TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds)); // Same object/dynamic and tuple names as destination type.
+                // PROTOTYPE(NullableReferenceTypes): We want to check nullability, but that would pull on NonNullTypes too early (ie. cause cycles).
+                //TypeCompareKind.CompareNullableModifiersForReferenceTypes)); // Same nullability as destination type.
 
             return resultType;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbol returnTypeWithCustomModifiers = sourceMethodReturnType.TypeSymbol;
             if (returnTypeSymbol.Equals(returnTypeWithCustomModifiers, TypeCompareKind.AllIgnoreOptions))
             {
-                returnType = returnType.Update(CopyTypeCustomModifiers(returnTypeWithCustomModifiers, returnTypeSymbol, destinationMethod.ContainingAssembly, nonNullTypesContext: destinationMethod),
+                returnType = returnType.WithTypeAndModifiers(CopyTypeCustomModifiers(returnTypeWithCustomModifiers, returnTypeSymbol, destinationMethod.ContainingAssembly, nonNullTypesContext: destinationMethod),
                                                sourceMethodReturnType.CustomModifiers);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -103,8 +103,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames)); // Same custom modifiers as source type.
             Debug.Assert(resultType.Equals(destinationType,
-                                           TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | // Same object/dynamic and tuple names as destination type.
-                                           TypeCompareKind.CompareNullableModifiersForReferenceTypes)); // Same nullability as destination type.
+               TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds)); // Same object/dynamic and tuple names as destination type.
+               // PROTOTYPE(NullableReferenceTypes): We want to check nullability, but that would pull on NonNullTypes too early (ie. cause cycles).
+               //TypeCompareKind.CompareNullableModifiersForReferenceTypes)); // Same nullability as destination type.
 
             return resultType;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Can add some diagnostics into <paramref name="diagnostics"/>. 
         /// Returns the type that it actually locks onto (it's possible that it had already locked onto ErrorType).
         /// </summary>
-        private TypeSymbol SetType(CSharpCompilation compilation, DiagnosticBag diagnostics, TypeSymbolWithAnnotations type)
+        private TypeSymbolWithAnnotations SetType(CSharpCompilation compilation, DiagnosticBag diagnostics, TypeSymbolWithAnnotations type)
         {
             var originalType = _lazyType;
 
@@ -123,14 +123,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 compilation.DeclarationDiagnostics.AddRange(diagnostics);
                 state.NotePartComplete(CompletionPart.Type);
             }
-            return _lazyType.TypeSymbol;
+            return _lazyType;
         }
 
         /// <summary>
         /// Can add some diagnostics into <paramref name="diagnostics"/>.
         /// Returns the type that it actually locks onto (it's possible that it had already locked onto ErrorType).
         /// </summary>
-        internal TypeSymbol SetType(TypeSymbolWithAnnotations type, DiagnosticBag diagnostics)
+        internal TypeSymbolWithAnnotations SetType(TypeSymbolWithAnnotations type, DiagnosticBag diagnostics)
         {
             return SetType(DeclaringCompilation, diagnostics, type);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -234,35 +234,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            if (parameterType.IsNullable == false &&
-                parameterType.IsReferenceType &&
-                convertedExpression.ConstantValue?.IsNull == true &&
-                !suppressNullableWarning(convertedExpression))
-            {
-                diagnostics.Add(ErrorCode.WRN_NullAsNonNullable, parameterSyntax.Default.Value.Location);
-            }
+            // PROTOTYPE(NullableReferenceTypes): calling IsNullable causes cycle
+            //if (parameterType.IsNullable == false &&
+            //    parameterType.IsReferenceType &&
+            //    convertedExpression.ConstantValue?.IsNull == true &&
+            //    !suppressNullableWarning(convertedExpression))
+            //{
+            //    diagnostics.Add(ErrorCode.WRN_NullAsNonNullable, parameterSyntax.Default.Value.Location);
+            //}
 
             // represent default(struct) by a Null constant:
             var value = convertedExpression.ConstantValue ?? ConstantValue.Null;
             VerifyParamDefaultValueMatchesAttributeIfAny(value, defaultSyntax.Value, diagnostics);
             return value;
 
-            bool suppressNullableWarning(BoundExpression expr)
-            {
-                while (true)
-                {
-                    switch (expr.Kind)
-                    {
-                        case BoundKind.Conversion:
-                            expr = ((BoundConversion)expr).Operand;
-                            break;
-                        case BoundKind.SuppressNullableWarningExpression:
-                            return true;
-                        default:
-                            return false;
-                    }
-                }
-            }
+            //bool suppressNullableWarning(BoundExpression expr)
+            //{
+            //    while (true)
+            //    {
+            //        switch (expr.Kind)
+            //        {
+            //            case BoundKind.Conversion:
+            //                expr = ((BoundConversion)expr).Operand;
+            //                break;
+            //            case BoundKind.SuppressNullableWarningExpression:
+            //                return true;
+            //            default:
+            //                return false;
+            //        }
+            //    }
+            //}
         }
 
         public override string MetadataName

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventSymbol.cs
@@ -66,8 +66,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if ((object)explicitlyImplementedEvent != null)
             {
                 CopyEventCustomModifiers(explicitlyImplementedEvent, ref _type, ContainingAssembly, nonNullTypesContext: this);
-
-                TypeSymbol.CheckNullableReferenceTypeMismatchOnImplementingMember(this, explicitlyImplementedEvent, true, diagnostics);
             }
 
             AccessorDeclarationSyntax addSyntax = null;
@@ -186,6 +184,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var explicitInterfaceSpecifier = this.ExplicitInterfaceSpecifier;
                 Debug.Assert(explicitInterfaceSpecifier != null);
                 _explicitInterfaceType.CheckAllConstraints(conversions, new SourceLocation(explicitInterfaceSpecifier.Name), diagnostics);
+            }
+
+            if (!_explicitInterfaceImplementations.IsEmpty)
+            {
+                // Note: we delayed nullable-related checks that could pull on NonNullTypes
+                EventSymbol explicitlyImplementedEvent = _explicitInterfaceImplementations[0];
+                TypeSymbol.CheckNullableReferenceTypeMismatchOnImplementingMember(this, explicitlyImplementedEvent, true, diagnostics);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -564,7 +564,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // we want to retain the original (incorrect) type to avoid hiding the type given in source.
             if (type.TypeSymbol.Equals(overriddenEventType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
             {
-                type = type.Update(CustomModifierUtils.CopyTypeCustomModifiers(overriddenEventType, type.TypeSymbol, containingAssembly, nonNullTypesContext),
+                type = type.WithTypeAndModifiers(CustomModifierUtils.CopyTypeCustomModifiers(overriddenEventType, type.TypeSymbol, containingAssembly, nonNullTypesContext),
                                    eventWithCustomModifiers.Type.CustomModifiers);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -473,7 +473,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 if ((object)initializerOpt.Type != null && !initializerOpt.Type.IsErrorType())
                                 {
-                                    type = TypeSymbolWithAnnotations.Create(initializerOpt.Type);
+                                    type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, initializerOpt.Type);
                                 }
 
                                 _lazyFieldTypeInferred = 1;
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         if ((object)type == null)
                         {
-                            type = TypeSymbolWithAnnotations.Create(binder.CreateErrorType("var"));
+                            type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, binder.CreateErrorType("var"));
                         }
                     }
                 }
@@ -514,7 +514,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // update the lazyType only if it contains value last seen by the current thread:
             if ((object)Interlocked.CompareExchange(
                 ref _lazyType,
-                type.WithModifiers(this.RequiredCustomModifiers).SetUnknownNullabilityForReferenceTypesIfNecessary(ContainingModule),
+                type.WithModifiers(this.RequiredCustomModifiers),
                 null) == null)
             {
                 TypeChecks(type.TypeSymbol, diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -620,7 +620,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 // We only bind early attributes, as binding all attributes leads to cycles
                 ModuleEarlyWellKnownAttributeData earlyAttributes = ComputeEarlyAttributes();
-                bool value = earlyAttributes?.NonNullTypes ?? UtilizesNullableReferenceTypes;
+
+                // If no module-level attribute was set, then the default is `[NonNullTypes(false)]`
+                bool value = earlyAttributes?.NonNullTypes ?? false;
                 _lazyNonNullTypes = value.ToThreeState();
                 return value;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -748,6 +748,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // NullableAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.NonNullTypesAttribute))
+            {
+                bool value = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
+                arguments.GetOrCreateData<TypeWellKnownAttributeData>().NonNullTypes = value;
+            }
             else
             {
                 var compilation = this.DeclaringCompilation;
@@ -923,8 +928,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                // PROTOTYPE(NullableReferenceTypes): temporary solution to avoid cycle
-                return SyntaxBasedNonNullTypes(this.GetAttributeDeclarations()) ?? base.NonNullTypes;
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NonNullTypes ?? base.NonNullTypes;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             newType = CustomModifierUtils.CopyTypeCustomModifiers(newType, this.Type.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: this);
 
-            TypeSymbolWithAnnotations newTypeWithModifiers = this.Type.Update(newType, newCustomModifiers);
+            TypeSymbolWithAnnotations newTypeWithModifiers = this.Type.WithTypeAndModifiers(newType, newCustomModifiers);
 
             if (newRefCustomModifiers.IsEmpty)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 PropertySymbol associatedProperty = _property;
                 var type = associatedProperty.Type;
-                _lazyReturnType = _lazyReturnType.Update(
+                _lazyReturnType = _lazyReturnType.WithTypeAndModifiers(
                     CustomModifierUtils.CopyTypeCustomModifiers(type.TypeSymbol, _lazyReturnType.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: associatedProperty),
                     type.CustomModifiers);
                 _lazyRefCustomModifiers = associatedProperty.RefCustomModifiers;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // we want to retain the original (incorrect) type to avoid hiding the type given in source.
                     if (_lazyType.TypeSymbol.Equals(overriddenPropertyType.TypeSymbol, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
                     {
-                        _lazyType = _lazyType.Update(
+                        _lazyType = _lazyType.WithTypeAndModifiers(
                             CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType.TypeSymbol, _lazyType.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: this),
                             overriddenPropertyType.CustomModifiers);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal static readonly SymbolDisplayFormat DebuggerDisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes /* | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier,
-            compilerInternalOptions: SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier*/);
+            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
+            /*compilerInternalOptions: SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier*/);
 
         internal static readonly SymbolDisplayFormat TestDisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -497,13 +497,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        public TypeSymbolWithAnnotations SetUnknownNullabilityForReferenceTypesIfNecessary(ModuleSymbol module)
-        {
-            return module.UtilizesNullableReferenceTypes ?
-                this :
-                this.SetUnknownNullabilityForReferenceTypes();
-        }
-
         public TypeSymbolWithAnnotations WithTopLevelNonNullabilityForReferenceTypes()
         {
             var typeSymbol = TypeSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -804,11 +804,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (!_underlying.TypeSymbol.IsValueType)
                 {
-                    //Debug.Assert(_underlying.IsNullable == false);
                     return _underlying;
                 }
 
-                //Debug.Assert(!this.IsNullable == false);
                 return this;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -34,14 +34,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier,
             compilerInternalOptions: SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier);
 
-        internal static TypeSymbolWithAnnotations CreateUnannotated(INonNullTypesContext nonNullTypesContext, TypeSymbol typeSymbol)
+        internal static TypeSymbolWithAnnotations CreateUnannotated(INonNullTypesContext nonNullTypesContext, TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers = default)
         {
-            return Create(typeSymbol, nonNullTypesContext, isAnnotated: false, ImmutableArray<CustomModifier>.Empty);
+            return Create(typeSymbol, nonNullTypesContext, isAnnotated: false, customModifiers.NullToEmpty());
         }
 
-        internal static TypeSymbolWithAnnotations CreateUnannotated(INonNullTypesContext nonNullTypesContext, TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
+        internal static TypeSymbolWithAnnotations Create(INonNullTypesContext nonNullTypesContext, TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers = default)
         {
-            return Create(typeSymbol, nonNullTypesContext, isAnnotated: false, customModifiers);
+            return Create(typeSymbol, nonNullTypesContext, isAnnotated: typeSymbol.IsNullableType(), customModifiers.NullToEmpty());
         }
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public abstract TypeSymbolWithAnnotations AsNotNullableReferenceType();
 
         public abstract TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers);
-        protected abstract TypeSymbolWithAnnotations WithNonNullTypesContext(INonNullTypesContext nonNullTypesContext);
+        public abstract TypeSymbolWithAnnotations WithNonNullTypesContext(INonNullTypesContext nonNullTypesContext);
 
         public abstract TypeSymbol TypeSymbol { get; }
         public virtual TypeSymbol NullableUnderlyingTypeOrSelf => TypeSymbol.StrippedType();
@@ -662,7 +662,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return new NonLazyType(_typeSymbol, NonNullTypesContext, _isAnnotated, customModifiers);
             }
 
-            protected override TypeSymbolWithAnnotations WithNonNullTypesContext(INonNullTypesContext nonNullTypesContext)
+            public override TypeSymbolWithAnnotations WithNonNullTypesContext(INonNullTypesContext nonNullTypesContext)
             {
                 Debug.Assert(nonNullTypesContext != null);
                 return NonNullTypesContext == nonNullTypesContext ?
@@ -799,7 +799,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return new NonLazyType(typeSymbol, NonNullTypesContext, isAnnotated: IsAnnotated, customModifiers);
             }
 
-            protected override TypeSymbolWithAnnotations WithNonNullTypesContext(INonNullTypesContext nonNullTypesContext)
+            public override TypeSymbolWithAnnotations WithNonNullTypesContext(INonNullTypesContext nonNullTypesContext)
             {
                 return _underlying.NonNullTypesContext == nonNullTypesContext ?
                     this :

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -683,7 +683,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
             {
-                // PROTOTYPE(NullableReferenceTypes): made an aggressive change here
                 return !_isAnnotated || _typeSymbol.IsNullableType() ?
                     this :
                     new NonLazyType(_typeSymbol, NonNullTypesContext, isAnnotated: false, _customModifiers);

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier,
             compilerInternalOptions: SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier);
 
+        // PROTOTYPE(NullableReferenceTypes): consider removing this method and using Create below (which handles nullable value types).
         internal static TypeSymbolWithAnnotations CreateUnannotated(INonNullTypesContext nonNullTypesContext, TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers = default)
         {
             return Create(typeSymbol, nonNullTypesContext, isAnnotated: false, customModifiers.NullToEmpty());
@@ -41,7 +42,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static TypeSymbolWithAnnotations Create(INonNullTypesContext nonNullTypesContext, TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers = default)
         {
-            return Create(typeSymbol, nonNullTypesContext, isAnnotated: typeSymbol.IsNullableType(), customModifiers.NullToEmpty());
+            bool isNullableType = typeSymbol.IsNullableType();
+
+            // PROTOTYPE(NullableReferenceTypes): this defaulting logic should be removed. There are many paths that currently don't have an explicit context at the moment.
+            nonNullTypesContext = nonNullTypesContext ?? NonNullTypesFalseContext.Instance;
+            return Create(typeSymbol, nonNullTypesContext, isAnnotated: isNullableType, customModifiers.NullToEmpty());
         }
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(containingType.IsScriptClass);
 
             _containingType = containingType;
-            CalculateReturnType(containingType.DeclaringCompilation, diagnostics, out _resultType, out _returnType);
+            CalculateReturnType(containingType, diagnostics, out _resultType, out _returnType);
         }
 
         public override string Name
@@ -231,11 +231,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private static void CalculateReturnType(
-            CSharpCompilation compilation,
+            SourceMemberContainerTypeSymbol containingType,
             DiagnosticBag diagnostics,
             out TypeSymbol resultType,
             out TypeSymbol returnType)
         {
+            CSharpCompilation compilation = containingType.DeclaringCompilation;
             var submissionReturnTypeOpt = compilation.ScriptCompilationInfo?.ReturnTypeOpt;
             var taskT = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
             var useSiteDiagnostic = taskT.GetUseSiteDiagnostic();
@@ -250,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             resultType = (object)submissionReturnTypeOpt == null
                 ? compilation.GetSpecialType(SpecialType.System_Object)
                 : compilation.GetTypeByReflectionType(submissionReturnTypeOpt, diagnostics);
-            returnType = taskT.Construct(resultType);
+            returnType = taskT.Construct(nonNullTypesContext: containingType, resultType);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override TypeSymbolWithAnnotations ReturnType
         {
-            get { return TypeSymbolWithAnnotations.Create(_returnType).SetUnknownNullabilityForReferenceTypesIfNecessary(ContainingModule); }
+            get { return TypeSymbolWithAnnotations.Create(nonNullTypesContext: ContainingSymbol, _returnType); }
         }
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -312,6 +312,18 @@ class C
             });
         }
 
+        private const string NonNullTypesAttributesDefinition = @"
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+    public sealed class NonNullTypesAttribute : Attribute
+    {
+        public NonNullTypesAttribute(bool flag = true) { }
+    }
+}
+";
+        private const string NonNullTypesTrue = "[module: System.Runtime.CompilerServices.NonNullTypes(true)]";
+
         [Fact]
         public void EmitAttribute_BaseClass()
         {
@@ -349,7 +361,7 @@ public class B2 : A<object?>
         F(y, y);
     }
 }";
-            var comp2 = CreateCompilation(source2, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
+            var comp2 = CreateCompilation(new[] { source2, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
                 // (8,14): warning CS8620: Nullability of reference types in argument of type 'B1' doesn't match target type 'A<object?>' for parameter 'y' in 'void C.F(A<object> x, A<object?> y)'.
                 //         F(x, x);
@@ -395,7 +407,7 @@ public class B : I<object?>
         F(y, y);
     }
 }";
-            var comp2 = CreateCompilation(source2, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
+            var comp2 = CreateCompilation(new[] { source2, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
                 // (8,14): warning CS8620: Nullability of reference types in argument of type 'A' doesn't match target type 'I<object?>' for parameter 'y' in 'void C.F(I<object> x, I<object?> y)'.
                 //         F(x, x);
@@ -445,7 +457,7 @@ public class B : I<(object X, object? Y)>
         F(b, b);
     }
 }";
-            var comp2 = CreateCompilation(source2, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
+            var comp2 = CreateCompilation(new[] { source2, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
                 // (8,14): warning CS8620: Nullability of reference types in argument of type 'A' doesn't match target type 'I<(object, object?)>' for parameter 'b' in 'void C.F(I<(object, object)> a, I<(object, object?)> b)'.
                 //         F(a, a);

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IIsPatternExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IIsPatternExpression.cs
@@ -594,7 +594,7 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'o 
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): cycle with NonNullTypes"), WorkItem(19927, "https://github.com/dotnet/roslyn/issues/19927")]
+        [Fact, WorkItem(19927, "https://github.com/dotnet/roslyn/issues/19927")]
         public void TestIsPatternExpression_InvalidInAttributeArgument()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IIsPatternExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IIsPatternExpression.cs
@@ -594,7 +594,7 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'o 
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(19927, "https://github.com/dotnet/roslyn/issues/19927")]
+        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): cycle with NonNullTypes"), WorkItem(19927, "https://github.com/dotnet/roslyn/issues/19927")]
         public void TestIsPatternExpression_InvalidInAttributeArgument()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -29995,7 +29995,7 @@ class C<T>
                 Diagnostic(ErrorCode.ERR_BadUnaryOp, "?").WithArguments("?", "Func<T>").WithLocation(6, 17));
         }
 
-        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): Equals pulls on NonNullTypes too early, causing cycle")]
+        [Fact]
         public void NonNullTypes_DecodeAttributeCycle_01()
         {
             var source =
@@ -30033,6 +30033,28 @@ struct S : I
             // PROTOTYPE(NullableReferenceTypes): cycles with Equals when copying modifiers
             var comp = CreateCompilation(
                 new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition },
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NonNullTypes_DecodeAttributeCycle_01_WithEvent()
+        {
+            var source =
+@"using System;
+using System.Runtime.InteropServices;
+interface I
+{
+    event Func<int> E;
+}
+[StructLayout(LayoutKind.Auto)]
+struct S : I
+{
+    public event Func<int> I.E { add => throw null; remove => throw null; }
+}";
+            // PROTOTYPE(NullableReferenceTypes): cycles with Equals when copying modifiers
+            var comp = CreateCompilation(
+                source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics();
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
     public class NullableReferenceTypesTests : CSharpTestBase
     {
-         private const string NullableAttributeDefinition = @"
+        private const string NullableAttributeDefinition = @"
 namespace System.Runtime.CompilerServices
 {
     [System.AttributeUsage(AttributeTargets.Event | // The type of the event is nullable, or has a nullable reference type as one of its constituents  

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -29467,7 +29467,7 @@ F(v).ToString();";
         /// should not result in a warning at the call site.
         /// </summary>
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
-        [Fact(Skip = "PROTOTYPE(NullalbeReferenceTypes): null check on default value temporarily skipped")]
+        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): null check on default value temporarily skipped")]
         public void ParameterDefaultValue_FromMetadata()
         {
             var source0 =
@@ -29506,7 +29506,7 @@ F(v).ToString();";
         }
 
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
-        [Fact(Skip = "PROTOTYPE(NullalbeReferenceTypes): null check on default value temporarily skipped")]
+        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): null check on default value temporarily skipped")]
         public void ParameterDefaultValue_01()
         {
             var source =
@@ -29600,7 +29600,7 @@ F(v).ToString();";
         }
 
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
-        [Fact(Skip = "PROTOTYPE(NullalbeReferenceTypes): null check on default value temporarily skipped")]
+        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): null check on default value temporarily skipped")]
         public void ParameterDefaultValue_03()
         {
             var source =
@@ -29766,7 +29766,7 @@ class P
         }
 
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
-        [Fact(Skip = "PROTOTYPE(NullalbeReferenceTypes): null check on default value temporarily skipped")]
+        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): null check on default value temporarily skipped")]
         public void ParameterDefaultValue_04()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -29926,9 +29926,10 @@ struct S : I
             comp.VerifyDiagnostics();
         }
 
-        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes) Cycle with Equals when copying modifiers")]
+        [Fact]
         public void NonNullTypes_DecodeAttributeCycle_01_WithEvent()
         {
+            // PROTOTYPE(NullableReferenceTypes) Cycle with Equals when copying modifiers
             var source =
 @"using System;
 using System.Runtime.InteropServices;
@@ -29939,7 +29940,7 @@ interface I
 [StructLayout(LayoutKind.Auto)]
 struct S : I
 {
-    public event Func<int> I.E { add => throw null; remove => throw null; }
+    event Func<int> I.E { add => throw null; remove => throw null; }
 }";
             // PROTOTYPE(NullableReferenceTypes): cycles with Equals when copying modifiers
             var comp = CreateCompilation(

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
     public class NullableReferenceTypesTests : CSharpTestBase
     {
-         const string NullableAttributeDefinition = @"
+         private const string NullableAttributeDefinition = @"
 namespace System.Runtime.CompilerServices
 {
     [System.AttributeUsage(AttributeTargets.Event | // The type of the event is nullable, or has a nullable reference type as one of its constituents  
@@ -8582,7 +8582,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string?[]"); // PROTOTYPE(NullableReferenceTypes): expecting string?[]
+            VerifyOutVar(c, "string?[]");
             c.VerifyTypes();
             c.VerifyDiagnostics(
                 // (7,9): warning CS8602: Possible dereference of a null reference.
@@ -8606,7 +8606,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string?[]"); // PROTOTYPE(NullableReferenceTypes): expecting string?[]
+            VerifyOutVar(c, "string?[]");
             c.VerifyTypes();
             c.VerifyDiagnostics(
                 // (7,9): warning CS8602: Possible dereference of a null reference.
@@ -29909,7 +29909,6 @@ struct S : I
         [Fact]
         public void NonNullTypes_DecodeAttributeCycle_01_WithEvent()
         {
-            // PROTOTYPE(NullableReferenceTypes) Cycle with Equals when copying modifiers
             var source =
 @"using System;
 using System.Runtime.InteropServices;
@@ -29922,7 +29921,6 @@ struct S : I
 {
     event Func<int> I.E { add => throw null; remove => throw null; }
 }";
-            // PROTOTYPE(NullableReferenceTypes): cycles with Equals when copying modifiers
             var comp = CreateCompilation(
                 new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition },
                 parseOptions: TestOptions.Regular8);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -243,7 +243,7 @@ class C
         public void UnannotatedAssemblies_WithSomeExtraAnnotations()
         {
             // PROTOTYPE(NullableReferenceTypes): external annotations should be removed or fully designed/productized
-            var comp = CreateCompilation(new[] { "", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation("", parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics();
             var systemNamespace = comp.GetMember<NamedTypeSymbol>("System.Object").ContainingNamespace;
 
@@ -8344,7 +8344,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string!"); // PROTOTYPE(NullableReferenceTypes): expecting string?
+            VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
                 // (8,13): warning CS8602: Possible dereference of a null reference.
@@ -8368,7 +8368,7 @@ public class C
             var model = compilation.GetSemanticModel(tree);
             var outVar = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single();
             var symbol = (LocalSymbol)model.GetSymbolInfo(outVar).Symbol;
-            Assert.Equal(expectedType, symbol.Type.ToDisplayString(TypeSymbolWithAnnotations.DebuggerDisplayFormat));
+            Assert.Equal(expectedType, symbol.Type.ToDisplayString(TypeSymbolWithAnnotations.TestDisplayFormat));
             Assert.Null(model.GetDeclaredSymbol(outVar));
         }
 
@@ -8382,7 +8382,7 @@ public class C
             var varDecl = tree.GetRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().Where(d => d.Declaration.Type.IsVar).Single();
             var variable = varDecl.Declaration.Variables.Single();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(variable);
-            Assert.Equal(expectedType, symbol.Type.ToDisplayString(TypeSymbolWithAnnotations.DebuggerDisplayFormat));
+            Assert.Equal(expectedType, symbol.Type.ToDisplayString(TypeSymbolWithAnnotations.TestDisplayFormat));
             Assert.Null(model.GetSymbolInfo(variable).Symbol);
         }
 
@@ -8510,7 +8510,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string!"); // PROTOTYPE(NullableReferenceTypes): expecting string?
+            VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
                 // (7,9): warning CS8602: Possible dereference of a null reference.
@@ -8534,7 +8534,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string!");// PROTOTYPE(NullableReferenceTypes): expecting string?
+            VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
                 // (7,9): warning CS8602: Possible dereference of a null reference.
@@ -8559,7 +8559,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string!"); // PROTOTYPE(NullableReferenceTypes): expecting string?
+            VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
                 // (8,9): warning CS8602: Possible dereference of a null reference.
@@ -8583,7 +8583,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string?[]!"); // PROTOTYPE(NullableReferenceTypes): expecting string?[]
+            VerifyOutVar(c, "string?[]"); // PROTOTYPE(NullableReferenceTypes): expecting string?[]
             c.VerifyTypes();
             c.VerifyDiagnostics(
                 // (7,9): warning CS8602: Possible dereference of a null reference.
@@ -8607,7 +8607,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string?[]!"); // PROTOTYPE(NullableReferenceTypes): expecting string?[]
+            VerifyOutVar(c, "string?[]"); // PROTOTYPE(NullableReferenceTypes): expecting string?[]
             c.VerifyTypes();
             c.VerifyDiagnostics(
                 // (7,9): warning CS8602: Possible dereference of a null reference.
@@ -8631,7 +8631,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string![]!"); // PROTOTYPE(NullableReferenceTypes): expecting string![]
+            VerifyOutVar(c, "string![]");
             c.VerifyTypes();
             c.VerifyDiagnostics();
         }
@@ -8652,7 +8652,7 @@ public class C
 }
 ", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string![]!"); // PROTOTYPE(NullableReferenceTypes): expecting string?[]
+            VerifyOutVar(c, "string![]"); // PROTOTYPE(NullableReferenceTypes): expecting string?[]
             c.VerifyTypes();
             c.VerifyDiagnostics();
         }
@@ -8673,7 +8673,7 @@ public class C
 }
 " + EnsuresNotNullAttributeDefinition, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string!"); // PROTOTYPE(NullableReferenceTypes): expecting string?
+            VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics();
         }
@@ -8694,7 +8694,7 @@ public class C
 }
 " + EnsuresNotNullAttributeDefinition, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string!"); // PROTOTYPE(NullableReferenceTypes): expecting string?
+            VerifyOutVar(c, "string"); // PROTOTYPE(NullableReferenceTypes): expecting string?
             c.VerifyTypes();
             c.VerifyDiagnostics();
         }
@@ -11230,7 +11230,7 @@ public class C
         public void EnsuresNotNull_TypeInference()
         {
             // PROTOTYPE(NullableReferenceTypes): This test raises the question of flowing information from annotations into the inferred type
-            CSharpCompilation c = CreateCompilation(@"
+            CSharpCompilation c = CreateCompilation(new[] { @"
 using System.Runtime.CompilerServices;
 public class C
 {
@@ -11241,7 +11241,7 @@ public class C
     }
     public static void ThrowIfNull<T>([EnsuresNotNull] T x1, out T x2) => throw null;
 }
-" + EnsuresNotNullAttributeDefinition, parseOptions: TestOptions.Regular8);
+", NonNullTypesTrue, NonNullTypesAttributesDefinition, EnsuresNotNullAttributeDefinition }, parseOptions: TestOptions.Regular8);
 
             c.VerifyTypes();
             c.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -1155,7 +1155,7 @@ class E
         External.s /*T:string!*/ = null; // warn 1
         External.ns /*T:string?*/ = null;
 
-        External.fs /*T:string!*/ = null!; // PROTOTYPE(NullableReferenceTypes): the type from metadata is incorrect
+        External.fs /*T:string*/ = null;
         External.fns /*T:string?*/ = null;
 
         OuterA.A.s /*T:string!*/ = null; // warn 2
@@ -1197,8 +1197,7 @@ class E
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(73, 36)
                 );
 
-            // PROTOTYPE(NullableReferenceTypes): problem when loading NonNullTypes from metadata
-            //verifyExternal(compilation);
+            verifyExternal(compilation);
 
             var outerA = (NamedTypeSymbol)compilation.GetMember("OuterA");
             Assert.False(outerA.NonNullTypes);
@@ -1348,7 +1347,7 @@ class E
         External.s.Item /*T:string!*/ = null; // warn 1
         External.ns.Item /*T:string?*/ = null;
 
-        External.fs.Item /*T:string!*/ = null!; // PROTOTYPE(NullableReferenceTypes): incorrect type from metadata (should be oblivious)
+        External.fs.Item /*T:string*/ = null;
         External.fns.Item /*T:string?*/ = null;
 
         OuterA.A.s.Item /*T:string!*/ = null; // warn 2
@@ -8673,7 +8672,7 @@ public class C
 }
 " + EnsuresNotNullAttributeDefinition, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string?");
+            VerifyOutVar(c, "string!"); // PROTOTYPE(NullableReferenceTypes): T is inferred to string! instead of string?, so the `var` gets `string!`
             c.VerifyTypes();
             c.VerifyDiagnostics();
         }
@@ -8694,7 +8693,7 @@ public class C
 }
 " + EnsuresNotNullAttributeDefinition, parseOptions: TestOptions.Regular8);
 
-            VerifyOutVar(c, "string"); // PROTOTYPE(NullableReferenceTypes): expecting string?
+            VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics();
         }
@@ -25208,26 +25207,7 @@ partial class C
                                               parseOptions: TestOptions.Regular8,
                                               options: TestOptions.ReleaseDll);
 
-            // PROTOTYPE(NullableReferenceTypes): Unexpected warnings
             c.VerifyDiagnostics(
-                // (11,20): warning CS8601: Possible null reference assignment.
-                //             c.F1 = x21;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(11, 20),
-                // (12,20): warning CS8601: Possible null reference assignment.
-                //             c.P1 = x21;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(12, 20),
-                // (13,18): warning CS8604: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
-                //             c.M3(x21);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(13, 18),
-                // (19,19): hidden CS8607: Expression is probably never null.
-                //             x22 = c.F1 ?? x22;
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(19, 19),
-                // (20,19): hidden CS8607: Expression is probably never null.
-                //             x22 = c.P1 ?? x22;
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(20, 19),
-                // (21,19): hidden CS8607: Expression is probably never null.
-                //             x22 = c.M1() ?? x22;
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(21, 19),
                 // (27,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x23 = c.F2; // warn 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F2").WithLocation(27, 19),
@@ -29487,7 +29467,7 @@ F(v).ToString();";
         /// should not result in a warning at the call site.
         /// </summary>
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(NullalbeReferenceTypes): null check on default value temporarily skipped")]
         public void ParameterDefaultValue_FromMetadata()
         {
             var source0 =
@@ -29526,7 +29506,7 @@ F(v).ToString();";
         }
 
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(NullalbeReferenceTypes): null check on default value temporarily skipped")]
         public void ParameterDefaultValue_01()
         {
             var source =
@@ -29620,7 +29600,7 @@ F(v).ToString();";
         }
 
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(NullalbeReferenceTypes): null check on default value temporarily skipped")]
         public void ParameterDefaultValue_03()
         {
             var source =
@@ -29786,7 +29766,7 @@ class P
         }
 
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(NullalbeReferenceTypes): null check on default value temporarily skipped")]
         public void ParameterDefaultValue_04()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -23972,7 +23972,6 @@ class Program
         [Fact, WorkItem(22880, "https://github.com/dotnet/roslyn/issues/22880")]
         public void AttributeCtorInParam()
         {
-            // PROTOTYPE(NullableReferenceTypes): cycle in symbol display (VisitTypeSymbolWithAnnotations) and MakeDefaultParameter
             var text = @"
 [A(1)]
 class A : System.Attribute {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -23972,6 +23972,7 @@ class Program
         [Fact, WorkItem(22880, "https://github.com/dotnet/roslyn/issues/22880")]
         public void AttributeCtorInParam()
         {
+            // PROTOTYPE(NullableReferenceTypes): cycle in symbol display (VisitTypeSymbolWithAnnotations) and MakeDefaultParameter
             var text = @"
 [A(1)]
 class A : System.Attribute {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -7,6 +7,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
     public class UninitializedNonNullableFieldTests : CSharpTestBase
     {
+        private const string NonNullTypesAttributesDefinition = @"
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+    public sealed class NonNullTypesAttribute : Attribute
+    {
+        public NonNullTypesAttribute(bool flag = true) { }
+    }
+}
+";
+        private const string NonNullTypesTrue = "[module: System.Runtime.CompilerServices.NonNullTypes(true)]";
+
         [Fact]
         public void NoNonNullWarnings_CSharp7()
         {
@@ -213,18 +225,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 ////     static C()
                 //Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(8, 12));
         }
-
-        private const string NonNullTypesAttributesDefinition = @"
-namespace System.Runtime.CompilerServices
-{
-    [System.AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
-    public sealed class NonNullTypesAttribute : Attribute
-    {
-        public NonNullTypesAttribute(bool flag = true) { }
-    }
-}
-";
-        private const string NonNullTypesTrue = "[module: System.Runtime.CompilerServices.NonNullTypes(true)]";
 
         // Each constructor is handled in isolation.
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
     internal object?[] F3;
     private object[]? F4;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (1,7): warning CS8618: Non-nullable field 'F3' is uninitialized.
                 // class C
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         F4 = new[] { x, y };
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (7,14): warning CS8618: Non-nullable field 'F3' is uninitialized.
                 //     internal C()
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
     internal readonly object?[] F3;
     private readonly object[]? F4;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (1,7): warning CS8618: Non-nullable field 'F3' is uninitialized.
                 // class C
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         F4 = new[] { x, y };
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (7,14): warning CS8618: Non-nullable field 'F3' is uninitialized.
                 //     internal C()
@@ -214,6 +214,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 //Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(8, 12));
         }
 
+        private const string NonNullTypesAttributesDefinition = @"
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+    public sealed class NonNullTypesAttribute : Attribute
+    {
+        public NonNullTypesAttribute(bool flag = true) { }
+    }
+}
+";
+        private const string NonNullTypesTrue = "[module: System.Runtime.CompilerServices.NonNullTypes(true)]";
+
         // Each constructor is handled in isolation.
         [Fact]
         public void ChainedConstructors()
@@ -246,7 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         F3 = z;
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (7,13): warning CS8618: Non-nullable field 'F2' is uninitialized.
                 //     private C()
@@ -286,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         P4 = new[] { x, y };
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (7,14): warning CS8618: Non-nullable property 'P3' is uninitialized.
                 //     internal C()
@@ -326,7 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         P4 = new[] { x, y };
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (7,14): warning CS8618: Non-nullable property 'P3' is uninitialized.
                 //     internal C()
@@ -449,7 +461,7 @@ class C
     {
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (10,13): warning CS8618: Non-nullable property 'P1' is uninitialized.
                 //     private C()
@@ -511,7 +523,7 @@ class C5<T, U> where T : A where U : T
     T F5;
     U G5;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (4,7): warning CS8618: Non-nullable field 'G1' is uninitialized.
                 // class C1<T, U> where U : T
@@ -572,7 +584,7 @@ class C5<T, U> where T : A where U : T
             P = new [] { s };
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (6,14): warning CS8618: Non-nullable property 'P' is uninitialized.
                 //     internal C(string s)
@@ -599,7 +611,7 @@ class C5<T, U> where T : A where U : T
             P = new [] { s };
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (6,14): error CS0843: Auto-implemented property 'S.P' must be fully assigned before control is returned to the caller.
                 //     internal S(string s)
@@ -710,7 +722,7 @@ class C
         L(new object());
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
                 // (6,5): warning CS8618: Non-nullable field 'G' is uninitialized.
                 //     C()

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5826,8 +5826,20 @@ class C
         [Fact]
         public void NullableReferenceTypes()
         {
-            var source =
-@"class A<T>
+            string attribute = @"
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+    public sealed class NonNullTypesAttribute : Attribute
+    {
+        public NonNullTypesAttribute(bool flag = true) { }
+    }
+}
+";
+
+            var source = @"
+[module: System.Runtime.CompilerServices.NonNullTypes(true)]
+class A<T>
 {
 }
 class B
@@ -5836,7 +5848,7 @@ class B
     static object?[] F2(object[]? o) => null;
     static A<object>? F3(A<object?> o) => null;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, attribute }, parseOptions: TestOptions.Regular8);
             var formatWithoutNonNullableModifier = new SymbolDisplayFormat(
                 memberOptions: SymbolDisplayMemberOptions.IncludeParameters | SymbolDisplayMemberOptions.IncludeType | SymbolDisplayMemberOptions.IncludeModifiers,
                 parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeParamsRefOut,

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -2562,9 +2562,10 @@ namespace NS
                 Diagnostic(ErrorCode.ERR_AbstractAndExtern, "E").WithArguments("C.E"));
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): cycle")]
         public void CS0181ERR_BadAttributeParamType_Dynamic()
         {
+            // PROTOTYPE(NullableReferenceTypes): cycle in MakeDefaultExpression calling IsNullable
             var text = @"
 using System;
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -2562,7 +2562,7 @@ namespace NS
                 Diagnostic(ErrorCode.ERR_AbstractAndExtern, "E").WithArguments("C.E"));
         }
 
-        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): cycle")]
+        [Fact]
         public void CS0181ERR_BadAttributeParamType_Dynamic()
         {
             // PROTOTYPE(NullableReferenceTypes): cycle in MakeDefaultExpression calling IsNullable

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -2565,7 +2565,6 @@ namespace NS
         [Fact]
         public void CS0181ERR_BadAttributeParamType_Dynamic()
         {
-            // PROTOTYPE(NullableReferenceTypes): cycle in MakeDefaultExpression calling IsNullable
             var text = @"
 using System;
 

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
@@ -52,6 +52,8 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Append '!' to non-nullable reference types.
+        /// Note this causes SymbolDisplay to pull on IsNullable and therefore NonNullTypes,
+        /// so don't use this option in binding, in order to avoid cycles.
         /// </summary>
         IncludeNonNullableTypeModifier = 1 << 6,
 

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayMiscellaneousOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayMiscellaneousOptions.cs
@@ -58,8 +58,6 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Append '?' to nullable reference types.
-        /// Note this causes SymbolDisplay to pull on IsNullable and therefore NonNullTypes,
-        /// so don't use this option in binding, in order to avoid cycles.
         /// PROTOTYPE(NullableReferenceTypes): review design for this option before shipping. See https://github.com/dotnet/roslyn/issues/26198
         /// </summary>
         IncludeNullableReferenceTypeModifier = 1 << 6,

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayMiscellaneousOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayMiscellaneousOptions.cs
@@ -58,6 +58,8 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Append '?' to nullable reference types.
+        /// Note this causes SymbolDisplay to pull on IsNullable and therefore NonNullTypes,
+        /// so don't use this option in binding, in order to avoid cycles.
         /// PROTOTYPE(NullableReferenceTypes): review design for this option before shipping. See https://github.com/dotnet/roslyn/issues/26198
         /// </summary>
         IncludeNullableReferenceTypeModifier = 1 << 6,

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -15,11 +15,18 @@ namespace Microsoft.CodeAnalysis
         IgnoreDynamic = 2,
         IgnoreTupleNames = 4,
         IgnoreDynamicAndTupleNames = IgnoreDynamic | IgnoreTupleNames,
+
         // PROTOTYPE(NullableReferenceTypes): Consider renaming the Nullable options,
         // perhaps CompareNullableAnnotations and IgnoreUnknownNullableAnnotations.
-        // Note: comparisons with nullability-related options pull on NonNullTypes, which can cause cycles.
+        /// <summary>
+        /// Note: comparisons with nullability-related options pull on NonNullTypes, which can cause cycles.
+        /// </summary>
         CompareNullableModifiersForReferenceTypes = 8,
-        UnknownNullableModifierMatchesAny = 16, // Has no impact without CompareNullableModifiersForReferenceTypes
+
+        /// <summary>
+        /// Has no impact without CompareNullableModifiersForReferenceTypes.
+        /// </summary>
+        UnknownNullableModifierMatchesAny = 16,
         AllAspects = CompareNullableModifiersForReferenceTypes, // PROTOTYPE(NullableReferenceTypes): Remove if not used.
         AllIgnoreOptions = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreDynamic | IgnoreTupleNames,
         AllIgnoreOptionsForVB = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreTupleNames

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis
         IgnoreDynamicAndTupleNames = IgnoreDynamic | IgnoreTupleNames,
         // PROTOTYPE(NullableReferenceTypes): Consider renaming the Nullable options,
         // perhaps CompareNullableAnnotations and IgnoreUnknownNullableAnnotations.
+        // Note: comparisons with nullability-related options pull on NonNullTypes, which can cause cycles.
         CompareNullableModifiersForReferenceTypes = 8,
         UnknownNullableModifierMatchesAny = 16, // Has no impact without CompareNullableModifiersForReferenceTypes
         AllAspects = CompareNullableModifiersForReferenceTypes, // PROTOTYPE(NullableReferenceTypes): Remove if not used.

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 string toDisplayString(SyntaxNode syntaxOpt)
                 {
                     return (syntaxOpt != null) && dictionary.TryGetValue(syntaxOpt, out var type) ?
-                        type.ToDisplayString(TypeSymbolWithAnnotations.DebuggerDisplayFormat) :
+                        type.ToDisplayString(TypeSymbolWithAnnotations.TestDisplayFormat) :
                         null;
                 }
             }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -19,11 +19,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
 
         private static readonly TestParameters s_nullableFeature = new TestParameters(parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
 
+        private const string NonNullTypes = @"
+[module: System.Runtime.CompilerServices.NonNullTypes(true)]
+
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+    public sealed class NonNullTypesAttribute : Attribute
+    {
+        public NonNullTypesAttribute(bool flag = true) { }
+    }
+}
+";
+
+
         [Fact]
         public async Task FixAll()
         {
             await TestInRegularAndScript1Async(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static string M()
     {
@@ -37,7 +52,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
             return null;
     }
 }",
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static string? M()
     {
@@ -57,14 +73,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixReturnType()
         {
             await TestInRegularAndScript1Async(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static string M()
     {
         return [|null|];
     }
 }",
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static string? M()
     {
@@ -77,14 +95,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixReturnType_WithTrivia()
         {
             await TestInRegularAndScript1Async(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static /*before*/ string /*after*/ M()
     {
         return [|null|];
     }
 }",
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static /*before*/ string? /*after*/ M()
     {
@@ -97,11 +117,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixReturnType_ArrowBody()
         {
             await TestInRegularAndScript1Async(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static string M() => [|null|];
 }",
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static string? M() => null;
 }", parameters: s_nullableFeature);
@@ -112,7 +134,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixReturnType_LocalFunction_ArrowBody()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static void M()
     {
@@ -126,7 +149,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixLocalFunctionReturnType()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     void M()
     {
@@ -142,7 +166,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task NoFixAlreadyNullableReturnType()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static string? M()
     {
@@ -156,7 +181,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixField()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     string x = [|null|];
 }", parameters: s_nullableFeature);
@@ -166,14 +192,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixLocalDeclaration()
         {
             await TestInRegularAndScript1Async(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static void M()
     {
         string x = [|null|];
     }
 }",
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static void M()
     {
@@ -186,7 +214,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixLocalDeclaration_WithVar()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static void M()
     {
@@ -199,7 +228,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task NoFixMultiDeclaration()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static void M()
     {
@@ -213,7 +243,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixPropertyDeclaration()
         {
             await TestMissingInRegularAndScriptAsync(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     string x { get; set; } = [|null|];
 }", parameters: s_nullableFeature);
@@ -223,11 +254,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixPropertyDeclaration_WithReturnNull()
         {
             await TestInRegularAndScript1Async(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     string x { get { return [|null|]; } }
 }",
-@"class Program
+NonNullTypes + @"
+class Program
 {
     string? x { get { return null; } }
 }", parameters: s_nullableFeature);
@@ -237,26 +270,30 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixPropertyDeclaration_ArrowBody()
         {
             await TestInRegularAndScript1Async(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     string x => [|null|];
 }",
-@"class Program
+NonNullTypes + @"
+class Program
 {
     string? x => null;
 }", parameters: s_nullableFeature);
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): the warning is temporarily disabled in this scenario to avoid cycle")]
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]
         public async Task FixOptionalParameter()
         {
             await TestInRegularAndScript1Async(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static void M(string x = [|null|]) { }
 }",
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static void M(string? x = null) { }
 }", parameters: s_nullableFeature);
@@ -266,14 +303,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.DeclareAsNu
         public async Task FixLocalWithAs()
         {
             await TestInRegularAndScript1Async(
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static void M(object o)
     {
         string x = [|o as string|];
     }
 }",
-@"class Program
+NonNullTypes + @"
+class Program
 {
     static void M(object o)
     {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -32,7 +32,6 @@ namespace System.Runtime.CompilerServices
 }
 ";
 
-
         [Fact]
         public async Task FixAll()
         {

--- a/src/VisualStudio/Core/Test/Diagnostics/DefaultDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DefaultDiagnosticUpdateSourceTests.vb
@@ -121,7 +121,7 @@ class A
                 Await listenerProvider.GetWaiter(FeatureAttribute.ErrorSquiggles).CreateWaitTask()
 
                 Assert.True(
-                    diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 2)
+                    diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 1)
             End Using
         End Function
 
@@ -155,7 +155,7 @@ class A
                 Await listenerProvider.GetWaiter(FeatureAttribute.ErrorSquiggles).CreateWaitTask()
 
                 Assert.True(
-                    diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 3)
+                    diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 2)
             End Using
         End Function
 


### PR DESCRIPTION
In a previous PR on `[NonNullTypes]` I used a syntax-based check to recognize the attribute, rather than use proper binding. This allowed for avoiding a number of cycles.

The current PR removes the use of syntax-based check for deciding if a source named type symbol has `NonNullTypes`. Other symbols will be address in follow-up PRs.


Even with the NonNullTypesContext design, there were a cycles left to fix, because we're pulling on NonNullTypes too early.
- Symbol display is easy to fix. But the impact on GetDebuggerDisplay is unfortunate.
- MakeDefaultExpression has a check that needs to be delayed. Currently commented out.
- SetUnknownNullabilityForReferenceTypesIfNecessary was removed. But it was hiding a bunch of missing contexts.
- CopyTypeModifiers has an assert with Equals, which pulls on NonNullTypes. Currently commented out.
- TypeSymbolWithAnnotation.Update (used in SourcePropertySymbol and other places) was conditional. Made it unconditional.


----

CheckNullableReferenceTypeMismatchOnImplementingMember:
This was fixed by calling CheckNullableReferenceTypeMismatchOnImplementingMember later.
```
Symbols.SourcePropertySymbol.NonNullTypes.get() Line 1519
Symbols.TypeSymbolWithAnnotations.IsAnnotatedWithNonNullTypesContext.get() Line 190
Symbols.TypeSymbolWithAnnotations.Equals(Symbols.TypeSymbolWithAnnotations other, TypeCompareKind comparison) Line 281
Symbols.TypeSymbol.CheckNullableReferenceTypeMismatchOnImplementingMember(Symbol implementingMember, Symbol interfaceMember, bool isExplicit, DiagnosticBag diagnostics) Line 1147
Symbols.SourcePropertySymbol.SourcePropertySymbol(Symbols.SourceMemberContainerTypeSymbol containingType, Binder bodyBinder, Syntax.BasePropertyDeclarationSyntax syntax, string name, Location location, DiagnosticBag diagnostics) Line 284
Symbols.SourcePropertySymbol.Create(Symbols.SourceMemberContainerTypeSymbol containingType, Binder bodyBinder, Syntax.PropertyDeclarationSyntax syntax, DiagnosticBag diagnostics) Line 458
```




SetUnknownNullabilityForReferenceTypesIfNecessary cycle via SourceMemberFieldSymbol.GetFieldType:
Fixed by removing the call to SetUnknownNullabilityForReferenceTypesIfNecessary. But caused other issues to become visible. Still working on those.
```
Symbols.FieldSymbolWithAttributesAndModifiers.NonNullTypes.get() Line 344
Symbols.TypeSymbolWithAnnotations.NonLazyType.IsNullable.get() Line 614
Symbols.TypeSymbolWithAnnotations.SetUnknownNullabilityForReferenceTypes() Line 510
Symbols.TypeSymbolWithAnnotations.SetUnknownNullabilityForReferenceTypesIfNecessary(Symbols.ModuleSymbol module) Line 490
Symbols.SourceMemberFieldSymbolFromDeclarator.GetFieldType(Roslyn.Utilities.ConsList<Symbols.FieldSymbol> fieldsBeingBound) Line 515
Symbols.FieldSymbol.Type.get() Line 55
Symbols.FieldSymbol.IsMetadataConstant.get() Line 119
Symbols.SourceMemberContainerTypeSymbol.AddInitializer(ref PooledObjects.ArrayBuilder<Symbols.FieldOrPropertyInitializer> initializers, ref int aggregateSyntaxLength, Symbols.FieldSymbol fieldOpt, CSharpSyntaxNode node) Line 2749
```


Cycle with SymbolDisplay:
Fixed by making symbol display as lazy as possible. 
I also had to change the display options used for debugger display, so that the debugger would not pull on NonNullTypes accidentally. It's better to only see `?` and blank, rather than no be able to see the type at all, while debugging.

```
Symbols.TypeSymbolWithAnnotations.NonLazyType.IsNullable.get() Line 614
SymbolDisplayVisitor.VisitTypeSymbolWithAnnotations(Symbols.TypeSymbolWithAnnotations type, SymbolDisplay.AbstractSymbolDisplayVisitor visitorOpt) Line 18
SymbolDisplayVisitor.AddTypeArguments(ISymbol owner, System.Collections.Immutable.ImmutableArray<System.Collections.Immutable.ImmutableArray<CustomModifier>> modifiers) Line 749
SymbolDisplayVisitor.AddNameAndTypeArgumentsOrParameters(INamedTypeSymbol symbol) Line 403
SymbolDisplayVisitor.VisitNamedType(INamedTypeSymbol symbol) Line 293
Symbols.NamedTypeSymbol.Accept(SymbolVisitor visitor) Line 1592
SymbolDisplay.ToDisplayParts(ISymbol symbol, SemanticModel semanticModelOpt, int positionOpt, SymbolDisplayFormat format, bool minimal) Line 129
SymbolDisplay.ToDisplayParts(ISymbol symbol, SymbolDisplayFormat format) Line 72
SymbolDisplay.ToDisplayString(ISymbol symbol, SymbolDisplayFormat format) Line 31
Symbol.ToDisplayString(SymbolDisplayFormat format) Line 1117
Symbols.ExplicitInterfaceHelpers.GetMemberName(string name, Symbols.TypeSymbol explicitInterfaceTypeOpt, string aliasQualifierOpt) Line 65
Symbols.ExplicitInterfaceHelpers.GetMemberNameAndInterfaceSymbol(Binder binder, Syntax.ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifierOpt, string name, DiagnosticBag diagnostics, out Symbols.TypeSymbol explicitInterfaceTypeOpt, out string aliasQualifierOpt) Line 52
Symbols.SourceOrdinaryMethodSymbol.CreateMethodSymbol(Symbols.NamedTypeSymbol containingType, Binder bodyBinder, Syntax.MethodDeclarationSyntax syntax, DiagnosticBag diagnostics) Line 57
Symbols.SourceMemberContainerTypeSymbol.AddNonTypeMembers(Symbols.SourceMemberContainerTypeSymbol.MembersAndInitializersBuilder builder, SyntaxList<Syntax.MemberDeclarationSyntax> members, DiagnosticBag diagnostics) Line 3012
Symbols.SourceMemberContainerTypeSymbol.AddDeclaredNontypeMembers(Symbols.SourceMemberContainerTypeSymbol.MembersAndInitializersBuilder builder, DiagnosticBag diagnostics) Line 2428
Symbols.SourceMemberContainerTypeSymbol.BuildMembersAndInitializers(DiagnosticBag diagnostics) Line 2343
Symbols.SourceMemberContainerTypeSymbol.GetMembersAndInitializers() Line 1339
Symbols.SourceMemberContainerTypeSymbol.MakeAllMembers(DiagnosticBag diagnostics) Line 2204
```


MakeDefaultExpression:
I temporarily temporarily commented out this check. We should execute this check later.

```
Symbols.SourceNamedTypeSymbol.NonNullTypes.get() Line 931
Symbols.MethodSymbol.NonNullTypes.get() Line 981
Symbols.SourceMemberMethodSymbol.NonNullTypes.get() Line 189
Symbols.TypeSymbolWithAnnotations.NonLazyType.IsNullable.get() Line 614
Symbols.SourceComplexParameterSymbol.MakeDefaultExpression(DiagnosticBag diagnostics, Binder binder) Line 237
Symbols.SourceComplexParameterSymbol.DefaultSyntaxValue.get() Line 160
Symbols.SourceComplexParameterSymbol.ExplicitDefaultConstantValue.get() Line 94
Binder.GetDefaultValueArgument(Symbols.ParameterSymbol parameter, Syntax.AttributeSyntax syntax, DiagnosticBag diagnostics) Line 720
Binder.GetRewrittenAttributeConstructorArguments(out System.Collections.Immutable.ImmutableArray<int> constructorArgumentsSourceIndices, Symbols.MethodSymbol attributeConstructor, System.Collections.Immutable.ImmutableArray<TypedConstant> constructorArgsArray, System.Collections.Immutable.ImmutableArray<string> constructorArgumentNamesOpt, Syntax.AttributeSyntax syntax, DiagnosticBag diagnostics, ref bool hasErrors) Line 615
Binder.GetAttribute(BoundAttribute boundAttribute, DiagnosticBag diagnostics) Line 213
Binder.GetAttribute(Syntax.AttributeSyntax node, Symbols.NamedTypeSymbol boundAttributeType, DiagnosticBag diagnostics) Line 100
Binder.GetAttributes(System.Collections.Immutable.ImmutableArray<Binder> binders, System.Collections.Immutable.ImmutableArray<Syntax.AttributeSyntax> attributesToBind, System.Collections.Immutable.ImmutableArray<Symbols.NamedTypeSymbol> boundAttributeTypes, Symbols.CSharpAttributeData[] attributesBuilder, DiagnosticBag diagnostics) Line 74
Symbol.LoadAndValidateAttributes(Roslyn.Utilities.OneOrMany<SyntaxList<Syntax.AttributeListSyntax>> attributesSyntaxLists, ref CustomAttributesBag<Symbols.CSharpAttributeData> lazyCustomAttributesBag, Symbols.AttributeLocation symbolPart, bool earlyDecodingOnly, Binder binderOpt, System.Func<Syntax.AttributeSyntax, bool> attributeMatchesOpt) Line 317
Symbols.SourceNamedTypeSymbol.GetAttributesBag() Line 460
Symbols.SourceNamedTypeSymbol.GetDecodedWellKnownAttributeData() Line 490
Symbols.SourceNamedTypeSymbol.NonNullTypes.get() Line 931
Symbols.MethodSymbol.NonNullTypes.get() Line 981
Symbols.SourceMemberMethodSymbol.NonNullTypes.get() Line 189
```




----
The cycles below are no longer relevant. They were all solved by the NonNullTypesContext design :-)

For context, here are the stack traces for the various cycles:
Cycle 11
```
Symbols.SourceNamedTypeSymbol.NonNullTypes.get() Line 942
Binder.NonNullTypes.get() Line 228
Binder.BindNamespaceOrTypeOrAliasSymbol(Syntax.ExpressionSyntax syntax, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, bool suppressUseSiteDiagnostics) Line 381
Binder.BindTypeOrAlias(Syntax.ExpressionSyntax syntax, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved) Line 271
Binder.BindType(Syntax.ExpressionSyntax syntax, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved) Line 251
Binder.BindAttributeTypes(System.Collections.Immutable.ImmutableArray<Binder> binders, System.Collections.Immutable.ImmutableArray<Syntax.AttributeSyntax> attributesToBind, Symbol ownerSymbol, Symbols.NamedTypeSymbol[] boundAttributeTypes, DiagnosticBag diagnostics) Line 45
Symbol.LoadAndValidateAttributes(Roslyn.Utilities.OneOrMany<SyntaxList<Syntax.AttributeListSyntax>> attributesSyntaxLists, ref CustomAttributesBag<Symbols.CSharpAttributeData> lazyCustomAttributesBag, Symbols.AttributeLocation symbolPart, bool earlyDecodingOnly, Binder binderOpt, System.Func<Syntax.AttributeSyntax, bool> attributeMatchesOpt) Line 293
Symbols.SourceNamedTypeSymbol.GetAttributesBag() Line 460
Symbols.SourceNamedTypeSymbol.GetEarlyDecodedWellKnownAttributeData() Line 507
Symbols.SourceNamedTypeSymbol.NonNullTypes.get() Line 942
```

Cycle 12 (hit in bootstrap build, fixed in `GetNextBaseTypeNoUseSiteDiagnostics` passing the `ignoreNonNullTypesAttribute` for the enum case as well):
```
Symbols.SourceNamedTypeSymbol.GetAttributesBag() Line 460
Symbols.SourceNamedTypeSymbol.GetEarlyDecodedWellKnownAttributeData() Line 507
Symbols.SourceNamedTypeSymbol.NonNullTypes.get() Line 942
Symbols.SourceNamedTypeSymbol.GetDeclaredBases(Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute) Line 229
Symbols.SourceNamedTypeSymbol.GetDeclaredBaseType(Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute) Line 243
Symbols.SourceNamedTypeSymbol.MakeAcyclicBaseType(DiagnosticBag diagnostics, bool ignoreNonNullTypesAttribute) Line 626
Symbols.SourceNamedTypeSymbol.GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute) Line 44
Symbols.TypeSymbol.BaseTypeNoUseSiteDiagnostics.get() Line 158
Symbols.TypeSymbolExtensions.GetNextBaseTypeNoUseSiteDiagnostics(Symbols.TypeSymbol type, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, CSharpCompilation compilation, ref PooledObjects.PooledHashSet<Symbols.NamedTypeSymbol> visited, bool ignoreNonNullTypesAttribute) Line 182
Binder.LookupMembersInClass(LookupResult result, Symbols.TypeSymbol type, string name, int arity, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 737
Binder.LookupMembersInType(LookupResult result, Symbols.TypeSymbol type, string name, int arity, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 187
Binder.LookupMembersInternal(LookupResult result, Symbols.NamespaceOrTypeSymbol nsOrType, string name, int arity, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 164
InContainerBinder.LookupSymbolsInSingleBinder(LookupResult result, string name, int arity, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 237
Binder.LookupSymbolsInternal(LookupResult result, string name, int arity, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, LookupOptions options, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 94
Binder.LookupSymbolsOrMembersInternal(LookupResult result, Symbols.NamespaceOrTypeSymbol qualifierOpt, string name, int arity, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, LookupOptions options, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 126
Binder.LookupAttributeType(LookupResult result, Symbols.NamespaceOrTypeSymbol qualifierOpt, string name, int arity, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, LookupOptions options, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 436
Binder.LookupSymbolsSimpleName(LookupResult result, Symbols.NamespaceOrTypeSymbol qualifierOpt, string plainName, int arity, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, LookupOptions options, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 34
Binder.BindNonGenericSimpleNamespaceOrTypeOrAliasSymbol(Syntax.IdentifierNameSyntax node, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, bool suppressUseSiteDiagnostics, Symbols.NamespaceOrTypeSymbol qualifierOpt) Line 716
Binder.BindNamespaceOrTypeOrAliasSymbol(Syntax.ExpressionSyntax syntax, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved, bool suppressUseSiteDiagnostics) Line 381
Binder.BindTypeOrAlias(Syntax.ExpressionSyntax syntax, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved) Line 271
Binder.BindType(Syntax.ExpressionSyntax syntax, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<Symbol> basesBeingResolved) Line 251
Binder.BindAttributeTypes(System.Collections.Immutable.ImmutableArray<Binder> binders, System.Collections.Immutable.ImmutableArray<Syntax.AttributeSyntax> attributesToBind, Symbol ownerSymbol, Symbols.NamedTypeSymbol[] boundAttributeTypes, DiagnosticBag diagnostics) Line 45
Symbol.LoadAndValidateAttributes(Roslyn.Utilities.OneOrMany<SyntaxList<Syntax.AttributeListSyntax>> attributesSyntaxLists, ref CustomAttributesBag<Symbols.CSharpAttributeData> lazyCustomAttributesBag, Symbols.AttributeLocation symbolPart, bool earlyDecodingOnly, Binder binderOpt, System.Func<Syntax.AttributeSyntax, bool> attributeMatchesOpt) Line 293
Symbols.SourceNamedTypeSymbol.GetAttributesBag() Line 460
```


Cycle 13 (and 14 is very closely related):
```
SourceNamedTypeSymbol.NonNullTypes.get() Line 942
SourceNamedTypeSymbol.GetDeclaredBases(Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute) Line 229
SourceNamedTypeSymbol.GetDeclaredInterfaces(Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved) Line 248
SourceNamedTypeSymbol.MakeAcyclicInterfaces(Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, DiagnosticBag diagnostics) Line 575
SourceNamedTypeSymbol.InterfacesNoUseSiteDiagnostics(Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved) Line 69
TypeSymbol.GetInterfaceInfo() Line 90
TypeSymbol.GetAllInterfaces() Line 342
TypeSymbol.AllInterfacesNoUseSiteDiagnostics.get() Line 208
TypeSymbol.AllInterfacesWithDefinitionUseSiteDiagnostics(ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 214
CSharp.Binder.LookupMembersInInterfaceOnly(CSharp.LookupResult current, NamedTypeSymbol type, string name, int arity, CSharp.LookupOptions options, CSharp.Binder originalBinder, TypeSymbol accessThroughType, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 915
CSharp.Binder.LookupMembersInInterface(CSharp.LookupResult current, NamedTypeSymbol type, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, CSharp.LookupOptions options, CSharp.Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 949
CSharp.Binder.LookupMembersInType(CSharp.LookupResult result, TypeSymbol type, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, CSharp.LookupOptions options, CSharp.Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 178
CSharp.Binder.LookupMembersInternal(CSharp.LookupResult result, NamespaceOrTypeSymbol nsOrType, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, CSharp.LookupOptions options, CSharp.Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 164
CSharp.InContainerBinder.LookupSymbolsInSingleBinder(CSharp.LookupResult result, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, CSharp.LookupOptions options, CSharp.Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 237
CSharp.Binder.LookupSymbolsInternal(CSharp.LookupResult result, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, CSharp.LookupOptions options, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 94
CSharp.Binder.LookupSymbolsWithFallback(CSharp.LookupResult result, string name, int arity, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, CSharp.LookupOptions options) Line 61
CSharp.Binder.InvocableNameofInScope() Line 1638
CSharp.Binder.TryBindNameofOperator(CSharp.Syntax.InvocationExpressionSyntax node, DiagnosticBag diagnostics, out CSharp.BoundExpression result) Line 1520
CSharp.Binder.BindInvocationExpression(CSharp.Syntax.InvocationExpressionSyntax node, DiagnosticBag diagnostics) Line 148
CSharp.Binder.BindExpressionInternal(CSharp.Syntax.ExpressionSyntax node, DiagnosticBag diagnostics, bool invoked, bool indexed) Line 384
CSharp.Binder.BindExpression(CSharp.Syntax.ExpressionSyntax node, DiagnosticBag diagnostics, bool invoked, bool indexed) Line 329
CSharp.Binder.BindExpression(CSharp.Syntax.ExpressionSyntax node, DiagnosticBag diagnostics) Line 324
CSharp.Binder.BindSimpleBinaryOperator(CSharp.Syntax.BinaryExpressionSyntax node, DiagnosticBag diagnostics) Line 416
CSharp.Binder.BindExpressionInternal(CSharp.Syntax.ExpressionSyntax node, DiagnosticBag diagnostics, bool invoked, bool indexed) Line 425
CSharp.Binder.BindExpression(CSharp.Syntax.ExpressionSyntax node, DiagnosticBag diagnostics, bool invoked, bool indexed) Line 329
CSharp.Binder.BindValue(CSharp.Syntax.ExpressionSyntax node, DiagnosticBag diagnostics, CSharp.Binder.BindValueKind valueKind) Line 228
CSharp.Binder.BindArgumentExpression(DiagnosticBag diagnostics, CSharp.Syntax.ExpressionSyntax argumentExpression, RefKind refKind, bool allowArglist) Line 2517
CSharp.Binder.BindAttributeArguments(CSharp.Syntax.AttributeArgumentListSyntax attributeArgumentList, NamedTypeSymbol attributeType, DiagnosticBag diagnostics) Line 303
CSharp.Binder.BindAttributeCore(CSharp.Syntax.AttributeSyntax node, NamedTypeSymbol attributeType, DiagnosticBag diagnostics) Line 147
CSharp.Binder.BindAttribute(CSharp.Syntax.AttributeSyntax node, NamedTypeSymbol attributeType, DiagnosticBag diagnostics) Line 105
CSharp.Binder.GetAttribute(CSharp.Syntax.AttributeSyntax node, NamedTypeSymbol boundAttributeType, DiagnosticBag diagnostics) Line 98
CSharp.EarlyWellKnownAttributeBinder.GetAttribute(CSharp.Syntax.AttributeSyntax node, NamedTypeSymbol boundAttributeType, out bool generatedDiagnostics) Line 25
CSharp.Symbol.EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(ref EarlyDecodeWellKnownAttributeArguments<CSharp.EarlyWellKnownAttributeBinder, NamedTypeSymbol, CSharp.Syntax.AttributeSyntax, AttributeLocation> arguments, out CSharpAttributeData attributeData, out ObsoleteAttributeData obsoleteData) Line 170
SourceNamedTypeSymbol.EarlyDecodeWellKnownAttribute(ref EarlyDecodeWellKnownAttributeArguments<CSharp.EarlyWellKnownAttributeBinder, NamedTypeSymbol, CSharp.Syntax.AttributeSyntax, AttributeLocation> arguments) Line 565
CSharp.Symbol.EarlyDecodeWellKnownAttributes(System.Collections.Immutable.ImmutableArray<CSharp.Binder> binders, System.Collections.Immutable.ImmutableArray<NamedTypeSymbol> boundAttributeTypes, System.Collections.Immutable.ImmutableArray<CSharp.Syntax.AttributeSyntax> attributesToBind, AttributeLocation symbolPart, CSharpAttributeData[] boundAttributesBuilder) Line 577
CSharp.Symbol.LoadAndValidateAttributes(Roslyn.Utilities.OneOrMany<SyntaxList<CSharp.Syntax.AttributeListSyntax>> attributesSyntaxLists, ref CustomAttributesBag<CSharpAttributeData> lazyCustomAttributesBag, AttributeLocation symbolPart, bool earlyDecodingOnly, CSharp.Binder binderOpt, System.Func<CSharp.Syntax.AttributeSyntax, bool> attributeMatchesOpt) Line 303
SourceNamedTypeSymbol.GetAttributesBag() Line 460
SourceNamedTypeSymbol.GetEarlyDecodedWellKnownAttributeData() Line 507
SourceNamedTypeSymbol.NonNullTypes.get() Line 942
SourceNamedTypeSymbol.GetDeclaredBases(Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute) Line 229
```

Cycle 15 is when there was in `MakeAcyclicBaseType`, which would call `FindBaseRefSyntax` (which calls `BindType`) to report use-site diagnostics on bases.

Cycle 16 isn't solved yet:
```


CSharp.Binder.NonNullTypes.get() Line 228
CSharp.Binder.BindNamespaceOrTypeOrAliasSymbol(CSharp.Syntax.ExpressionSyntax syntax, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved, bool suppressUseSiteDiagnostics) Line 376
CSharp.Binder.BindTypeOrAlias(CSharp.Syntax.ExpressionSyntax syntax, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved) Line 271
CSharp.Binder.BindType(CSharp.Syntax.ExpressionSyntax syntax, DiagnosticBag diagnostics, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved) Line 251
CSharp.Symbols.SourcePropertySymbol.ComputeType(CSharp.Binder binder,Syntax.BasePropertyDeclarationSyntax syntax, DiagnosticBag diagnostics) Line 1441
CSharp.Symbols.SourcePropertySymbol.SourcePropertySymbol(CSharp.Symbols.SourceMemberContainerTypeSymbol containingType,Binder bodyBinder,Syntax.BasePropertyDeclarationSyntax syntax, string name, Location location, DiagnosticBag diagnostics) Line 241
CSharp.Symbols.SourcePropertySymbol.Create(CSharp.Symbols.SourceMemberContainerTypeSymbol containingType,Binder bodyBinder,Syntax.PropertyDeclarationSyntax syntax, DiagnosticBag diagnostics) Line 458
CSharp.Symbols.SourceMemberContainerTypeSymbol.AddNonTypeMembers(CSharp.Symbols.SourceMemberContainerTypeSymbol.MembersAndInitializersBuilder builder, SyntaxList<CSharp.Syntax.MemberDeclarationSyntax> members, DiagnosticBag diagnostics) Line 3058
CSharp.Symbols.SourceMemberContainerTypeSymbol.AddDeclaredNontypeMembers(CSharp.Symbols.SourceMemberContainerTypeSymbol.MembersAndInitializersBuilder builder, DiagnosticBag diagnostics) Line 2419
CSharp.Symbols.SourceMemberContainerTypeSymbol.BuildMembersAndInitializers(DiagnosticBag diagnostics) Line 2343
CSharp.Symbols.SourceMemberContainerTypeSymbol.GetMembersAndInitializers() Line 1339
CSharp.Symbols.SourceMemberContainerTypeSymbol.GetEarlyAttributeDecodingMembersDictionary() Line 1312
CSharp.Symbols.SourceMemberContainerTypeSymbol.GetEarlyAttributeDecodingMembers(string name) Line 1305
CSharp.Binder.GetCandidateMembers(CSharp.Symbols.NamespaceOrTypeSymbol nsOrType, string name,LookupOptions options,Binder originalBinder) Line 1075
CSharp.Binder.LookupMembersWithoutInheritance(CSharp.LookupResult result,Symbols.TypeSymbol type, string name, int arity,LookupOptions options,Binder originalBinder,Symbols.TypeSymbol accessThroughType, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved) Line 664
CSharp.Binder.LookupMembersInClass(CSharp.LookupResult result,Symbols.TypeSymbol type, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved,LookupOptions options,Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 697
CSharp.Binder.LookupMembersInType(CSharp.LookupResult result,Symbols.TypeSymbol type, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved,LookupOptions options,Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 187
CSharp.Binder.LookupMembersInternal(CSharp.LookupResult result,Symbols.NamespaceOrTypeSymbol nsOrType, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved,LookupOptions options,Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 164
CSharp.InContainerBinder.LookupSymbolsInSingleBinder(CSharp.LookupResult result, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved,LookupOptions options,Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 237
CSharp.Binder.LookupSymbolsInternal(CSharp.LookupResult result, string name, int arity, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved,LookupOptions options, bool diagnose, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics) Line 94
CSharp.Binder.LookupSymbolsWithFallback(CSharp.LookupResult result, string name, int arity, ref System.Collections.Generic.HashSet<DiagnosticInfo> useSiteDiagnostics, Roslyn.Utilities.ConsList<CSharp.Symbol> basesBeingResolved,LookupOptions options) Line 61
CSharp.Binder.BindIdentifier(CSharp.Syntax.SimpleNameSyntax node, bool invoked, bool indexed, DiagnosticBag diagnostics) Line 1216
CSharp.Binder.BindLeftOfPotentialColorColorMemberAccess(CSharp.Syntax.ExpressionSyntax left, DiagnosticBag diagnostics) Line 5224
CSharp.Binder.BindMemberAccess(CSharp.Syntax.MemberAccessExpressionSyntax node, bool invoked, bool indexed, DiagnosticBag diagnostics) Line 5172
CSharp.Binder.BindExpressionInternal(CSharp.Syntax.ExpressionSyntax node, DiagnosticBag diagnostics, bool invoked, bool indexed) Line 402
CSharp.Binder.BindExpression(CSharp.Syntax.ExpressionSyntax node, DiagnosticBag diagnostics, bool invoked, bool indexed) Line 329
CSharp.Binder.BindValue(CSharp.Syntax.ExpressionSyntax node, DiagnosticBag diagnostics,Binder.BindValueKind valueKind) Line 228
CSharp.Binder.BindArgumentExpression(DiagnosticBag diagnostics,Syntax.ExpressionSyntax argumentExpression, RefKind refKind, bool allowArglist) Line 2517
CSharp.Binder.BindAttributeArguments(CSharp.Syntax.AttributeArgumentListSyntax attributeArgumentList,Symbols.NamedTypeSymbol attributeType, DiagnosticBag diagnostics) Line 303
CSharp.Binder.BindAttributeCore(CSharp.Syntax.AttributeSyntax node,Symbols.NamedTypeSymbol attributeType, DiagnosticBag diagnostics) Line 147
CSharp.Binder.BindAttribute(CSharp.Syntax.AttributeSyntax node,Symbols.NamedTypeSymbol attributeType, DiagnosticBag diagnostics) Line 105
CSharp.Binder.GetAttribute(CSharp.Syntax.AttributeSyntax node,Symbols.NamedTypeSymbol boundAttributeType, DiagnosticBag diagnostics) Line 98
CSharp.EarlyWellKnownAttributeBinder.GetAttribute(CSharp.Syntax.AttributeSyntax node,Symbols.NamedTypeSymbol boundAttributeType, out bool generatedDiagnostics) Line 25
CSharp.Symbols.SourceNamedTypeSymbol.EarlyDecodeWellKnownAttribute(ref EarlyDecodeWellKnownAttributeArguments<CSharp.EarlyWellKnownAttributeBinder,Symbols.NamedTypeSymbol,Syntax.AttributeSyntax,Symbols.AttributeLocation> arguments) Line 577
CSharp.Symbol.EarlyDecodeWellKnownAttributes(System.Collections.Immutable.ImmutableArray<CSharp.Binder> binders, System.Collections.Immutable.ImmutableArray<CSharp.Symbols.NamedTypeSymbol> boundAttributeTypes, System.Collections.Immutable.ImmutableArray<CSharp.Syntax.AttributeSyntax> attributesToBind,Symbols.AttributeLocation symbolPart,Symbols.CSharpAttributeData[] boundAttributesBuilder) Line 577
CSharp.Symbol.LoadAndValidateAttributes(Roslyn.Utilities.OneOrMany<SyntaxList<CSharp.Syntax.AttributeListSyntax>> attributesSyntaxLists, ref CustomAttributesBag<CSharp.Symbols.CSharpAttributeData> lazyCustomAttributesBag,Symbols.AttributeLocation symbolPart, bool earlyDecodingOnly,Binder binderOpt, System.Func<CSharp.Syntax.AttributeSyntax, bool> attributeMatchesOpt) Line 303
CSharp.Symbols.SourceNamedTypeSymbol.GetAttributesBag() Line 460
CSharp.Symbols.SourceNamedTypeSymbol.GetEarlyDecodedWellKnownAttributeData() Line 507
CSharp.Symbols.SourceNamedTypeSymbol.NonNullTypes.get() Line 942
CSharp.Symbols.PropertySymbol.NonNullTypes.get() Line 177
CSharp.Symbols.SourcePropertySymbol.NonNullTypes.get() Line 1519
CSharp.Binder.NonNullTypes.get() Line 228
```

There was another cycle, but I lost my notes for it. I'll gather the information and add here.