### PR TITLE
Enable two-way IPC channels for integration testing

### DIFF
--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Ipc;
@@ -13,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Roslyn.Utilities;
+using Hashtable = System.Collections.Hashtable;
 
 namespace Microsoft.CodeAnalysis.Interactive
 {
@@ -37,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Interactive
         private int _remoteServiceInstanceId;
 
         // Remoting channel to communicate with the remote service.
-        private IpcServerChannel _serverChannel;
+        private IpcChannel _channel;
 
         private TextWriter _output;
         private TextWriter _errorOutput;
@@ -59,9 +61,17 @@ namespace Microsoft.CodeAnalysis.Interactive
             _outputGuard = new object();
             _errorOutputGuard = new object();
 
-            var serverProvider = new BinaryServerFormatterSinkProvider { TypeFilterLevel = TypeFilterLevel.Full };
-            _serverChannel = new IpcServerChannel(GenerateUniqueChannelLocalName(), "ReplChannel-" + Guid.NewGuid(), serverProvider);
-            ChannelServices.RegisterChannel(_serverChannel, ensureSecurity: false);
+            var name = GenerateUniqueChannelLocalName();
+            var portName = "ReplChannel-" + Guid.NewGuid();
+            _channel = new IpcChannel(
+                new Hashtable
+                {
+                    { "name", name },
+                    { "portName", portName },
+                },
+                new BinaryClientFormatterSinkProvider(),
+                new BinaryServerFormatterSinkProvider { TypeFilterLevel = TypeFilterLevel.Full });
+            ChannelServices.RegisterChannel(_channel, ensureSecurity: true);
         }
 
         #region Test hooks
@@ -87,9 +97,9 @@ namespace Microsoft.CodeAnalysis.Interactive
         // The ProcessExited event is not hooked yet.
         internal event Action<Process> InteractiveHostProcessCreated;
 
-        internal IpcServerChannel _ServerChannel
+        internal IpcChannel _ServerChannel
         {
-            get { return _serverChannel; }
+            get { return _channel; }
         }
 
         #endregion
@@ -260,10 +270,15 @@ namespace Microsoft.CodeAnalysis.Interactive
 
         private void DisposeChannel()
         {
-            if (_serverChannel != null)
+            if (_channel != null)
             {
-                ChannelServices.UnregisterChannel(_serverChannel);
-                _serverChannel = null;
+                if (ChannelServices.RegisteredChannels.Contains(_channel))
+                {
+                    ChannelServices.UnregisterChannel(_channel);
+                }
+
+                _channel.StopListening(null);
+                _channel = null;
             }
         }
 

--- a/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
+++ b/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
@@ -19,13 +19,15 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
             typeof(CSharpCompilation)
         };
 
+        private static readonly FieldInfo s_ipcChannelServerChannel = typeof(IpcChannel).GetField("_serverChannel", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly FieldInfo s_ipcServerChannelListenerThread = typeof(IpcServerChannel).GetField("_listenerThread", BindingFlags.NonPublic | BindingFlags.Instance);
 
         internal static void DisposeInteractiveHostProcess(InteractiveHost process)
         {
-            IpcServerChannel serverChannel = process._ServerChannel;
+            var channel = process._ServerChannel;
             process.Dispose();
 
+            var serverChannel = (IpcServerChannel)s_ipcChannelServerChannel.GetValue(channel);
             var listenerThread = (Thread)s_ipcServerChannelListenerThread.GetValue(serverChannel);
             listenerThread.Join();
         }


### PR DESCRIPTION
This change updates the integration tests to use two-way IPC channels, which allows callback objects in the test process to be marshalled to the Visual Studio instance. Enabling this callback channel with security forces the second callback channel (interactive host) to also use a channel requiring security, so both are updated at the same time.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
