### PR TITLE
Auto-attach debugger to target instance of Visual Studio during integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -82,6 +82,19 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             SupportedPackageIds = supportedPackageIds;
             InstallationPath = installationPath;
 
+            if (System.Diagnostics.Debugger.IsAttached)
+            {
+                // If a Visual Studio debugger is attached to the test process, attach it to the instance running
+                // integration tests as well.
+                var debuggerHostDte = GetDebuggerHostDte();
+                int targetProcessId = Process.GetCurrentProcess().Id;
+                var localProcess = debuggerHostDte?.Debugger.LocalProcesses.OfType<EnvDTE80.Process2>().FirstOrDefault(p => p.ProcessID == hostProcess.Id);
+                if (localProcess != null)
+                {
+                    localProcess.Attach2("Managed");
+                }
+            }
+
             StartRemoteIntegrationService(dte);
 
             _integrationServiceChannel = new IpcClientChannel($"IPC channel client for {HostProcess.Id}", sinkProvider: null);
@@ -196,6 +209,21 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             {
                 CloseHostProcess();
             }
+        }
+
+        private static DTE GetDebuggerHostDte()
+        {
+            var currentProcessId = Process.GetCurrentProcess().Id;
+            foreach (var process in Process.GetProcessesByName("devenv"))
+            {
+                var dte = IntegrationHelper.TryLocateDteForProcess(process);
+                if (dte?.Debugger?.DebuggedProcesses?.OfType<EnvDTE.Process>().Any(p => p.ProcessID == currentProcessId) ?? false)
+                {
+                    return dte;
+                }
+            }
+
+            return null;
         }
 
         private void CloseHostProcess()


### PR DESCRIPTION
<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
