### PR TITLE
Improvements to the integration test screenshot service

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/ScreenshotService.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/ScreenshotService.cs
@@ -9,7 +9,7 @@ using PixelFormats = System.Windows.Media.PixelFormats;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 {
-    internal class ScreenshotService
+    internal static class ScreenshotService
     {
         private static readonly object s_gate = new object();
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/ScreenshotService.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/ScreenshotService.cs
@@ -4,6 +4,8 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Windows.Forms;
+using System.Windows.Media.Imaging;
+using PixelFormats = System.Windows.Media.PixelFormats;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 {
@@ -25,17 +27,20 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             //    to the same file
             lock (s_gate)
             {
-                using (var bitmap = TryCaptureFullScreen())
+                var bitmap = TryCaptureFullScreen();
+                if (bitmap == null)
                 {
-                    if (bitmap == null)
-                    {
-                        return;
-                    }
+                    return;
+                }
 
-                    var directory = Path.GetDirectoryName(fullPath);
-                    Directory.CreateDirectory(directory);
+                var directory = Path.GetDirectoryName(fullPath);
+                Directory.CreateDirectory(directory);
 
-                    bitmap.Save(fullPath, ImageFormat.Png);
+                using (var fileStream = new FileStream(fullPath, FileMode.Create, FileAccess.Write))
+                {
+                    var encoder = new PngBitmapEncoder();
+                    encoder.Frames.Add(BitmapFrame.Create(bitmap));
+                    encoder.Save(fileStream);
                 }
             }
         }
@@ -47,7 +52,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// A <see cref="Bitmap"/> containing the screen capture of the desktop, or null if a screen
         /// capture can't be created.
         /// </returns>
-        private static Bitmap TryCaptureFullScreen()
+        private static BitmapSource TryCaptureFullScreen()
         {
             int width = Screen.PrimaryScreen.Bounds.Width;
             int height = Screen.PrimaryScreen.Bounds.Height;
@@ -59,8 +64,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 return null;
             }
 
-            var bitmap = new Bitmap(width, height);
-
+            using (var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb))
             using (var graphics = Graphics.FromImage(bitmap))
             {
                 graphics.CopyFromScreen(
@@ -70,9 +74,29 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                     destinationY: 0,
                     blockRegionSize: bitmap.Size,
                     copyPixelOperation: CopyPixelOperation.SourceCopy);
-            }
 
-            return bitmap;
+                var bitmapData = bitmap.LockBits(
+                    new Rectangle(0, 0, bitmap.Width, bitmap.Height),
+                    ImageLockMode.ReadOnly,
+                    PixelFormat.Format32bppArgb);
+                try
+                {
+                    return BitmapSource.Create(
+                        bitmapData.Width,
+                        bitmapData.Height,
+                        bitmap.HorizontalResolution,
+                        bitmap.VerticalResolution,
+                        PixelFormats.Bgra32,
+                        null,
+                        bitmapData.Scan0,
+                        bitmapData.Stride * bitmapData.Height,
+                        bitmapData.Stride);
+                }
+                finally
+                {
+                    bitmap.UnlockBits(bitmapData);
+                }
+            }
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 var assemblyDirectory = GetAssemblyDirectory();
                 var testName = CaptureTestNameAttribute.CurrentName ?? "Unknown";
                 var logDir = Path.Combine(assemblyDirectory, "xUnitResults", "Screenshots");
-                var baseFileName = $"{testName}-{eventArgs.Exception.GetType().Name}-{DateTime.Now:HH.mm.ss}";
+                var baseFileName = $"{DateTime.Now:HH.mm.ss}-{testName}-{eventArgs.Exception.GetType().Name}";
                 ScreenshotService.TakeScreenshot(Path.Combine(logDir, $"{baseFileName}.png"));
 
                 var exception = eventArgs.Exception;


### PR DESCRIPTION
* Avoid concurrency
* Capture a `BitmapSource` instead of a `Bitmap` (errors reported during save are more actionable on this code path)
* Make `ScreenshotService` static

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
