### PR TITLE
Add new rule for moveability of pointer element expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6153,6 +6153,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!hasError && fieldSymbol.IsFixed && !IsInsideNameof)
             {
+                // SPEC: In a member access of the form E.I, if E is of a struct type and a member lookup of I in
+                // that struct type identifies a fixed size member, then E.I is evaluated an classified as follows:
+                // * If the expression E.I does not occur in an unsafe context, a compile-time error occurs.
+                // * If E is classified as a value, a compile-time error occurs.
+                // * Otherwise, if E is a moveable variable and the expression E.I is not a fixed_pointer_initializer,
+                //   a compile-time error occurs.
+                // * Otherwise, E references a fixed variable and the result of the expression is a pointer to the
+                //   first element of the fixed size buffer member I in E. The result is of type S*, where S is
+                //   the element type of I, and is classified as a value.
+
                 TypeSymbol receiverType = receiver.Type;
 
                 // Reflect errors that have been reported elsewhere...
@@ -6161,11 +6171,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (!hasError)
                 {
                     var isFixedStatementExpression = SyntaxFacts.IsFixedStatementExpression(node);
-                    Symbol accessedLocalOrParameterOpt;
-                    if (ExpressionRequiresFixing(receiver, out accessedLocalOrParameterOpt) != isFixedStatementExpression)
+
+                    if (IsMoveableVariable(receiver, out Symbol accessedLocalOrParameterOpt) != isFixedStatementExpression)
                     {
                         if (indexed)
                         {
+                            // SPEC C# 7.3: If the fixed size buffer access is the receiver of an element_access_expression,
+                            // E may be either fixed or moveable
                             CheckFeatureAvailability(node, MessageID.IDS_FeatureIndexingMovableFixedBuffers, diagnostics);
                         }
                         else

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2135,8 +2135,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundAddressOfOperator(node, operand, pointerType, hasErrors);
         }
 
-        // Basically a port of ExpressionBinder::isFixedExpression, which basically implements spec section 18.3.
-        // NOTE: internal to allow using in tests.
+        /// <summary>
+        /// Checks to see whether an expression is a "moveable" variable according to the spec. Moveable
+        /// variables have underlying memory which may be moved by the runtime. The spec defines anything
+        /// not fixed as moveable and specifies the expressions which are fixed.
+        /// </summary>
+
         internal bool IsMoveableVariable(BoundExpression expr, out Symbol accessedLocalOrParameterOpt)
         {
             accessedLocalOrParameterOpt = null;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
@@ -1078,17 +1078,17 @@ unsafe struct S
 }
 unsafe class C
 {
-    static S s_s;
+    static S s_f;
     public void M()
     {
-        s_s.Buf[0] = 1;
+        s_f.Buf[0] = 1;
     }
 }", options: TestOptions.UnsafeReleaseDll);
             verifier.VerifyIL("C.M", @"
 {
   // Code size       18 (0x12)
   .maxstack  2
-  IL_0000:  ldsflda    ""S C.s_s""
+  IL_0000:  ldsflda    ""S C.s_f""
   IL_0005:  ldflda     ""int* S.Buf""
   IL_000a:  ldflda     ""int S.<Buf>e__FixedBuffer.FixedElementField""
   IL_000f:  ldc.i4.1

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
@@ -1067,5 +1067,72 @@ unsafe struct Foo
                 //     public int* M2 => &Bar[1];
                 Diagnostic(ErrorCode.ERR_FixedNeeded, "&Bar[1]").WithLocation(7, 23));
         }
+
+        [Fact]
+        public void StaticField()
+        {
+            var verifier = CompileAndVerify(@"
+unsafe struct S
+{
+    public fixed int Buf[1];
+}
+unsafe class C
+{
+    static S s_s;
+    public void M()
+    {
+        s_s.Buf[0] = 1;
+    }
+}", options: TestOptions.UnsafeReleaseDll);
+            verifier.VerifyIL("C.M", @"
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  ldsflda    ""S C.s_s""
+  IL_0005:  ldflda     ""int* S.Buf""
+  IL_000a:  ldflda     ""int S.<Buf>e__FixedBuffer.FixedElementField""
+  IL_000f:  ldc.i4.1
+  IL_0010:  stind.i4
+  IL_0011:  ret
+}");
+        }
+
+        [Fact]
+        public void FixedSizeBufferOffPointerAcess()
+        {
+            var verifier = CompileAndVerify(@"
+using System;
+unsafe struct S
+{
+    public fixed int Buf[1];
+}
+unsafe class C
+{
+    public void M(IntPtr ptr)
+    {
+        S* s = (S*)ptr;
+        int* x = s->Buf;
+        int* y = &s->Buf[0];
+    }
+}", options: TestOptions.UnsafeReleaseDll, verify: Verification.Fails);
+            verifier.VerifyIL("C.M", @"
+{
+  // Code size       32 (0x20)
+  .maxstack  1
+  .locals init (S* V_0) //s
+  IL_0000:  ldarg.1
+  IL_0001:  call       ""void* System.IntPtr.op_Explicit(System.IntPtr)""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  ldflda     ""int* S.Buf""
+  IL_000d:  ldflda     ""int S.<Buf>e__FixedBuffer.FixedElementField""
+  IL_0012:  pop
+  IL_0013:  ldloc.0
+  IL_0014:  ldflda     ""int* S.Buf""
+  IL_0019:  ldflda     ""int S.<Buf>e__FixedBuffer.FixedElementField""
+  IL_001e:  pop
+  IL_001f:  ret
+}");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -7047,7 +7047,7 @@ class Program
 
         #region sizeof semantic model tests
 
-        private static readonly Dictionary<SpecialType, int> s_fpecialTypeSizeOfMap = new Dictionary<SpecialType, int>
+        private static readonly Dictionary<SpecialType, int> s_specialTypeSizeOfMap = new Dictionary<SpecialType, int>
         {
             { SpecialType.System_SByte, 1 },
             { SpecialType.System_Byte, 1 },
@@ -7124,7 +7124,7 @@ class Program
                 Assert.Equal(0, sizeOfSummary.MethodGroup.Length);
                 Assert.Null(sizeOfSummary.Alias);
                 Assert.True(sizeOfSummary.IsCompileTimeConstant);
-                Assert.Equal(s_fpecialTypeSizeOfMap[type.SpecialType], sizeOfSummary.ConstantValue);
+                Assert.Equal(s_specialTypeSizeOfMap[type.SpecialType], sizeOfSummary.ConstantValue);
             }
         }
 
@@ -7187,7 +7187,7 @@ enum E2 : long
                 Assert.Equal(0, sizeOfSummary.MethodGroup.Length);
                 Assert.Null(sizeOfSummary.Alias);
                 Assert.True(sizeOfSummary.IsCompileTimeConstant);
-                Assert.Equal(s_fpecialTypeSizeOfMap[type.GetEnumUnderlyingType().SpecialType], sizeOfSummary.ConstantValue);
+                Assert.Equal(s_specialTypeSizeOfMap[type.GetEnumUnderlyingType().SpecialType], sizeOfSummary.ConstantValue);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -2308,7 +2308,7 @@ No, Parameter 'x' does not require fixing. It has an underlying symbol 'x'
                     {
                         text = SymbolDisplay.FormatLiteral(text, quote: false);
 
-                        if (_binder.ExpressionRequiresFixing(expr, out Symbol accessedLocalOrParameterOpt))
+                        if (_binder.IsMoveableVariable(expr, out Symbol accessedLocalOrParameterOpt))
                         {
                             _builder.Add($"Yes, {expr.Kind} '{text}' requires fixing.");
                         }
@@ -8690,5 +8690,123 @@ public class Test
         }
 
         #endregion
+
+        [Fact]
+        public void AddressOfFixedSizeBuffer()
+        {
+            CreateCompilation(@"
+unsafe struct S
+{
+    public fixed int Buf[1];
+}
+
+unsafe class C
+{
+    static S s_s;
+    void M(S s)
+    {
+        fixed (int* a = &s.Buf) {}
+        fixed (int* b = &s_s.Buf) {}
+        int* c = &s.Buf;
+        int* d = &s_s.Buf;
+    }
+}", options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+                // (12,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
+                //         fixed (int* a = &s.Buf) {}
+                Diagnostic(ErrorCode.ERR_FixedNotNeeded, "&s.Buf").WithLocation(12, 25),
+                // (13,26): error CS1666: You cannot use fixed size buffers contained in unfixed expressions. Try using the fixed statement.
+                //         fixed (int* b = &s_s.Buf) {}
+                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_s.Buf").WithLocation(13, 26),
+                // (14,18): error CS0266: Cannot implicitly convert type 'int**' to 'int*'. An explicit conversion exists (are you missing a cast?)
+                //         int* c = &s.Buf;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "&s.Buf").WithArguments("int**", "int*").WithLocation(14, 18),
+                // (15,19): error CS1666: You cannot use fixed size buffers contained in unfixed expressions. Try using the fixed statement.
+                //         int* d = &s_s.Buf;
+                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_s.Buf").WithLocation(15, 19));
+        }
+
+        [Fact]
+        public void FixedFixedSizeBuffer()
+        {
+            CreateCompilation(@"
+unsafe struct S
+{
+    public fixed int Buf[1];
+}
+
+unsafe class C
+{
+    static S s_s;
+    void M(S s)
+    {
+        fixed (int* a = s.Buf) {}
+        fixed (int* b = s_s.Buf) {}
+        int* c = s.Buf;
+        int* d = s_s.Buf;
+    }
+}", options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+                // (12,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
+                //         fixed (int* a = s.Buf) {}
+                Diagnostic(ErrorCode.ERR_FixedNotNeeded, "s.Buf").WithLocation(12, 25),
+                // (15,18): error CS1666: You cannot use fixed size buffers contained in unfixed expressions. Try using the fixed statement.
+                //         int* d = s_s.Buf;
+                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_s.Buf").WithLocation(15, 18));
+        }
+
+        [Fact]
+        public void NoPointerDerefMoveableFixedSizeBuffer()
+        {
+            CreateCompilation(@"
+unsafe struct S
+{
+    public fixed int Buf[1];
+}
+
+unsafe class C
+{
+    static S s_s;
+    void M(S s)
+    {
+        int x = *s.Buf;
+        int y = *s_s.Buf;
+    }
+}", options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+                // (13,18): error CS1666: You cannot use fixed size buffers contained in unfixed expressions. Try using the fixed statement.
+                //         int y = *s_s.Buf;
+                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_s.Buf").WithLocation(13, 18));
+        }
+
+        [Fact]
+        public void AddressOfElementAccessFixedSizeBuffer()
+        {
+            CreateCompilation(@"
+unsafe struct S
+{
+    public fixed int Buf[1];
+}
+
+unsafe class C
+{
+    static S s_s;
+    void M(S s)
+    {
+        fixed (int* a = &s.Buf[0]) { }
+        fixed (int* b = &s_s.Buf[0]) { }
+        int* c = &s.Buf[0];
+        int* d = &s_s.Buf[0];
+        int* e = &(s.Buf[0]);
+        int* f = &(s_s.Buf[0]);
+    }
+}", options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+                // (12,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
+                //         fixed (int* a = &s.Buf[0]) { }
+                Diagnostic(ErrorCode.ERR_FixedNotNeeded, "&s.Buf[0]").WithLocation(12, 25),
+                // (15,18): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
+                //         int* d = &s_s.Buf[0];
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&s_s.Buf[0]").WithLocation(15, 18),
+                // (17,18): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
+                //         int* f = &(s_s.Buf[0]);
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&(s_s.Buf[0])").WithLocation(17, 18));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -7047,7 +7047,7 @@ class Program
 
         #region sizeof semantic model tests
 
-        private static readonly Dictionary<SpecialType, int> s_specialTypeSizeOfMap = new Dictionary<SpecialType, int>
+        private static readonly Dictionary<SpecialType, int> s_fpecialTypeSizeOfMap = new Dictionary<SpecialType, int>
         {
             { SpecialType.System_SByte, 1 },
             { SpecialType.System_Byte, 1 },
@@ -7124,7 +7124,7 @@ class Program
                 Assert.Equal(0, sizeOfSummary.MethodGroup.Length);
                 Assert.Null(sizeOfSummary.Alias);
                 Assert.True(sizeOfSummary.IsCompileTimeConstant);
-                Assert.Equal(s_specialTypeSizeOfMap[type.SpecialType], sizeOfSummary.ConstantValue);
+                Assert.Equal(s_fpecialTypeSizeOfMap[type.SpecialType], sizeOfSummary.ConstantValue);
             }
         }
 
@@ -7187,7 +7187,7 @@ enum E2 : long
                 Assert.Equal(0, sizeOfSummary.MethodGroup.Length);
                 Assert.Null(sizeOfSummary.Alias);
                 Assert.True(sizeOfSummary.IsCompileTimeConstant);
-                Assert.Equal(s_specialTypeSizeOfMap[type.GetEnumUnderlyingType().SpecialType], sizeOfSummary.ConstantValue);
+                Assert.Equal(s_fpecialTypeSizeOfMap[type.GetEnumUnderlyingType().SpecialType], sizeOfSummary.ConstantValue);
             }
         }
 
@@ -8702,27 +8702,27 @@ unsafe struct S
 
 unsafe class C
 {
-    static S s_s;
+    static S s_f;
     void M(S s)
     {
         fixed (int* a = &s.Buf) {}
-        fixed (int* b = &s_s.Buf) {}
+        fixed (int* b = &s_f.Buf) {}
         int* c = &s.Buf;
-        int* d = &s_s.Buf;
+        int* d = &s_f.Buf;
     }
 }", options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
                 // (12,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
                 //         fixed (int* a = &s.Buf) {}
                 Diagnostic(ErrorCode.ERR_FixedNotNeeded, "&s.Buf").WithLocation(12, 25),
                 // (13,26): error CS1666: You cannot use fixed size buffers contained in unfixed expressions. Try using the fixed statement.
-                //         fixed (int* b = &s_s.Buf) {}
-                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_s.Buf").WithLocation(13, 26),
+                //         fixed (int* b = &s_f.Buf) {}
+                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_f.Buf").WithLocation(13, 26),
                 // (14,18): error CS0266: Cannot implicitly convert type 'int**' to 'int*'. An explicit conversion exists (are you missing a cast?)
                 //         int* c = &s.Buf;
                 Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "&s.Buf").WithArguments("int**", "int*").WithLocation(14, 18),
                 // (15,19): error CS1666: You cannot use fixed size buffers contained in unfixed expressions. Try using the fixed statement.
-                //         int* d = &s_s.Buf;
-                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_s.Buf").WithLocation(15, 19));
+                //         int* d = &s_f.Buf;
+                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_f.Buf").WithLocation(15, 19));
         }
 
         [Fact]
@@ -8736,21 +8736,21 @@ unsafe struct S
 
 unsafe class C
 {
-    static S s_s;
+    static S s_f;
     void M(S s)
     {
         fixed (int* a = s.Buf) {}
-        fixed (int* b = s_s.Buf) {}
+        fixed (int* b = s_f.Buf) {}
         int* c = s.Buf;
-        int* d = s_s.Buf;
+        int* d = s_f.Buf;
     }
 }", options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
                 // (12,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
                 //         fixed (int* a = s.Buf) {}
                 Diagnostic(ErrorCode.ERR_FixedNotNeeded, "s.Buf").WithLocation(12, 25),
                 // (15,18): error CS1666: You cannot use fixed size buffers contained in unfixed expressions. Try using the fixed statement.
-                //         int* d = s_s.Buf;
-                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_s.Buf").WithLocation(15, 18));
+                //         int* d = s_f.Buf;
+                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_f.Buf").WithLocation(15, 18));
         }
 
         [Fact]
@@ -8764,16 +8764,16 @@ unsafe struct S
 
 unsafe class C
 {
-    static S s_s;
+    static S s_f;
     void M(S s)
     {
         int x = *s.Buf;
-        int y = *s_s.Buf;
+        int y = *s_f.Buf;
     }
 }", options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
                 // (13,18): error CS1666: You cannot use fixed size buffers contained in unfixed expressions. Try using the fixed statement.
-                //         int y = *s_s.Buf;
-                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_s.Buf").WithLocation(13, 18));
+                //         int y = *s_f.Buf;
+                Diagnostic(ErrorCode.ERR_FixedBufferNotFixed, "s_f.Buf").WithLocation(13, 18));
         }
 
         [Fact]
@@ -8787,26 +8787,26 @@ unsafe struct S
 
 unsafe class C
 {
-    static S s_s;
+    static S s_f;
     void M(S s)
     {
         fixed (int* a = &s.Buf[0]) { }
-        fixed (int* b = &s_s.Buf[0]) { }
+        fixed (int* b = &s_f.Buf[0]) { }
         int* c = &s.Buf[0];
-        int* d = &s_s.Buf[0];
+        int* d = &s_f.Buf[0];
         int* e = &(s.Buf[0]);
-        int* f = &(s_s.Buf[0]);
+        int* f = &(s_f.Buf[0]);
     }
 }", options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
                 // (12,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
                 //         fixed (int* a = &s.Buf[0]) { }
                 Diagnostic(ErrorCode.ERR_FixedNotNeeded, "&s.Buf[0]").WithLocation(12, 25),
                 // (15,18): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
-                //         int* d = &s_s.Buf[0];
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&s_s.Buf[0]").WithLocation(15, 18),
+                //         int* d = &s_f.Buf[0];
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&s_f.Buf[0]").WithLocation(15, 18),
                 // (17,18): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
-                //         int* f = &(s_s.Buf[0]);
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&(s_s.Buf[0])").WithLocation(17, 18));
+                //         int* f = &(s_f.Buf[0]);
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&(s_f.Buf[0])").WithLocation(17, 18));
         }
     }
 }


### PR DESCRIPTION

### Customer scenario

Legal C# code involving taking an address of a fixed size buffer may break 
when a user upgrades their compiler.

When we enabled pointer_element_access to work on fixed sized buffers
regardless of the moveability of the receiver of the buffer access, we
did not repair the safety rules to prevent leaking a pointer to a
moveable variable back into the language.

This change adds a new rule, which makes the moveability of a
pointer_element_access on a fixed size buffer dependent on the
moveability of its receiver. This should require the use of a `fixed`
statement to prevent safety holes.


### Bugs this fixes

Fixes #28476 

### Workarounds, if any

None.

### Risk

I have developed an informal proof of the safety of the new language rule
in the associated bug that I will copy below:

First, a reminder of what a pointer is in C#. A pointer is an unmanaged reference, so if a pointer is pointing into a managed object, the GC can move the underlying memory or free it if there isn't something preventing it from doing so. Pointers in C# are unsafe, so there are no guarantees from the compiler that they're being used correctly, but the language does have substantial guardrails in place to make it less likely certain things will happen, especially getting a pointer to a managed object that may be moved by the GC.

This notion is formalized in the language by a notion of ["moveable" and "fixed" variables](https://github.com/dotnet/csharplang/blob/master/spec/unsafe-code.md#fixed-and-moveable-variables). A moveable variable may be moved by the GC, so the language provides the `fixed` statement to provide a scoped region where the variable may not be moved by the GC. This leads to the single most important pointer safety principle in the language: **you cannot get a pointer to a moveable variable unless it is inside a `fixed` statement initializer**. Once you have one, that's where the guard rails end. The language won't prevent you from stashing away the pointer for longer than the lifetime of the `fixed` statement, but it will provide the base level of security of requiring moveable variables to be fixed before you can retrieve a pointer. This also means that subsequent safety guardrails of the language are dependent on the assumption that, if you have a pointer, its target must be fixed.

Now that we know the principle, we can track down the rules that enforce it. The most obvious is around the "address-of" (`&`) operator. This is one of the only ways to get a pointer in pure C# code. The spec says this about address-of and moveable variables:

> the address of a moveable variable can only be obtained using a fixed statement

So the principle is safe.

Another way to get a pointer is the `stackalloc` expression. This expression is always immovable, so it is also safe.

The only other way I can find to get a pointer in pure C# code is a [fixed size buffer](https://github.com/dotnet/csharplang/blob/master/spec/unsafe-code.md#fixed-size-buffers). In this case, the native type of a fixed size buffer is *already a pointer*, so the address-of operator rule cannot help. The only way this can be guaranteed to be safe is if (1) fixed size buffers are always non-moveable variables or (2) there is another rule about fixed size buffer usage. (1) is not true, but (2) is. The spec has this to say about [accessing fixed size buffers](https://github.com/dotnet/csharplang/blob/master/spec/unsafe-code.md#fixed-size-buffers-in-expressions):

>In a member access of the form `E.I` ...  if `E` is a moveable variable... and the expression `E.I` is not a _fixed_pointer_initializer_, a compile-time error occurs.

And so C# 6 is safe.

Now, enter C# 7.3. A feature is [proposed](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.3/indexing-movable-fixed-fields.md) to allow a _pointer_member_access_ to a moveable fixed size buffer outside a fixed statement. This can be seen as essentially sugar for turning `T x = fixed_buf[0]` into

```C#
T x;
fixed (T* ptr = &fixed_buf)
{
    x = ptr[0];
}
```

However, this absolutely breaks the C# 6 safety principle: you can now get a pointer to a moveable variable outside the fixed statement. Luckily, the result of the expression must be a primitive type, so there are no complex questions about the result type, but there's still the concern that we could get back to the original pointer without a fixed statement. To prove that is not possible, we can use the assumption from before: there are only two ways to get a pointer in pure C#: address-of and fixed size buffers. Since the resulting type is a primitive type, there is no way to get a fixed size buffer off of it. Thus, the only way is address-of. If the value resulting from `moveable_fixed_buf[0]` is moveable, then we know this is safe from the previous lemma.

Unfortunately, that is not true. The spec says:

> a fixed variable is... a variable resulting from a... _pointer_element_access_ of the form `P[E]`

Our new expression is a _pointer_element_access_ of that form. Note that the rule does not consider whether or not `P` is moveable -- it is assumed that all pointers are fixed because of the application of the previous safety rules.

Thus, we have a safety hole. The expression `&moveable_fixed_buf[0]` appears to result in a non-moveable variable, even though the resulting pointer is to moveable memory.

To repair this hole, I propose a modification to the existing rule for _pointer_element_access_, namely:

> a variable resulting from a... _pointer_element_access_ of the form `P[E]` [is fixed] if `P` is not a fixed size buffer expression, or if the expression is a fixed size buffer _member_access_ of the form `E.I` and `E` is a fixed variable

This effectively means that a _pointer_element_access_ off a moveable fixed sized buffer will result in a moveable variable, instead of a fixed one. We should now be able to apply the earlier lemma and consider safety proved.

### Performance impact

None. Basically the same cost as the previous check.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

Fixed size buffers are a very rarely used feature of the language and some of the
behaviors are very subtle.

### How was the bug found?

Building Visual Studio
