### PR TITLE
Several simplifications to TypeSymbolWithAnnotations

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3242,34 +3242,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        internal TypeSymbolWithAnnotations GetFieldTypeWithAdjustedNullableAnnotations(FieldSymbol field, ConsList<FieldSymbol> fieldsBeingBound)
-        {
-            FieldSymbol definition = field.OriginalDefinition;
-
-            if (!ShouldSuppressNullableAnnotations(definition))
-            {
-                return field.GetFieldType(fieldsBeingBound);
-            }
-
-            // Nullable annotations on definition should be ignored
-            TypeSymbolWithAnnotations definitionType = definition.GetFieldType(fieldsBeingBound);
-            TypeSymbolWithAnnotations adjustedDefinitionType = definitionType.SetUnknownNullabilityForReferenceTypes();
-
-            if ((object)definition == field)
-            {
-                return adjustedDefinitionType;
-            }
-
-            if ((object)definitionType == adjustedDefinitionType)
-            {
-                // Adjustment has no effect
-                return field.GetFieldType(fieldsBeingBound);
-            }
-
-            // The original symbol was substituted, need to re-apply substitution to the adjusted type.   
-            return adjustedDefinitionType.SubstituteType(field.ContainingType.TypeSubstitution);
-        }
-
         private abstract class AbstractSymbolSearcher
         {
             private readonly PooledDictionary<Declaration, NamespaceOrTypeSymbol> _cache;

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -139,20 +139,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal TypeSymbolWithAnnotations SubstituteTypeWithTupleUnification(TypeSymbol previous)
         {
+            return SubstituteType(previous, withTupleUnification: true);
+        }
+
+        internal TypeSymbolWithAnnotations SubstituteType(TypeSymbol previous, bool withTupleUnification)
+        {
             var result = SubstituteType(previous);
 
-            // Make it a tuple if it became compatible with one.
-            // PROTOTYPE(NullableReferenceTypes): Avoid resolving result.TypeSymbol eagerly.
-            var type = result.TypeSymbol;
-            if ((object)type != null && !previous.IsTupleCompatible())
+            if (withTupleUnification)
             {
-                var possiblyTuple = TupleTypeSymbol.TransformToTupleIfCompatible(type);
-                if ((object)type != possiblyTuple)
+                // Make it a tuple if it became compatible with one.
+                // PROTOTYPE(NullableReferenceTypes): Avoid resolving result.TypeSymbol eagerly.
+                var type = result.TypeSymbol;
+                if ((object)type != null && !previous.IsTupleCompatible())
                 {
-                    // PROTOTYPE(NullableReferenceTypes): This ignores the particular TypeSymbolWithAnnotations
-                    // derived type from result (for instance, NullableReferenceTypeWithoutCustomModifiers)
-                    // so nullable-ness may be lost.
-                    result = TypeSymbolWithAnnotations.Create(possiblyTuple, result.CustomModifiers);
+                    var possiblyTuple = TupleTypeSymbol.TransformToTupleIfCompatible(type);
+                    if ((object)type != possiblyTuple)
+                    {
+                        // PROTOTYPE(NullableReferenceTypes): This ignores the particular TypeSymbolWithAnnotations
+                        // derived type from result (for instance, NullableReferenceTypeWithoutCustomModifiers)
+                        // so nullable-ness may be lost.
+                        result = TypeSymbolWithAnnotations.Create(possiblyTuple, result.CustomModifiers);
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -351,7 +351,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (newTypeWithModifiers.TypeSymbol.IsNullableType())
                 {
                     Debug.Assert(newIsNullable == true);
-
                     if (newCustomModifiers.IsEmpty)
                     {
                         return newTypeWithModifiers;
@@ -378,10 +377,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return newTypeWithModifiers;
                 }
 
-                newCustomModifiers = newCustomModifiers.Concat(newTypeWithModifiers.CustomModifiers);
-
-                Debug.Assert(newIsNullable != false);
-                return new NonLazyType(newTypeWithModifiers.TypeSymbol, newIsNullable, newCustomModifiers);
+                return new NonLazyType(newTypeWithModifiers.TypeSymbol, newIsNullable, newCustomModifiers.Concat(newTypeWithModifiers.CustomModifiers));
             }
 
             return this; // substitution had no effect on the type or modifiers
@@ -776,10 +772,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             protected override bool TypeSymbolEquals(TypeSymbolWithAnnotations other, TypeCompareKind comparison)
             {
                 var otherLazy = other as LazyNullableTypeParameter;
+
                 if ((object)otherLazy != null)
                 {
                     return _underlying.TypeSymbolEquals(otherLazy._underlying, comparison);
                 }
+
                 return base.TypeSymbolEquals(other, comparison);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1541,7 +1541,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         [Obsolete("Use TypeSymbolWithAnnotations.Is method.", true)]
         internal bool Equals(TypeSymbolWithAnnotations other)
         {
-            return other.Is(this);
+            throw ExceptionUtilities.Unreachable;
         }
     }
 }


### PR DESCRIPTION
Minor changes to `TypeSymbolWithAnnotations`:
- Move `ToDisplayString` to base class
- Add `withTupleUnification` parameter to `SubstituteType`
- Simplified `LazyNullableTypeParameter.SpecialType` and `IsRestrictedType`

Code changes separated out from #28453.