### PR TITLE
Remove support for throw expression on the rhs of null coalescing ass…

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -643,11 +643,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var binaryParent = (BinaryExpressionSyntax)parent;
                         return node == binaryParent.Right;
                     }
-                case SyntaxKind.CoalesceAssignmentExpression: // ??=
-                    {
-                        var assignmentParent = (AssignmentExpressionSyntax)parent;
-                        return node == assignmentParent.Right;
-                    }
                 case SyntaxKind.ArrowExpressionClause:
                 case SyntaxKind.ParenthesizedLambdaExpression:
                 case SyntaxKind.SimpleLambdaExpression:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/NullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/NullCoalescingAssignmentTests.cs
@@ -1406,38 +1406,20 @@ public class C
         [Fact]
         public void ThrowExpressionRHS()
         {
-            CompileAndVerify(@"
+            CreateCompilation(@"
 using System;
 public class C
 {
     public static void Main()
     {
-        try
-        {
-            object o = null;
-            o ??= throw new Exception();
-        }
-        catch (Exception)
-        {
-            Console.WriteLine(""Succeeded"");
-        }
-    }
-}
-", expectedOutput: "Succeeded");
-
-            CreateCompilation(@"
-public class C
-{
-    static object Property { get; }
-    public static void Main()
-    {
-        Property ??= throw null;
+        object o = null;
+        o ??= throw new Exception();
     }
 }
 ").VerifyDiagnostics(
-                // (7,9): error CS0200: Property or indexer 'C.Property' cannot be assigned to -- it is read only
-                //         Property ??= throw null;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "Property").WithArguments("C.Property").WithLocation(7, 9)
+                // (8,15): error CS8115: A throw expression is not allowed in this context.
+                //         o ??= throw new Exception();
+                Diagnostic(ErrorCode.ERR_ThrowMisplaced, "throw").WithLocation(8, 15)
             );
         }
 


### PR DESCRIPTION
…ignment.

@dotnet/roslyn-compiler small change, updating throw expression support as per LDM.