### PR TITLE
Code Cleanup AB Test

### DIFF
--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -432,6 +432,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change configuration.
+        /// </summary>
+        internal static string Change_configuration {
+            get {
+                return ResourceManager.GetString("Change_configuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change Signature.
         /// </summary>
         internal static string Change_Signature {
@@ -797,6 +806,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string Format_Document {
             get {
                 return ResourceManager.GetString("Format_Document", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Format Document performed additional cleanup.
+        /// </summary>
+        internal static string Format_document_performed_additional_cleanup {
+            get {
+                return ResourceManager.GetString("Format_document_performed_additional_cleanup", resourceCulture);
             }
         }
         

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -809,6 +809,9 @@ Do you want to proceed?</value>
   <data name="Code_cleanup_is_not_configured" xml:space="preserve">
     <value>Code cleanup is not configured</value>
   </data>
+  <data name="Format_document_performed_additional_cleanup" xml:space="preserve">
+    <value>Format Document performed additional cleanup</value>
+  </data>
   <data name="Configure_it_now" xml:space="preserve">
     <value>Configure it now</value>
   </data>
@@ -817,5 +820,8 @@ Do you want to proceed?</value>
   </data>
   <data name="Applying_changes" xml:space="preserve">
     <value>Applying changes</value>
+  </data>
+  <data name="Change_configuration" xml:space="preserve">
+    <value>Change configuration</value>
   </data>
 </root>

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -53,8 +53,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 
             // wording for the Code Cleanup infobar will be different depending on if the feature is enabled
             var infoBarMessage = performAdditionalCodeCleanupDuringFormatting
-                    ? EditorFeaturesResources.Format_document_performed_additional_cleanup
-                    : EditorFeaturesResources.Code_cleanup_is_not_configured;
+                ? EditorFeaturesResources.Format_document_performed_additional_cleanup
+                : EditorFeaturesResources.Code_cleanup_is_not_configured;
 
             var configButtonText = performAdditionalCodeCleanupDuringFormatting
                 ? EditorFeaturesResources.Change_configuration

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -175,8 +175,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                 if (experimentationService != null
                     && experimentationService.IsExperimentEnabled(s_experimentName))
                 {
-                    workspace.Options = workspace.Options.WithChangedOption(new OptionKey(CodeCleanupABTestOptions.SettingIsAlreadyUpdatedByExperiment), true);
-                    workspace.Options = workspace.Options.WithChangedOption(new OptionKey(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, document.Project.Language), true);
+                    workspace.Options = workspace.Options.WithChangedOption(CodeCleanupABTestOptions.SettingIsAlreadyUpdatedByExperiment, true);
+                    workspace.Options = workspace.Options.WithChangedOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, document.Project.Language, true);
                     return true;
                 }
             }

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatDocument.cs
@@ -128,16 +128,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
         {
             var workspace = document.Project.Solution.Workspace;
             var isFeatureTurnedOnThroughABTest = TurnOnCodeCleanupForGroupBIfInABTest(document, workspace);
+            var performAdditionalCodeCleanupDuringFormatting = workspace.Options.GetOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, document.Project.Language);
 
             // if feature is turned on through AB test, we need to show the Gold bar even if they set NeverShowCodeCleanupInfoBarAgain == true before
             if (isFeatureTurnedOnThroughABTest ||
                 !workspace.Options.GetOption(CodeCleanupOptions.NeverShowCodeCleanupInfoBarAgain, document.Project.Language))
             {
                 // Show different gold bar text depends on PerformAdditionalCodeCleanupDuringFormatting value
-                ShowGoldBarForCodeCleanupConfiguration(document, workspace.Options.GetOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, document.Project.Language));
+                ShowGoldBarForCodeCleanupConfiguration(document, performAdditionalCodeCleanupDuringFormatting);
             }
 
-            if (workspace.Options.GetOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, document.Project.Language))
+            if (performAdditionalCodeCleanupDuringFormatting)
             {
                 // Start with a single progress item, which is the one to actually apply
                 // the changes.
@@ -175,8 +176,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                 if (experimentationService != null
                     && experimentationService.IsExperimentEnabled(s_experimentName))
                 {
-                    workspace.Options = workspace.Options.WithChangedOption(CodeCleanupABTestOptions.SettingIsAlreadyUpdatedByExperiment, true);
-                    workspace.Options = workspace.Options.WithChangedOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, document.Project.Language, true);
+                    workspace.Options = workspace.Options.WithChangedOption(CodeCleanupABTestOptions.SettingIsAlreadyUpdatedByExperiment, true)
+                                                         .WithChangedOption(CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, document.Project.Language, true);
                     return true;
                 }
             }

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="new">Applying changes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Change_configuration">
+        <source>Change configuration</source>
+        <target state="new">Change configuration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_cleanup_is_not_configured">
         <source>Code cleanup is not configured</source>
         <target state="new">Code cleanup is not configured</target>
@@ -20,6 +25,11 @@
       <trans-unit id="Do_not_show_this_message_again">
         <source>Do not show this message again</source>
         <target state="new">Do not show this message again</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_document_performed_additional_cleanup">
+        <source>Format Document performed additional cleanup</source>
+        <target state="new">Format Document performed additional cleanup</target>
         <note />
       </trans-unit>
       <trans-unit id="Preprocessor_Text">

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupABTestOptions.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupABTestOptions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.CodeCleanup
+{
+    internal static class CodeCleanupABTestOptions
+    {
+        private const string LocalRegistryPath = @"Roslyn\Internal\CodeCleanup\";
+
+        public static readonly Option<bool> ParticipatedInExperiment = new Option<bool>(nameof(CodeCleanupABTestOptions), nameof(ParticipatedInExperiment),
+            defaultValue: false, storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(ParticipatedInExperiment)));
+    }
+}

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupABTestOptions.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupABTestOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
     {
         private const string LocalRegistryPath = @"Roslyn\Internal\CodeCleanup\";
 
-        public static readonly Option<bool> ParticipatedInExperiment = new Option<bool>(nameof(CodeCleanupABTestOptions), nameof(ParticipatedInExperiment),
-            defaultValue: false, storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(ParticipatedInExperiment)));
+        public static readonly Option<bool> SettingIsAlreadyUpdatedByExperiment = new Option<bool>(nameof(CodeCleanupABTestOptions), nameof(SettingIsAlreadyUpdatedByExperiment),
+            defaultValue: false, storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(SettingIsAlreadyUpdatedByExperiment)));
     }
 }

--- a/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
+++ b/src/Features/Core/Portable/CodeCleanup/CodeCleanupLogMessage.cs
@@ -7,13 +7,13 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
 {
     internal static class CodeCleanupLogMessage
     {
-        public static KeyValueLogMessage Create(DocumentOptionSet docOptions)
+        public static KeyValueLogMessage Create(OptionSet optionSet)
         {
             return KeyValueLogMessage.Create(LogType.UserAction, m =>
             {
                 foreach (var option in CodeCleanupOptionsProvider.SingletonOptions)
                 {
-                    m[option.Name] = docOptions.GetOption((PerLanguageOption<bool>)option, LanguageNames.CSharp);
+                    m[option.Name] = optionSet.GetOption((PerLanguageOption<bool>)option, LanguageNames.CSharp);
                 }
             });
         }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -427,6 +427,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         CodeCleanup_ApplyCodeFixesAsync,
         CodeCleanup_RemoveUnusedImports,
         CodeCleanup_SortImports,
-        CodeCleanup_Format
+        CodeCleanup_Format,
+        CodeCleanupABTest_AssignedToOnByDefault,
+        CodeCleanupABTest_AssignedToOffByDefault
     }
 }


### PR DESCRIPTION
### Customer scenario
Currently, the code cleanup feature is off by default.  This A/B test will allow us to determine if having Edit.FormatDocument with additional cleanup on by default creates a better experience.  Questions answered by this test include:
- Do users use Edit.FormatDocument more or less now? Did we negatively impact usage of Edit.FormatDocument?
- Do more users use Edit.FormatDocument with additional cleanup if it is on or off by default?
- Did the performance of the command do ok? (if it is bad, has to be off by default)
- Is the new cleanup discoverable?

### Bugs this fixes
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/650688 

### Workarounds, if any
n/a

### Risk
n/a

### Performance impact
Low

### Is this a regression from a previous update?
No

### Root cause analysis
n/a

How did we miss it?  What tests are we adding to guard against it in the future?
n/a

### How was the bug found?
n/a

### Test documentation updated?
n/a

</details>
