### PR TITLE
make AbstractObjectBrowserLibraryManager constructor lazier

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
             if (await GetServiceAsync(typeof(SVsObjectManager)).ConfigureAwait(true) is IVsObjectManager2 objectManager)
             {
-                _libraryManager = new ObjectBrowserLibraryManager(this);
+                _libraryManager = new ObjectBrowserLibraryManager(this, ComponentModel, Workspace);
 
                 if (ErrorHandler.Failed(objectManager.RegisterSimpleLibrary(_libraryManager, out _libraryManagerCookie)))
                 {

--- a/src/VisualStudio/CSharp/Impl/ObjectBrowser/ObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/CSharp/Impl/ObjectBrowser/ObjectBrowserLibraryManager.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -9,8 +10,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser
 {
     internal class ObjectBrowserLibraryManager : AbstractObjectBrowserLibraryManager
     {
-        public ObjectBrowserLibraryManager(IServiceProvider serviceProvider)
-            : base(LanguageNames.CSharp, Guids.CSharpLibraryId, __SymbolToolLanguage.SymbolToolLanguage_CSharp, serviceProvider)
+        public ObjectBrowserLibraryManager(IServiceProvider serviceProvider, IComponentModel componentModel, VisualStudioWorkspace workspace)
+            : base(LanguageNames.CSharp, Guids.CSharpLibraryId, __SymbolToolLanguage.SymbolToolLanguage_CSharp, serviceProvider, componentModel, workspace)
         {
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -25,16 +25,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
     {
         internal readonly VisualStudioWorkspace Workspace;
 
-        internal ILibraryService LibraryService
-        {
-            get
-            {
-                return _libraryService.Value;
-            }
-        }
+        internal ILibraryService LibraryService => _libraryService.Value;
 
-        private IServiceProvider _serviceProvider;
-        private Lazy<ILibraryService> _libraryService;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly Lazy<ILibraryService> _libraryService;
 
         private readonly string _languageName;
         private readonly __SymbolToolLanguage _preferredLanguage;

--- a/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
@@ -4,6 +4,7 @@ Imports System.Runtime.ExceptionServices
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser.Mocks
 
@@ -38,10 +39,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
             Dim result As TestState = Nothing
 
             Try
+                Dim vsWorkspace = New MockVisualStudioWorkspace(workspace)
                 Dim mockComponentModel = New MockComponentModel(workspace.ExportProvider)
-                mockComponentModel.ProvideService(Of VisualStudioWorkspace)(New MockVisualStudioWorkspace(workspace))
+                mockComponentModel.ProvideService(Of VisualStudioWorkspace)(vsWorkspace)
                 Dim mockServiceProvider = New MockServiceProvider(mockComponentModel)
-                Dim libraryManager = CreateLibraryManager(mockServiceProvider)
+                Dim libraryManager = CreateLibraryManager(mockServiceProvider, mockComponentModel, vsWorkspace)
 
                 result = New TestState(workspace, libraryManager)
             Finally
@@ -53,7 +55,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
             Return result
         End Function
 
-        Friend MustOverride Function CreateLibraryManager(serviceProvider As IServiceProvider) As AbstractObjectBrowserLibraryManager
+        Friend MustOverride Function CreateLibraryManager(serviceProvider As IServiceProvider, componentModel As IComponentModel, workspace As VisualStudioWorkspace) As AbstractObjectBrowserLibraryManager
 
         Friend Function ProjectNode(name As String) As NavInfoNodeDescriptor
             Return New NavInfoNodeDescriptor With {.Kind = ObjectListKind.Projects, .Name = name}

--- a/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
@@ -3,6 +3,7 @@
 Imports System.Globalization
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
 Imports Roslyn.Test.Utilities
@@ -17,8 +18,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser.CSharp
             End Get
         End Property
 
-        Friend Overrides Function CreateLibraryManager(serviceProvider As IServiceProvider) As AbstractObjectBrowserLibraryManager
-            Return New ObjectBrowserLibraryManager(serviceProvider)
+        Friend Overrides Function CreateLibraryManager(serviceProvider As IServiceProvider, componentModel As IComponentModel, workspace As VisualStudioWorkspace) As AbstractObjectBrowserLibraryManager
+            Return New ObjectBrowserLibraryManager(serviceProvider, componentModel, workspace)
         End Function
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.ObjectBrowser)>
@@ -1352,7 +1353,7 @@ $"    {String.Format(ServicesVSResources.Member_of_0, "C")}")
 using System.Runtime.InteropServices;
 class C
 {
-    [DllImport("User32.dll", CharSet=CharSet.Unicode)] 
+    [DllImport("User32.dll", CharSet=CharSet.Unicode)]
     public static extern int MessageBox(System.IntPtr h, string m, string c, int type);
 }
 </Code>

--- a/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
@@ -3,6 +3,7 @@
 Imports System.Globalization
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ObjectBrowser
 Imports Roslyn.Test.Utilities
@@ -17,8 +18,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser.Visual
             End Get
         End Property
 
-        Friend Overrides Function CreateLibraryManager(serviceProvider As IServiceProvider) As AbstractObjectBrowserLibraryManager
-            Return New ObjectBrowserLibraryManager(serviceProvider)
+        Friend Overrides Function CreateLibraryManager(serviceProvider As IServiceProvider, componentModel As IComponentModel, workspace As VisualStudioWorkspace) As AbstractObjectBrowserLibraryManager
+            Return New ObjectBrowserLibraryManager(serviceProvider, componentModel, workspace)
         End Function
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.ObjectBrowser)>
@@ -2105,9 +2106,9 @@ Class C
      ExactSpelling:=True,
      CallingConvention:=CallingConvention.StdCall)&gt;
     Public Shared Function moveFile(ByVal src As String, ByVal dst As String) As Boolean
-        ' This function copies a file from the path src to the path dst. 
-        ' Leave this function empty. The DLLImport attribute forces calls 
-        ' to moveFile to be forwarded to MoveFileW in KERNEL32.DLL. 
+        ' This function copies a file from the path src to the path dst.
+        ' Leave this function empty. The DLLImport attribute forces calls
+        ' to moveFile to be forwarded to MoveFileW in KERNEL32.DLL.
     End Function
 End Class
 </Code>

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -116,7 +116,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
             Dim objectManager = TryCast(Await GetServiceAsync(GetType(SVsObjectManager)).ConfigureAwait(True), IVsObjectManager2)
             If objectManager IsNot Nothing Then
-                Me._libraryManager = New ObjectBrowserLibraryManager(Me)
+                Me._libraryManager = New ObjectBrowserLibraryManager(Me, ComponentModel, Workspace)
 
                 If ErrorHandler.Failed(objectManager.RegisterSimpleLibrary(Me._libraryManager, Me._libraryManagerCookie)) Then
                     Me._libraryManagerCookie = 0

--- a/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/ObjectBrowserLibraryManager.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/ObjectBrowserLibraryManager.vb
@@ -3,13 +3,14 @@
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
+Imports Microsoft.VisualStudio.ComponentModelHost
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ObjectBrowser
     Friend Class ObjectBrowserLibraryManager
         Inherits AbstractObjectBrowserLibraryManager
 
-        Public Sub New(serviceProvider As IServiceProvider)
-            MyBase.New(LanguageNames.VisualBasic, Guids.VisualBasicLibraryId, __SymbolToolLanguage.SymbolToolLanguage_VB, serviceProvider)
+        Public Sub New(serviceProvider As IServiceProvider, componentModel As IComponentModel, workspace As VisualStudioWorkspace)
+            MyBase.New(LanguageNames.VisualBasic, Guids.VisualBasicLibraryId, __SymbolToolLanguage.SymbolToolLanguage_VB, serviceProvider, componentModel, workspace)
         End Sub
 
         Friend Overrides Function CreateDescriptionBuilder(


### PR DESCRIPTION
Fixing https://devdiv.visualstudio.com/DevDiv/_workitems/edit/639095

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
