### PR TITLE
Do not qualify member accesses that appear inside attributes.

### DIFF
--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1288,5 +1288,110 @@ CodeStyleOptions.QualifyPropertyAccess);
 }",
 CodeStyleOptions.QualifyPropertyAccess);
         }
+
+        [WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInAttribute1()
+        {
+            await TestMissingAsyncWithOption(
+@"
+using System;
+
+class MyAttribute : Attribute 
+{
+    public MyAttribute(string name) { }
+}
+
+[My(nameof([|Goo|]))]
+class Program
+{
+    int Goo { get; set; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInAttribute2()
+        {
+            await TestMissingAsyncWithOption(
+@"
+using System;
+
+class MyAttribute : Attribute 
+{
+    public MyAttribute(string name) { }
+}
+
+class Program
+{
+    [My(nameof([|Goo|]))]
+    int Goo { get; set; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInAttribute3()
+        {
+            await TestMissingAsyncWithOption(
+@"
+using System;
+
+class MyAttribute : Attribute 
+{
+    public MyAttribute(string name) { }
+}
+
+class Program
+{
+    [My(nameof([|Goo|]))]
+    public int Bar = 0 ;
+    public int Goo { get; set; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInAttribute4()
+        {
+            await TestMissingAsyncWithOption(
+@"
+using System;
+
+class MyAttribute : Attribute 
+{
+    public MyAttribute(string name) { }
+}
+
+class Program
+{
+    int Goo { [My(nameof([|Goo|]))]get; set; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInAttribute5()
+        {
+            await TestMissingAsyncWithOption(
+@"
+using System;
+
+class MyAttribute : Attribute 
+{
+    public MyAttribute(string name) { }
+}
+
+class Program
+{
+    int Goo { get; set; }
+    void M([My(nameof([|Goo|]))]int i) { }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -619,5 +619,93 @@ End Class
 ",
 CodeStyleOptions.QualifyFieldAccess)
         End Function
+
+        <WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_InAttribute1() As Task
+            Await TestMissingAsyncWithOption("
+Imports System
+
+Class MyAttribute
+    Inherits Attribute
+
+    Public Sub New(name as String)
+    End Sub
+End Class
+
+<My(NameOf([|Goo|]))>
+Class C
+    Private Property Goo As String
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
+
+        <WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_InAttribute2() As Task
+            Await TestMissingAsyncWithOption("
+Imports System
+
+Class MyAttribute
+    Inherits Attribute
+
+    Public Sub New(name as String)
+    End Sub
+End Class
+
+Class C
+    <My(NameOf([|Goo|]))>
+    Private Property Goo As String
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
+
+        <WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_InAttribute3() As Task
+            Await TestMissingAsyncWithOption("
+Imports System
+
+Class MyAttribute
+    Inherits Attribute
+
+    Public Sub New(name as String)
+    End Sub
+End Class
+
+Class C
+    Private Property Goo As String
+
+    <My(NameOf([|Goo|]))>
+    Private Bar As Integer
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
+
+        <WorkItem(26893, "https://github.com/dotnet/roslyn/issues/26893")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_InAttribute4() As Task
+            Await TestMissingAsyncWithOption("
+Imports System
+
+Class MyAttribute
+    Inherits Attribute
+
+    Public Sub New(name as String)
+    End Sub
+End Class
+
+Class C
+    Private Property Goo As String
+
+    Sub X(<My(NameOf([|Goo|]))>v as integer)
+    End Sub    
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.QualifyMemberAccess;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.QualifyMemberAccess
 {
@@ -22,9 +23,16 @@ namespace Microsoft.CodeAnalysis.CSharp.QualifyMemberAccess
         // or member is in object initialization context,
         // or member in property or field initialization, it cannot be qualified.
         protected override bool CanMemberAccessBeQualified(ISymbol containingSymbol, SyntaxNode node)
-            => !(node.IsKind(SyntaxKind.BaseExpression) ||
-                node.Parent.Parent.IsKind(SyntaxKind.ObjectInitializerExpression) ||
-                IsInPropertyOrFieldInitialization(containingSymbol, node));
+        {
+            if (node.GetAncestorOrThis<AttributeSyntax>() != null)
+            {
+                return false;
+            }
+
+            return !(node.IsKind(SyntaxKind.BaseExpression) ||
+                     node.Parent.Parent.IsKind(SyntaxKind.ObjectInitializerExpression) ||
+                     IsInPropertyOrFieldInitialization(containingSymbol, node));
+        }
 
         private bool IsInPropertyOrFieldInitialization(ISymbol containingSymbol, SyntaxNode node)
         {

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
@@ -18,9 +18,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.QualifyMemberAccess
         End Function
 
         Protected Overrides Function CanMemberAccessBeQualified(containingSymbol As ISymbol, node As SyntaxNode) As Boolean
+            ' if we're in an attribute, we can't be qualified.
+            If node.GetAncestorOrThis(Of AttributeSyntax) IsNot Nothing Then
+                Return False
+            End If
+
             ' If the member is already qualified with `MyBase.`, or `MyClass.`,
             ' or member is in object initialization context, it cannot be qualified.
-            Return Not (node.IsKind(SyntaxKind.MyBaseExpression) OrElse node.IsKind(SyntaxKind.MyClassExpression) OrElse node.IsKind(SyntaxKind.ObjectCreationExpression))
+            Return Not (
+                node.IsKind(SyntaxKind.MyBaseExpression) OrElse
+                node.IsKind(SyntaxKind.MyClassExpression) OrElse
+                node.IsKind(SyntaxKind.ObjectCreationExpression))
         End Function
 
         Protected Overrides Function GetLocation(operation As IOperation) As Location


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/26893