### PR TITLE
`is` operator informs nullability analysis

### DIFF
--- a/docs/features/nullable-reference-types.md
+++ b/docs/features/nullable-reference-types.md
@@ -75,9 +75,17 @@ Flow analysis is used to infer the nullability of variables within executable co
 
 ### Warnings
 _Describe set of warnings. Differentiate W warnings._
+If the analysis determines that a null check always (or never) passes, a hidden warning is produced. For example: `"string" is null`.
 
 ### Null tests
-_Describe the set of tests that affect flow state._
+A number of null checks affect the flow state when tested for:
+- comparisons to `null`: `x == null` and `x != null`
+- `is` operator: `x is null`, `x is K` (where `K` is a constant), `x is string`, `x is string s`
+
+Invocation to methods annotated with the following attributes will also affect flow analysis:
+- `[NotNullWhenTrue]` (e.g. `TryGetValue`) and `[NotNullWhenFalse]` (e.g. `string.IsNullOrEmpty`)
+- `[EnsuresNotNull]` (e.g. `ThrowIfNull`)
+- `[AssertsTrue]` (e.g. `Debug.Assert`) and `[AssertsFalse]`
 
 ## `default`
 `default(T)` is `T?` if `T` is a reference type.

--- a/docs/features/nullable-reference-types.md
+++ b/docs/features/nullable-reference-types.md
@@ -75,14 +75,14 @@ Flow analysis is used to infer the nullability of variables within executable co
 
 ### Warnings
 _Describe set of warnings. Differentiate W warnings._
-If the analysis determines that a null check always (or never) passes, a hidden warning is produced. For example: `"string" is null`.
+If the analysis determines that a null check always (or never) passes, a hidden diagnostic is produced. For example: `"string" is null`.
 
 ### Null tests
 A number of null checks affect the flow state when tested for:
 - comparisons to `null`: `x == null` and `x != null`
 - `is` operator: `x is null`, `x is K` (where `K` is a constant), `x is string`, `x is string s`
 
-Invocation to methods annotated with the following attributes will also affect flow analysis:
+Invocation of methods annotated with the following attributes will also affect flow analysis:
 - `[NotNullWhenTrue]` (e.g. `TryGetValue`) and `[NotNullWhenFalse]` (e.g. `string.IsNullOrEmpty`)
 - `[EnsuresNotNull]` (e.g. `ThrowIfNull`)
 - `[AssertsTrue]` (e.g. `Debug.Assert`) and `[AssertsFalse]`

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -827,6 +827,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            Debug.Assert(!IsConditionalState);
             base.VisitPattern(expression, pattern);
             Debug.Assert(IsConditionalState);
 
@@ -3680,7 +3681,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             int slot = -1;
             var operand = node.Operand;
-            if (operand.Type?.IsReferenceType == true)
+            if (operand.Type?.IsValueType == false)
             {
                 slot = MakeSlot(operand);
                 if (slot > 0)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -815,6 +815,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
+            Debug.Assert(!IsConditionalState);
             int slot = -1;
             if (isNull != null)
             {
@@ -827,7 +828,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            Debug.Assert(!IsConditionalState);
             base.VisitPattern(expression, pattern);
             Debug.Assert(IsConditionalState);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -801,8 +801,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // The result type and state of the expression carry into the variable declared by var pattern
                         Symbol variable = declarationPattern.Variable;
-                        _variableTypes[variable] = expressionResultType;
-                        TrackNullableStateForAssignment(expression, expressionResultType, GetOrCreateSlot(variable), expressionResultType);
+                        // No variable declared for discard (`i is var _`)
+                        if ((object)variable != null)
+                        {
+                            _variableTypes[variable] = expressionResultType;
+                            TrackNullableStateForAssignment(expression, expressionResultType, GetOrCreateSlot(variable), expressionResultType);
+                        }
                     }
                     else
                     {
@@ -3676,7 +3680,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             int slot = -1;
             var operand = node.Operand;
-            if (operand.Type.IsReferenceType)
+            if (operand.Type?.IsReferenceType == true)
             {
                 slot = MakeSlot(operand);
                 if (slot > 0)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -781,7 +781,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// `switch (x) ... case Point p:` // PROTOTYPE(NullableReferenceTypes): not yet handled
         ///
         /// If the expression is trackable, we'll return with different null-states for that expression in the two conditional states.
-        /// If the patterns is a `var` pattern, we'll also have re-inferred the `var` type with nullability and
+        /// If the pattern is a `var` pattern, we'll also have re-inferred the `var` type with nullability and
         /// updated the state for that declared local.
         /// </summary>
         private void VisitPattern(BoundExpression expression, TypeSymbolWithAnnotations expressionResultType, BoundPattern pattern)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -950,9 +950,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
         {
+            Debug.Assert(!IsConditionalState);
             VisitRvalue(node.Expression);
             VisitPattern(node.Expression, node.Pattern);
-            return null;
+            return node;
         }
 
         public virtual void VisitPattern(BoundExpression expression, BoundPattern pattern)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -12131,12 +12131,21 @@ class C
     {
         if (x is var c)
         {
-            x.ToString(); // warn
-            c /*T:object?*/ .ToString(); // warn
+            x.ToString(); // warn 1
+            c /*T:object?*/ .ToString(); // warn 2
         }
         else
         {
-            x.ToString(); // warn
+            x.ToString(); // warn 3
+        }
+
+        if (x is var _)
+        {
+            x.ToString(); // warn 4
+        }
+        else
+        {
+            x.ToString(); // warn 5
         }
     }
 }
@@ -12145,14 +12154,20 @@ class C
             c.VerifyTypes();
             c.VerifyDiagnostics(
                 // (8,13): warning CS8602: Possible dereference of a null reference.
-                //             x.ToString(); // warn
+                //             x.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
                 // (9,13): warning CS8602: Possible dereference of a null reference.
-                //             c /*T:object?*/ .ToString(); // warn
+                //             c /*T:object?*/ .ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(9, 13),
                 // (13,13): warning CS8602: Possible dereference of a null reference.
-                //             x.ToString(); // warn
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(13, 13)
+                //             x.ToString(); // warn 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(13, 13),
+                // (18,13): warning CS8602: Possible dereference of a null reference.
+                //             x.ToString(); // warn 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(18, 13),
+                // (22,13): warning CS8602: Possible dereference of a null reference.
+                //             x.ToString(); // warn 5
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(22, 13)
                 );
         }
 


### PR DESCRIPTION
We know that `x` is not `null` following `x is string`, `x is string s`, `x is K` (where `K` is a non-null constant).
We know that `s` is not `null` following `x is string s`.
We know that `y` has the same nullability as `x` following `x is var y`.
Produce a hidden warning if a `null` test could never succeed (`"string" is null`).

Relates to https://github.com/dotnet/roslyn/issues/22152