### PR TITLE
Calculate `IsNullable` lazily in `TypeSymbolWithAnnotations`

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2634,7 +2634,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            var result = TupleTypeDecoder.DecodeTupleTypesIfApplicable(first, mergedNames);
+            var result = TupleTypeDecoder.DecodeTupleTypesIfApplicable(nonNullTypes: false, first, mergedNames); // PROTOTYPE(NullableReferenceTypes): Set nonNullTypes.
             return TypeSymbolWithAnnotations.Create(result); // PROTOTYPE(NullableReferenceTypes): Handle nullability.
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureMethod.cs
@@ -55,6 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     typeMap = lambdaFrame.TypeMap.WithConcatAlphaRename(
                         originalMethod,
                         this,
+                        originalMethod.NonNullTypes,
                         out typeParameters,
                         out constructedFromTypeParameters,
                         lambdaFrame.OriginalContainingMethodOpt);
@@ -65,6 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     typeMap = TypeMap.Empty.WithConcatAlphaRename(
                         originalMethod,
                         this,
+                        originalMethod.NonNullTypes,
                         out typeParameters,
                         out constructedFromTypeParameters,
                         stopAt: null);

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -663,7 +663,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    typeMap = typeMap.WithAlphaRename(methodBeingWrapped, this, out typeParameters);
+                    typeMap = typeMap.WithAlphaRename(methodBeingWrapped, this, methodBeingWrapped.NonNullTypes, out typeParameters);
                 }
 
                 AssignTypeMapAndTypeParameters(typeMap, typeParameters);

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             base(originalDefinition)
         {
             _containingSymbol = containingSymbol;
-            _map = containingSymbol.TypeSubstitution.WithAlphaRename(originalDefinition, this, out _typeParameters);
+            _map = containingSymbol.TypeSubstitution.WithAlphaRename(originalDefinition, this, originalDefinition.NonNullTypes, out _typeParameters);
         }
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -420,8 +420,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 var indexed = builder.ToImmutableAndFree();
 
-                typeMap1 = new TypeMap(member1.GetMemberTypeParameters(), indexed, true);
-                typeMap2 = new TypeMap(typeParameters2, indexed, true);
+                typeMap1 = new TypeMap(member1.NonNullTypes, member1.GetMemberTypeParameters(), indexed, true);
+                typeMap2 = new TypeMap(member2.NonNullTypes, typeParameters2, indexed, true);
             }
             else
             {
@@ -589,6 +589,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return typeParameters.IsEmpty ?
                 null :
                 new TypeMap(
+                    member.NonNullTypes,
                     typeParameters,
                     IndexedTypeParameterSymbol.Take(member.GetMemberArity()),
                     true);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MemberRefMetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MemberRefMetadataDecoder.cs
@@ -223,6 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // IndexedTypeParameterSymbol is not going to be exposed anywhere,
             // so we'll cheat and use it here for comparison purposes.
             TypeMap candidateMethodTypeMap = new TypeMap(
+                candidateMethod.OriginalDefinition.NonNullTypes,
                 candidateMethod.TypeParameters,
                 IndexedTypeParameterSymbol.Take(candidateMethod.Arity), true);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -685,7 +685,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override ImmutableArray<TypeSymbolWithAnnotations> TypeArguments => IsGenericMethod ? TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations) : ImmutableArray<TypeSymbolWithAnnotations>.Empty;
+        public override ImmutableArray<TypeSymbolWithAnnotations> TypeArguments => IsGenericMethod ? GetTypeParametersAsTypeArguments() : ImmutableArray<TypeSymbolWithAnnotations>.Empty;
 
         public override Symbol AssociatedSymbol => _associatedPropertyOrEventOpt;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2457,8 +2457,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 // containing symbol for the temporary type is the namespace directly.
                 var nestedType = Create(this.ContainingPEModule, (PENamespaceSymbol)this.ContainingNamespace, _handle, null);
                 var nestedTypeParameters = nestedType.TypeParameters;
-                var containingTypeMap = new TypeMap(containingTypeParameters, IndexedTypeParameterSymbol.Take(n), allowAlpha: false);
-                var nestedTypeMap = new TypeMap(nestedTypeParameters, IndexedTypeParameterSymbol.Take(nestedTypeParameters.Length), allowAlpha: false);
+                var containingTypeMap = new TypeMap(container.NonNullTypes, containingTypeParameters, IndexedTypeParameterSymbol.Take(n), allowAlpha: false);
+                var nestedTypeMap = new TypeMap(nestedType.NonNullTypes, nestedTypeParameters, IndexedTypeParameterSymbol.Take(nestedTypeParameters.Length), allowAlpha: false);
 
                 for (int i = 0; i < n; i++)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             continue;
                         }
 
-                        var type = TypeSymbolWithAnnotations.Create(typeSymbol, isNullableIfReferenceType: null);
+                        var type = TypeSymbolWithAnnotations.CreateNonNull(containingType.NonNullTypes, typeSymbol);
                         if (moduleSymbol.UtilizesNullableReferenceTypes)
                         {
                             type = NullableTypeDecoder.TransformType(type, constraintHandle, moduleSymbol);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -60,13 +60,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
     /// </summary>
     internal struct TupleTypeDecoder
     {
+        private readonly bool _nonNullTypes;
         private readonly ImmutableArray<string> _elementNames;
         // Keep track of how many names we've "used" during decoding. Starts at
         // the back of the array and moves forward.
         private int _namesIndex;
 
-        private TupleTypeDecoder(ImmutableArray<string> elementNames)
+        private TupleTypeDecoder(bool nonNullTypes, ImmutableArray<string> elementNames)
         {
+            _nonNullTypes = nonNullTypes;
             _elementNames = elementNames;
             _namesIndex = elementNames.IsDefault ? 0 : elementNames.Length;
         }
@@ -89,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return new UnsupportedMetadataTypeSymbol();
             }
 
-            return DecodeTupleTypesInternal(metadataType, elementNames, hasTupleElementNamesAttribute);
+            return DecodeTupleTypesInternal(containingModule.UtilizesNullableReferenceTypes, metadataType, elementNames, hasTupleElementNamesAttribute);
         }
 
         public static TypeSymbolWithAnnotations DecodeTupleTypesIfApplicable(
@@ -109,25 +111,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return TypeSymbolWithAnnotations.Create(new UnsupportedMetadataTypeSymbol(), isNullableIfReferenceType: null);
             }
 
+            bool nonNullTypes = containingModule.UtilizesNullableReferenceTypes;
             TypeSymbol type = metadataType.TypeSymbol;
-            TypeSymbol decoded = DecodeTupleTypesInternal(type, elementNames, hasTupleElementNamesAttribute);
+            TypeSymbol decoded = DecodeTupleTypesInternal(nonNullTypes, type, elementNames, hasTupleElementNamesAttribute);
             return (object)decoded == (object)type ?
                 metadataType :
-                TypeSymbolWithAnnotations.Create(decoded, isNullableIfReferenceType: metadataType.IsNullable, metadataType.CustomModifiers);
+                TypeSymbolWithAnnotations.Create(decoded, nonNullTypes: nonNullTypes, isAnnotated: metadataType.IsAnnotated, metadataType.CustomModifiers);
         }
 
         public static TypeSymbol DecodeTupleTypesIfApplicable(
+            bool nonNullTypes,
             TypeSymbol metadataType,
             ImmutableArray<string> elementNames)
         {
-            return DecodeTupleTypesInternal(metadataType, elementNames, hasTupleElementNamesAttribute: !elementNames.IsDefaultOrEmpty);
+            return DecodeTupleTypesInternal(nonNullTypes, metadataType, elementNames, hasTupleElementNamesAttribute: !elementNames.IsDefaultOrEmpty);
         }
 
-        private static TypeSymbol DecodeTupleTypesInternal(TypeSymbol metadataType, ImmutableArray<string> elementNames, bool hasTupleElementNamesAttribute)
+        private static TypeSymbol DecodeTupleTypesInternal(bool nonNullTypes, TypeSymbol metadataType, ImmutableArray<string> elementNames, bool hasTupleElementNamesAttribute)
         {
             Debug.Assert((object)metadataType != null);
 
-            var decoder = new TupleTypeDecoder(elementNames);
+            var decoder = new TupleTypeDecoder(nonNullTypes, elementNames);
             try
             {
                 var decoded = decoder.DecodeType(metadataType);
@@ -290,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             TypeSymbol decoded = DecodeType(type);
             return ReferenceEquals(decoded, type) ?
                 typeWithAnnotations :
-                TypeSymbolWithAnnotations.Create(decoded, typeWithAnnotations.IsNullable, typeWithAnnotations.CustomModifiers);
+                TypeSymbolWithAnnotations.Create(decoded, nonNullTypes: _nonNullTypes, isAnnotated: typeWithAnnotations.IsAnnotated, typeWithAnnotations.CustomModifiers);
         }
 
         private ImmutableArray<string> EatElementNamesIfAvailable(int numberOfElements)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -217,6 +217,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public abstract ImmutableArray<TypeParameterSymbol> TypeParameters { get; }
 
+        internal ImmutableArray<TypeSymbolWithAnnotations> GetTypeParametersAsTypeArguments() =>
+            GetTypeParametersAsTypeArguments(OriginalDefinition.NonNullTypes);
+
+        internal ImmutableArray<TypeSymbolWithAnnotations> GetTypeParametersAsTypeArguments(bool nonNullTypes) =>
+            TypeMap.TypeParametersAsTypeSymbolsWithAnnotations(nonNullTypes, TypeParameters);
+
         /// <summary>
         /// Call <see cref="TryGetThisParameter"/> and throw if it returns false.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(reducedFrom.ParameterCount > 0);
 
             _reducedFrom = reducedFrom;
-            _typeMap = TypeMap.Empty.WithAlphaRename(reducedFrom, this, out _typeParameters);
+            _typeMap = TypeMap.Empty.WithAlphaRename(reducedFrom, this, reducedFrom.NonNullTypes, out _typeParameters);
             _typeArguments = _typeMap.SubstituteTypes(reducedFrom.TypeArguments);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             {
                 if (IsGenericMethod)
                 {
-                    return this.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations);
+                    return GetTypeParametersAsTypeArguments();
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // We also preserve tuple names, if present and different
                 ImmutableArray<string> names = CSharpCompilation.TupleNamesEncoder.Encode(destinationType);
-                resultType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeWithDynamic, names);
+                resultType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(destinationUsesNonNullTypes, typeWithDynamic, names);
             }
             else
             {
@@ -89,8 +89,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // Preserve nullable modifiers as well.
-            // PROTOTYPE(NullableReferenceTypes): Set unknown nullability otherwise.
-            if (containingAssembly.Modules[0].UtilizesNullableReferenceTypes)
+            // PROTOTYPE(NullableReferenceTypes): Is it reasonable to copy annotations from the source?
+            // If the destination had some of those annotations but not all, then clearly the destination
+            // was incorrect. Or if the destination is C#7, then the destination will advertise annotations
+            // that the author did not write and did not validate.
+            if (destinationUsesNonNullTypes)
             {
                 var flagsBuilder = ArrayBuilder<bool>.GetInstance();
                 destinationType.AddNullableTransforms(flagsBuilder);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override int Arity => TypeParameters.Length;
 
-        public override ImmutableArray<TypeSymbolWithAnnotations> TypeArguments => TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations);
+        public override ImmutableArray<TypeSymbolWithAnnotations> TypeArguments => GetTypeParametersAsTypeArguments();
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters 
             => _typeParameters.Cast<SourceMethodTypeParameterSymbol, TypeParameterSymbol>();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -794,7 +794,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                             if (overridingMethod.IsGenericMethod)
                             {
-                                overriddenMethod = overriddenMethod.Construct(overridingMethod.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                                overriddenMethod = overriddenMethod.Construct(overridingMethod.TypeArguments);
                             }
 
                             // Check for mismatched byref returns and return type. Ignore custom modifiers, because this diagnostic is based on the C# semantics.
@@ -835,7 +835,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                             if (overriddenMember.Kind == SymbolKind.Method && (overriddenMethod = (MethodSymbol)overriddenMember).IsGenericMethod)
                             {
-                                overriddenParameters = overriddenMethod.Construct(((MethodSymbol)overridingMember).TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations)).Parameters;
+                                overriddenParameters = overriddenMethod.Construct(((MethodSymbol)overridingMember).TypeArguments).Parameters;
                             }
                             else
                             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -690,11 +690,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                // PROTOTYPE(NullableReferenceTypes):
-                // Should probably be: TypeParameters.SelectAsArray((typeParameter, module) => TypeSymbolWithAnnotations.Create(module, typeParameter), ContainingModule);
-                // Relevant test: TestOverrideGenericMethodWithTypeParamDiffNameWithCustomModifiers
-
-                return TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations);
+                return GetTypeParametersAsTypeArguments();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -1096,7 +1096,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 implementation.NonNullTypes)
             {
                 ImmutableArray<ParameterSymbol> implementationParameters = implementation.Parameters;
-                ImmutableArray<ParameterSymbol> definitionParameters = definition.ConstructIfGeneric(implementation.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations)).Parameters;
+                ImmutableArray<ParameterSymbol> definitionParameters = definition.ConstructIfGeneric(implementation.TypeArguments).Parameters;
 
                 for (int i = 0; i < implementationParameters.Length; i++)
                 {
@@ -1125,10 +1125,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
+            var nonNullTypes = part1.NonNullTypes;
             var typeParameters2 = part2.TypeParameters;
             var indexedTypeParameters = IndexedTypeParameterSymbol.Take(arity);
-            var typeMap1 = new TypeMap(typeParameters1, indexedTypeParameters, allowAlpha: true);
-            var typeMap2 = new TypeMap(typeParameters2, indexedTypeParameters, allowAlpha: true);
+            var typeMap1 = new TypeMap(nonNullTypes, typeParameters1, indexedTypeParameters, allowAlpha: true);
+            var typeMap2 = new TypeMap(nonNullTypes, typeParameters2, indexedTypeParameters, allowAlpha: true);
 
             return MemberSignatureComparer.HaveSameConstraints(typeParameters1, typeMap1, typeParameters2, typeMap2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -586,7 +586,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         Debug.Assert(overriddenTypeParameters.Length == overridingTypeParameters.Length);
 
-                        var typeMap = new TypeMap(overriddenTypeParameters, overridingTypeParameters, allowAlpha: true);
+                        var typeMap = new TypeMap(_overridingMethod.NonNullTypes, overriddenTypeParameters, overridingTypeParameters, allowAlpha: true);
                         Interlocked.CompareExchange(ref _lazyTypeMap, typeMap, null);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(ReferenceEquals(_constructedFrom, this));
 
             // We're creating a new unconstructed Method from another; alpha-rename type parameters.
-            var newMap = _inputMap.WithAlphaRename(this.OriginalDefinition, this, out typeParameters);
+            var newMap = _inputMap.WithAlphaRename(this.OriginalDefinition, this, this.OriginalDefinition.NonNullTypes, out typeParameters);
 
             var prevMap = Interlocked.CompareExchange(ref _lazyMap, newMap, null);
             if (prevMap != null)
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations);
+                return GetTypeParametersAsTypeArguments();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<TypeParameterSymbol> typeParameters;
 
             // We're creating a new unconstructed Method from another; alpha-rename type parameters.
-            var newMap = _inputMap.WithAlphaRename(OriginalDefinition, this, out typeParameters);
+            var newMap = _inputMap.WithAlphaRename(OriginalDefinition, this, OriginalDefinition.NonNullTypes, out typeParameters);
 
             var prevMap = Interlocked.CompareExchange(ref _lazyMap, newMap, null);
             if (prevMap != null)

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -81,16 +81,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static TypeSymbolWithAnnotations CreateNonNull(bool nonNullTypes, TypeSymbol typeSymbol)
         {
-            return Create(typeSymbol, isNullableIfReferenceType: nonNullTypes ? (bool?)false : null);
+            return Create(typeSymbol, nonNullTypes: nonNullTypes, isAnnotated: false, ImmutableArray<CustomModifier>.Empty);
         }
 
         internal static TypeSymbolWithAnnotations Create(ModuleSymbol module, TypeSymbol typeSymbol)
         {
-            return Create(typeSymbol, isNullableIfReferenceType: module.UtilizesNullableReferenceTypes ? (bool?)false : null);
+            return CreateNonNull(module.NonNullTypes, typeSymbol);
         }
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
         // member signatures visible outside the assembly. Consider overriding, implementing, NoPIA embedding, etc.
+        // PROTOTYPE(NullableReferenceTypes): [Obsolete("Use explicit NonNullTypes context")]
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol)
         {
             return Create(typeSymbol, ImmutableArray<CustomModifier>.Empty);
@@ -98,6 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
         // member signatures visible outside the assembly. Consider overriding, implementing, NoPIA embedding, etc.
+        // PROTOTYPE(NullableReferenceTypes): [Obsolete("Use explicit NonNullTypes context")]
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
         {
             if (typeSymbol is null)
@@ -110,32 +112,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
         // member signatures visible outside the assembly. Consider overriding, implementing, NoPIA embedding, etc.
+        // PROTOTYPE(NullableReferenceTypes): [Obsolete("Use explicit NonNullTypes context")]
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, bool? isNullableIfReferenceType)
         {
-            return Create(typeSymbol, isNullableIfReferenceType, ImmutableArray<CustomModifier>.Empty);
+            return Create(typeSymbol, nonNullTypes: IsNullableToNonNullTypes(isNullableIfReferenceType), isAnnotated: IsNullableToIsAnnotated(isNullableIfReferenceType), ImmutableArray<CustomModifier>.Empty);
         }
 
         // PROTOTYPE(NullableReferenceTypes): Check we are not using this method on type references in
         // member signatures visible outside the assembly. Consider overriding, implementing, NoPIA embedding, etc.
-        public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, bool? isNullableIfReferenceType, ImmutableArray<CustomModifier> customModifiers)
+        public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, bool nonNullTypes, bool isAnnotated, ImmutableArray<CustomModifier> customModifiers)
         {
             if (typeSymbol is null)
             {
                 return null;
             }
 
-            if (isNullableIfReferenceType == null && typeSymbol.TypeKind == TypeKind.TypeParameter)
+            if (!isAnnotated && typeSymbol is TypeParameterSymbol)
             {
-                return new NonLazyType(typeSymbol, isNullable: null, customModifiers);
+                return new NonLazyType(typeSymbol, nonNullTypes: nonNullTypes, isAnnotated: isAnnotated, customModifiers);
             }
 
-            if (isNullableIfReferenceType == false || !typeSymbol.IsReferenceType || typeSymbol.IsNullableType())
+            if (!isAnnotated || !typeSymbol.IsReferenceType || typeSymbol.IsNullableType())
             {
-                return Create(typeSymbol, customModifiers);
+                return new NonLazyType(typeSymbol, nonNullTypes: nonNullTypes, isAnnotated: typeSymbol.IsNullableType(), customModifiers);
             }
 
             Debug.Assert(!typeSymbol.IsNullableType());
-            return new NonLazyType(typeSymbol, isNullableIfReferenceType, customModifiers);
+            return new NonLazyType(typeSymbol, nonNullTypes: nonNullTypes, isAnnotated: isAnnotated, customModifiers);
         }
 
         public TypeSymbolWithAnnotations AsNullableReferenceOrValueType(CSharpCompilation compilation)
@@ -167,9 +170,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public abstract TypeSymbolWithAnnotations AsNullableReferenceType();
         public abstract TypeSymbolWithAnnotations AsNotNullableReferenceType();
-        public abstract TypeSymbolWithAnnotations AsObliviousReferenceType();
 
         public abstract TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers);
+        protected abstract TypeSymbolWithAnnotations WithNonNullTypes(bool nonNullTypes);
 
         public abstract TypeSymbol TypeSymbol { get; }
         public virtual TypeSymbol NullableUnderlyingTypeOrSelf => TypeSymbol.StrippedType();
@@ -182,6 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// simply returns a symbol for the reference type.
         /// </summary>
         public abstract bool? IsNullable { get; }
+        public abstract bool IsAnnotated { get; }
 
         /// <summary>
         /// Is this System.Nullable`1 type, or its substitution.
@@ -341,45 +345,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var newCustomModifiers = typeMap.SubstituteCustomModifiers(this.CustomModifiers);
             var newTypeWithModifiers = typeMap.SubstituteType(this.TypeSymbol, withTupleUnification);
-            bool? newIsNullable = (newTypeWithModifiers.IsNullable != null && this.IsNullable != true) ? newTypeWithModifiers.IsNullable : this.IsNullable;
+            bool newIsAnnotated = this.IsAnnotated || newTypeWithModifiers.IsAnnotated;
 
             if (!TypeSymbolEquals(newTypeWithModifiers, TypeCompareKind.CompareNullableModifiersForReferenceTypes) ||
                 !newTypeWithModifiers.CustomModifiers.IsEmpty ||
-                newIsNullable != this.IsNullable ||
+                newIsAnnotated != this.IsAnnotated ||
                 newCustomModifiers != this.CustomModifiers)
             {
-                if (newTypeWithModifiers.TypeSymbol.IsNullableType())
+                var newIsNullableType = newTypeWithModifiers.TypeSymbol.IsNullableType();
+                if (newIsNullableType || !newIsAnnotated)
                 {
-                    Debug.Assert(newIsNullable == true);
                     if (newCustomModifiers.IsEmpty)
                     {
                         return newTypeWithModifiers;
                     }
-
-                    return TypeSymbolWithAnnotations.Create(newTypeWithModifiers.TypeSymbol, newCustomModifiers.Concat(newTypeWithModifiers.CustomModifiers));
+                    newIsAnnotated = newTypeWithModifiers.IsAnnotated;
                 }
-
-                if (newIsNullable == false)
+                else
                 {
-                    Debug.Assert(newTypeWithModifiers.IsNullable != true);
-                    if (newCustomModifiers.IsEmpty)
+                    if (newCustomModifiers.IsEmpty && newTypeWithModifiers.IsAnnotated == newIsAnnotated)
                     {
                         return newTypeWithModifiers;
                     }
-
-                    return TypeSymbolWithAnnotations.Create(newTypeWithModifiers.TypeSymbol, newCustomModifiers.Concat(newTypeWithModifiers.CustomModifiers));
                 }
-
-                Debug.Assert(newIsNullable != false);
-
-                if (newCustomModifiers.IsEmpty && newTypeWithModifiers.IsNullable == newIsNullable)
-                {
-                    return newTypeWithModifiers;
-                }
-
-                return new NonLazyType(newTypeWithModifiers.TypeSymbol, newIsNullable, newCustomModifiers.Concat(newTypeWithModifiers.CustomModifiers));
+                return new NonLazyType(newTypeWithModifiers.TypeSymbol, nonNullTypes: ((NonLazyType)newTypeWithModifiers).NonNullTypes, isAnnotated: newIsAnnotated, newCustomModifiers.Concat(newTypeWithModifiers.CustomModifiers));
             }
 
+            // PROTOTYPE(NullableReferenceTypes): We're dropping newTypeWithModifiers.NonNullTypes!
             return this; // substitution had no effect on the type or modifiers
         }
 
@@ -395,9 +387,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public abstract TypeSymbol AsTypeSymbolOnly();
 
         /// <summary>
-        /// Is this an equal type symbol without annotations/custom modifiers?
+        /// Is this the given type parameter?
         /// </summary>
-        public abstract bool Is(TypeSymbol other);
+        public abstract bool Is(TypeParameterSymbol other);
 
         public TypeSymbolWithAnnotations Update(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
         {
@@ -426,7 +418,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public void AddNullableTransforms(ArrayBuilder<bool> transforms)
         {
             var typeSymbol = TypeSymbol;
-            transforms.Add(IsNullable == true && !typeSymbol.IsNullableType() && !typeSymbol.IsValueType);
+            transforms.Add(IsAnnotated && !typeSymbol.IsValueType);
             typeSymbol.AddNullableTransforms(transforms);
         }
 
@@ -434,15 +426,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             result = this;
 
-            bool isNullable;
+            bool isAnnotated;
             if (transforms.IsDefault)
             {
-                // No explicit transforms. All reference types are non-nullable.
-                isNullable = false;
+                // No explicit transforms. All reference types are unannotated.
+                isAnnotated = false;
             }
             else if (position < transforms.Length)
             {
-                isNullable = transforms[position++];
+                isAnnotated = transforms[position++];
             }
             else
             {
@@ -464,23 +456,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!result.IsValueType)
             {
-                if (isNullable)
+                if (isAnnotated)
                 {
                     result = result.AsNullableReferenceType();
                 }
                 else
                 {
-                    if (useNonNullTypes)
-                    {
-                        result = result.AsNotNullableReferenceType();
-                    }
-                    else
-                    {
-                        result = result.AsObliviousReferenceType();
-                    }
+                    result = result.AsNotNullableReferenceType();
                 }
             }
 
+            result = result.WithNonNullTypes(useNonNullTypes);
             return true;
         }
 
@@ -525,25 +511,59 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return this;
         }
 
+        private static bool IsNullableToNonNullTypes(bool? isNullable) => isNullable != null;
+        private static bool IsNullableToIsAnnotated(bool? isNullable) => isNullable == true;
+
         private sealed class NonLazyType : TypeSymbolWithAnnotations
         {
             private readonly TypeSymbol _typeSymbol;
-            private readonly bool? _isNullable;
+            private readonly bool _nonNullTypes; // PROTOTYPE(NullableReferenceTypes): _nonNullTypes should be lazy to avoid unnecessary cycles.
+            private readonly bool _isAnnotated;
             private readonly ImmutableArray<CustomModifier> _customModifiers;
 
-            public NonLazyType(TypeSymbol typeSymbol, bool? isNullable, ImmutableArray<CustomModifier> customModifiers)
+            // PROTOTYPE(NullableReferenceTypes): [Obsolete("Use explicit NonNullTypes context")]
+            public NonLazyType(TypeSymbol typeSymbol, bool? isNullable, ImmutableArray<CustomModifier> customModifiers) :
+                this(typeSymbol, nonNullTypes: IsNullableToNonNullTypes(isNullable), isAnnotated: IsNullableToIsAnnotated(isNullable), customModifiers)
+            {
+            }
+
+            public NonLazyType(TypeSymbol typeSymbol, bool nonNullTypes, bool isAnnotated, ImmutableArray<CustomModifier> customModifiers)
             {
                 Debug.Assert((object)typeSymbol != null);
                 Debug.Assert(!customModifiers.IsDefault);
-                Debug.Assert(!typeSymbol.IsNullableType() || isNullable == true);
+                Debug.Assert(!typeSymbol.IsNullableType() || isAnnotated == true);
                 _typeSymbol = typeSymbol;
-                _isNullable = isNullable;
+                _nonNullTypes = nonNullTypes;
+                _isAnnotated = isAnnotated;
                 _customModifiers = customModifiers;
             }
 
-            public sealed override TypeSymbol TypeSymbol => _typeSymbol;
-            public sealed override bool? IsNullable => _isNullable;
+            public override TypeSymbol TypeSymbol => _typeSymbol;
+
+            public override bool? IsNullable
+            {
+                get
+                {
+                    if (_isAnnotated)
+                    {
+                        return true;
+                    }
+                    if (_nonNullTypes)
+                    {
+                        return false;
+                    }
+                    if (_typeSymbol.IsValueType)
+                    {
+                        return false;
+                    }
+                    return null;
+                }
+            }
+
+            public override bool IsAnnotated => _isAnnotated;
             public override ImmutableArray<CustomModifier> CustomModifiers => _customModifiers;
+
+            internal bool NonNullTypes => _nonNullTypes;
 
             internal override bool GetIsReferenceType(ConsList<TypeParameterSymbol> inProgress)
             {
@@ -565,40 +585,39 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers)
             {
-                return new NonLazyType(_typeSymbol, _isNullable, customModifiers);
+                return new NonLazyType(_typeSymbol, _nonNullTypes, _isAnnotated, customModifiers);
+            }
+
+            protected override TypeSymbolWithAnnotations WithNonNullTypes(bool nonNullTypes)
+            {
+                return _nonNullTypes == nonNullTypes ?
+                    this :
+                    new NonLazyType(_typeSymbol, nonNullTypes, _isAnnotated, _customModifiers);
             }
 
             public override TypeSymbol AsTypeSymbolOnly() => _typeSymbol;
 
             // PROTOTYPE(NullableReferenceTypes): Use WithCustomModifiers.Is() => false
             // and set IsNullable=null always for GetTypeParametersAsTypeArguments.
-            public override bool Is(TypeSymbol other) => _typeSymbol.Equals(other, TypeCompareKind.CompareNullableModifiersForReferenceTypes) && _customModifiers.IsEmpty;
+            public override bool Is(TypeParameterSymbol other) => _typeSymbol.Equals(other, TypeCompareKind.CompareNullableModifiersForReferenceTypes) && _customModifiers.IsEmpty;
 
-            protected sealed override TypeSymbolWithAnnotations DoUpdate(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
+            protected override TypeSymbolWithAnnotations DoUpdate(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
             {
-                return new NonLazyType(typeSymbol, _isNullable, customModifiers);
+                return new NonLazyType(typeSymbol, _nonNullTypes, _isAnnotated, customModifiers);
             }
 
             public override TypeSymbolWithAnnotations AsNullableReferenceType()
             {
-                return _isNullable == true ?
+                return _isAnnotated ?
                     this :
-                    new NonLazyType(_typeSymbol, isNullable: true, _customModifiers);
+                    new NonLazyType(_typeSymbol, nonNullTypes: _nonNullTypes, isAnnotated: true, _customModifiers);
             }
 
             public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
             {
-                return _isNullable == false || _typeSymbol.IsNullableType() ?
+                return IsNullable == false || _typeSymbol.IsNullableType() ?
                     this :
-                    new NonLazyType(_typeSymbol, isNullable: false, _customModifiers);
-            }
-
-            public override TypeSymbolWithAnnotations AsObliviousReferenceType()
-            {
-                Debug.Assert(_isNullable != true);
-                return _isNullable == null ?
-                    this :
-                    new NonLazyType(_typeSymbol, isNullable: null, _customModifiers);
+                    new NonLazyType(_typeSymbol, nonNullTypes: _nonNullTypes, isAnnotated: false, _customModifiers);
             }
         }
 
@@ -609,20 +628,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private sealed class LazyNullableTypeParameter : TypeSymbolWithAnnotations
         {
             private readonly CSharpCompilation _compilation;
-            private readonly TypeSymbolWithAnnotations _underlying;
+            private readonly NonLazyType _underlying;
             private TypeSymbol _resolved;
 
             public LazyNullableTypeParameter(CSharpCompilation compilation, TypeSymbolWithAnnotations underlying)
             {
                 Debug.Assert(compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking));
-                Debug.Assert(underlying.IsNullable != true);
+                Debug.Assert(!underlying.IsAnnotated);
                 Debug.Assert(underlying.TypeKind == TypeKind.TypeParameter);
                 Debug.Assert(underlying.CustomModifiers.IsEmpty);
                 _compilation = compilation;
-                _underlying = underlying;
+                _underlying = (NonLazyType)underlying;
             }
 
             public override bool? IsNullable => true;
+            public override bool IsAnnotated => true;
             public override bool IsVoid => false;
             public override bool IsSZArray() => false;
             public override bool IsStatic => false;
@@ -640,7 +660,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         else
                         {
                             Interlocked.CompareExchange(ref _resolved,
-                                _compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(ImmutableArray.Create(_underlying)),
+                                _compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(ImmutableArray.Create<TypeSymbolWithAnnotations>(_underlying)),
                                 null);
                         }
                     }
@@ -671,7 +691,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return TypeSymbol;
             }
 
-            public override bool Is(TypeSymbol other)
+            // PROTOTYPE(NullableReferenceTypes): This implementation looks
+            // incorrect since a type parameter cannot be Nullable<T>.
+            public override bool Is(TypeParameterSymbol other)
             {
                 if (!other.IsNullableType())
                 {
@@ -700,6 +722,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return new NonLazyType(typeSymbol, isNullable: true, customModifiers);
             }
 
+            protected override TypeSymbolWithAnnotations WithNonNullTypes(bool nonNullTypes)
+            {
+                return _underlying.NonNullTypes == nonNullTypes ?
+                    this :
+                    new LazyNullableTypeParameter(_compilation, _underlying.WithNonNullTypes(nonNullTypes));
+            }
+
             protected override TypeSymbolWithAnnotations DoUpdate(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
             {
                 if (typeSymbol.IsNullableType())
@@ -722,14 +751,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 Debug.Assert(!this.IsNullable == false);
                 return this;
-            }
-
-            public override TypeSymbolWithAnnotations AsObliviousReferenceType()
-            {
-                // AsObliviousReferenceType is used to produce a null-oblivious when applying a nullable transform
-                // in a context with [NonNullTypes(false)]. But that attribute only affects types that don't have
-                // a `?` annotation. Since LazyNullableType always results from a `?` annotation, this method is unreachable.
-                throw ExceptionUtilities.Unreachable;
             }
 
             protected override TypeSymbolWithAnnotations SubstituteType(AbstractTypeMap typeMap, bool withTupleUnification)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else
             {
-                TypeMap = TypeMap.Empty.WithConcatAlphaRename(containingMethod, this, out _typeParameters, out _constructedFromTypeParameters);
+                TypeMap = TypeMap.Empty.WithConcatAlphaRename(containingMethod, this, containingMethod.NonNullTypes, out _typeParameters, out _constructedFromTypeParameters);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleMethodSymbol.cs
@@ -24,9 +24,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(underlyingMethod.ConstructedFrom == (object)underlyingMethod);
             _containingType = container;
 
-            TypeMap.Empty.WithAlphaRename(underlyingMethod, this, out _typeParameters);
-            _underlyingMethod = underlyingMethod.ConstructIfGeneric(TypeArguments);
+            bool nonNullTypes = GetNonNullTypes(underlyingMethod);
+            TypeMap.Empty.WithAlphaRename(underlyingMethod, this, nonNullTypes, out _typeParameters);
+            _underlyingMethod = underlyingMethod.ConstructIfGeneric(GetTypeParametersAsTypeArguments(nonNullTypes));
         }
+
+        private static bool GetNonNullTypes(MethodSymbol underlyingMethod) => underlyingMethod.OriginalDefinition.NonNullTypes;
 
         public override bool IsTupleMethod
         {
@@ -130,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _typeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations);
+                return GetTypeParametersAsTypeArguments(GetNonNullTypes(_underlyingMethod));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1139,7 +1139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (implementingMember.Kind == SymbolKind.Method && (implementedMethod = (MethodSymbol)interfaceMember).IsGenericMethod)
                 {
-                    implementedMember = implementedMethod.Construct(((MethodSymbol)implementingMember).TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                    implementedMember = implementedMethod.Construct(((MethodSymbol)implementingMember).TypeArguments);
                 }
                 else
                 {
@@ -1282,8 +1282,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var typeParameters2 = implicitImpl.TypeParameters;
                 var indexedTypeParameters = IndexedTypeParameterSymbol.Take(arity);
 
-                var typeMap1 = new TypeMap(typeParameters1, indexedTypeParameters, allowAlpha: true);
-                var typeMap2 = new TypeMap(typeParameters2, indexedTypeParameters, allowAlpha: true);
+                var typeMap1 = new TypeMap(interfaceMethod.NonNullTypes, typeParameters1, indexedTypeParameters, allowAlpha: true);
+                var typeMap2 = new TypeMap(implicitImpl.NonNullTypes, typeParameters2, indexedTypeParameters, allowAlpha: true);
 
                 // Report any mismatched method constraints.
                 for (int i = 0; i < arity; i++)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -3397,7 +3397,7 @@ class Test
         ///                                        TInner modopt(IsConst)[] modopt(IsConst) y, 
         ///                                        TMethod modopt(IsConst)[] modopt(IsConst) z);
         /// </summary>
-        [Fact(Skip = "PROTOTYPE(NullableReferenceTypes): Symbols with nullability are incorrectly getting created in a C# 7 compilation")]
+        [Fact]
         public void TestOverrideGenericMethodWithTypeParamDiffNameWithCustomModifiers()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -1927,6 +1927,71 @@ class B
             comp.VerifyDiagnostics();
         }
 
+        [WorkItem(28324, "https://github.com/dotnet/roslyn/issues/28324")]
+        [Fact]
+        public void NonNullTypes_GenericOverriddenMethod_ValueType()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+[module: NonNullTypes(false)]
+class C<T> { }
+abstract class A
+{
+    internal abstract C<T> F<T>() where T : struct;
+}
+class B : A
+{
+    internal override C<T> F<T>() => throw null;
+}";
+            var comp = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+
+            var method = comp.GetMember<MethodSymbol>("A.F");
+            var typeArg = ((NamedTypeSymbol)method.ReturnType.TypeSymbol).TypeArgumentsNoUseSiteDiagnostics[0];
+            Assert.True(typeArg.IsValueType);
+            Assert.Equal(false, typeArg.IsNullable);
+
+            method = comp.GetMember<MethodSymbol>("B.F");
+            typeArg = ((NamedTypeSymbol)method.ReturnType.TypeSymbol).TypeArgumentsNoUseSiteDiagnostics[0];
+            Assert.True(typeArg.IsValueType);
+            Assert.Equal(false, typeArg.IsNullable);
+
+            // PROTOTYPE(NullableReferenceTypes): Test all combinations of base and derived
+            // including explicit Nullable<T>.
+        }
+
+        // Example where the bound expression type contains an unannotated type
+        // parameter but the inferred type contains a non-nullable type parameter.
+        [Fact]
+        public void CompareUnannotatedAndNonNullableTypeParameter()
+        {
+            var source =
+@"#pragma warning disable 0649
+using System.Threading.Tasks;
+class C<T>
+{
+    T[] _f;
+    Task<T> F() => Task.FromResult(_f[0]);
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void CircularConstraints()
+        {
+            var source =
+@"class A<T> where T : B<T>.I
+{
+    internal interface I { }
+}
+class B<T> : A<T> where T : A<T>.I
+{
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7);
+            comp.VerifyDiagnostics();
+        }
+
         [Fact]
         public void AssignObliviousIntoLocals()
         {
@@ -2652,6 +2717,143 @@ public struct D<T, NT>
                 //         nt.Item /*T:S?*/ .ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "nt.Item").WithLocation(15, 9)
                 );
+        }
+
+        [Fact]
+        public void IsAnnotated_01()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C1
+{
+    string F1() => throw null;
+    string? F2() => throw null;
+    int F3() => throw null;
+    int? F4() => throw null;
+    Nullable<int> F5() => throw null;
+}
+[NonNullTypes(false)]
+class C2
+{
+    string F1() => throw null;
+    string? F2() => throw null;
+    int F3() => throw null;
+    int? F4() => throw null;
+    Nullable<int> F5() => throw null;
+}
+[NonNullTypes(true)]
+class C3
+{
+    string F1() => throw null;
+    string? F2() => throw null;
+    int F3() => throw null;
+    int? F4() => throw null;
+    Nullable<int> F5() => throw null;
+}";
+            var comp = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+            verify("C1.F1", "System.String!", isAnnotated: false, isNullable: false);
+            verify("C1.F2", "System.String?", isAnnotated: true, isNullable: true);
+            verify("C1.F3", "System.Int32", isAnnotated: false, isNullable: false);
+            verify("C1.F4", "System.Int32?", isAnnotated: true, isNullable: true);
+            verify("C1.F5", "System.Int32?", isAnnotated: true, isNullable: true);
+            verify("C2.F1", "System.String", isAnnotated: false, isNullable: null);
+            verify("C2.F2", "System.String?", isAnnotated: true, isNullable: true);
+            verify("C2.F3", "System.Int32", isAnnotated: false, isNullable: false);
+            verify("C2.F4", "System.Int32?", isAnnotated: true, isNullable: true);
+            verify("C2.F5", "System.Int32?", isAnnotated: true, isNullable: true);
+            verify("C3.F1", "System.String!", isAnnotated: false, isNullable: false);
+            verify("C3.F2", "System.String?", isAnnotated: true, isNullable: true);
+            verify("C3.F3", "System.Int32", isAnnotated: false, isNullable: false);
+            verify("C3.F4", "System.Int32?", isAnnotated: true, isNullable: true);
+            verify("C3.F5", "System.Int32?", isAnnotated: true, isNullable: true);
+
+            // PROTOTYPE(NullableReferenceTypes): Test nested nullability.
+
+            void verify(string methodName, string displayName, bool isAnnotated, bool? isNullable)
+            {
+                var method = comp.GetMember<MethodSymbol>(methodName);
+                var type = method.ReturnType;
+                Assert.Equal(displayName, type.ToTestDisplayString(true));
+                Assert.Equal(isAnnotated, type.IsAnnotated);
+                Assert.Equal(isNullable, type.IsNullable);
+            }
+        }
+
+        [Fact]
+        public void IsAnnotated_02()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C1
+{
+    T F1<T>() => throw null;
+    T? F2<T>() => throw null;
+    T F3<T>() where T : class => throw null;
+    T? F4<T>() where T : class => throw null;
+    T F5<T>() where T : struct => throw null;
+    T? F6<T>() where T : struct => throw null;
+    Nullable<T> F7<T>() where T : struct => throw null;
+}
+[NonNullTypes(false)]
+class C2
+{
+    T F1<T>() => throw null;
+    T? F2<T>() => throw null;
+    T F3<T>() where T : class => throw null;
+    T? F4<T>() where T : class => throw null;
+    T F5<T>() where T : struct => throw null;
+    T? F6<T>() where T : struct => throw null;
+    Nullable<T> F7<T>() where T : struct => throw null;
+}
+[NonNullTypes(true)]
+class C3
+{
+    T F1<T>() => throw null;
+    T? F2<T>() => throw null;
+    T F3<T>() where T : class => throw null;
+    T? F4<T>() where T : class => throw null;
+    T F5<T>() where T : struct => throw null;
+    T? F6<T>() where T : struct => throw null;
+    Nullable<T> F7<T>() where T : struct => throw null;
+}";
+            var comp = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+            verify("C1.F1", "T!", isAnnotated: false, isNullable: false);
+            verify("C1.F2", "T?", isAnnotated: true, isNullable: true);
+            verify("C1.F3", "T!", isAnnotated: false, isNullable: false);
+            verify("C1.F4", "T?", isAnnotated: true, isNullable: true);
+            verify("C1.F5", "T", isAnnotated: false, isNullable: false);
+            verify("C1.F6", "T?", isAnnotated: true, isNullable: true);
+            verify("C1.F7", "T?", isAnnotated: true, isNullable: true);
+            verify("C2.F1", "T", isAnnotated: false, isNullable: null);
+            verify("C2.F2", "T?", isAnnotated: true, isNullable: true);
+            verify("C2.F3", "T", isAnnotated: false, isNullable: null);
+            verify("C2.F4", "T?", isAnnotated: true, isNullable: true);
+            verify("C2.F5", "T", isAnnotated: false, isNullable: false);
+            verify("C2.F6", "T?", isAnnotated: true, isNullable: true);
+            verify("C2.F7", "T?", isAnnotated: true, isNullable: true);
+            verify("C3.F1", "T!", isAnnotated: false, isNullable: false);
+            verify("C3.F2", "T?", isAnnotated: true, isNullable: true);
+            verify("C3.F3", "T!", isAnnotated: false, isNullable: false);
+            verify("C3.F4", "T?", isAnnotated: true, isNullable: true);
+            verify("C3.F5", "T", isAnnotated: false, isNullable: false);
+            verify("C3.F6", "T?", isAnnotated: true, isNullable: true);
+            verify("C3.F7", "T?", isAnnotated: true, isNullable: true);
+
+            // PROTOTYPE(NullableReferenceTypes): Test nested nullability.
+            // PROTOTYPE(NullableReferenceTypes): Test all combinations of overrides.
+
+            void verify(string methodName, string displayName, bool isAnnotated, bool? isNullable)
+            {
+                var method = comp.GetMember<MethodSymbol>(methodName);
+                var type = method.ReturnType;
+                Assert.Equal(displayName, type.ToTestDisplayString(true));
+                Assert.Equal(isAnnotated, type.IsAnnotated);
+                Assert.Equal(isNullable, type.IsNullable);
+            }
         }
 
         [Fact]
@@ -4500,7 +4702,12 @@ class B : A
 }
 ";
             var compilation = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
-            compilation.VerifyDiagnostics();
+            // PROTOTYPE(NullableReferenceTypes): Should report return type mismatch
+            // for M1 and M2 (see https://github.com/dotnet/roslyn/issues/28684).
+            compilation.VerifyDiagnostics(
+                // (20,16): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                //         return new string?[] {};
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[] {}").WithArguments("string?[]", "string[]").WithLocation(20, 16));
         }
 
         [Fact]
@@ -4643,13 +4850,6 @@ class B : IA
         public void Implementing_11()
         {
             var source = @"
-class C
-{
-    public static void Main()
-    { 
-    }
-}
-
 interface IA
 {
     string[] M1(); 
@@ -4672,14 +4872,12 @@ class B : IA
 }
 ";
             var compilation = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
-
+            // PROTOTYPE(NullableReferenceTypes): Should report return type mismatch
+            // for M1 and M2 (see https://github.com/dotnet/roslyn/issues/28684).
             compilation.VerifyDiagnostics(
-                // (24,13): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'T[] IA.M2<T>()'.
-                //     S?[] IA.M2<S>() 
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M2").WithArguments("T[] IA.M2<T>()").WithLocation(24, 13),
-                // (18,18): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'string[] IA.M1()'.
-                //     string?[] IA.M1()
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M1").WithArguments("string[] IA.M1()").WithLocation(18, 18)
+                // (13,16): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                //         return new string?[] {};
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[] {}").WithArguments("string?[]", "string[]").WithLocation(13, 16)
                 );
         }
 
@@ -4745,12 +4943,6 @@ class B : A
         {
             var source = @"
 [module: System.Runtime.CompilerServices.NonNullTypes(true)]
-class C
-{
-    public static void Main()
-    { 
-    }
-}
 
 abstract class A
 {
@@ -19586,10 +19778,10 @@ class C
             var model = comp.GetSemanticModel(tree);
             var declarators = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ToArray();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[0]);
-            Assert.Equal("System.String?", symbol.Type.ToTestDisplayString());
+            Assert.Equal("System.String?", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(true, symbol.Type.IsNullable);
             symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[1]);
-            Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
+            Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(false, symbol.Type.IsNullable);
         }
 
@@ -19620,10 +19812,10 @@ class C
             var model = comp.GetSemanticModel(tree);
             var declarators = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ToArray();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[0]);
-            Assert.Equal("System.String?", symbol.Type.ToTestDisplayString());
+            Assert.Equal("System.String?", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(true, symbol.Type.IsNullable);
             symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[1]);
-            Assert.Equal("System.Int32?", symbol.Type.ToTestDisplayString());
+            Assert.Equal("System.Int32?", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(true, symbol.Type.IsNullable);
         }
 
@@ -19657,10 +19849,11 @@ class C
             var model = comp.GetSemanticModel(tree);
             var declarators = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ToArray();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[0]);
-            Assert.Equal("T", symbol.Type.ToTestDisplayString());
+            Assert.Equal("T", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(null, symbol.Type.IsNullable);
             symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[1]);
-            Assert.Equal("T", symbol.Type.ToTestDisplayString());
+            // PROTOTYPE(NullableReferenceTypes): Is T correct?
+            Assert.Equal("T", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(null, symbol.Type.IsNullable);
         }
 
@@ -19694,10 +19887,10 @@ class C
             var model = comp.GetSemanticModel(tree);
             var declarators = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ToArray();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[0]);
-            Assert.Equal("T?", symbol.Type.ToTestDisplayString());
+            Assert.Equal("T?", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(true, symbol.Type.IsNullable);
             symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[1]);
-            Assert.Equal("T?", symbol.Type.ToTestDisplayString());
+            Assert.Equal("T?", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(true, symbol.Type.IsNullable);
         }
 
@@ -19731,10 +19924,10 @@ class C
             var model = comp.GetSemanticModel(tree);
             var declarators = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ToArray();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[0]);
-            Assert.Equal("System.String", symbol.Type.ToTestDisplayString());
+            Assert.Equal("System.String!", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(false, symbol.Type.IsNullable);
             symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[1]);
-            Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
+            Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(false, symbol.Type.IsNullable);
         }
 
@@ -19765,10 +19958,10 @@ class C
             var model = comp.GetSemanticModel(tree);
             var declarators = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ToArray();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[0]);
-            Assert.Equal("System.String?", symbol.Type.ToTestDisplayString());
+            Assert.Equal("System.String?", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(true, symbol.Type.IsNullable);
             symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[1]);
-            Assert.Equal("System.Int32?", symbol.Type.ToTestDisplayString());
+            Assert.Equal("System.Int32?", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(true, symbol.Type.IsNullable);
         }
 
@@ -19802,10 +19995,11 @@ class C
             var model = comp.GetSemanticModel(tree);
             var declarators = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ToArray();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[0]);
-            Assert.Equal("T", symbol.Type.ToTestDisplayString());
+            Assert.Equal("T!", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(false, symbol.Type.IsNullable);
             symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[1]);
-            Assert.Equal("T?", symbol.Type.ToTestDisplayString());
+            // PROTOTYPE(NullableReferenceTypes): Is T? correct? Compare with default(T?) which is T! (see Default_TUnconstrained test).
+            Assert.Equal("T?", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(true, symbol.Type.IsNullable);
         }
 
@@ -19842,10 +20036,10 @@ class C
             var model = comp.GetSemanticModel(tree);
             var declarators = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ToArray();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[0]);
-            Assert.Equal("T", symbol.Type.ToTestDisplayString());
+            Assert.Equal("T!", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(false, symbol.Type.IsNullable);
             symbol = (LocalSymbol)model.GetDeclaredSymbol(declarators[1]);
-            Assert.Equal("T?", symbol.Type.ToTestDisplayString());
+            Assert.Equal("T?", symbol.Type.ToTestDisplayString(true));
             Assert.Equal(true, symbol.Type.IsNullable);
         }
 


### PR DESCRIPTION
Store `IsAnnotated` and `NonNullTypes` as separate fields in `TypeSymbolWithAnnotations` and only calculate `bool? IsNullable` on demand, to help avoid cycles.

Next steps:
1. Remove obsolete `TypeSymbolWithAnnotations.Create` overloads that do not have an explicit `NonNullTypes` context, and update callers.
1. Make `NonNullTypes` lazy rather than using `bool`.

Replaces #28453.