### PR TITLE
Add a Jenkins leg to check for loc changes

### DIFF
--- a/build/scripts/check-for-loc-changes.cmd
+++ b/build/scripts/check-for-loc-changes.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\check-for-loc-changes.ps1" %*

--- a/build/scripts/check-for-loc-changes.ps1
+++ b/build/scripts/check-for-loc-changes.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+
+Checks if a merge will result in changes to .xlf files, and returns a failure
+code if true.
+
+.DESCRIPTION
+
+The point of this script is to block changes to localized resources after we've
+entered a Loc freeze. It's meant to be run in a CI system prior to merging a PR.
+
+.PARAMETER base
+
+Generally the branch a change will be merged into, but this could also be a
+commit or tag.
+
+.PARAMETER head
+
+The commit that will be merged into $base. Again, this can be a branch, tag, or
+commit.
+#>
+
+[CmdletBinding(PositionalBinding=$false)]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$base,
+
+    [Parameter(Mandatory=$true)]
+    [string]$head
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+try {
+    . (Join-Path $PSScriptRoot "build-utils.ps1")
+    Push-Location $repoDir
+
+    # Find the merge base, then the list of files that changed since then.
+    $mergeBase = & git merge-base $base $head
+    $changedFiles = @(& git diff --name-only $mergeBase $head)
+
+    # Filter out everything that isn't a .xlf file.
+    $changedXlfFiles = @($changedFiles | where { [IO.Path]::GetExtension($_) -eq ".xlf" })
+
+    # Fail if there are any changed .xlf files.
+    $changedXlfFiles | % { Write-Host "$_ has been modified" }
+    if ($changedXlfFiles.Count -eq 0) {
+        exit 0
+    }
+    else {
+        exit 1
+    }
+}
+catch [exception] {
+    Write-Host $_
+    Write-Host $_.Exception
+    exit 1
+}
+finally {
+    Pop-Location
+}

--- a/netci.groovy
+++ b/netci.groovy
@@ -258,6 +258,28 @@ commitPullList.each { isPr ->
   }
 }
 
+// Loc change check
+commitPullList.each { isPr ->
+  // This job blocks PRs with loc changes, so only activate it for PR builds of
+  // release branches after a loc freeze.
+  if (isPr
+      && (branchName == "dev15.8.x"
+          || branchName == "dev15.8.x-vs-deps")) {
+    def jobName = Utilities.getFullJobName(projectName, "windows_loc_changes", isPr)
+    def myJob = job(jobName) {
+        description('Validate that a PR contains no localization changes')
+        steps {
+            batchFile(""".\\build\\scripts\\check-for-loc-changes.cmd -base %GIT_BRANCH% -head %GIT_COMMIT%""")
+        }
+    }
+
+    def triggerPhraseOnly = false
+    def triggerPhraseExtra = "loc changes"
+    Utilities.setMachineAffinity(myJob, 'Windows_NT', windowsUnitTestMachine)
+    addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
+  }
+}
+
 JobReport.Report.generateJobReport(out)
 
 // Make the call to generate the help job


### PR DESCRIPTION
Add a Jenkins leg to check for loc changes. Once we're past the loc
freeze date for a release branch we want to block any PRs that modify
.xlf files.

Note that we *do* need a way to let updates from the Loc team through,
but that is not addressed by this change.
