### PR TITLE
Added support for setting null-conditional access receiver state.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -110,6 +110,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private bool _disableDiagnostics = false;
 
+        /// <summary>
+        /// Used to allow <see cref="MakeSlot(BoundExpression)"/> to substitute the correct slot for a <see cref="BoundConditionalReceiver"/> when
+        /// it's encountered.
+        /// </summary>
+        private int _lastConditionalAccessSlot = -1;
+
         protected override void Free()
         {
             _variableTypes.Free();
@@ -407,6 +413,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (_placeholderLocals != null && _placeholderLocals.TryGetValue(node, out ObjectCreationPlaceholderLocal placeholder))
                     {
                         return GetOrCreateSlot(placeholder);
+                    }
+                    break;
+                case BoundKind.ConditionalReceiver:
+                    if (_lastConditionalAccessSlot != -1)
+                    {
+                        int slot = _lastConditionalAccessSlot;
+                        _lastConditionalAccessSlot = -1;
+                        return slot;
                     }
                     break;
             }
@@ -1447,26 +1461,115 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (operandComparedToNull.Type?.IsReferenceType == true)
                         {
-                            int slot = MakeSlot(operandComparedToNull);
-
-                            if (slot > 0)
+                            ImmutableArray<int> slots = getOperandSlots(operandComparedToNull);
+                            if (!slots.IsEmpty)
                             {
-                                if (slot >= this.State.Capacity) Normalize(ref this.State);
-
                                 Split();
-
-                                if (op == BinaryOperatorKind.Equal)
+                                foreach (int slot in slots)
                                 {
-                                    this.StateWhenFalse[slot] = true;
-                                }
-                                else
-                                {
-                                    this.StateWhenTrue[slot] = true;
+                                    if (op == BinaryOperatorKind.Equal)
+                                    {
+                                        this.StateWhenFalse[slot] = true;
+                                    }
+                                    else
+                                    {
+                                        this.StateWhenTrue[slot] = true;
+                                    }
                                 }
                             }
                         }
                     }
                 }
+            }
+
+            ImmutableArray<int> getOperandSlots(BoundExpression operand)
+            {
+                Debug.Assert(operand != null);
+                Debug.Assert(_lastConditionalAccessSlot == -1);
+                ArrayBuilder<int> slotListBuilder = null;
+                int slot;
+
+                do
+                {
+                    // Due to the nature of binding, if there are conditional access they will be at the top of the bound tree,
+                    // potentially with a conversion on top of it. We go through any conditional accesses, adding slots for the
+                    // condtional receivers if they have them. If we ever get to a receiver that MakeSlot doesn't return a slot
+                    // for, nothing underneath is trackable and we bail at that point. Example:
+                    //
+                    //     a?.GetB()?.C // a is a field, GetB is a method, and C is a property
+                    //
+                    // The top of the tree is the a?.GetB() conditional call. We'll ask for a slot for a, and we'll get one because
+                    // locals have slots. The AccessExpression of the BoundCondtionalAccess is another BoundCondtionalAccess, this time
+                    // with a reciever of the GetB() BoundCall. Attempting to get a slot for this receiver will fail, and we'll
+                    // return an array with just the slot for a.
+                    switch (operand.Kind)
+                    {
+                        case BoundKind.Conversion:
+                            operand = ((BoundConversion)operand).Operand;
+                            continue;
+                        case BoundKind.ConditionalAccess:
+                            var conditional = (BoundConditionalAccess)operand;
+
+                            slot = MakeSlot(conditional.Receiver);
+                            if (slot > 0)
+                            {
+                                // If we got a slot we must have processed the previous conditional receiver.
+                                Debug.Assert(_lastConditionalAccessSlot == -1);
+
+                                if (slot >= this.State.Capacity) Normalize(ref this.State);
+                                if (slotListBuilder == null)
+                                {
+                                    slotListBuilder = ArrayBuilder<int>.GetInstance();
+                                }
+                                slotListBuilder.Add(slot);
+
+                                // When MakeSlot is called on the nested AccessExpression, it will recurse through receivers
+                                // until it gets to the BoundConditionalRecevier associated with this node. In our override
+                                _lastConditionalAccessSlot = slot;
+
+                                operand = conditional.AccessExpression;
+                                continue;
+                            }
+                            else
+                            {
+                                // If we didn't get a slot, it's possible that the current _lastConditionalSlot was never processed,
+                                // so we reset before leaving the function.
+                                _lastConditionalAccessSlot = -1;
+
+                                // If the current element doesn't have a slot, nothing underneath will have a slot either.
+                                return slotListBuilder?.ToImmutableAndFree() ?? ImmutableArray<int>.Empty;
+                            }
+                        default:
+                            // Attempt to create a slot for the current thing. If there were any more conditional accesses,
+                            // they would have been on top, so this is the last thing we need to specially handle.
+
+                            // PROTOTYPE(NullableReferenceTypes): When we handle unconditional access survival (ie after
+                            // c.D has been invoked, c must be nonnull or we've thrown a NullRef), revisit whether
+                            // we need more special handling here
+
+                            slot = MakeSlot(operand);
+                            if (slot > 0)
+                            {
+                                // If we got a slot we must have processed the previous conditional receiver.
+                                Debug.Assert(_lastConditionalAccessSlot == -1);
+
+                                if (slot >= this.State.Capacity) Normalize(ref this.State);
+                                if (slotListBuilder == null)
+                                {
+                                    slotListBuilder = ArrayBuilder<int>.GetInstance();
+                                }
+                                slotListBuilder.Add(slot);
+                            }
+                            else
+                            {
+                                // If we didn't get a slot, it's possible that the current _lastConditionalSlot was never processed,
+                                // so we reset before leaving the function.
+                                _lastConditionalAccessSlot = -1;
+                            }
+
+                            return slotListBuilder?.ToImmutableAndFree() ?? ImmutableArray<int>.Empty;
+                    }
+                } while (true);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1530,7 +1530,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                                 // We need to continue the walk regardless of whether the receiver is a value
                                 // type, but we only want to update the slots of reference types
-                                if (conditional.Receiver.Type?.IsReferenceType == true)
+                                if (shouldUpdateType(conditional.Receiver.Type))
                                 {
                                     slotBuilder.Add(slot);
                                 }
@@ -1556,7 +1556,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // we need more special handling here
 
                             slot = MakeSlot(operand);
-                            if (slot > 0 && operand.Type?.IsReferenceType == true)
+                            if (slot > 0 && shouldUpdateType(operand.Type))
                             {
                                 // If we got a slot then all previous BoundCondtionalReceivers must have been handled.
                                 Debug.Assert(_lastConditionalAccessSlot == -1);
@@ -1572,6 +1572,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _lastConditionalAccessSlot = -1;
                     return;
                 } while (true);
+
+                bool shouldUpdateType(TypeSymbol operandType) =>
+                    operandType != null &&
+                    (operandType.IsReferenceType == true || operandType.IsUnconstrainedTypeParameter());
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1574,8 +1574,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 } while (true);
 
                 bool shouldUpdateType(TypeSymbol operandType) =>
-                    operandType != null &&
-                    (operandType.IsReferenceType == true || operandType.IsUnconstrainedTypeParameter());
+                    !(operandType is null) &&
+                    (operandType.IsReferenceType || operandType.IsUnconstrainedTypeParameter());
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1462,10 +1462,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (operandComparedToNull.Type?.IsReferenceType == true)
                         {
                             var slotBuilder = ArrayBuilder<int>.GetInstance();
+
+                            // Set all nested conditional slots. For example in a?.b?.c we'll set a, b, and c
                             getOperandSlots(operandComparedToNull, slotBuilder);
-                            Normalize(ref this.State);
                             if (slotBuilder.Count != 0)
                             {
+                                Normalize(ref this.State);
                                 Split();
                                 ref LocalState state = ref (op == BinaryOperatorKind.Equal) ? ref this.StateWhenFalse : ref this.StateWhenTrue;
                                 foreach (int slot in slotBuilder)
@@ -1536,13 +1538,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // c.D has been invoked, c must be nonnull or we've thrown a NullRef), revisit whether
                             // we need more special handling here
 
-                            // If we're in this case, then all previous BoundCondtionalReceivers must have been handled.
-                            Debug.Assert(_lastConditionalAccessSlot == -1);
                             slot = MakeSlot(operand);
                             if (slot > 0)
                             {
+                                // If we got a slot then all previous BoundCondtionalReceivers must have been handled.
+                                Debug.Assert(_lastConditionalAccessSlot == -1);
+
                                 slotBuilder.Add(slot);
                             }
+
                             break;
                     }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -12380,6 +12380,29 @@ class C
         }
 
         [Fact]
+        public void ConditionalBranching_18()
+        {
+            var compilation = CreateCompilation(@"
+class C
+{
+    void Test(C? x, C? y)
+    {
+        if ((x = y)?.GetHashCode() != null)
+        {
+            x.ToString();
+            y.ToString(); // warn
+        }
+    }
+}", parseOptions: TestOptions.Regular8);
+
+            compilation.VerifyDiagnostics(
+                // (10,13): warning CS8602: Possible dereference of a null reference.
+                //             y.ToString(); // warn
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(10, 13)
+                );
+        }
+
+        [Fact]
         public void ConditionalBranching_Is_ReferenceType()
         {
             CSharpCompilation c = CreateCompilation(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -11756,7 +11756,7 @@ class C
         }
         else
         {
-            c1._cField.ToString(); // warn
+            c1._cField.ToString(); // warn 1 2
         }
     }
 
@@ -11769,7 +11769,7 @@ class C
         }
         else
         {
-            c2._cField.ToString(); // warn x2
+            c2._cField.ToString(); // warn 3 4
         }
     }
 
@@ -11782,11 +11782,11 @@ class C
         else if (c3?._cField != null)
         {
             c3._cField.ToString();
-            c3._cField._cField.ToString(); // warn
+            c3._cField._cField.ToString(); // warn 5
         }
         else
         {
-            c3.ToString(); // warn
+            c3.ToString(); // warn 6
         }
     }
 
@@ -11798,7 +11798,7 @@ class C
         }
         else
         {
-            c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn x3
+            c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn 7 8 9
         }
     }
 
@@ -11806,7 +11806,7 @@ class C
     {
         if (c5?._cField == null)
         {
-            c5._cField.ToString(); // warn x2
+            c5._cField.ToString(); // warn 10 11
         }
         else
         {
@@ -11818,7 +11818,7 @@ class C
     {
         if (c6?._cField?.GetC() != null)
         {
-            c6._cField.GetC().ToString(); // warn
+            c6._cField.GetC().ToString(); // warn 12
         }
     }
 
@@ -11834,45 +11834,46 @@ class C
 
             compilation.VerifyDiagnostics(
                 // (17,13): warning CS8602: Possible dereference of a null reference.
-                //             c1._cField.ToString(); // warn
+                //             c1._cField.ToString(); // warn 1 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(17, 13),
                 // (17,13): warning CS8602: Possible dereference of a null reference.
-                //             c1._cField.ToString(); // warn
+                //             c1._cField.ToString(); // warn 1 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1._cField").WithLocation(17, 13),
 
                 // (30,13): warning CS8602: Possible dereference of a null reference.
-                //             c2._cField.ToString(); // warn x2
+                //             c2._cField.ToString(); // warn 3 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(30, 13),
                 // (30,13): warning CS8602: Possible dereference of a null reference.
-                //             c2._cField.ToString(); // warn x2
+                //             c2._cField.ToString(); // warn 3 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2._cField").WithLocation(30, 13),
 
                 // (43,13): warning CS8602: Possible dereference of a null reference.
-                //             c3._cField._cField.ToString(); // warn
+                //             c3._cField._cField.ToString(); // warn 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c3._cField._cField").WithLocation(43, 13),
+
                 // (47,13): warning CS8602: Possible dereference of a null reference.
-                //             c3.ToString(); // warn
+                //             c3.ToString(); // warn 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c3").WithLocation(47, 13),
 
                 // (59,13): warning CS8602: Possible dereference of a null reference.
-                //             c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn x3
+                //             c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn 7 8 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c4").WithLocation(59, 13),
                 // (59,13): warning CS8602: Possible dereference of a null reference.
-                //             c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn x3
+                //             c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn 7 8 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c4._nonNullCField._cField").WithLocation(59, 13),
                 // (59,13): warning CS8602: Possible dereference of a null reference.
-                //             c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn x3
+                //             c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn 7 8 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c4._nonNullCField._cField._nonNullCField._cField").WithLocation(59, 13),
 
                 // (67,13): warning CS8602: Possible dereference of a null reference.
-                //             c5._cField.ToString(); // warn x2
+                //             c5._cField.ToString(); // warn 10 11
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c5").WithLocation(67, 13),
                 // (67,13): warning CS8602: Possible dereference of a null reference.
-                //             c5._cField.ToString(); // warn x2
+                //             c5._cField.ToString(); // warn 10 11
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c5._cField").WithLocation(67, 13),
 
                 // (79,13): warning CS8602: Possible dereference of a null reference.
-                //             c6._cField.GetC().ToString(); // warn
+                //             c6._cField.GetC().ToString(); // warn 12
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c6._cField.GetC()").WithLocation(79, 13)
             );
         }
@@ -11888,11 +11889,11 @@ class C
         if (c1?[0] != null)
         {
             c1.ToString();
-            c1[0].ToString(); // warn
+            c1[0].ToString(); // warn 1
         }
         else
         {
-            c1.ToString(); // warn
+            c1.ToString(); // warn 2
         }
     }
 
@@ -11902,12 +11903,73 @@ class C
 
             compilation.VerifyDiagnostics(
                 // (9,13): warning CS8602: Possible dereference of a null reference.
-                //             c1[0].ToString(); // warn
+                //             c1[0].ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1[0]").WithLocation(9, 13),
                 // (13,13): warning CS8602: Possible dereference of a null reference.
-                //             c1.ToString(); // warn
+                //             c1.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(13, 13)
             );
+        }
+
+        [Fact]
+        public void ConditionalBranching_16()
+        {
+            var compilation = CreateCompilation(@"
+class C
+{
+    void Test<T>(T t)
+    {
+        if (t?.ToString() != null)
+        {
+            t.ToString();
+        }
+        else
+        {
+            t.ToString(); // warn
+        }
+    }
+}", parseOptions: TestOptions.Regular8);
+
+            // PROTOTYPE(NullableReferenceTypes): We are currently warning on all unconstrained type parameter invocations
+            // https://github.com/dotnet/roslyn/issues/28792
+            compilation.VerifyDiagnostics(
+                // (6,13): warning CS8602: Possible dereference of a null reference.
+                //         if (t?.ToString() != null)
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(6, 13),
+                // (8,13): warning CS8602: Possible dereference of a null reference.
+                //             t.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(8, 13),
+                // (12,13): warning CS8602: Possible dereference of a null reference.
+                //             t.ToString(); // warn
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(12, 13)
+                );
+        }
+
+        [Fact]
+        public void ConditionalBranching_17()
+        {
+            var compilation = CreateCompilation(@"
+class C
+{
+    object? Prop { get; }
+    object? GetObj(bool val) => null;
+    void Test(C? c1, C? c2)
+    {
+        if (c1?.GetObj(c2?.Prop != null) != null)
+        {
+            c2.Prop.ToString(); // warn 1 2
+        }
+    }
+}", parseOptions: TestOptions.Regular8);
+
+            compilation.VerifyDiagnostics(
+                // (10,13): warning CS8602: Possible dereference of a null reference.
+                //             c2.Prop.ToString(); // warn 1 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(10, 13),
+                // (10,13): warning CS8602: Possible dereference of a null reference.
+                //             c2.Prop.ToString(); // warn 1 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2.Prop").WithLocation(10, 13)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -12396,9 +12396,9 @@ class C
 }", parseOptions: TestOptions.Regular8);
 
             compilation.VerifyDiagnostics(
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Possible dereference of a null reference.
                 //             y.ToString(); // warn
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(10, 13)
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 13)
                 );
         }
 


### PR DESCRIPTION
For something like
```C#
if (c?.d != null)
{
    c.d.ToString();
}
```
we will now track nullability of conditionally accessed expressions.

@dotnet/roslyn-compiler @jcouv @cston for review.