### PR TITLE
Fix windows_loc_changes leg

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -269,7 +269,7 @@ commitPullList.each { isPr ->
     def myJob = job(jobName) {
         description('Validate that a PR contains no localization changes')
         steps {
-            batchFile(""".\\build\\scripts\\check-for-loc-changes.cmd -base %GIT_BRANCH% -head %GIT_COMMIT%""")
+            batchFile(""".\\build\\scripts\\check-for-loc-changes.cmd -base origin/${branchName} -head %GIT_COMMIT%""")
         }
     }
 


### PR DESCRIPTION
When I created the windows_loc_changes job for Jenkins I thought the
`GIT_BRANCH` environment variable contained the name of the branch a
change would be merged into. Instead, it contains the name of the
"head" branch, which is not helpful for this purpose. I have not yet
been able to identify an environment variable that has the name of the
"base" branch instead.

As a workaround, this commit updates netci.groovy to capture the branch
name when the job is generated.


