### PR TITLE
Switch to procdump64.exe to take dumps

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -699,13 +699,13 @@ function Ensure-ProcDump() {
 
     # Jenkins images default to having procdump installed in the root.  Use that if available to avoid
     # an unnecessary download.
-    if (Test-Path "c:\SysInternals\procdump.exe") {
+    if (Test-Path "c:\SysInternals\procdump64.exe") {
         return "c:\SysInternals";
     }
 
     $toolsDir = Join-Path $binariesDir "Tools"
     $outDir = Join-Path $toolsDir "ProcDump"
-    $filePath = Join-Path $outDir "procdump.exe"
+    $filePath = Join-Path $outDir "procdump64.exe"
     if (-not (Test-Path $filePath)) {
         Remove-Item -Re $filePath -ErrorAction SilentlyContinue
         Create-Directory $outDir

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
@@ -278,6 +278,13 @@ namespace Microsoft.CodeAnalysis.Interactive
                         }
 
                         // the client can instantiate interactive host now:
+
+                        // DO NOT MERGE: intentional infinite hang to confirm dumping is working of 64-bit InteractiveHost
+                        if (Environment.Is64BitProcess)
+                        {
+                            Thread.Sleep(Timeout.Infinite);
+                        }
+
                         semaphore.Release();
                     }
 

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -244,7 +244,7 @@ namespace RunTests
         {
             if (!string.IsNullOrEmpty(options.ProcDumpDirectory))
             {
-                return new ProcDumpInfo(Path.Combine(options.ProcDumpDirectory, "procdump.exe"), options.LogsDirectory);
+                return new ProcDumpInfo(Path.Combine(options.ProcDumpDirectory, "procdump64.exe"), options.LogsDirectory);
             }
 
             return null;


### PR DESCRIPTION
The 32-bit procdump can only dump 32-bit processes, whereas the 64-bit one can dump both. By default, the 64-bit procdump still takes 32-bit dumps, so people shouldn't have issues with WOW.