### PR TITLE
Lazily evaluate NonNullTypes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => Symbol as NamespaceOrTypeSymbol;
             internal bool IsDefault => _symbolOrTypeSymbolWithAnnotations is null;
 
-            internal static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateNonNull(bool nonNullTypes, Symbol symbol)
+            internal static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateUnannotated(INonNullTypesContext nonNullTypesContext, Symbol symbol)
             {
                 if (symbol is null)
                 {
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     return new NamespaceOrTypeOrAliasSymbolWithAnnotations(symbol);
                 }
-                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.CreateNonNull(nonNullTypes, type));
+                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext, type));
             }
 
             public static implicit operator NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -215,19 +215,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Are we in a context where un-annotated types should be interpreted as non-null?
-        /// The binder flags are used to break cycles.
         /// </summary>
-        internal bool NonNullTypes
-        {
-            get
-            {
-                if ((Flags & BinderFlags.NonNullTypesTrue) != 0)
-                {
-                    return true;
-                }
-                return ContainingMember().NonNullTypes;
-            }
-        }
+        internal Symbol NonNullTypesContext => ContainingMember();
 
         /// <summary>
         /// Is the contained code within a member method body?

--- a/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
@@ -103,12 +103,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         InContextualAttributeBinder = 1 << 29,
 
-        /// <summary>
-        /// Indicates a context with [NonNullTypes(true)], so unannotated reference types should be interpreted as non-null.
-        /// This flag is used to avoid cycles.
-        /// </summary>
-        NonNullTypesTrue = 1 << 30,
-
         // Groups
 
         AllClearedAtExecutableCodeBoundary = InLockBody | InCatchBlock | InCatchFilter | InFinallyBlock | InTryBlockOfTryCatch | InNestedFinallyBlock,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -250,13 +250,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbolWithAnnotations declType = BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar, out aliasOpt);
             if (isVar)
             {
-                declType = TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes, operandType);
+                declType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, operandType);
             }
 
             if (declType == (object)null)
             {
                 Debug.Assert(hasErrors);
-                declType = TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes, this.CreateErrorType("var"));
+                declType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, this.CreateErrorType("var"));
             }
 
             var boundDeclType = new BoundTypeExpression(typeSyntax, aliasOpt, inferredType: isVar, type: declType.TypeSymbol);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case SyntaxKind.TupleType:
                     {
-                        return TypeSymbolWithAnnotations.Create(BindTupleType((TupleTypeSyntax)syntax, diagnostics));
+                        return TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, BindTupleType((TupleTypeSyntax)syntax, diagnostics));
                     }
 
                 case SyntaxKind.RefType:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     CheckFeatureAvailability(syntax, MessageID.IDS_FeatureImplicitLocal, diagnostics);
                 }
 
-                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateNonNull(NonNullTypes, symbol);
+                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, symbol);
             }
             else
             {
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     CheckFeatureAvailability(syntax, MessageID.IDS_FeatureUnmanagedGenericTypeConstraint, diagnostics);
                 }
 
-                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateNonNull(NonNullTypes, symbol);
+                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, symbol);
             }
             else
             {
@@ -365,24 +365,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.PredefinedType:
                     {
                         var type = BindPredefinedTypeSymbol((PredefinedTypeSyntax)syntax, diagnostics);
-                        if (type.SpecialType == SpecialType.System_Boolean)
-                        {
-                            // Breaking a cycle when binding the `NonNullTypes` attribute constructor
-                            // PROTOTYPE(NullableReferenceTypes): test this with some extra/unrelated constructors on NonNullTypesAttribute
-                            return TypeSymbolWithAnnotations.CreateNonNull(nonNullTypes: true, type);
-                        }
-                        else
-                        {
-                            return TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes, type);
-                        }
+                        return TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, type);
                     }
 
                 case SyntaxKind.IdentifierName:
-                    return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateNonNull(NonNullTypes,
+                    return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext,
                         BindNonGenericSimpleNamespaceOrTypeOrAliasSymbol((IdentifierNameSyntax)syntax, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics, qualifierOpt: null));
 
                 case SyntaxKind.GenericName:
-                    return TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes,
+                    return TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext,
                         BindGenericSimpleNamespaceOrTypeOrAliasSymbol((GenericNameSyntax)syntax, diagnostics, basesBeingResolved, qualifierOpt: null));
 
                 case SyntaxKind.AliasQualifiedName:
@@ -397,19 +388,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return TypeSymbolWithAnnotations.Create(new ExtendedErrorTypeSymbol(left, LookupResultKind.NotATypeOrNamespace, diagnostics.Add(ErrorCode.ERR_ColColWithTypeAlias, node.Alias.Location, node.Alias.Identifier.Text)));
                         }
 
-                        return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateNonNull(NonNullTypes, this.BindSimpleNamespaceOrTypeOrAliasSymbol(node.Name, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics, left));
+                        return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, this.BindSimpleNamespaceOrTypeOrAliasSymbol(node.Name, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics, left));
                     }
 
                 case SyntaxKind.QualifiedName:
                     {
                         var node = (QualifiedNameSyntax)syntax;
-                        return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateNonNull(NonNullTypes, BindQualifiedName(node.Left, node.Right, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics));
+                        return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, BindQualifiedName(node.Left, node.Right, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics));
                     }
 
                 case SyntaxKind.SimpleMemberAccessExpression:
                     {
                         var node = (MemberAccessExpressionSyntax)syntax;
-                        return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateNonNull(NonNullTypes, BindQualifiedName(node.Expression, node.Name, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics));
+                        return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, BindQualifiedName(node.Expression, node.Name, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics));
                     }
 
                 case SyntaxKind.ArrayType:
@@ -446,7 +437,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else
                             {
-                                type = TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes, array);
+                                type = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, array);
                             }
                         }
 
@@ -816,7 +807,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // PROTOTYPE(NullableReferenceTypes): test with different NonNullTypes contexts
                 AliasSymbol discarded;
-                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateNonNull(NonNullTypes, (NamespaceOrTypeSymbol)UnwrapAlias(symbol.Symbol, out discarded, diagnostics, syntax, basesBeingResolved));
+                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, (NamespaceOrTypeSymbol)UnwrapAlias(symbol.Symbol, out discarded, diagnostics, syntax, basesBeingResolved));
             }
 
             return symbol;
@@ -827,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (symbol.IsAlias)
             {
                 // PROTOTYPE(NullableReferenceTypes): test with different NonNullTypes contexts
-                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateNonNull(NonNullTypes, (NamespaceOrTypeSymbol)UnwrapAlias(symbol.Symbol, out alias, diagnostics, syntax, basesBeingResolved));
+                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, (NamespaceOrTypeSymbol)UnwrapAlias(symbol.Symbol, out alias, diagnostics, syntax, basesBeingResolved));
             }
 
             alias = null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -410,7 +410,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ImmutableArray<Location> elementLocations = elements.SelectAsArray(e => e.Syntax.Location);
 
-            var tuple = TupleTypeSymbol.Create(locationOpt: null, elementTypes: convertedTypes.SelectAsArray((t, m) => TypeSymbolWithAnnotations.Create(m, t), compilation.SourceModule),
+            var tuple = TupleTypeSymbol.Create(locationOpt: null,
+                elementTypes: convertedTypes.SelectAsArray((t, m) => TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: m, t), compilation.SourceModule),
                 elementLocations, elementNames: names, compilation,
                 shouldCheckConstraints: true, errorPositions: default, syntax, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/INonNullTypesContext.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/INonNullTypesContext.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Roslyn.Utilities;
+
 namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
@@ -11,15 +13,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         bool NonNullTypes { get; }
     }
 
-    internal sealed class NonNullTypesContextTrue : INonNullTypesContext
+    // PROTOTYPE(NullableReferenceTypes): this probably can be removed once fine-grained context is passed everywhere
+    internal sealed class NonNullTypesTrueContext : INonNullTypesContext
     {
-        public static INonNullTypesContext Instance = new NonNullTypesContextTrue();
+        public static readonly INonNullTypesContext Instance = new NonNullTypesTrueContext();
         public bool NonNullTypes => true;
     }
 
-    internal sealed class NonNullTypesContextFalse : INonNullTypesContext
+    // PROTOTYPE(NullableReferenceTypes): this probably can be removed once fine-grained context is passed everywhere
+    internal sealed class NonNullTypesFalseContext : INonNullTypesContext
     {
-        public static INonNullTypesContext Instance = new NonNullTypesContextFalse();
+        public static readonly INonNullTypesContext Instance = new NonNullTypesFalseContext();
         public bool NonNullTypes => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/INonNullTypesContext.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/INonNullTypesContext.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// Instead of storing a bool to tell us if we're in a NonNullTypes context,
+    /// we use this interface to pull on that information lazily.
+    /// </summary>
+    internal interface INonNullTypesContext
+    {
+        bool NonNullTypes { get; }
+    }
+
+    internal sealed class NonNullTypesContextTrue : INonNullTypesContext
+    {
+        public static INonNullTypesContext Instance = new NonNullTypesContextTrue();
+        public bool NonNullTypes => true;
+    }
+
+    internal sealed class NonNullTypesContextFalse : INonNullTypesContext
+    {
+        public static INonNullTypesContext Instance = new NonNullTypesContextFalse();
+        public bool NonNullTypes => false;
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/SemanticFacts.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/SemanticFacts.cs
@@ -8,7 +8,8 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal partial class Symbol
+
+    internal partial class Symbol : INonNullTypesContext
     {
         /// <summary>
         /// Checks if 'symbol' is accessible from within named type 'within'.  If 'symbol' is accessed off

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/SemanticFacts.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/SemanticFacts.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.CSharp
 {
 
-    internal partial class Symbol : INonNullTypesContext
+    internal partial class Symbol
     {
         /// <summary>
         /// Checks if 'symbol' is accessible from within named type 'within'.  If 'symbol' is accessed off

--- a/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ReportInferenceFailure(inferenceDiagnostics);
                     }
 
-                    type = fieldSymbol.SetType(TypeSymbolWithAnnotations.Create(this.VariableSymbol.ContainingModule, type), inferenceDiagnostics);
+                    type = fieldSymbol.SetType(TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this.VariableSymbol.ContainingModule, type), inferenceDiagnostics);
                     inferenceDiagnostics.Free();
 
                     return new BoundFieldAccess(this.Syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorStateMachine.cs
@@ -54,9 +54,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _interfaces;
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return ContainingAssembly.GetSpecialType(SpecialType.System_Object);
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => ContainingAssembly.GetSpecialType(SpecialType.System_Object);
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureMethod.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     typeMap = lambdaFrame.TypeMap.WithConcatAlphaRename(
                         originalMethod,
                         this,
-                        originalMethod.NonNullTypes,
+                        nonNullTypesContext: originalMethod,
                         out typeParameters,
                         out constructedFromTypeParameters,
                         lambdaFrame.OriginalContainingMethodOpt);
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     typeMap = TypeMap.Empty.WithConcatAlphaRename(
                         originalMethod,
                         this,
-                        originalMethod.NonNullTypes,
+                        nonNullTypesContext: originalMethod,
                         out typeParameters,
                         out constructedFromTypeParameters,
                         stopAt: null);

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -663,7 +663,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    typeMap = typeMap.WithAlphaRename(methodBeingWrapped, this, methodBeingWrapped.NonNullTypes, out typeParameters);
+                    typeMap = typeMap.WithAlphaRename(methodBeingWrapped, this, nonNullTypesContext: methodBeingWrapped, out typeParameters);
                 }
 
                 AssignTypeMapAndTypeParameters(typeMap, typeParameters);

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -228,10 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 throw ExceptionUtilities.Unreachable;
             }
 
-            internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-            {
-                return this.Manager.System_Object;
-            }
+            internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => this.Manager.System_Object;
 
             public override TypeKind TypeKind
             {
@@ -326,7 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return AttributeUsageInfo.Null;
             }
 
-            internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute)
+            internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
             {
                 return this.Manager.System_Object;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -338,10 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return ImmutableArray<NamedTypeSymbol>.Empty;
             }
 
-            internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-            {
-                return this.Manager.System_Object;
-            }
+            internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => this.Manager.System_Object;
 
             public override TypeKind TypeKind
             {
@@ -376,7 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return this; }
             }
 
-            internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute)
+            internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
             {
                 return this.Manager.System_Object;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -197,10 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return _baseType;
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => _baseType;
 
         public override bool IsReferenceType
         {
@@ -387,12 +384,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ElementType.AddNullableTransforms(transforms);
         }
 
-        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, bool useNonNullTypes, ref int position, out TypeSymbol result)
+        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, INonNullTypesContext nonNullTypesContext, ref int position, out TypeSymbol result)
         {
             TypeSymbolWithAnnotations oldElementType = ElementType;
             TypeSymbolWithAnnotations newElementType;
 
-            if (!oldElementType.ApplyNullableTransforms(transforms, useNonNullTypes, ref position, out newElementType))
+            if (!oldElementType.ApplyNullableTransforms(transforms, nonNullTypesContext, ref position, out newElementType))
             {
                 result = this;
                 return false; 

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/ModuleEarlyWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/ModuleEarlyWellKnownAttributeData.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class ModuleEarlyWellKnownAttributeData : EarlyWellKnownAttributeData
     {
+        // PROTOTYPE(NullableReferenceTypes): we may not need an early attribute after cycle-busting refactoring
         #region NonNullTypesAttribute
         private bool? _nonNullTypes;
         public bool? NonNullTypes

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -80,10 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return null;
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => null;
 
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved)
         {
@@ -228,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
         }
 
-        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, bool useNonNullTypes, ref int position, out TypeSymbol result)
+        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, INonNullTypesContext nonNullTypesContext, ref int position, out TypeSymbol result)
         {
             result = this;
             return true;

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -419,7 +419,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute) => null;
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => null;
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
@@ -433,7 +433,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute)
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
         {
             return null;
         }
@@ -592,7 +592,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _hashCode;
         }
 
-        internal override bool NonNullTypes => false;
+        public override bool NonNullTypes => false;
     }
 
     internal sealed class ConstructedErrorTypeSymbol : SubstitutedErrorTypeSymbol
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             base(originalDefinition)
         {
             _containingSymbol = containingSymbol;
-            _map = containingSymbol.TypeSubstitution.WithAlphaRename(originalDefinition, this, nonNullTypes: NonNullTypes, out _typeParameters);
+            _map = containingSymbol.TypeSubstitution.WithAlphaRename(originalDefinition, this, nonNullTypesContext: this, out _typeParameters);
         }
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters

--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool HasSpecialName { get; }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute)
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
         {
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract ConstantValue GetConstantValue(ConstantFieldsInProgress inProgress, bool earlyDecodingWellKnownAttributes);
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -420,8 +420,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 var indexed = builder.ToImmutableAndFree();
 
-                typeMap1 = new TypeMap(member1.NonNullTypes, member1.GetMemberTypeParameters(), indexed, true);
-                typeMap2 = new TypeMap(member2.NonNullTypes, typeParameters2, indexed, true);
+                typeMap1 = new TypeMap(nonNullTypesContext: member1, member1.GetMemberTypeParameters(), indexed, true);
+                typeMap2 = new TypeMap(nonNullTypesContext: member2, typeParameters2, indexed, true);
             }
             else
             {
@@ -589,7 +589,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return typeParameters.IsEmpty ?
                 null :
                 new TypeMap(
-                    member.NonNullTypes,
+                    nonNullTypesContext: member,
                     typeParameters,
                     IndexedTypeParameterSymbol.Take(member.GetMemberArity()),
                     true);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MemberRefMetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MemberRefMetadataDecoder.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // IndexedTypeParameterSymbol is not going to be exposed anywhere,
             // so we'll cheat and use it here for comparison purposes.
             TypeMap candidateMethodTypeMap = new TypeMap(
-                candidateMethod.NonNullTypes,
+                nonNullTypesContext: candidateMethod,
                 candidateMethod.TypeParameters,
                 IndexedTypeParameterSymbol.Take(candidateMethod.Arity), true);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -30,8 +30,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             int position = 0;
             TypeSymbolWithAnnotations result;
-            // PROTOTYPE(NullableReferenceTypes): handle NonNullTypes from metadata
-            if (metadataType.ApplyNullableTransforms(nullableTransformFlags, useNonNullTypes: true, ref position, out result) &&
+            // PROTOTYPE(NullableReferenceTypes): handle NonNullTypesContext from metadata
+            if (metadataType.ApplyNullableTransforms(nullableTransformFlags, metadataType.NonNullTypesContext, ref position, out result) &&
                 (nullableTransformFlags.IsDefault || position == nullableTransformFlags.Length))
             {
                 return result;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -471,7 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get { return null; }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -507,7 +507,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get { return null; }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -711,7 +711,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -705,7 +705,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -397,14 +397,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
         {
-            if (ReferenceEquals(_lazyBaseType, ErrorTypeSymbol.UnknownResultType))
+            get
             {
-                Interlocked.CompareExchange(ref _lazyBaseType, MakeAcyclicBaseType(), ErrorTypeSymbol.UnknownResultType);
-            }
+                if (ReferenceEquals(_lazyBaseType, ErrorTypeSymbol.UnknownResultType))
+                {
+                    Interlocked.CompareExchange(ref _lazyBaseType, MakeAcyclicBaseType(), ErrorTypeSymbol.UnknownResultType);
+                }
 
-            return _lazyBaseType;
+                return _lazyBaseType;
+            }
         }
 
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved = null)
@@ -422,9 +425,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return InterfacesNoUseSiteDiagnostics();
         }
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute = false)
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
         {
-            // PROTOTYPE(NullableReferenceTypes): confirm that the ignoreNonNullTypesAttribute and ignoreNullability flags are indeed different. Add a comment to clarify.
             return GetDeclaredBaseType(ignoreNullability: false);
         }
 
@@ -2002,7 +2004,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {
@@ -2457,8 +2459,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 // containing symbol for the temporary type is the namespace directly.
                 var nestedType = Create(this.ContainingPEModule, (PENamespaceSymbol)this.ContainingNamespace, _handle, null);
                 var nestedTypeParameters = nestedType.TypeParameters;
-                var containingTypeMap = new TypeMap(container.NonNullTypes, containingTypeParameters, IndexedTypeParameterSymbol.Take(n), allowAlpha: false);
-                var nestedTypeMap = new TypeMap(nestedType.NonNullTypes, nestedTypeParameters, IndexedTypeParameterSymbol.Take(nestedTypeParameters.Length), allowAlpha: false);
+                var containingTypeMap = new TypeMap(nonNullTypesContext: container, containingTypeParameters, IndexedTypeParameterSymbol.Take(n), allowAlpha: false);
+                var nestedTypeMap = new TypeMap(nonNullTypesContext: nestedType, nestedTypeParameters, IndexedTypeParameterSymbol.Take(nestedTypeParameters.Length), allowAlpha: false);
 
                 for (int i = 0; i < n; i++)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -732,7 +732,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get { return null; }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         }
 
                         // PROTOTYPE(NullableReferenceTypes): Test different [NonNullTypes] on method and containing type.
-                        var type = TypeSymbolWithAnnotations.CreateNonNull(_containingSymbol.NonNullTypes, typeSymbol);
+                        var type = TypeSymbolWithAnnotations.CreateUnannotated(_containingSymbol, typeSymbol);
                         if (moduleSymbol.UtilizesNullableReferenceTypes)
                         {
                             type = NullableTypeDecoder.TransformType(type, constraintHandle, moduleSymbol);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
@@ -172,9 +172,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private static TypeSymbolWithAnnotations CreateType(TypeSymbol type, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers)
         {
-            // NonNullTypes context is unset because the actual context will
+            // NonNullTypesContext is unset because the actual context will
             // be set when these types are transformed by the caller.
-            return TypeSymbolWithAnnotations.Create(type, nonNullTypes: false, isAnnotated: false, CSharpCustomModifier.Convert(customModifiers));
+            return TypeSymbolWithAnnotations.Create(type, NonNullTypesContextFalse.Instance, isAnnotated: false, CSharpCustomModifier.Convert(customModifiers));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             // NonNullTypesContext is unset because the actual context will
             // be set when these types are transformed by the caller.
-            return TypeSymbolWithAnnotations.Create(type, NonNullTypesContextFalse.Instance, isAnnotated: false, CSharpCustomModifier.Convert(customModifiers));
+            return TypeSymbolWithAnnotations.Create(type, NonNullTypesFalseContext.Instance, isAnnotated: false, CSharpCustomModifier.Convert(customModifiers));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             TypeSymbol decoded = DecodeTupleTypesInternal(type, elementNames, hasTupleElementNamesAttribute);
             return (object)decoded == (object)type ?
                 metadataType :
-                TypeSymbolWithAnnotations.Create(decoded, nonNullTypes: metadataType.NonNullTypes, isAnnotated: metadataType.IsAnnotated, metadataType.CustomModifiers);
+                TypeSymbolWithAnnotations.Create(decoded, metadataType.NonNullTypesContext, isAnnotated: metadataType.IsAnnotated, metadataType.CustomModifiers);
         }
 
         public static TypeSymbol DecodeTupleTypesIfApplicable(
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             TypeSymbol decoded = DecodeType(type);
             return ReferenceEquals(decoded, type) ?
                 typeWithAnnotations :
-                TypeSymbolWithAnnotations.Create(decoded, nonNullTypes: typeWithAnnotations.NonNullTypes, isAnnotated: typeWithAnnotations.IsAnnotated, typeWithAnnotations.CustomModifiers);
+                TypeSymbolWithAnnotations.Create(decoded, typeWithAnnotations.NonNullTypesContext, isAnnotated: typeWithAnnotations.IsAnnotated, typeWithAnnotations.CustomModifiers);
         }
 
         private ImmutableArray<string> EatElementNamesIfAvailable(int numberOfElements)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -222,12 +222,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Resolving [NonNullTypes] only makes sense within the definition of the generic type
             // or method. If this is a substituted symbol, we use the default NonNullTypes context.
             var definition = OriginalDefinition;
-            bool nonNullTypes = (object)this == definition ? definition.NonNullTypes : false;
-            return GetTypeParametersAsTypeArguments(nonNullTypes);
+            INonNullTypesContext nonNullTypesContext = (object)this == definition ? definition : NonNullTypesContextFalse.Instance;
+            return GetTypeParametersAsTypeArguments(nonNullTypesContext);
         }
 
-        internal ImmutableArray<TypeSymbolWithAnnotations> GetTypeParametersAsTypeArguments(bool nonNullTypes) =>
-            TypeMap.TypeParametersAsTypeSymbolsWithAnnotations(nonNullTypes, TypeParameters);
+        internal ImmutableArray<TypeSymbolWithAnnotations> GetTypeParametersAsTypeArguments(INonNullTypesContext nonNullTypesContext) =>
+            TypeMap.TypeParametersAsTypeSymbolsWithAnnotations(nonNullTypesContext, TypeParameters);
 
         /// <summary>
         /// Call <see cref="TryGetThisParameter"/> and throw if it returns false.
@@ -960,7 +960,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </remarks>
         internal abstract int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree);
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -219,10 +219,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal ImmutableArray<TypeSymbolWithAnnotations> GetTypeParametersAsTypeArguments()
         {
-            // Resolving [NonNullTypes] only makes sense within the definition of the generic type
-            // or method. If this is a substituted symbol, we use the default NonNullTypes context.
+            // Resolving [NonNullTypes] only makes sense within the definition of the generic type or method.
+            // If this is a substituted symbol, we use a dummy NonNullTypes context.
             var definition = OriginalDefinition;
-            INonNullTypesContext nonNullTypesContext = (object)this == definition ? definition : NonNullTypesContextFalse.Instance;
+            INonNullTypesContext nonNullTypesContext = (object)this == definition ? definition : NonNullTypesFalseContext.Instance;
             return GetTypeParametersAsTypeArguments(nonNullTypesContext);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -617,7 +617,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal abstract NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute = false);
+        internal abstract NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved);
 
         internal abstract ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<Symbol> basesBeingResolved);
 
@@ -776,7 +776,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, bool useNonNullTypes, ref int position, out TypeSymbol result)
+        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, INonNullTypesContext nonNullTypesContext, ref int position, out TypeSymbol result)
         {
             if (!IsGenericType)
             {
@@ -792,7 +792,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 TypeSymbolWithAnnotations oldTypeArgument = allTypeArguments[i];
                 TypeSymbolWithAnnotations newTypeArgument;
-                if (!oldTypeArgument.ApplyNullableTransforms(transforms, useNonNullTypes, ref position, out newTypeArgument))
+                if (!oldTypeArgument.ApplyNullableTransforms(transforms, nonNullTypesContext, ref position, out newTypeArgument))
                 {
                     allTypeArguments.Free();
                     result = this;
@@ -1072,7 +1072,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // PROTOTYPE(NullableReferenceTypes): Set IsNullable=null always, even in C#8,
             // and set TypeSymbolWithAnnotations.WithCustomModifiers.Is() => false.
-            return this.TypeParameters.SelectAsArray((typeParameter, module) => TypeSymbolWithAnnotations.Create(module, typeParameter), ContainingModule);
+            return this.TypeParameters.SelectAsArray((typeParameter, module) => TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: module, typeParameter), ContainingModule);
         }
 
         /// <summary>
@@ -1301,7 +1301,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </remarks>
         internal abstract ConstantValue ExplicitDefaultConstantValue { get; }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -234,7 +234,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                Debug.Assert(false); // PROTOTYPE(NullableReferenceTypes): Can we reach this?
                 Debug.Assert(IsDefinition);
                 return ContainingSymbol?.NonNullTypes == true;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -68,10 +68,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
         {
-            // Pointers do not support boxing, so they really have no base type.
-            return null;
+            get
+            {
+                // Pointers do not support boxing, so they really have no base type.
+                return null;
+            }
         }
 
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved)
@@ -256,12 +259,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             PointedAtType.AddNullableTransforms(transforms);
         }
 
-        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, bool useNonNullTypes, ref int position, out TypeSymbol result)
+        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, INonNullTypesContext nonNullTypesContext, ref int position, out TypeSymbol result)
         {
             TypeSymbolWithAnnotations oldPointedAtType = PointedAtType;
             TypeSymbolWithAnnotations newPointedAtType;
 
-            if (!oldPointedAtType.ApplyNullableTransforms(transforms, useNonNullTypes, ref position, out newPointedAtType))
+            if (!oldPointedAtType.ApplyNullableTransforms(transforms, nonNullTypesContext, ref position, out newPointedAtType))
             {
                 result = this;
                 return false;

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool HasSpecialName { get; }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(reducedFrom.ParameterCount > 0);
 
             _reducedFrom = reducedFrom;
-            _typeMap = TypeMap.Empty.WithAlphaRename(reducedFrom, this, reducedFrom.NonNullTypes, out _typeParameters);
+            _typeMap = TypeMap.Empty.WithAlphaRename(reducedFrom, this, nonNullTypesContext: reducedFrom, out _typeParameters);
             _typeArguments = _typeMap.SubstituteTypes(reducedFrom.TypeArguments);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingEventSymbol.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             get { return null; }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingFieldSymbol.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             get { return null; }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
         public override ModuleMetadata GetMetadata() => _underlyingModule.GetMetadata();
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             get { return null; }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -61,6 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="sourceType">Type that already has custom modifiers.</param>
         /// <param name="destinationType">Same as <paramref name="sourceType"/>, but without custom modifiers.  May differ in object/dynamic.</param>
         /// <param name="containingAssembly">The assembly containing the signature referring to the destination type.</param>
+        /// <param name="nonNullTypesContext">The NonNullTypes context at the destination.</param>
         /// <returns><paramref name="destinationType"/> with custom modifiers copied from <paramref name="sourceType"/>.</returns>
         internal static TypeSymbol CopyTypeCustomModifiers(TypeSymbol sourceType, TypeSymbol destinationType, AssemblySymbol containingAssembly, INonNullTypesContext nonNullTypesContext)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="containingAssembly">The assembly containing the signature referring to the destination type.</param>
         /// <param name="nonNullTypesContext">If the destination is in a context with NonNullTypes set. If true, unannotated references types are treated as non-nullable, otherwise as null-oblivious.</param>
         /// <returns><paramref name="destinationType"/> with custom modifiers copied from <paramref name="sourceType"/>.</returns>
-        internal static TypeSymbol CopyTypeCustomModifiers(TypeSymbol sourceType, TypeSymbol destinationType, AssemblySymbol containingAssembly, Symbol nonNullTypesContext)
+        internal static TypeSymbol CopyTypeCustomModifiers(TypeSymbol sourceType, TypeSymbol destinationType, AssemblySymbol containingAssembly, INonNullTypesContext nonNullTypesContext)
         {
             Debug.Assert(sourceType.Equals(destinationType, TypeCompareKind.AllIgnoreOptions));
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -61,11 +61,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="sourceType">Type that already has custom modifiers.</param>
         /// <param name="destinationType">Same as <paramref name="sourceType"/>, but without custom modifiers.  May differ in object/dynamic.</param>
         /// <param name="containingAssembly">The assembly containing the signature referring to the destination type.</param>
-        /// <param name="nonNullTypesContext">If the destination is in a context with NonNullTypes set. If true, unannotated references types are treated as non-nullable, otherwise as null-oblivious.</param>
         /// <returns><paramref name="destinationType"/> with custom modifiers copied from <paramref name="sourceType"/>.</returns>
         internal static TypeSymbol CopyTypeCustomModifiers(TypeSymbol sourceType, TypeSymbol destinationType, AssemblySymbol containingAssembly, INonNullTypesContext nonNullTypesContext)
         {
             Debug.Assert(sourceType.Equals(destinationType, TypeCompareKind.AllIgnoreOptions));
+            Debug.Assert(nonNullTypesContext != null);
 
             const RefKind refKind = RefKind.None;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool NonNullTypes
+        public sealed override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (isVar)
                 {
                     diagnostics.Add(ErrorCode.ERR_RecursivelyTypedVariable, this.ErrorLocation, this);
-                    type = TypeSymbolWithAnnotations.CreateNonNull(binder.NonNullTypes, binder.CreateErrorType("var"));
+                    type = TypeSymbolWithAnnotations.CreateUnannotated(binder.NonNullTypesContext, binder.CreateErrorType("var"));
                 }
 
                 SetType(compilation, diagnostics, type);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -52,10 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Returns null for a submission class.
         /// This ensures that a submission class does not inherit methods such as ToString or GetHashCode.
         /// </summary>
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return IsScriptClass ? null : this.DeclaringCompilation.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_Object);
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
+            => IsScriptClass ? null : this.DeclaringCompilation.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_Object);
 
         protected override void CheckBase(DiagnosticBag diagnostics)
         {
@@ -68,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute)
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
         {
             return BaseTypeNoUseSiteDiagnostics;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -871,7 +871,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return (SourceModuleSymbol)this.Modules[0]; }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics: diagnostics);
 
             _lazyIsVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
-            _lazyReturnType = TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes, bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            _lazyReturnType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
 
             var location = this.Locations[0];
             if (MethodKind == MethodKind.StaticConstructor && (_lazyParameters.Length != 0))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventSymbol.cs
@@ -59,13 +59,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     EventSymbol overriddenEvent = this.OverriddenEvent;
                     if ((object)overriddenEvent != null)
                     {
-                        CopyEventCustomModifiers(overriddenEvent, ref _type, ContainingAssembly, NonNullTypes);
+                        CopyEventCustomModifiers(overriddenEvent, ref _type, ContainingAssembly, nonNullTypesContext: this);
                     }
                 }
             }
             else if ((object)explicitlyImplementedEvent != null)
             {
-                CopyEventCustomModifiers(explicitlyImplementedEvent, ref _type, ContainingAssembly, NonNullTypes);
+                CopyEventCustomModifiers(explicitlyImplementedEvent, ref _type, ContainingAssembly, nonNullTypesContext: this);
 
                 TypeSymbol.CheckNullableReferenceTypeMismatchOnImplementingMember(this, explicitlyImplementedEvent, true, diagnostics);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -49,10 +49,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var returnType = binder.BindType(returnTypeSyntax, diagnostics);
 
             // reuse types to avoid reporting duplicate errors if missing:
-            var voidType = TypeSymbolWithAnnotations.CreateNonNull(delegateType.NonNullTypes, binder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            var voidType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
             // PROTOTYPE(NullableReferenceTypes): Should the 'object' parameter be considered nullable?
-            var objectType = TypeSymbolWithAnnotations.CreateNonNull(delegateType.NonNullTypes, binder.GetSpecialType(SpecialType.System_Object, diagnostics, syntax));
-            var intPtrType = TypeSymbolWithAnnotations.CreateNonNull(delegateType.NonNullTypes, binder.GetSpecialType(SpecialType.System_IntPtr, diagnostics, syntax));
+            var objectType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_Object, diagnostics, syntax));
+            var intPtrType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_IntPtr, diagnostics, syntax));
 
             if (returnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
@@ -74,8 +74,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // WinRT delegates don't have Begin/EndInvoke methods
                 !delegateType.IsCompilationOutputWinMdObj())
             {
-                var iAsyncResultType = TypeSymbolWithAnnotations.CreateNonNull(delegateType.NonNullTypes, binder.GetSpecialType(SpecialType.System_IAsyncResult, diagnostics, syntax));
-                var asyncCallbackType = TypeSymbolWithAnnotations.CreateNonNull(delegateType.NonNullTypes, binder.GetSpecialType(SpecialType.System_AsyncCallback, diagnostics, syntax));
+                var iAsyncResultType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_IAsyncResult, diagnostics, syntax));
+                var asyncCallbackType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_AsyncCallback, diagnostics, syntax));
 
                 // (3) BeginInvoke
                 symbols.Add(new BeginInvokeMethod(invoke, iAsyncResultType, objectType, asyncCallbackType, syntax));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // EventRegistrationToken add_E(EventDelegate d);
 
                         // Leave the returns void bit in this.flags false.
-                        _lazyReturnType = TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes, eventTokenType);
+                        _lazyReturnType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, eventTokenType);
 
                         var parameter = new SynthesizedAccessorValueParameterSymbol(this, _event.Type, 0);
                         _lazyParameters = ImmutableArray.Create<ParameterSymbol>(parameter);
@@ -77,10 +77,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         TypeSymbol voidType = compilation.GetSpecialType(SpecialType.System_Void);
                         Binder.ReportUseSiteDiagnostics(voidType, diagnostics, this.Location);
-                        _lazyReturnType = TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes, voidType);
+                        _lazyReturnType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, voidType);
                         this.SetReturnsVoid(returnsVoid: true);
 
-                        var parameter = new SynthesizedAccessorValueParameterSymbol(this, TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes, eventTokenType), 0);
+                        var parameter = new SynthesizedAccessorValueParameterSymbol(this, TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, eventTokenType), 0);
                         _lazyParameters = ImmutableArray.Create<ParameterSymbol>(parameter);
                     }
                 }
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     TypeSymbol voidType = compilation.GetSpecialType(SpecialType.System_Void);
                     Binder.ReportUseSiteDiagnostics(voidType, diagnostics, this.Location);
-                    _lazyReturnType = TypeSymbolWithAnnotations.CreateNonNull(NonNullTypes, voidType);
+                    _lazyReturnType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, voidType);
                     this.SetReturnsVoid(returnsVoid: true);
 
                     var parameter = new SynthesizedAccessorValueParameterSymbol(this, _event.Type, 0);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {
@@ -552,7 +552,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return SourceDocumentationCommentUtils.GetAndCacheDocumentationComment(this, expandIncludes, ref _lazyDocComment);
         }
 
-        protected static void CopyEventCustomModifiers(EventSymbol eventWithCustomModifiers, ref TypeSymbolWithAnnotations type, AssemblySymbol containingAssembly, bool nonNullTypes)
+        protected static void CopyEventCustomModifiers(EventSymbol eventWithCustomModifiers, ref TypeSymbolWithAnnotations type, AssemblySymbol containingAssembly, Symbol nonNullTypesContext)
         {
             Debug.Assert((object)eventWithCustomModifiers != null);
 
@@ -563,7 +563,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // we want to retain the original (incorrect) type to avoid hiding the type given in source.
             if (type.TypeSymbol.Equals(overriddenEventType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
             {
-                type = type.Update(CustomModifierUtils.CopyTypeCustomModifiers(overriddenEventType, type.TypeSymbol, containingAssembly, nonNullTypes),
+                type = type.Update(CustomModifierUtils.CopyTypeCustomModifiers(overriddenEventType, type.TypeSymbol, containingAssembly, nonNullTypesContext),
                                    eventWithCustomModifiers.Type.CustomModifiers);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -555,6 +555,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected static void CopyEventCustomModifiers(EventSymbol eventWithCustomModifiers, ref TypeSymbolWithAnnotations type, AssemblySymbol containingAssembly, Symbol nonNullTypesContext)
         {
             Debug.Assert((object)eventWithCustomModifiers != null);
+            Debug.Assert(nonNullTypesContext != null);
 
             TypeSymbol overriddenEventType = eventWithCustomModifiers.Type.TypeSymbol;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldLikeEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldLikeEventSymbol.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 EventSymbol overriddenEvent = this.OverriddenEvent;
                 if ((object)overriddenEvent != null)
                 {
-                    CopyEventCustomModifiers(overriddenEvent, ref _type, ContainingAssembly, NonNullTypes);
+                    CopyEventCustomModifiers(overriddenEvent, ref _type, ContainingAssembly, nonNullTypesContext: this);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
@@ -229,9 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return Accessibility.Public; }
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return ContainingAssembly.GetSpecialType(SpecialType.System_ValueType);
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
+            => ContainingAssembly.GetSpecialType(SpecialType.System_ValueType);
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -728,7 +728,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
-                                overridingMember.NonNullTypes &&
                                 (compilation = overridingMember.DeclaringCompilation) != null &&
                                 !overridingMemberType.Equals(overriddenProperty.Type,
                                                              TypeCompareKind.AllIgnoreOptions |
@@ -775,7 +774,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
-                                overridingMember.NonNullTypes &&
                                 (compilation = overridingMember.DeclaringCompilation) != null &&
                                 !overridingMemberType.Equals(overriddenEvent.Type,
                                                              TypeCompareKind.AllIgnoreOptions |
@@ -813,7 +811,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
                                 !overridingMember.IsImplicitlyDeclared && !overridingMember.IsAccessor() &&
-                                overridingMember.NonNullTypes &&
                                 (compilation = overridingMember.DeclaringCompilation) != null &&
                                 !overridingMethod.ReturnType.Equals(overriddenMethod.ReturnType,
                                                                     TypeCompareKind.AllIgnoreOptions |
@@ -826,7 +823,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
                             !overridingMember.IsImplicitlyDeclared && !overridingMember.IsAccessor() &&
-                            overridingMember.NonNullTypes &&
                             (compilation = overridingMember.DeclaringCompilation) != null)
                         {
                             ImmutableArray<ParameterSymbol> overridingParameters = overridingMember.GetParameters();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _cachedDiagnostics; }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -609,7 +609,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -919,7 +919,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -1129,11 +1129,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // declarations, although that is not the case currently. Uncomment the Debug.Assert
             // when NonNullTypes no longer uses SyntaxBasedNonNullTypes.
             //Debug.Assert(part1.NonNullTypes == part2.NonNullTypes);
-            var nonNullTypes = part1.NonNullTypes;
             var typeParameters2 = part2.TypeParameters;
             var indexedTypeParameters = IndexedTypeParameterSymbol.Take(arity);
-            var typeMap1 = new TypeMap(nonNullTypes, typeParameters1, indexedTypeParameters, allowAlpha: true);
-            var typeMap2 = new TypeMap(nonNullTypes, typeParameters2, indexedTypeParameters, allowAlpha: true);
+            var typeMap1 = new TypeMap(nonNullTypesContext: part1, typeParameters1, indexedTypeParameters, allowAlpha: true);
+            var typeMap2 = new TypeMap(nonNullTypesContext: part1, typeParameters2, indexedTypeParameters, allowAlpha: true);
 
             return MemberSignatureComparer.HaveSameConstraints(typeParameters1, typeMap1, typeParameters2, typeMap2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -1092,6 +1092,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentConstraints, implementation.Locations[0], implementation);
             }
 
+            // PROTOTYPE(NullableReferenceTypes): We should probably not be using NonNullTypes here (ie. in binding)
             if (((CSharpParseOptions)implementation.Locations[0].SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
                 implementation.NonNullTypes)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal SourceParameterSymbol WithCustomModifiersAndParamsCore(TypeSymbol newType, ImmutableArray<CustomModifier> newCustomModifiers, ImmutableArray<CustomModifier> newRefCustomModifiers, bool newIsParams)
         {
-            newType = CustomModifierUtils.CopyTypeCustomModifiers(newType, this.Type.TypeSymbol, this.ContainingAssembly, destinationUsesNonNullTypes: false); // PROTOTYPE(NullableReferenceTypes): handle this
+            newType = CustomModifierUtils.CopyTypeCustomModifiers(newType, this.Type.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: null); // PROTOTYPE(NullableReferenceTypes): handle this
 
             TypeSymbolWithAnnotations newTypeWithModifiers = this.Type.Update(newType, newCustomModifiers);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal SourceParameterSymbol WithCustomModifiersAndParamsCore(TypeSymbol newType, ImmutableArray<CustomModifier> newCustomModifiers, ImmutableArray<CustomModifier> newRefCustomModifiers, bool newIsParams)
         {
-            newType = CustomModifierUtils.CopyTypeCustomModifiers(newType, this.Type.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: null); // PROTOTYPE(NullableReferenceTypes): handle this
+            newType = CustomModifierUtils.CopyTypeCustomModifiers(newType, this.Type.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: this);
 
             TypeSymbolWithAnnotations newTypeWithModifiers = this.Type.Update(newType, newCustomModifiers);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 PropertySymbol associatedProperty = _property;
                 var type = associatedProperty.Type;
                 _lazyReturnType = _lazyReturnType.Update(
-                    CustomModifierUtils.CopyTypeCustomModifiers(type.TypeSymbol, _lazyReturnType.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: this),
+                    CustomModifierUtils.CopyTypeCustomModifiers(type.TypeSymbol, _lazyReturnType.TypeSymbol, this.ContainingAssembly, associatedProperty),
                     type.CustomModifiers);
                 _lazyRefCustomModifiers = associatedProperty.RefCustomModifiers;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 PropertySymbol associatedProperty = _property;
                 var type = associatedProperty.Type;
                 _lazyReturnType = _lazyReturnType.Update(
-                    CustomModifierUtils.CopyTypeCustomModifiers(type.TypeSymbol, _lazyReturnType.TypeSymbol, this.ContainingAssembly, NonNullTypes),
+                    CustomModifierUtils.CopyTypeCustomModifiers(type.TypeSymbol, _lazyReturnType.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: this),
                     type.CustomModifiers);
                 _lazyRefCustomModifiers = associatedProperty.RefCustomModifiers;
             }
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else
             {
                 var binder = GetBinder();
-                return TypeSymbolWithAnnotations.Create(ContainingModule, binder.GetSpecialType(SpecialType.System_Void, diagnostics, this.GetSyntax()));
+                return TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, binder.GetSpecialType(SpecialType.System_Void, diagnostics, this.GetSyntax()));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 PropertySymbol associatedProperty = _property;
                 var type = associatedProperty.Type;
                 _lazyReturnType = _lazyReturnType.Update(
-                    CustomModifierUtils.CopyTypeCustomModifiers(type.TypeSymbol, _lazyReturnType.TypeSymbol, this.ContainingAssembly, associatedProperty),
+                    CustomModifierUtils.CopyTypeCustomModifiers(type.TypeSymbol, _lazyReturnType.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: associatedProperty),
                     type.CustomModifiers);
                 _lazyRefCustomModifiers = associatedProperty.RefCustomModifiers;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (_lazyType.TypeSymbol.Equals(overriddenPropertyType.TypeSymbol, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
                     {
                         _lazyType = _lazyType.Update(
-                            CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType.TypeSymbol, _lazyType.TypeSymbol, this.ContainingAssembly, this.NonNullTypes),
+                            CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType.TypeSymbol, _lazyType.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: this),
                             overriddenPropertyType.CustomModifiers);
                     }
 
@@ -1511,7 +1511,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (syntax.Kind() == SyntaxKind.IndexerDeclaration) ? ((IndexerDeclarationSyntax)syntax).ParameterList : null;
         }
 
-        internal override bool NonNullTypes
+        public override bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -586,7 +586,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         Debug.Assert(overriddenTypeParameters.Length == overridingTypeParameters.Length);
 
-                        var typeMap = new TypeMap(_overridingMethod.NonNullTypes, overriddenTypeParameters, overridingTypeParameters, allowAlpha: true);
+                        var typeMap = new TypeMap(nonNullTypesContext: _overridingMethod, overriddenTypeParameters, overridingTypeParameters, allowAlpha: true);
                         Interlocked.CompareExchange(ref _lazyTypeMap, typeMap, null);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(ReferenceEquals(_constructedFrom, this));
 
             // We're creating a new unconstructed Method from another; alpha-rename type parameters.
-            var newMap = _inputMap.WithAlphaRename(this.OriginalDefinition, this, this.NonNullTypes, out typeParameters);
+            var newMap = _inputMap.WithAlphaRename(this.OriginalDefinition, this, nonNullTypesContext: this, out typeParameters);
 
             var prevMap = Interlocked.CompareExchange(ref _lazyMap, newMap, null);
             if (prevMap != null)
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal sealed override bool NonNullTypes => false;
+        public sealed override bool NonNullTypes => false;
 
         private int ComputeHashCode()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<TypeParameterSymbol> typeParameters;
 
             // We're creating a new unconstructed Method from another; alpha-rename type parameters.
-            var newMap = _inputMap.WithAlphaRename(OriginalDefinition, this, NonNullTypes, out typeParameters);
+            var newMap = _inputMap.WithAlphaRename(OriginalDefinition, this, nonNullTypesContext: this, out typeParameters);
 
             var prevMap = Interlocked.CompareExchange(ref _lazyMap, newMap, null);
             if (prevMap != null)
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _underlyingType; }
         }
 
-        internal sealed override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute)
+        internal sealed override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
         {
             return _unbound ? null : Map.SubstituteNamedType(OriginalDefinition.GetDeclaredBaseType(basesBeingResolved));
         }
@@ -147,10 +147,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _unbound ? ImmutableArray<NamedTypeSymbol>.Empty : Map.SubstituteNamedTypes(OriginalDefinition.GetDeclaredInterfaces(basesBeingResolved));
         }
 
-        internal sealed override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return _unbound ? null : Map.SubstituteNamedType(OriginalDefinition.BaseTypeNoUseSiteDiagnostics);
-        }
+        internal sealed override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
+            => _unbound ? null : Map.SubstituteNamedType(OriginalDefinition.BaseTypeNoUseSiteDiagnostics);
 
         internal sealed override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved)
         {
@@ -364,6 +362,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal sealed override bool NonNullTypes => false;
+        public sealed override bool NonNullTypes => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// exposed by the compiler.
     /// </summary>
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-    internal abstract partial class Symbol : ISymbol, IFormattable
+    internal abstract partial class Symbol : ISymbol, IFormattable, INonNullTypesContext
     {
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // Changes to the public interface of this class should remain synchronized with the VB version of Symbol.

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -834,8 +834,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Is module/type/method/field/property/event/parameter definition opted-in/out of treating un-annotated types as non-null.
         /// This is determined by the presence of the `[NonNullTypes]` attribute.
-        /// PROTOTYPE(NullableReferenceTypes): presumably whether the feature is turned on or off will affect NonNullTypes default value on source module.
         /// Not valid to call on non-definitions.
+        ///
+        /// To avoid cycles, this property should not be accessed directly, except in its overrides (fall back to parent).
+        /// It can be accessed indirectly via <see cref="TypeSymbolWithAnnotations.IsNullable"/> and
+        /// <see cref="TypeSymbolWithAnnotations.IsAnnotatedWithNonNullTypesContext"/>, which delay its evaluation using
+        /// <see cref="INonNullTypesContext"/>.
         /// </summary>
         public virtual bool NonNullTypes
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -837,7 +837,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// PROTOTYPE(NullableReferenceTypes): presumably whether the feature is turned on or off will affect NonNullTypes default value on source module.
         /// Not valid to call on non-definitions.
         /// </summary>
-        internal virtual bool NonNullTypes
+        public virtual bool NonNullTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, bool? isNullableIfReferenceType, ImmutableArray<CustomModifier> customModifiers)
         {
             // PROTOTYPE(NullableReferenceTypes): Should be using fine-grained NonNullTypesContext
-            var context = isNullableIfReferenceType == null ? NonNullTypesContextFalse.Instance : NonNullTypesContextTrue.Instance;
+            var context = isNullableIfReferenceType == null ? NonNullTypesFalseContext.Instance : NonNullTypesTrueContext.Instance;
             return Create(typeSymbol, context, isAnnotated: isNullableIfReferenceType == true, customModifiers);
         }
 
@@ -500,7 +500,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return this;
             }
 
-            return new NonLazyType(typeSymbol, NonNullTypesContextTrue.Instance, isAnnotated: false, CustomModifiers);
+            return new NonLazyType(typeSymbol, NonNullTypesTrueContext.Instance, isAnnotated: false, CustomModifiers);
         }
 
         public TypeSymbolWithAnnotations SetUnknownNullabilityForReferenceTypes()
@@ -512,7 +512,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (!typeSymbol.IsValueType)
                 {
                     typeSymbol = typeSymbol.SetUnknownNullabilityForReferenceTypes();
-                    return new NonLazyType(typeSymbol, NonNullTypesContextFalse.Instance,  isAnnotated: false, CustomModifiers);
+                    return new NonLazyType(typeSymbol, NonNullTypesFalseContext.Instance,  isAnnotated: false, CustomModifiers);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -21,58 +21,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public string Name => TypeSymbol.Name;
         public SymbolKind Kind => TypeSymbol.Kind;
 
-#pragma warning disable CS0809
-        [Obsolete("Unsupported", error: true)]
-        public sealed override bool Equals(object other)
-#pragma warning restore CS0809
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-#pragma warning disable CS0809
-        [Obsolete("Unsupported", error: true)]
-        public sealed override int GetHashCode()
-#pragma warning restore CS0809
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator ==(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator !=(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator ==(Symbol x, TypeSymbolWithAnnotations y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator !=(Symbol x, TypeSymbolWithAnnotations y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator ==(TypeSymbolWithAnnotations x, Symbol y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
-        [Obsolete("Unsupported", error: true)]
-        public static bool operator !=(TypeSymbolWithAnnotations x, Symbol y)
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
-
         internal static readonly SymbolDisplayFormat DebuggerDisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
@@ -576,6 +524,58 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return this;
+        }
+
+#pragma warning disable CS0809
+        [Obsolete("Unsupported", error: true)]
+        public sealed override bool Equals(object other)
+#pragma warning restore CS0809
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+#pragma warning disable CS0809
+        [Obsolete("Unsupported", error: true)]
+        public sealed override int GetHashCode()
+#pragma warning restore CS0809
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator ==(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator !=(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator ==(Symbol x, TypeSymbolWithAnnotations y)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator !=(Symbol x, TypeSymbolWithAnnotations y)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator ==(TypeSymbolWithAnnotations x, Symbol y)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator !=(TypeSymbolWithAnnotations x, Symbol y)
+        {
+            throw ExceptionUtilities.Unreachable;
         }
 
         private sealed class NonLazyType : TypeSymbolWithAnnotations

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // type parameters in UnconstrainedTypeParameter_Return_03.
 
             if ((!isAnnotated && typeSymbol is TypeParameterSymbol) ||
-                (isAnnotated && typeSymbol.IsReferenceType))
+                (isAnnotated && typeSymbol.IsReferenceType && !typeSymbol.IsNullableType()))
             {
                 // T (leave unannotated)
                 // string? (leave annotated)
@@ -149,6 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // T? where T : class (leave annotated)
                 // string, int (leave unannotated)
                 // int?, T? where T : struct (add annotation)
+                // int? (error type)
                 isAnnotated = typeSymbol.IsNullableType();
             }
 
@@ -705,7 +706,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override bool? IsNullable => true;
             public override bool IsAnnotated => true;
-            public override INonNullTypesContext NonNullTypesContext => throw ExceptionUtilities.Unreachable;
+            public override INonNullTypesContext NonNullTypesContext => _underlying.NonNullTypesContext;
             public override bool IsVoid => false;
             public override bool IsSZArray() => false;
             public override bool IsStatic => false;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else
             {
-                TypeMap = TypeMap.Empty.WithConcatAlphaRename(containingMethod, this, containingMethod.NonNullTypes, out _typeParameters, out _constructedFromTypeParameters);
+                TypeMap = TypeMap.Empty.WithConcatAlphaRename(containingMethod, this, nonNullTypesContext: containingMethod, out _typeParameters, out _constructedFromTypeParameters);
             }
         }
 
@@ -170,12 +170,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit() => CalculateInterfacesToEmit();
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return ContainingAssembly.GetSpecialType(this.TypeKind == TypeKind.Struct ? SpecialType.System_ValueType : SpecialType.System_Object);
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => ContainingAssembly.GetSpecialType(this.TypeKind == TypeKind.Struct ? SpecialType.System_ValueType : SpecialType.System_Object);
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute) => BaseTypeNoUseSiteDiagnostics;
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved) => BaseTypeNoUseSiteDiagnostics;
 
         internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<Symbol> basesBeingResolved) => InterfacesNoUseSiteDiagnostics(basesBeingResolved);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -76,10 +76,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return true; }
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return ContainingAssembly.GetSpecialType(SpecialType.System_MulticastDelegate);
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
+            => ContainingAssembly.GetSpecialType(SpecialType.System_MulticastDelegate);
 
         private sealed class DelegateConstructor : SynthesizedInstanceConstructor
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -124,10 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsInterface => false;
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return _baseType;
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => _baseType;
 
         internal override ObsoleteAttributeData ObsoleteAttributeData => null;
 
@@ -145,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override AttributeUsageInfo GetAttributeUsageInfo() => AttributeUsageInfo.Default;
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute) => _baseType;
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved) => _baseType;
 
         internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<Symbol> basesBeingResolved) => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else
             {
                 var systemVoid = Binder.GetSpecialType(compilation, SpecialType.System_Void, DummySyntax(), diagnostics);
-                return new ScriptEntryPoint(containingType, TypeSymbolWithAnnotations.CreateNonNull(containingType.NonNullTypes, systemVoid));
+                return new ScriptEntryPoint(containingType, TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: containingType, systemVoid));
             }
         }
 
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override ImmutableArray<ParameterSymbol> Parameters => _parameters;
 
-            public override TypeSymbolWithAnnotations ReturnType => TypeSymbolWithAnnotations.Create(ContainingModule, _getAwaiterGetResultCall.Type);
+            public override TypeSymbolWithAnnotations ReturnType => TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, _getAwaiterGetResultCall.Type);
 
             internal override BoundBlock CreateBody(DiagnosticBag diagnostics)
             {
@@ -495,7 +495,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 Debug.Assert(containingType.IsSubmissionClass);
                 Debug.Assert(returnType.SpecialType != SpecialType.System_Void);
-                _parameters = ImmutableArray.Create<ParameterSymbol>(SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(ContainingModule, submissionArrayType), 0, RefKind.None, "submissionArray"));
+                _parameters = ImmutableArray.Create(SynthesizedParameterSymbol.Create(this,
+                    TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, submissionArrayType), 0, RefKind.None, "submissionArray"));
+
                 _returnType = returnType;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
@@ -41,9 +41,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // alpha-rename to get the implementation's type parameters
             var typeMap = interfaceMethod.ContainingType.TypeSubstitution ?? TypeMap.Empty;
-            typeMap.WithAlphaRename(interfaceMethod, this, NonNullTypes, out _typeParameters);
+            typeMap.WithAlphaRename(interfaceMethod, this, nonNullTypesContext: this, out _typeParameters);
 
-            _interfaceMethod = interfaceMethod.ConstructIfGeneric(GetTypeParametersAsTypeArguments(NonNullTypes));
+            _interfaceMethod = interfaceMethod.ConstructIfGeneric(GetTypeParametersAsTypeArguments(nonNullTypesContext: this));
             _parameters = SynthesizedParameterSymbol.DeriveParameters(_interfaceMethod, this);
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override ImmutableArray<TypeSymbolWithAnnotations> TypeArguments
         {
-            get { return GetTypeParametersAsTypeArguments(NonNullTypes); }
+            get { return GetTypeParametersAsTypeArguments(nonNullTypesContext: this); }
         }
 
         public override RefKind RefKind
@@ -260,6 +260,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ImmutableArray<string>.Empty;
         }
 
-        internal override bool NonNullTypes => false;
+        public override bool NonNullTypes => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override TypeSymbolWithAnnotations ReturnType
         {
-            get { return TypeSymbolWithAnnotations.Create(ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
+            get { return TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
         }
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return TypeSymbolWithAnnotations.Create(ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void));
+                return TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleMethodSymbol.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(underlyingMethod.ConstructedFrom == (object)underlyingMethod);
             _containingType = container;
 
-            TypeMap.Empty.WithAlphaRename(underlyingMethod, this, NonNullTypes, out _typeParameters);
-            _underlyingMethod = underlyingMethod.ConstructIfGeneric(GetTypeParametersAsTypeArguments(NonNullTypes));
+            TypeMap.Empty.WithAlphaRename(underlyingMethod, this, nonNullTypesContext: this, out _typeParameters);
+            _underlyingMethod = underlyingMethod.ConstructIfGeneric(GetTypeParametersAsTypeArguments(nonNullTypesContext: this));
         }
 
         public override bool IsTupleMethod
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return GetTypeParametersAsTypeArguments(NonNullTypes);
+                return GetTypeParametersAsTypeArguments(nonNullTypesContext: this);
             }
         }
 
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        internal override bool NonNullTypes => false;
+        public override bool NonNullTypes => false;
 
         public override int GetHashCode()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -679,10 +679,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return _underlyingType.BaseTypeNoUseSiteDiagnostics;
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => _underlyingType.BaseTypeNoUseSiteDiagnostics;
 
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved)
         {
@@ -1443,9 +1440,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _underlyingType.AddNullableTransforms(transforms);
         }
 
-        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, bool useNonNullTypes, ref int position, out TypeSymbol result)
+        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, INonNullTypesContext nonNullTypesContext, ref int position, out TypeSymbol result)
         {
-            if (_underlyingType.ApplyNullableTransforms(transforms, useNonNullTypes, ref position, out TypeSymbol underlying))
+            if (_underlyingType.ApplyNullableTransforms(transforms, nonNullTypesContext, ref position, out TypeSymbol underlying))
             {
                 result = this.WithUnderlyingType((NamedTypeSymbol)underlying);
                 return true;
@@ -1507,7 +1504,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return underlying.SelectAsArray((u, tuple) => tuple.GetTupleMemberSymbolForUnderlyingMember(u), this).WhereAsArray(m => (object)m != null);
         }
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute)
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
         {
             return _underlyingType.GetDeclaredBaseType(basesBeingResolved);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -251,10 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            return null;
-        }
+        internal sealed override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => null;
 
         internal sealed override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved = null)
         {
@@ -578,7 +575,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
         }
 
-        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, bool useNonNullTypes, ref int position, out TypeSymbol result)
+        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, INonNullTypesContext nonNullTypesContext, ref int position, out TypeSymbol result)
         {
             result = this;
             return true;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -1845,7 +1845,7 @@ public class Oblivious { }
             VerifyNonNullTypes(compilation.GetMember("Oblivious"), false);
         }
 
-        [Fact(Skip = "Hit assertion in BindNamespaceOrTypeOrAliasSymbol, since only bool is special-cased")]
+        [Fact]
         public void NonNullTypes_OnModule_WithExtraConstructor()
         {
             var obliviousLib = @"
@@ -1863,7 +1863,7 @@ namespace System.Runtime.CompilerServices
 }
 ";
 
-            var obliviousComp = CreateCompilation(obliviousLib + NonNullTypesAttributesDefinition, parseOptions: TestOptions.Regular8);
+            var obliviousComp = CreateCompilation(obliviousLib, parseOptions: TestOptions.Regular8);
             obliviousComp.VerifyDiagnostics();
             VerifyNonNullTypes(obliviousComp.GetMember("Oblivious"), expectNonNullTypes: false);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -4079,7 +4079,7 @@ abstract class A
 class B1 : A
 {
     [System.Runtime.CompilerServices.NonNullTypes(false)]
-    public override event System.Action<string?> E1 {add {} remove{}}
+    public override event System.Action<string?> E1 {add {} remove{}} // 1
     [System.Runtime.CompilerServices.NonNullTypes(false)]
     public override event System.Action<string> E2 {add {} remove{}}
 }
@@ -4089,7 +4089,7 @@ class B2 : A
     [System.Runtime.CompilerServices.NonNullTypes(false)]
     public override event System.Action<string?> E1; // 2
     [System.Runtime.CompilerServices.NonNullTypes(false)]
-    public override event System.Action<string> E2; // 2
+    public override event System.Action<string> E2;
 
     void Dummy()
     {
@@ -4100,7 +4100,14 @@ class B2 : A
 ";
             var compilation = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            compilation.VerifyDiagnostics();
+            compilation.VerifyDiagnostics(
+                // (27,50): warning CS8608: Nullability of reference types in type doesn't match overridden member.
+                //     public override event System.Action<string?> E1; // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E1").WithLocation(27, 50),
+                // (19,50): warning CS8608: Nullability of reference types in type doesn't match overridden member.
+                //     public override event System.Action<string?> E1 {add {} remove{}} // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E1").WithLocation(19, 50)
+                );
         }
 
         [Fact]
@@ -4715,7 +4722,11 @@ class B : A
             var compilation = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             // PROTOTYPE(NullableReferenceTypes): Should report return type mismatch
             // for M1 and M2 (see https://github.com/dotnet/roslyn/issues/28684).
-            compilation.VerifyDiagnostics();
+            compilation.VerifyDiagnostics(
+                // (18,31): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override string?[] M1()
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M1").WithLocation(18, 31)
+                );
         }
 
         [Fact]
@@ -5023,7 +5034,11 @@ class B : A
 ";
             var compilation = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
-            compilation.VerifyDiagnostics();
+            compilation.VerifyDiagnostics(
+                // (13,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
+                //     public override void M1(string?[] x)
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M1").WithArguments("x").WithLocation(13, 26)
+                );
             // PROTOTYPE(NullableReferenceTypes): should warn on B.M1 and B.M2
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -221,10 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
-        {
-            throw new NotImplementedException();
-        }
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => throw new NotImplementedException();
 
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved)
         {
@@ -236,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             throw new NotImplementedException();
         }
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute)
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
         {
             throw new NotImplementedException();
         }

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -9085,7 +9085,11 @@ End Module
             Assert.Equal("I1#I2#I3#I5#I6#I7#Item1#Item2#Item3#Item4#Item5#Item6#Item7#Item8#Item9#Rest", fields.Join("#"))
         End Sub
 
-        <Fact>
+        ' The NonNullTypes context for nested tuple types is using a dummy rather than actual context from surrounding code.
+        ' This does not affect `IsNullable`, but it affects `IsAnnotatedWithNonNullTypesContext`, which is used in comparisons.
+        ' So when we copy modifiers (re-applying nullability information, including actual NonNullTypes context), we make the comparison fail.
+        ' I think the solution is to never use a dummy context, even for value types.
+        <Fact(Skip:="PROTOTYPE(NullableReferenceTypes): Hitting assertion in  CopyTypeCustomModifiers")>
         Public Sub TupleNamesFromCS001()
 
             Dim csCompilation = CreateCSharpCompilation("CSDll",

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1683,8 +1683,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
 
             var indexedTypeParameters = IndexedTypeParameterSymbol.Take(arity);
-            var candidateTypeMap = new TypeMap(NonNullTypesContextFalse.Instance, candidateTypeParameters, indexedTypeParameters, allowAlpha: true);
-            var desiredTypeMap = new TypeMap(NonNullTypesContextFalse.Instance, desiredTypeParameters, indexedTypeParameters, allowAlpha: true);
+            var candidateTypeMap = new TypeMap(NonNullTypesFalseContext.Instance, candidateTypeParameters, indexedTypeParameters, allowAlpha: true);
+            var desiredTypeMap = new TypeMap(NonNullTypesFalseContext.Instance, desiredTypeParameters, indexedTypeParameters, allowAlpha: true);
 
             return MemberSignatureComparer.HaveSameConstraints(candidateTypeParameters, candidateTypeMap, desiredTypeParameters, desiredTypeMap);
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1682,10 +1682,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 return true;
             }
 
-            bool nonNullTypes = false;
             var indexedTypeParameters = IndexedTypeParameterSymbol.Take(arity);
-            var candidateTypeMap = new TypeMap(nonNullTypes, candidateTypeParameters, indexedTypeParameters, allowAlpha: true);
-            var desiredTypeMap = new TypeMap(nonNullTypes, desiredTypeParameters, indexedTypeParameters, allowAlpha: true);
+            var candidateTypeMap = new TypeMap(NonNullTypesContextFalse.Instance, candidateTypeParameters, indexedTypeParameters, allowAlpha: true);
+            var desiredTypeMap = new TypeMap(NonNullTypesContextFalse.Instance, desiredTypeParameters, indexedTypeParameters, allowAlpha: true);
 
             return MemberSignatureComparer.HaveSameConstraints(candidateTypeParameters, candidateTypeMap, desiredTypeParameters, desiredTypeMap);
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 (tp, i, arg) => (TypeParameterSymbol)new EETypeParameterSymbol(this, tp, i, getTypeMap),
                 (object)null);
             _allTypeParameters = container.TypeParameters.Concat(_typeParameters);
-            this.TypeMap = new TypeMap(nonNullTypes: false, allSourceTypeParameters, _allTypeParameters);
+            this.TypeMap = new TypeMap(NonNullTypesContextFalse.Instance, allSourceTypeParameters, _allTypeParameters);
 
             EENamedTypeSymbol.VerifyTypeParameters(this, _typeParameters);
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 (tp, i, arg) => (TypeParameterSymbol)new EETypeParameterSymbol(this, tp, i, getTypeMap),
                 (object)null);
             _allTypeParameters = container.TypeParameters.Concat(_typeParameters);
-            this.TypeMap = new TypeMap(NonNullTypesContextFalse.Instance, allSourceTypeParameters, _allTypeParameters);
+            this.TypeMap = new TypeMap(NonNullTypesFalseContext.Instance, allSourceTypeParameters, _allTypeParameters);
 
             EENamedTypeSymbol.VerifyTypeParameters(this, _typeParameters);
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 (tp, i, arg) => (TypeParameterSymbol)new EETypeParameterSymbol(this, tp, i, getTypeMap),
                 (object)null);
 
-            typeMap = new TypeMap(nonNullTypesContext: NonNullTypesContextFalse.Instance, this.SourceTypeParameters, _typeParameters);
+            typeMap = new TypeMap(nonNullTypesContext: NonNullTypesFalseContext.Instance, this.SourceTypeParameters, _typeParameters);
 
             VerifyTypeParameters(this, _typeParameters);
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 (tp, i, arg) => (TypeParameterSymbol)new EETypeParameterSymbol(this, tp, i, getTypeMap),
                 (object)null);
 
-            typeMap = new TypeMap(nonNullTypes: false, this.SourceTypeParameters, _typeParameters);
+            typeMap = new TypeMap(nonNullTypesContext: NonNullTypesContextFalse.Instance, this.SourceTypeParameters, _typeParameters);
 
             VerifyTypeParameters(this, _typeParameters);
 
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved, bool ignoreNonNullTypesAttribute)
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
         {
             return _baseType;
         }
@@ -260,9 +260,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal override NamedTypeSymbol GetBaseTypeNoUseSiteDiagnostics(bool ignoreNonNullTypesAttribute)
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
         {
-            return _baseType;
+            get { return _baseType; }
         }
 
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved)


### PR DESCRIPTION
This PR reverts the cycle mitigations put in place in https://github.com/dotnet/roslyn/pull/28320 and delays the evaluation of `NonNullTypes` by using `INonNullTypesContext`. 
This generally holds the symbol who can give us the answer, but in some cases, we also use some dummy contexts (which always answer `NonNullTypes==true` or `NonNullTypes==false`).

I'm still working on a couple of test regressions (in OHI).