### PR TITLE
Fix race condition where Encapsulate Field could silently fail

### DIFF
--- a/src/EditorFeatures/Core/Implementation/EncapsulateField/AbstractEncapsulateFieldCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/EncapsulateField/AbstractEncapsulateFieldCommandHandler.cs
@@ -82,6 +82,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EncapsulateField
 
                 var service = document.GetLanguageService<AbstractEncapsulateFieldService>();
 
+                var result = service.EncapsulateFieldAsync(document, spans.First().Span.ToTextSpan(), true, cancellationToken).WaitAndGetResult(cancellationToken);
+                var finalSolution = result?.GetSolutionAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+
                 // This is the last point where the operation can be canceled by the operation context
                 // managed by the command system. Make sure to not ignore a cancellation request which
                 // occurred prior to this line before proceeding with the Roslyn-managed dialogs.
@@ -97,16 +100,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EncapsulateField
                 // a different one for future operations in this command handler.
                 cancellationToken = CancellationToken.None;
 
-                var result = service.EncapsulateFieldAsync(document, spans.First().Span.ToTextSpan(), true, cancellationToken).WaitAndGetResult(cancellationToken);
-
                 if (result == null)
                 {
                     var notificationService = workspace.Services.GetService<INotificationService>();
                     notificationService.SendNotification(EditorFeaturesResources.Please_select_the_definition_of_the_field_to_encapsulate, severity: NotificationSeverity.Error);
                     return false;
                 }
-
-                var finalSolution = result.GetSolutionAsync(cancellationToken).WaitAndGetResult(cancellationToken);
 
                 var previewService = workspace.Services.GetService<IPreviewDialogService>();
                 if (previewService != null)

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
@@ -32,7 +32,7 @@ namespace myNamespace
     }
 }";
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/19816")]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateThroughCommand()
         {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEncapsulateField.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEncapsulateField.cs
@@ -27,7 +27,7 @@ Module Module1
     End Sub
 End Module";
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/19816")]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateThroughCommand()
         {


### PR DESCRIPTION
Fixes #19816

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
