### PR TITLE
Make module-level NonNullTypes explicit in tests

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -901,14 +901,15 @@ namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     [NonNullTypes(true)]
+    [System.Obsolete(""obsolete"")]
     class NonNullTypesAttribute : Attribute
     {
         public NonNullTypesAttribute(bool flag = true) { }
     }
 }
 ";
-            var comp = CreateCompilation(new[] { source }, parseOptions: TestOptions.Regular8);
             // PROTOTYPE(NullableReferenceTypes): Why isn't the usage of NonNullTypes reported as obsolete?
+            var comp = CreateCompilation(new[] { source }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics();
 
             VerifyNonNullTypes(comp.GetMember("System.Runtime.CompilerServices.NonNullTypesAttribute"), true);
@@ -2090,7 +2091,7 @@ class B<T> : A<T> where T : A<T>.I
             var comp = CreateCompilation(new[] { source }, parseOptions: TestOptions.Regular7);
             comp.VerifyDiagnostics();
 
-            // PROTOTYPE(NullableReferenceTypes): We need to poison the attribute
+            // PROTOTYPE(NullableReferenceTypes): We need to poison the attribute (currently asserts in VerifyUsesOfNullability)
             //var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular7);
             //comp.VerifyDiagnostics();
 
@@ -29781,7 +29782,7 @@ class P
             // No warnings with C#7.3.
             //comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular7_3);
             //comp.VerifyDiagnostics();
-            // PROTOTYPE(NullableReferenceTypes): poison NonNullTypes attribute
+            // PROTOTYPE(NullableReferenceTypes): We need to poison the attribute (currently asserts in VerifyUsesOfNullability)
         }
 
         [WorkItem(26626, "https://github.com/dotnet/roslyn/issues/26626")]

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -354,8 +354,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             string sourceFileName = "",
             bool skipUsesIsNullable = false) => CreateCompilation(source, references, options, parseOptions, TargetFramework.Mscorlib45, assemblyName, sourceFileName, skipUsesIsNullable);
 
+        public static CSharpCompilation CreateCompilationWithMscorlib45(
+            string[] source,
+            IEnumerable<MetadataReference> references = null,
+            CSharpCompilationOptions options = null,
+            CSharpParseOptions parseOptions = null,
+            string assemblyName = "",
+            string sourceFileName = "",
+            bool skipUsesIsNullable = false) => CreateCompilation(source, references, options, parseOptions, TargetFramework.Mscorlib45, assemblyName, sourceFileName, skipUsesIsNullable);
+
         public static CSharpCompilation CreateCompilationWithMscorlib46(
             CSharpTestSource source,
+            IEnumerable<MetadataReference> references = null,
+            CSharpCompilationOptions options = null,
+            CSharpParseOptions parseOptions = null,
+            string assemblyName = "",
+            string sourceFileName = "") => CreateCompilation(source, references, options, parseOptions, TargetFramework.Mscorlib46, assemblyName, sourceFileName);
+
+        public static CSharpCompilation CreateCompilationWithMscorlib46(
+            string[] source,
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
@@ -380,6 +397,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 
         public static CSharpCompilation CreateCompilationWithMscorlib40AndSystemCore(
             CSharpTestSource source,
+            IEnumerable<MetadataReference> references = null,
+            CSharpCompilationOptions options = null,
+            CSharpParseOptions parseOptions = null,
+            string assemblyName = "",
+            string sourceFileName = "") => CreateCompilation(source, references, options, parseOptions, TargetFramework.Mscorlib40AndSystemCore, assemblyName, sourceFileName);
+
+        public static CSharpCompilation CreateCompilationWithMscorlib40AndSystemCore(
+            string[] source,
             IEnumerable<MetadataReference> references = null,
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,


### PR DESCRIPTION
While trying to fix some cycles when binding NonNullTypes on types (https://github.com/dotnet/roslyn/pull/28491), I tried removing the `SetUnknownNullabilityForReferenceTypesIfNecessary` method (which causes cycles by pulling on `NonNullTypes`). But that caused many regressions, since that method is essential when the implicit context is `[NonNullTypes(true)]`. So, in order to make progress, I took a stab at changing that implicit context.
 
This PR contains most of the test changes in preparation for such a transition (about a dozen tests need further investigation, I think). I'll let Fred go ahead with making that change as planned, but this should make the transition easier.

There's also a few new tests which came from that branch. I can remove them if you prefer, but I figured it doesn't hurt to leave them.

Tagging @cston @333fred 