### PR TITLE
Remove this recommendation for anonymous functions in static methods

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
@@ -490,6 +490,7 @@ $$");
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
         public async Task TestInNestedLambdaExpressionInAnonymousMethod()
         {
@@ -509,6 +510,7 @@ $$");
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
         public async Task TestInNestedAnonymousInLambdaExpression()
         {
@@ -528,6 +530,7 @@ $$");
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
         public async Task TestInNestedAnonymousMethodInLambdaExpressionInStaticMethod()
         {
@@ -547,6 +550,7 @@ $$");
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
         public async Task TestInNestedLambdaExpressionInAnonymousMethodInStaticMethod()
         {
@@ -562,6 +566,34 @@ $$");
                 $$
             };
         };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedLambdaExpressionInAProperty()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    Action A
+    {
+        get { return delegate { $$ } }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedLambdaExpressionInAStaticProperty()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static Action A
+    {
+        get { return delegate { $$ } }
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
@@ -572,13 +572,13 @@ $$");
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
-        public async Task TestInNestedLambdaExpressionInAProperty()
+        public async Task TestInAnonymousMethodInAProperty()
         {
             await VerifyKeywordAsync(
 @"class C
 {
-    Action A
-    {
+    Action A 
+    { 
         get { return delegate { $$ } }
     }
 }");
@@ -586,7 +586,40 @@ $$");
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
-        public async Task TestInNestedLambdaExpressionInAStaticProperty()
+        public async Task TestInAnonymousMethodInAPropertyInitializer()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    Action B { get; } = delegate { $$ }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInAnonymousMethodInAExpressionProperty()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    Action A => delegate { $$ }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInAnonymousMethodInAFieldInitializer()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    Action A = delegate { $$ }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInAnonymousMethodInAStaticProperty()
         {
             await VerifyAbsenceAsync(
 @"class C
@@ -598,6 +631,38 @@ $$");
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInAnonymousMethodInAStaticPropertyInitializer()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static Action B { get; } = delegate { $$ }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInAnonymousMethodInAStaticExpressionProperty()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static Action A => delegate { $$ }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInAnonymousMethodInAStaticFieldInitializer()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static Action A = delegate { $$ }
+}");
+        }
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAttribute()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
@@ -343,6 +343,230 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInAnonymousMethod()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    int Method()
+    {
+        Action a = delegate
+        {
+            $$
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedAnonymousMethod()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    int Method()
+    {
+        Action a = delegate
+        {
+            Action b = delegate
+            {
+                $$
+            };
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInAnonymousMethodInStaticMethod()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static int Method()
+    {
+        Action a = delegate
+        {
+            $$
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedAnonymousMethodInStaticMethod()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static int Method()
+    {
+        Action a = delegate
+        {
+            Action b = delegate
+            {
+                $$
+            };
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInLambdaExpression()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    int Method()
+    {
+        Action a = () =>
+        {
+            $$
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedLambdaExpression()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    int Method()
+    {
+        Action a = () =>
+        {
+            Action b = () =>
+            {
+                $$
+            };
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInLambdaExpressionInStaticMethod()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static int Method()
+    {
+        Action a = () =>
+        {
+            $$
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedLambdaExpressionInStaticMethod()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static int Method()
+    {
+        Action a = () =>
+        {
+            Action b = () =>
+            {
+                $$
+            };
+        };
+    }
+}");
+        }
+
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedLambdaExpressionInAnonymousMethod()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    int Method()
+    {
+        Action a = delegate
+        {
+            Action b = () =>
+            {
+                $$
+            };
+        };
+    }
+}");
+        }
+
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedAnonymousInLambdaExpression()
+        {
+            await VerifyKeywordAsync(
+@"class C
+{
+    int Method()
+    {
+        Action a = () =>
+        {
+            Action b = delegate
+            {
+                $$
+            };
+        };
+    }
+}");
+        }
+
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedAnonymousMethodInLambdaExpressionInStaticMethod()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static int Method()
+    {
+        Action a = () =>
+        {
+            Action b = delegate
+            {
+                $$
+            };
+        };
+    }
+}");
+        }
+
+        [WorkItem(27923, "https://github.com/dotnet/roslyn/issues/27923")]
+        public async Task TestInNestedLambdaExpressionInAnonymousMethodInStaticMethod()
+        {
+            await VerifyAbsenceAsync(
+@"class C
+{
+    static int Method()
+    {
+        Action a = delegate
+        {
+            Action b = () =>
+            {
+                $$
+            };
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAttribute()
         {
             await VerifyKeywordAsync(

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1772,10 +1772,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             var enclosingSymbol = semanticModel.GetEnclosingSymbol(targetToken.SpanStart, cancellationToken);
 
-            while (enclosingSymbol is IMethodSymbol method && enclosingSymbol.ContainingSymbol is IMethodSymbol)
+            while (enclosingSymbol is IMethodSymbol && enclosingSymbol.ContainingSymbol is IMethodSymbol)
             {
                 // It is allowed to reference the instance (`this`) within a local function or anonymous function, as long as the containing method allows it
-                enclosingSymbol = method.ContainingSymbol;
+                enclosingSymbol = enclosingSymbol.ContainingSymbol;
             }
 
             return !enclosingSymbol.IsStatic;

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1772,7 +1772,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             var enclosingSymbol = semanticModel.GetEnclosingSymbol(targetToken.SpanStart, cancellationToken);
 
-            while (enclosingSymbol is IMethodSymbol && enclosingSymbol.ContainingSymbol is IMethodSymbol)
+            while (enclosingSymbol is IMethodSymbol method && (method.MethodKind == MethodKind.LocalFunction || method.MethodKind == MethodKind.AnonymousFunction))
             {
                 // It is allowed to reference the instance (`this`) within a local function or anonymous function, as long as the containing method allows it
                 enclosingSymbol = enclosingSymbol.ContainingSymbol;

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1772,7 +1772,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             var enclosingSymbol = semanticModel.GetEnclosingSymbol(targetToken.SpanStart, cancellationToken);
 
-            while (enclosingSymbol is IMethodSymbol method && method.MethodKind == MethodKind.LocalFunction)
+            while (enclosingSymbol is IMethodSymbol method && (method.MethodKind == MethodKind.LocalFunction || method.MethodKind == MethodKind.AnonymousFunction))
             {
                 // It is allowed to reference the instance (`this`) within a local function, as long as the containing method allows it
                 enclosingSymbol = method.ContainingSymbol;

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1772,9 +1772,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             var enclosingSymbol = semanticModel.GetEnclosingSymbol(targetToken.SpanStart, cancellationToken);
 
-            while (enclosingSymbol is IMethodSymbol method && (method.MethodKind == MethodKind.LocalFunction || method.MethodKind == MethodKind.AnonymousFunction))
+            while (enclosingSymbol is IMethodSymbol method && enclosingSymbol.ContainingSymbol is IMethodSymbol)
             {
-                // It is allowed to reference the instance (`this`) within a local function, as long as the containing method allows it
+                // It is allowed to reference the instance (`this`) within a local function or anonymous function, as long as the containing method allows it
                 enclosingSymbol = method.ContainingSymbol;
             }
 


### PR DESCRIPTION
### Customer scenario

`this` keyword should not be offered as completion for anonymous functions in static methods

### Bugs this fixes

Fixes #27923 

### Workarounds, if any

Do not select `this` when offered for anonymous functions in static methods.

### Risk

Little risk.

### Performance impact

Low.

### Is this a regression from a previous update?

No.

### Root cause analysis

Missed this in [PR #27690](https://github.com/dotnet/roslyn/pull/27690).

### How was the bug found?

@Neme12 found this in [PR #27690](https://github.com/dotnet/roslyn/pull/27690)

### Test documentation updated?

Test documentation update is not needed for this PR.

</details>
