### PR TITLE
Prioritize NavigateTo searches to care most about the current actives docs/project.

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -1021,7 +1021,8 @@ class D
 </Workspace>
 ", exportProvider: TestExportProvider.ExportProviderWithCSharpAndVisualBasic))
             {
-                _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+                _provider = new NavigateToItemProvider(
+                    workspace, AsynchronousOperationListenerProvider.NullListener, documentTrackingService: null);
                 _aggregator = new NavigateToTestAggregator(_provider);
 
                 var items = await _aggregator.GetItemsAsync("VisibleMethod");

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -113,14 +113,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                     var visibleDocsFromProject = visibleDocs.Where(d => d.Project == activeProject);
                     var priorityDocs = ImmutableArray.Create(activeDocOpt).AddRange(visibleDocsFromProject);
 
-                    // Search the current project first.  That way we can deliver
-                    // results that are closer in scope to the user quicker without
-                    // forcing them to do something like NavToInCurrentDoc
+                    // Search the active project first.  That way we can deliver results that are
+                    // closer in scope to the user quicker without forcing them to do something like
+                    // NavToInCurrentDoc
                     await Task.Run(() => SearchAsync(activeProject, priorityDocs), _cancellationToken).ConfigureAwait(false);
                 }
 
-                // Now, process all visible docs that were not processed in the project for the
-                // active doc.
+                // Now, process all visible docs that were not from the active project.
                 var tasks = new List<Task>();
                 foreach (var group in visibleDocs.GroupBy(d => d.Project))
                 {

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
         private class Searcher
         {
             private readonly Solution _solution;
+            private readonly IAsynchronousOperationListener _asyncListener;
+            private readonly IDocumentTrackingService _documentTrackingService;
             private readonly INavigateToItemDisplayFactory _displayFactory;
             private readonly INavigateToCallback _callback;
             private readonly string _searchPattern;
@@ -30,12 +32,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             private readonly IImmutableSet<string> _kinds;
             private readonly Document _currentDocument;
             private readonly ProgressTracker _progress;
-            private readonly IAsynchronousOperationListener _asyncListener;
             private readonly CancellationToken _cancellationToken;
 
             public Searcher(
                 Solution solution,
                 IAsynchronousOperationListener asyncListener,
+                IDocumentTrackingService documentTrackingService,
                 INavigateToItemDisplayFactory displayFactory,
                 INavigateToCallback callback,
                 string searchPattern,
@@ -44,6 +46,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 CancellationToken cancellationToken)
             {
                 _solution = solution;
+                _asyncListener = asyncListener;
+                _documentTrackingService = documentTrackingService;
                 _displayFactory = displayFactory;
                 _callback = callback;
                 _searchPattern = searchPattern;
@@ -51,7 +55,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 _kinds = kinds;
                 _cancellationToken = cancellationToken;
                 _progress = new ProgressTracker((_, current, maximum) => callback.ReportProgress(current, maximum));
-                _asyncListener = asyncListener;
 
                 if (_searchCurrentDocument)
                 {
@@ -75,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                         // If the workspace is tracking documents, use that to prioritize our search
                         // order.  That way we provide results for the documents the user is working
                         // on faster than the rest of the solution.
-                        var docTrackingService = workspace.Services.GetService<IDocumentTrackingService>();
+                        var docTrackingService = _documentTrackingService ?? workspace.Services.GetService<IDocumentTrackingService>();
                         if (docTrackingService != null)
                         {
                             await SearchProjectsInPriorityOrder(docTrackingService).ConfigureAwait(false);

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -122,14 +122,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
 
                 // Now, process all visible docs that were not from the active project.
                 var tasks = new List<Task>();
-                foreach (var group in visibleDocs.GroupBy(d => d.Project))
+                foreach (var (currentProject, priorityDocs) in visibleDocs.GroupBy(d => d.Project))
                 {
-                    var currentProject = group.Key;
-
                     // make sure we only process this project if we didn't already process it above.
                     if (processedProjects.Add(currentProject))
                     {
-                        tasks.Add(Task.Run(() => SearchAsync(currentProject, group.ToImmutableArray()), _cancellationToken));
+                        tasks.Add(Task.Run(() => SearchAsync(currentProject, priorityDocs.ToImmutableArray()), _cancellationToken));
                     }
                 }
 

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -144,6 +144,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                         tasks.Add(Task.Run(() => SearchAsync(currentProject, ImmutableArray<Document>.Empty), _cancellationToken));
                     }
                 }
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
             }
 
             private async Task SearchAllProjectsAsync()

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -100,6 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                                                     .Select(d => _solution.GetDocument(d))
                                                     .Where(d => d != activeDocOpt)
                                                     .WhereNotNull()
+                                                    .Distinct()
                                                     .ToImmutableArray();
 
                 // First, if there's an active document, search that project first, prioritizing

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             public Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
                 => _navigateToSearchService.SearchDocumentAsync(document, searchPattern, cancellationToken);
 
-            public Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
+            public Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
                 => _navigateToSearchService.SearchProjectAsync(project, searchPattern, cancellationToken);
         }
     }

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -18,19 +18,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
     {
         private readonly Workspace _workspace;
         private readonly IAsynchronousOperationListener _asyncListener;
+        private readonly IDocumentTrackingService _documentTrackingService;
         private readonly INavigateToItemDisplayFactory _displayFactory;
 
         private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
         public NavigateToItemProvider(
             Workspace workspace,
-            IAsynchronousOperationListener asyncListener)
+            IAsynchronousOperationListener asyncListener,
+            IDocumentTrackingService documentTrackingService)
         {
             Contract.ThrowIfNull(workspace);
             Contract.ThrowIfNull(asyncListener);
 
             _workspace = workspace;
             _asyncListener = asyncListener;
+            _documentTrackingService = documentTrackingService;
             _displayFactory = new NavigateToItemDisplayFactory();
         }
 
@@ -142,6 +145,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             var searcher = new Searcher(
                 _workspace.CurrentSolution,
                 _asyncListener,
+                _documentTrackingService,
                 _displayFactory,
                 callback,
                 searchValue,

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProviderFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProviderFactory.cs
@@ -36,7 +36,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 return false;
             }
 
-            provider = new NavigateToItemProvider(workspace, _asyncListener);
+            provider = new NavigateToItemProvider(
+                workspace, _asyncListener, documentTrackingService: null);
             return true;
         }
     }

--- a/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
+++ b/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
@@ -64,7 +64,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
 
         internal async Task TestAsync(string content, Func<TestWorkspace, Task> body, bool outOfProcess)
         {
-            using (var workspace = SetupWorkspace(content))
+            await TestAsync(content, body, outOfProcess, null);
+            await TestAsync(content, body, outOfProcess, w => new FirstDocIsActiveDocumentTrackingService(w));
+            await TestAsync(content, body, outOfProcess, w => new FirstDocIsVisibleDocumentTrackingService(w));
+            await TestAsync(content, body, outOfProcess, w => new FirstDocIsActiveAndVisibleDocumentTrackingService(w));
+        }
+
+        internal async Task TestAsync(
+            string content, Func<TestWorkspace, Task> body, bool outOfProcess, 
+            Func<TestWorkspace, IDocumentTrackingService> createTrackingService)
+        {
+            using (var workspace = SetupWorkspace(
+                content, TestExportProvider.ExportProviderWithCSharpAndVisualBasic, createTrackingService))
             {
                 workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)
                                                      .WithChangedOption(RemoteFeatureOptions.OutOfProcessAllowed, outOfProcess)
@@ -74,23 +85,30 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
             }
         }
 
-        protected TestWorkspace SetupWorkspace(XElement workspaceElement)
+        private protected TestWorkspace SetupWorkspace(
+            XElement workspaceElement, ExportProvider exportProvider, 
+            Func<TestWorkspace, IDocumentTrackingService> createTrackingService)
         {
-            var workspace = TestWorkspace.Create(workspaceElement, exportProvider: TestExportProvider.ExportProviderWithCSharpAndVisualBasic);
-            InitializeWorkspace(workspace);
+            var workspace = TestWorkspace.Create(workspaceElement, exportProvider: exportProvider);
+            var trackingService = createTrackingService?.Invoke(workspace);
+            InitializeWorkspace(workspace, trackingService);
             return workspace;
         }
 
-        protected TestWorkspace SetupWorkspace(string content)
+        private protected TestWorkspace SetupWorkspace(
+            string content, ExportProvider exportProvider, 
+            Func<TestWorkspace, IDocumentTrackingService> createTrackingService)
         {
-            var workspace = CreateWorkspace(content, TestExportProvider.ExportProviderWithCSharpAndVisualBasic);
-            InitializeWorkspace(workspace);
+            var workspace = CreateWorkspace(content, exportProvider);
+            var trackingService = createTrackingService?.Invoke(workspace);
+            InitializeWorkspace(workspace, trackingService);
             return workspace;
         }
 
-        internal void InitializeWorkspace(TestWorkspace workspace)
+        internal void InitializeWorkspace(
+            TestWorkspace workspace, IDocumentTrackingService documentTrackingService)
         {
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, documentTrackingService);
             _aggregator = new NavigateToTestAggregator(_provider);
         }
 
@@ -181,4 +199,63 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
         }
 #pragma warning restore CS0618 // MatchKind is obsolete
     }
+
+#pragma warning disable CS0067
+    public class FirstDocIsActiveDocumentTrackingService : IDocumentTrackingService
+    {
+        private readonly Workspace _workspace;
+
+        public FirstDocIsActiveDocumentTrackingService(Workspace workspace)
+        {
+            _workspace = workspace;
+        }
+
+        public event EventHandler<DocumentId> ActiveDocumentChanged;
+        public event EventHandler<EventArgs> NonRoslynBufferTextChanged;
+
+        public DocumentId GetActiveDocument()
+            => _workspace.CurrentSolution.Projects.First().DocumentIds.First();
+
+        public ImmutableArray<DocumentId> GetVisibleDocuments()
+            => ImmutableArray<DocumentId>.Empty;
+    }
+
+    public class FirstDocIsVisibleDocumentTrackingService : IDocumentTrackingService
+    {
+        private readonly Workspace _workspace;
+
+        public FirstDocIsVisibleDocumentTrackingService(Workspace workspace)
+        {
+            _workspace = workspace;
+        }
+
+        public event EventHandler<DocumentId> ActiveDocumentChanged;
+        public event EventHandler<EventArgs> NonRoslynBufferTextChanged;
+
+        public DocumentId GetActiveDocument()
+            => null;
+
+        public ImmutableArray<DocumentId> GetVisibleDocuments()
+            => ImmutableArray.Create(_workspace.CurrentSolution.Projects.First().DocumentIds.First());
+    }
+
+    public class FirstDocIsActiveAndVisibleDocumentTrackingService : IDocumentTrackingService
+    {
+        private readonly Workspace _workspace;
+
+        public FirstDocIsActiveAndVisibleDocumentTrackingService(Workspace workspace)
+        {
+            _workspace = workspace;
+        }
+
+        public event EventHandler<DocumentId> ActiveDocumentChanged;
+        public event EventHandler<EventArgs> NonRoslynBufferTextChanged;
+
+        public DocumentId GetActiveDocument()
+            => _workspace.CurrentSolution.Projects.First().DocumentIds.First();
+
+        public ImmutableArray<DocumentId> GetVisibleDocuments()
+            => ImmutableArray.Create(_workspace.CurrentSolution.Projects.First().DocumentIds.First());
+    }
+#pragma warning restore
 }

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -739,7 +739,7 @@ Public Class Goo
 End Class
                         </Document>
                     </Project>
-                </Workspace>)
+                </Workspace>, exportProvider:=Nothing, createTrackingService:=Nothing)
 
                 Dim item As NavigateToItem = (Await _aggregator.GetItemsAsync("G")).Single()
                 Dim itemDisplay As INavigateToItemDisplay = item.DisplayFactory.CreateItemDisplay(item)

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                                                .ToImmutableArray();
 
             var highPriDocsSet = highPriDocs.ToSet();
-            var lowPriDocs = project.Documents.Where(d => !highPriDocs.Contains(d));
+            var lowPriDocs = project.Documents.Where(d => !highPriDocsSet.Contains(d));
 
             var orderedDocs = highPriDocs.AddRange(lowPriDocs);
 

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -172,12 +172,10 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
             var orderedDocs = highPriDocs.AddRange(lowPriDocs);
 
-#if DEBUG
             Debug.Assert(priorityDocuments.All(d => project.ContainsDocument(d.Id)), "Priority docs included doc not from project.");
             Debug.Assert(orderedDocs.Length == project.Documents.Count(), "Didn't have the same number of project after ordering them!");
             Debug.Assert(orderedDocs.Distinct().Count() == orderedDocs.Count(), "Ordered list contained a duplicate!");
             Debug.Assert(project.Documents.All(d => orderedDocs.Contains(d)), "At least one document from the project was missing from the ordered list!");
-#endif
 
             foreach (var document in orderedDocs)
             {

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -173,6 +173,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             var orderedDocs = highPriDocs.AddRange(lowPriDocs);
 
 #if DEBUG
+            Debug.Assert(priorityDocuments.All(d => project.ContainsDocument(d.Id)), "Priority docs included doc not from project.");
             Debug.Assert(orderedDocs.Length == project.Documents.Count(), "Didn't have the same number of project after ordering them!");
             Debug.Assert(orderedDocs.Distinct().Count() == orderedDocs.Count(), "Ordered list contained a duplicate!");
             Debug.Assert(project.Documents.All(d => orderedDocs.Contains(d)), "At least one document from the project was missing from the ordered list!");

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
@@ -25,13 +25,13 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         }
 
         private async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInRemoteProcessAsync(
-            RemoteHostClient client, Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
+            RemoteHostClient client, Project project, Document activeDocumentOpt, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             var solution = project.Solution;
 
             var serializableResults = await client.TryRunCodeAnalysisRemoteAsync<IList<SerializableNavigateToSearchResult>>(
                 solution, nameof(IRemoteNavigateToSearchService.SearchProjectAsync),
-                new object[] { project.Id, searchPattern, kinds.ToArray() }, cancellationToken).ConfigureAwait(false);
+                new object[] { project.Id, activeDocumentOpt?.Id, searchPattern, kinds.ToArray() }, cancellationToken).ConfigureAwait(false);
 
             return serializableResults.SelectAsArray(r => r.Rehydrate(solution));
         }

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
@@ -25,13 +25,13 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         }
 
         private async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInRemoteProcessAsync(
-            RemoteHostClient client, Project project, Document activeDocumentOpt, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
+            RemoteHostClient client, Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             var solution = project.Solution;
 
             var serializableResults = await client.TryRunCodeAnalysisRemoteAsync<IList<SerializableNavigateToSearchResult>>(
                 solution, nameof(IRemoteNavigateToSearchService.SearchProjectAsync),
-                new object[] { project.Id, activeDocumentOpt?.Id, searchPattern, kinds.ToArray() }, cancellationToken).ConfigureAwait(false);
+                new object[] { project.Id, priorityDocuments.Select(d => d.Id).ToArray(), searchPattern, kinds.ToArray() }, cancellationToken).ConfigureAwait(false);
 
             return serializableResults.SelectAsArray(r => r.Rehydrate(solution));
         }

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
@@ -42,18 +42,18 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         }
 
         public async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(
-            Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
+            Project project, Document activeDocumentOpt, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             var client = await TryGetRemoteHostClientAsync(project, cancellationToken).ConfigureAwait(false);
             if (client == null)
             {
                 return await SearchProjectInCurrentProcessAsync(
-                    project, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
+                    project, activeDocumentOpt, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 return await SearchProjectInRemoteProcessAsync(
-                    client, project, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
+                    client, activeDocumentOpt, project, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
@@ -42,18 +42,18 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         }
 
         public async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(
-            Project project, Document activeDocumentOpt, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
+            Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
         {
             var client = await TryGetRemoteHostClientAsync(project, cancellationToken).ConfigureAwait(false);
             if (client == null)
             {
                 return await SearchProjectInCurrentProcessAsync(
-                    project, activeDocumentOpt, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
+                    project, priorityDocuments, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 return await SearchProjectInRemoteProcessAsync(
-                    client, activeDocumentOpt, project, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
+                    client, project, priorityDocuments, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             get;
         }
 
-        Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, Document activeDocumentOpt, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
+        Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
         Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             get;
         }
 
-        Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
+        Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, Document activeDocumentOpt, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
         Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
@@ -10,6 +10,6 @@ namespace Microsoft.CodeAnalysis.NavigateTo
     internal interface IRemoteNavigateToSearchService
     {
         Task<IList<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern, string[] kinds, CancellationToken cancellationToken);
-        Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, string searchPattern, string[] kinds, CancellationToken cancellationToken);
+        Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, DocumentId activeDocumentIdOpt, string searchPattern, string[] kinds, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
@@ -10,6 +10,6 @@ namespace Microsoft.CodeAnalysis.NavigateTo
     internal interface IRemoteNavigateToSearchService
     {
         Task<IList<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern, string[] kinds, CancellationToken cancellationToken);
-        Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, DocumentId activeDocumentIdOpt, string searchPattern, string[] kinds, CancellationToken cancellationToken);
+        Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, DocumentId[] priorityDocumentIds, string searchPattern, string[] kinds, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/IDocumentTrackingServiceExtensions.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IDocumentTrackingServiceExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class IDocumentTrackingServiceExtensions
+    {
+        /// <summary>
+        /// Gets the active <see cref="Document"/> the user is currently working in. May be null if
+        /// there is no active document or the active document is not in this <paramref name="solution"/>.
+        /// </summary>
+        public static Document GetActiveDocument(this IDocumentTrackingService service, Solution solution)
+        {
+            // Note: GetDocument checks that the DocId is contained in the solution, and returns null if not.
+            return solution.GetDocument(service.GetActiveDocument());
+        }
+
+        /// <summary>
+        /// Get a read only collection of all the unique visible documents in the workspace that are
+        /// contained within <paramref name="solution"/>.
+        /// </summary>
+        public static ImmutableArray<Document> GetVisibleDocuments(this IDocumentTrackingService service, Solution solution)
+            => service.GetVisibleDocuments()
+                      .Select(d => solution.GetDocument(d))
+                      .WhereNotNull()
+                      .Distinct()
+                      .ToImmutableArray();
+    }
+}

--- a/src/Workspaces/CoreTestUtilities/ExportProviderCache.cs
+++ b/src/Workspaces/CoreTestUtilities/ExportProviderCache.cs
@@ -163,9 +163,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
-        public static ComposableCatalog WithoutPartsOfTypes(this ComposableCatalog catalog, params Type[] types)
-            => WithoutPartsOfTypes(catalog, (IEnumerable<Type>)types);
-
         public static IExportProviderFactory GetOrCreateExportProviderFactory(ComposableCatalog catalog)
         {
             if (catalog == s_defaultHostCatalog)

--- a/src/Workspaces/CoreTestUtilities/ExportProviderCache.cs
+++ b/src/Workspaces/CoreTestUtilities/ExportProviderCache.cs
@@ -163,6 +163,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
+        public static ComposableCatalog WithoutPartsOfTypes(this ComposableCatalog catalog, params Type[] types)
+            => WithoutPartsOfTypes(catalog, (IEnumerable<Type>)types);
+
         public static IExportProviderFactory GetOrCreateExportProviderFactory(ComposableCatalog catalog)
         {
             if (catalog == s_defaultHostCatalog)

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         public Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(
-            ProjectId projectId, string searchPattern, string[] kinds, CancellationToken cancellationToken)
+            ProjectId projectId, DocumentId activeDocIdOpt, string searchPattern, string[] kinds, CancellationToken cancellationToken)
         {
             return RunServiceAsync(async token =>
             {
@@ -38,8 +38,10 @@ namespace Microsoft.CodeAnalysis.Remote
                     var solution = await GetSolutionAsync(token).ConfigureAwait(false);
 
                     var project = solution.GetProject(projectId);
+                    var activeDocumentOpt = solution.GetDocument(activeDocIdOpt);
+
                     var result = await AbstractNavigateToSearchService.SearchProjectInCurrentProcessAsync(
-                        project, searchPattern, kinds.ToImmutableHashSet(), token).ConfigureAwait(false);
+                        project, activeDocumentOpt, searchPattern, kinds.ToImmutableHashSet(), token).ConfigureAwait(false);
 
                     return Convert(result);
                 }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.NavigateTo;
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         public Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(
-            ProjectId projectId, DocumentId activeDocIdOpt, string searchPattern, string[] kinds, CancellationToken cancellationToken)
+            ProjectId projectId, DocumentId[] priorityDocumentIds, string searchPattern, string[] kinds, CancellationToken cancellationToken)
         {
             return RunServiceAsync(async token =>
             {
@@ -38,10 +39,11 @@ namespace Microsoft.CodeAnalysis.Remote
                     var solution = await GetSolutionAsync(token).ConfigureAwait(false);
 
                     var project = solution.GetProject(projectId);
-                    var activeDocumentOpt = solution.GetDocument(activeDocIdOpt);
+                    var priorityDocuments = priorityDocumentIds.Select(d => solution.GetDocument(d))
+                                                               .ToImmutableArray();
 
                     var result = await AbstractNavigateToSearchService.SearchProjectInCurrentProcessAsync(
-                        project, activeDocumentOpt, searchPattern, kinds.ToImmutableHashSet(), token).ConfigureAwait(false);
+                        project, priorityDocuments, searchPattern, kinds.ToImmutableHashSet(), token).ConfigureAwait(false);
 
                     return Convert(result);
                 }


### PR DESCRIPTION
This is valuable for people who would like to search, knowing something is in the files they have opened.  Instead of blindly searching everything, we prioritize their opened work, and then search everything else after that.