### PR TITLE
Add cache for GetTypeByMetadataName

### DIFF
--- a/src/Compilers/Core/Portable/Collections/ConcurrentCache.cs
+++ b/src/Compilers/Core/Portable/Collections/ConcurrentCache.cs
@@ -13,8 +13,7 @@ namespace Microsoft.CodeAnalysis
 {
     // very simple cache with a specified size.
     // expiration policy is "new entry wins over old entry if hashed into the same bucket"
-    internal class ConcurrentCache<TKey, TValue> :
-        CachingBase<ConcurrentCache<TKey, TValue>.Entry> where TKey : IEquatable<TKey>
+    internal class ConcurrentCache<TKey, TValue> : CachingBase<ConcurrentCache<TKey, TValue>.Entry>
     {
         private readonly IEqualityComparer<TKey> _keyComparer;
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -909,7 +909,7 @@ namespace Microsoft.CodeAnalysis
         // is that there are maybe a couple dozen analyzers in the solution and each one has
         // ~0-2 unique well-known types, and the chance of hash collision is very low.
         private ConcurrentCache<string, INamedTypeSymbol> _getTypeCache =
-            new ConcurrentCache<string, INamedTypeSymbol>(50);
+            new ConcurrentCache<string, INamedTypeSymbol>(50, ReferenceEqualityComparer.Instance);
 
         /// <summary>
         /// Gets the type within the compilation's assembly and all referenced assemblies (other than

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -905,7 +905,9 @@ namespace Microsoft.CodeAnalysis
         // PERF: Traces show that analyzers may use this method frequently, often requesting
         // the same symbol over and over again. In certain instances this can even consume 1% of
         // the total CPU time of compilation. This is an extremely simple cache that evicts on
-        // hash code conflicts, but seems to do the trick.
+        // hash code conflicts, but seems to do the trick. The size is mostly arbitrary. My guess
+        // is that there are maybe a couple dozen analyzers in the solution and each one has
+        // ~0-2 unique well-known types, and the chance of hash collision is very low.
         private ConcurrentCache<string, INamedTypeSymbol> _getTypeCache =
             new ConcurrentCache<string, INamedTypeSymbol>(50);
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -902,9 +902,9 @@ namespace Microsoft.CodeAnalysis
 
         protected abstract IPointerTypeSymbol CommonCreatePointerTypeSymbol(ITypeSymbol elementType);
 
-        // PERF: Traces show that analyzers may use this method frequently, often requesting
-        // the same symbol over and over again. In certain instances this can even consume 1% of
-        // the total CPU time of compilation. This is an extremely simple cache that evicts on
+        // PERF: ETW Traces show that analyzers may use this method frequently, often requesting
+        // the same symbol over and over again. XUnit analyzers, in particular, were consuming almost
+        // 1% of CPU time when building Roslyn itself. This is an extremely simple cache that evicts on
         // hash code conflicts, but seems to do the trick. The size is mostly arbitrary. My guess
         // is that there are maybe a couple dozen analyzers in the solution and each one has
         // ~0-2 unique well-known types, and the chance of hash collision is very low.


### PR DESCRIPTION
This seems to be a popular call among analyzers, especially XUnit. It's a
reasonable way to acquire a well-known analyzer type, but analyzers often
don't save the resulting symbol. This causes significant CPU work to be done
repeatedly as XUnit looks for the same symbol over and over, passing in the
same type name each time.

A very small, simple cache seems to solve the problem without requiring any
changes on the XUnit side.