### PR TITLE
Fix rename with F# projects referencing C# projects

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ConstructorSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ConstructorSymbols.vb
@@ -791,5 +791,30 @@ class Program
 </Workspace>
             Await TestAPIAndFeature(input)
         End Function
+
+        <WorkItem(25655, "https://github.com/dotnet/roslyn/issues/25655")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestNoCompilationProjectReferencingCSharp() As Task
+            Dim input =
+<Workspace>
+    <Project Language="NoCompilation" CommonReferences="false">
+        <ProjectReference>CSharpProject</ProjectReference>
+        <Document>
+            // a no-compilation document
+        </Document>
+    </Project>
+    <Project Language="C#" AssemblyName="CSharpProject" CommonReferences="true">
+        <Document>
+public class A
+{
+    public {|Definition:$$A|}()
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -6162,6 +6162,31 @@ End Class
             End Using
         End Sub
 
+        <WorkItem(25655, "https://github.com/dotnet/roslyn/issues/25655")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameClassWithNoCompilationProjectReferencingProject()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="NoCompilation" CommonReferences="false">
+                        <ProjectReference>CSharpProject</ProjectReference>
+                        <Document>
+                            // a no-compilation document
+                        </Document>
+                    </Project>
+                    <Project Language="C#" AssemblyName="CSharpProject" CommonReferences="true">
+                        <Document>
+                            public class [|$$A|]
+                            {
+                                public [|A|]()
+                                {
+                                }
+                            }
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="B")
+            End Using
+        End Sub
+
 #Region "Rename in strings/comments"
 
         <WorkItem(700923, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/700923"), WorkItem(700925, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/700925")>

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (HasReferenceTo(sourceAssembly, sourceProject, project, cancellationToken))
+                if (project.SupportsCompilation && HasReferenceTo(sourceAssembly, sourceProject, project, cancellationToken))
                 {
                     var hasInternalsAccess = await HasInternalsAccessAsync(
                         sourceAssembly, internalsVisibleToMap, 

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -660,7 +660,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                     foreach (var language in documentsFromAffectedProjects.Select(d => d.Project.Language).Distinct())
                     {
                         solution.Workspace.Services.GetLanguageServices(language).GetService<IRenameRewriterLanguageService>()
-                            .TryAddPossibleNameConflicts(symbol, _replacementText, _possibleNameConflicts);
+                            ?.TryAddPossibleNameConflicts(symbol, _replacementText, _possibleNameConflicts);
                     }
 
                     await AddDocumentsWithPotentialConflicts(documentsFromAffectedProjects).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
@@ -424,17 +424,21 @@ namespace Microsoft.CodeAnalysis.Rename
                 foreach (var documentsGroupedByLanguage in RenameUtilities.GetDocumentsAffectedByRename(originalSymbol, solution, renameLocations).GroupBy(d => d.Project.Language))
                 {
                     var syntaxFactsLanguageService = solution.Workspace.Services.GetLanguageServices(documentsGroupedByLanguage.Key).GetService<ISyntaxFactsService>();
-                    foreach (var document in documentsGroupedByLanguage)
-                    {
-                        if (renameInStrings)
-                        {
-                            await AddLocationsToRenameInStringsAsync(document, renameText, syntaxFactsLanguageService,
-                                stringLocations, cancellationToken).ConfigureAwait(false);
-                        }
 
-                        if (renameInComments)
+                    if (syntaxFactsLanguageService != null)
+                    {
+                        foreach (var document in documentsGroupedByLanguage)
                         {
-                            await AddLocationsToRenameInCommentsAsync(document, renameText, commentLocations, cancellationToken).ConfigureAwait(false);
+                            if (renameInStrings)
+                            {
+                                await AddLocationsToRenameInStringsAsync(document, renameText, syntaxFactsLanguageService,
+                                    stringLocations, cancellationToken).ConfigureAwait(false);
+                            }
+
+                            if (renameInComments)
+                            {
+                                await AddLocationsToRenameInCommentsAsync(document, renameText, commentLocations, cancellationToken).ConfigureAwait(false);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This is a series of fixes to make F# projects referencing C# projects not crash or break rename.

<details><summary>Ask Mode template</summary>

### Customer scenario

A customer has a project with F# and C# projects. The F# project references the C# project. In this case, many features like rename/find references will just silently fail, or may (potentially) crash. As a concrete example, applying a rename fails silently: the identifiers you're trying to change doesn't get changed once you hit enter.

### Bugs this fixes

Fixes #25655.

### Workarounds, if any

Unload the F# projects, but if customers want to work with them that's hard.

### Risk

Quite low: this is just adding null checks or simple guards to avoid codepaths that would clearly crash.

### Performance impact

No changes.

### Is this a regression from a previous update?

Unsure: some bugs seem to date back to 15.7, but we've gotten increased attention on them recently with feedback.

### Root cause analysis

For F# projects, they are modeled in our workspace as projects, but certain Roslyn APIs do not work with them. It's up to some features like find references or rename to be aware those APIs might not work and deal with them accordingly. In some cases, we failed to do so. This causes exceptions to be thrown internally. Many features ultimately are catching those exceptions to avoid a crash but are still causing issues.

### How was the bug found?

Customer reports.

</details>
