### PR TITLE
Don't attach trivia to nodes that will be removed, fixes #28323

### DIFF
--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests_FixAllTests.cs
@@ -303,5 +303,86 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InlineDeclaration
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        [WorkItem(28323, "https://github.com/dotnet/roslyn/issues/28323")]
+        public async Task FixAllInDocumentComments1()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        /* leading */ int {|FixAllInDocument:i1|}; int i2; // trailing
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        // trailing
+        /* leading */
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        [WorkItem(28323, "https://github.com/dotnet/roslyn/issues/28323")]
+        public async Task FixAllInDocumentComments2()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        /* leading */ int dummy; /* inbetween */ int {|FixAllInDocument:i1|}; int i2; // trailing
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+        dummy = 42;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        /* leading */ int dummy; /* inbetween */   // trailing
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+        dummy = 42;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        [WorkItem(28323, "https://github.com/dotnet/roslyn/issues/28323")]
+        public async Task FixAllInDocumentComments3()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int {|FixAllInDocument:i1|}; /* 0 */int /* 1 */ dummy /* 2 */; /* 3*/ int i2;
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+        dummy = 42;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        /* 0 */
+        int /* 1 */ dummy /* 2 */; /* 3*/
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+        dummy = 42;
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests_FixAllTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InlineDeclaration
@@ -93,6 +94,212 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InlineDeclaration
     void M()
     {
         GetExeAndArguments(useCmdShell, executable, arguments, out string finalExecutable, out string finalArguments);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        [WorkItem(28323, "https://github.com/dotnet/roslyn/issues/28323")]
+        public async Task FixAllInDocument4()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int {|FixAllInDocument:i1|}; int i2;
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        [WorkItem(28323, "https://github.com/dotnet/roslyn/issues/28323")]
+        public async Task FixAllInDocument5()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int dummy; int {|FixAllInDocument:i1|}; int i2;
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+        dummy = 42;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        int dummy;  
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+        dummy = 42;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        [WorkItem(28323, "https://github.com/dotnet/roslyn/issues/28323")]
+        public async Task FixAllInDocument6()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int {|FixAllInDocument:i1|}; int dummy; int i2;
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+        dummy = 42;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        int dummy;
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+        dummy = 42;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        [WorkItem(28323, "https://github.com/dotnet/roslyn/issues/28323")]
+        public async Task FixAllInDocument7()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int {|FixAllInDocument:i1|}; int i2; int dummy;
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+        dummy = 42;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        int dummy;
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+        dummy = 42;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task FixAllInDocument8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int dummy, {|FixAllInDocument:i1|}, i2;
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+        dummy = 42;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        int dummy;
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+        dummy = 42;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task FixAllInDocument9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int {|FixAllInDocument:i1|}, dummy, i2;
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+        dummy = 42;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        int dummy;
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+        dummy = 42;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task FixAllInDocument10()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int {|FixAllInDocument:i1|}, i2, dummy;
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+        dummy = 42;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        int dummy;
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
+        dummy = 42;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task FixAllInDocument11()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        int {|FixAllInDocument:i1|}, i2;
+        int.TryParse(v, out i1);
+        int.TryParse(v, out i2);
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        int.TryParse(v, out int i1);
+        int.TryParse(v, out int i2);
     }
 }");
         }

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -44,6 +43,14 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
         {
             var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
+            // Gather all statements to be removed
+            // We need this to find the statements we can safely attach trivia to
+            var declarationsToRemove = new HashSet<StatementSyntax>();
+            foreach (var diagnostic in diagnostics)
+            {
+                declarationsToRemove.Add((LocalDeclarationStatementSyntax)diagnostic.AdditionalLocations[0].FindNode(cancellationToken).Parent.Parent);
+            }
+
             // Attempt to use an out-var declaration if that's the style the user prefers.
             // Note: if using 'var' would cause a problem, we will use the actual type
             // of the local.  This is necessary in some cases (for example, when the
@@ -53,14 +60,14 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 await AddEditsAsync(
-                    document, editor, diagnostic,
-                    options, cancellationToken).ConfigureAwait(false);
+                    document, editor, diagnostic, options,
+                    declarationsToRemove, cancellationToken).ConfigureAwait(false);
             }
         }
 
         private async Task AddEditsAsync(
             Document document, SyntaxEditor editor, Diagnostic diagnostic,
-            OptionSet options, CancellationToken cancellationToken)
+            OptionSet options, HashSet<StatementSyntax> declarationsToRemove, CancellationToken cancellationToken)
         {
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
@@ -84,16 +91,34 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
 
             if (singleDeclarator)
             {
-                // This was a local statement with a single variable in it.  Just Remove 
-                // the entire local declaration statement.  Note that comments belonging to
+                // This was a local statement with a single variable in it.  Just Remove
+                // the entire local declaration statement. Note that comments belonging to
                 // this local statement will be moved to be above the statement containing
-                // the out-var. 
+                // the out-var.
                 var localDeclarationStatement = (LocalDeclarationStatementSyntax)declaration.Parent;
                 var block = (BlockSyntax)localDeclarationStatement.Parent;
                 var declarationIndex = block.Statements.IndexOf(localDeclarationStatement);
 
-                if (declarationIndex > 0 &&
-                    sourceText.AreOnSameLine(block.Statements[declarationIndex - 1].GetLastToken(), localDeclarationStatement.GetFirstToken()))
+                // Try to find a predecessor Statement on the same line that isn't going to be removed
+                StatementSyntax priorStatementSyntax = null;
+                var localDeclarationToken = localDeclarationStatement.GetFirstToken();
+                for (int i = declarationIndex - 1; i >= 0; i--)
+                {
+                    var statementSyntax = block.Statements[i];
+                    if (declarationsToRemove.Contains(statementSyntax))
+                    {
+                        continue;
+                    }
+
+                    if (sourceText.AreOnSameLine(statementSyntax.GetLastToken(), localDeclarationToken))
+                    {
+                        priorStatementSyntax = statementSyntax;
+                    }
+
+                    break;
+                }
+
+                if (priorStatementSyntax != null)
                 {
                     // There's another statement on the same line as this declaration statement.
                     // i.e.   int a; int b;
@@ -101,16 +126,31 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                     // Just move all trivia from our statement to be trailing trivia of the previous
                     // statement
                     editor.ReplaceNode(
-                        block.Statements[declarationIndex - 1],
+                        priorStatementSyntax,
                         (s, g) => s.WithAppendedTrailingTrivia(localDeclarationStatement.GetTrailingTrivia()));
                 }
                 else
                 {
                     // Trivia on the local declaration will move to the next statement.
-                    // use the callback form as the next statement may be the place where we're 
+                    // use the callback form as the next statement may be the place where we're
                     // inlining the declaration, and thus need to see the effects of that change.
+
+                    // Find the next Statement that isn't going to be removed.
+                    // We initialize this to null here but we must see at least the statement
+                    // into which the declaration is going to be inlined so this will be not null
+                    StatementSyntax nextStatementSyntax = null;
+                    for (int i = declarationIndex + 1; i < block.Statements.Count; i++)
+                    {
+                        var statement = block.Statements[i];
+                        if (!declarationsToRemove.Contains(statement))
+                        {
+                            nextStatementSyntax = statement;
+                            break;
+                        }
+                    }
+
                     editor.ReplaceNode(
-                        block.Statements[declarationIndex + 1],
+                        nextStatementSyntax,
                         (s, g) => s.WithPrependedNonIndentationTriviaFrom(localDeclarationStatement));
                 }
 
@@ -124,8 +164,8 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                 //
                 //      var /*c1*/ i /*c2*/, /*c3*/ j /*c4*/;
                 //
-                // In this case 'c1' is owned by the 'var' token, not 'i', and 'c3' is owned by 
-                // the comment token not 'j'.  
+                // In this case 'c1' is owned by the 'var' token, not 'i', and 'c3' is owned by
+                // the comment token not 'j'.
 
                 editor.RemoveNode(declarator);
                 if (declarator == declaration.Variables[0])


### PR DESCRIPTION
Fixes #28323

The issue was that in FixAll mode, it was trying to move trivia to nodes that would be deleted or already were deleted. The fix is to first find all Statements that are going to be removed and then skip over them when searching for Statements to attach the trivia to

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
