### PR TITLE
Keep ProcDump logs for instances we've attached

### DIFF
--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -353,7 +353,7 @@ function Test-SupportedVisualStudioVersion([string]$version) {
 # meets our minimal requirements for the Roslyn repo.
 function Get-VisualStudioDirAndId() {
     $vswhere = Join-Path (Ensure-BasicTool "vswhere") "tools\vswhere.exe"
-    $output = Exec-Command $vswhere "-requires Microsoft.Component.MSBuild -format json" | Out-String
+    $output = Exec-Command $vswhere "-prerelease -requires Microsoft.Component.MSBuild -format json" | Out-String
     $j = ConvertFrom-Json $output
     foreach ($obj in $j) { 
 


### PR DESCRIPTION
This is a quick hack to try to diagnose what is up with some integration test runs I'm seeing failing. Not planning on merging at the moment,