### PR TITLE
Have Windows make dump files

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -586,6 +586,13 @@ function Test-XUnit() {
             New-ItemProperty -Path $key -Name DumpFolder -PropertyType String -Value $logsDir -Force
             New-ItemProperty -Path $key -Name DumpCount -PropertyType DWord -Value 2 -Force
             New-ItemProperty -Path $key -Name DumpType -PropertyType DWord -Value 2 -Force
+
+            # Collect heap dumps if xunit crashes
+            $key = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\xunit.console.x86.exe'
+            New-Item -Path $key -Force
+            New-ItemProperty -Path $key -Name DumpFolder -PropertyType String -Value $logsDir -Force
+            New-ItemProperty -Path $key -Name DumpCount -PropertyType DWord -Value 2 -Force
+            New-ItemProperty -Path $key -Name DumpType -PropertyType DWord -Value 2 -Force
         }
 
         # Since they require Visual Studio to be installed, ensure that the MSBuildWorkspace tests run along with our VS

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -579,6 +579,15 @@ function Test-XUnit() {
         }
     }
     elseif ($testVsi) {
+        if ($cibuild) {
+            # Collect heap dumps if Visual Studio crashes
+            $key = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\devenv.exe'
+            New-Item -Path $key -Force
+            New-ItemProperty -Path $key -Name DumpFolder -PropertyType String -Value $logsDir -Force
+            New-ItemProperty -Path $key -Name DumpCount -PropertyType DWord -Value 2 -Force
+            New-ItemProperty -Path $key -Name DumpType -PropertyType DWord -Value 2 -Force
+        }
+
         # Since they require Visual Studio to be installed, ensure that the MSBuildWorkspace tests run along with our VS
         # integration tests in CI.
         if ($cibuild) {


### PR DESCRIPTION
This is cherry-picking @sharwell's changes out that use the windows error reporting options to capture dumps. Right now this is pulled out in isolation while we try to track down some crashes that aren't getting dumps.