### PR TITLE
Run the simplifier over the expression generation tests to fix issue 26586

### DIFF
--- a/src/EditorFeatures/Test/CodeGeneration/AbstractCodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/AbstractCodeGenerationTests.cs
@@ -1,44 +1,119 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Microsoft.VisualStudio.Composition;
 using Roslyn.Test.Utilities;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
 {
     [UseExportProvider]
     public abstract class AbstractCodeGenerationTests
     {
+        private static SyntaxNode Simplify(
+            AdhocWorkspace workspace,
+            SyntaxNode syntaxNode,
+            string languageName)
+        {
+            var projectId = ProjectId.CreateNewId();
+
+            var project = workspace.CurrentSolution
+                .AddProject(projectId, languageName, $"{languageName}.dll", languageName).GetProject(projectId);
+
+            var normalizedSyntax = syntaxNode.NormalizeWhitespace().ToFullString();
+            var document = project.AddMetadataReference(TestReferences.NetFx.v4_0_30319.mscorlib)
+                .AddDocument("Fake Document", SourceText.From(normalizedSyntax));
+
+            var annotatedDocument = document.WithSyntaxRoot(
+                    document.GetSyntaxRootAsync().Result.WithAdditionalAnnotations(Simplification.Simplifier.Annotation));
+
+            var annotatedRootNode = annotatedDocument.GetSyntaxRootAsync().Result;
+
+            var simplifiedDocument = Simplification.Simplifier.ReduceAsync(annotatedDocument).Result;
+
+            var rootNode = simplifiedDocument.GetSyntaxRootAsync().Result;
+
+            return rootNode;
+        }
+
+        private static SyntaxNode WrapExpressionInBoilerplate(SyntaxNode expression, SyntaxGenerator codeDefFactory)
+        {
+            return codeDefFactory.CompilationUnit(
+                codeDefFactory.NamespaceImportDeclaration(codeDefFactory.IdentifierName("System")),
+                codeDefFactory.ClassDeclaration(
+                    "C",
+                    members: new[]
+                    {
+                        codeDefFactory.MethodDeclaration(
+                            "Dummy",
+                            returnType: null,
+                            statements: new[]
+                            {
+                                codeDefFactory.LocalDeclarationStatement("test", expression)
+                            })
+                    })
+                );
+        }
+
         internal void Test(
             Func<SyntaxGenerator, SyntaxNode> nodeCreator,
-            string cs, string vb)
+            string cs, string csSimple,
+            string vb, string vbSimple)
         {
+            Assert.True(cs != null || csSimple != null || vb != null || vbSimple != null,
+                $"At least one of {nameof(cs)}, {nameof(csSimple)}, {nameof(vb)}, {nameof(vbSimple)} must be provided");
+
             var hostServices = MefV1HostServices.Create(TestExportProvider.ExportProviderWithCSharpAndVisualBasic.AsExportProvider());
             var workspace = new AdhocWorkspace(hostServices);
 
-            if (cs != null)
+            if (cs != null || csSimple != null)
             {
-                var csharpCodeGenService = workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService<ICodeGenerationService>();
                 var codeDefFactory = workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService<SyntaxGenerator>();
 
                 var node = nodeCreator(codeDefFactory);
                 node = node.NormalizeWhitespace();
-                TokenUtilities.AssertTokensEqual(cs, node.ToFullString(), LanguageNames.CSharp);
+
+                if (cs != null)
+                {
+                    TokenUtilities.AssertTokensEqual(cs, node.ToFullString(), LanguageNames.CSharp);
+                }
+                
+                if (csSimple != null)
+                {
+                    var simplifiedRootNode = Simplify(workspace, WrapExpressionInBoilerplate(node, codeDefFactory), LanguageNames.CSharp);
+                    var expression = simplifiedRootNode.DescendantNodes().OfType<EqualsValueClauseSyntax>().First().Value;
+
+                    TokenUtilities.AssertTokensEqual(csSimple, expression.NormalizeWhitespace().ToFullString(), LanguageNames.CSharp);
+                }
             }
 
-            if (vb != null)
+            if (vb != null || vbSimple != null)
             {
-                var visualBasicCodeGenService = workspace.Services.GetLanguageServices(LanguageNames.VisualBasic).GetService<ICodeGenerationService>();
                 var codeDefFactory = workspace.Services.GetLanguageServices(LanguageNames.VisualBasic).GetService<SyntaxGenerator>();
 
                 var node = nodeCreator(codeDefFactory);
                 node = node.NormalizeWhitespace();
-                TokenUtilities.AssertTokensEqual(vb, node.ToString(), LanguageNames.VisualBasic);
+
+                if (vb != null)
+                {
+                    TokenUtilities.AssertTokensEqual(vb, node.ToFullString(), LanguageNames.VisualBasic);
+                }
+
+                if (vbSimple != null)
+                {
+                    var simplifiedRootNode = Simplify(workspace, WrapExpressionInBoilerplate(node, codeDefFactory), LanguageNames.VisualBasic);
+                    var expression = simplifiedRootNode.DescendantNodes().OfType<EqualsValueSyntax>().First().Value;
+
+                    TokenUtilities.AssertTokensEqual(vbSimple, expression.NormalizeWhitespace().ToFullString(), LanguageNames.VisualBasic);
+                }
             }
         }
 

--- a/src/EditorFeatures/Test/CodeGeneration/ExpressionGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/ExpressionGenerationTests.cs
@@ -14,7 +14,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.FalseLiteralExpression(),
                 cs: "false",
-                vb: "False");
+                csSimple: "false",
+                vb: "False",
+                vbSimple: "False");
         }
 
         [Fact]
@@ -23,7 +25,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.TrueLiteralExpression(),
                 cs: "true",
-                vb: "True");
+                csSimple: "true",
+                vb: "True",
+                vbSimple: "True");
         }
 
         [Fact]
@@ -32,7 +36,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.NullLiteralExpression(),
                 cs: "null",
-                vb: "Nothing");
+                csSimple: "null",
+                vb: "Nothing",
+                vbSimple: "Nothing");
         }
 
         [Fact]
@@ -41,7 +47,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.ThisExpression(),
                 cs: "this",
-                vb: "Me");
+                csSimple: "this",
+                vb: "Me",
+                vbSimple: "Me");
         }
 
         [Fact]
@@ -50,7 +58,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.BaseExpression(),
                 cs: "base",
-                vb: "MyBase");
+                csSimple: "base",
+                vb: "MyBase",
+                vbSimple: "MyBase");
         }
 
         [Fact]
@@ -59,7 +69,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.LiteralExpression(0),
                 cs: "0",
-                vb: "0");
+                csSimple: "0",
+                vb: "0",
+                vbSimple: "0");
         }
 
         [Fact]
@@ -68,7 +80,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.LiteralExpression(1),
                 cs: "1",
-                vb: "1");
+                csSimple: "1",
+                vb: "1",
+                vbSimple: "1");
         }
 
         [Fact]
@@ -77,7 +91,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.LiteralExpression(0L),
                 cs: "0L",
-                vb: "0L");
+                csSimple: "0L",
+                vb: "0L",
+                vbSimple: "0L");
         }
 
         [Fact]
@@ -86,7 +102,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.LiteralExpression(1L),
                 cs: "1L",
-                vb: "1L");
+                csSimple: "1L",
+                vb: "1L",
+                vbSimple: "1L");
         }
 
         [Fact]
@@ -95,7 +113,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.LiteralExpression(0.0f),
                 cs: "0F",
-                vb: "0F");
+                csSimple: "0F",
+                vb: "0F",
+                vbSimple: "0F");
         }
 
         [Fact]
@@ -104,7 +124,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.LiteralExpression(0.5F),
                 cs: "0.5F",
-                vb: "0.5F");
+                csSimple: "0.5F",
+                vb: "0.5F",
+                vbSimple: "0.5F");
         }
 
         [Fact]
@@ -113,7 +135,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.LiteralExpression(0.0d),
                 cs: "0D",
-                vb: "0R");
+                csSimple: "0D",
+                vb: "0R",
+                vbSimple: "0R");
         }
 
         [Fact]
@@ -122,21 +146,25 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.LiteralExpression(0.5D),
                 cs: "0.5D",
-                vb: "0.5R");
+                csSimple: "0.5D",
+                vb: "0.5R",
+                vbSimple: "0.5R");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestAddExpression1()
         {
             Test(
                 f => f.AddExpression(
                     f.LiteralExpression(1),
                     f.LiteralExpression(2)),
-                cs: "1 + 2",
-                vb: "1 + 2");
+                cs: "(1) + (2)",
+                csSimple: "1 + 2",
+                vb: "(1) + (2)",
+                vbSimple: "1 + 2");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestAddExpression2()
         {
             Test(
@@ -145,11 +173,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.AddExpression(
                         f.LiteralExpression(2),
                         f.LiteralExpression(3))),
-                cs: "1 + 2 + 3",
-                vb: "1 + 2 + 3");
+                cs: "(1) + ((2) + (3))",
+                csSimple: "1 + 2 + 3",
+                vb: "(1) + ((2) + (3))",
+                vbSimple: "1 + 2 + 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestAddExpression3()
         {
             Test(
@@ -158,22 +188,26 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.LiteralExpression(3)),
-                cs: "1 + 2 + 3",
-                vb: "1 + 2 + 3");
+                cs: "((1) + (2)) + (3)",
+                csSimple: "1 + 2 + 3",
+                vb: "((1) + (2)) + (3)",
+                vbSimple: "1 + 2 + 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMultiplyExpression1()
         {
             Test(
                 f => f.MultiplyExpression(
                     f.LiteralExpression(1),
                     f.LiteralExpression(2)),
-                cs: "1 * 2",
-                vb: "1 * 2");
+                cs: "(1) * (2)",
+                csSimple: "1 * 2",
+                vb: "(1) * (2)",
+                vbSimple: "1 * 2");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMultiplyExpression2()
         {
             Test(
@@ -182,11 +216,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.MultiplyExpression(
                         f.LiteralExpression(2),
                         f.LiteralExpression(3))),
-                cs: "1 * 2 * 3",
-                vb: "1 * 2 * 3");
+                cs: "(1) * ((2) * (3))",
+                csSimple: "1 * 2 * 3",
+                vb: "(1) * ((2) * (3))",
+                vbSimple: "1 * 2 * 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMultiplyExpression3()
         {
             Test(
@@ -195,52 +231,62 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.LiteralExpression(3)),
-                cs: "1 * 2 * 3",
-                vb: "1 * 2 * 3");
+                cs: "((1) * (2)) * (3)",
+                csSimple: "1 * 2 * 3",
+                vb: "((1) * (2)) * (3)",
+                vbSimple: "1 * 2 * 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestBinaryAndExpression1()
         {
             Test(
                 f => f.BitwiseAndExpression(
                     f.LiteralExpression(1),
                     f.LiteralExpression(2)),
-                cs: "1 & 2",
-                vb: "1 And 2");
+                cs: "(1) & (2)",
+                csSimple: "1 & 2",
+                vb: "(1) And (2)",
+                vbSimple: "1 And 2");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestBinaryOrExpression1()
         {
             Test(
                 f => f.BitwiseOrExpression(
                     f.LiteralExpression(1),
                     f.LiteralExpression(2)),
-                cs: "1 | 2",
-                vb: "1 Or 2");
+                cs: "(1) | (2)",
+                csSimple: "1 | 2",
+                vb: "(1) Or (2)",
+                vbSimple: "1 Or 2");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestLogicalAndExpression1()
         {
             Test(
                 f => f.LogicalAndExpression(
                     f.LiteralExpression(1),
                     f.LiteralExpression(2)),
-                cs: "1 && 2",
-                vb: "1 AndAlso 2");
+                cs: "(1) && (2)",
+                csSimple: "1 && 2",
+                vb: "(1) AndAlso (2)",
+                vbSimple: "1 AndAlso 2");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestLogicalOrExpression1()
         {
             Test(
                 f => f.LogicalOrExpression(
                     f.LiteralExpression(1),
                     f.LiteralExpression(2)),
-                cs: "1 || 2",
-                vb: "1 OrElse 2");
+                cs: "(1) || (2)",
+                csSimple: "1 || 2",
+                vb: "(1) OrElse (2)",
+                vbSimple: "1 OrElse 2");
         }
 
         [Fact]
@@ -251,10 +297,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.IdentifierName("E"),
                     f.IdentifierName("M")),
                 cs: "E.M",
-                vb: "E.M");
+                csSimple: "E.M",
+                vb: "E.M",
+                vbSimple: "E.M");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestConditionalExpression1()
         {
             Test(
@@ -262,8 +310,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.IdentifierName("E"),
                     f.IdentifierName("T"),
                     f.IdentifierName("F")),
-                cs: "E ? T : F",
-                vb: "If(E, T, F)");
+                cs: "(E) ? (T) : (F)",
+                csSimple: "E ? T : F",
+                vb: "If(E, T, F)",
+                vbSimple: "If(E, T, F)");
         }
 
         [Fact]
@@ -273,7 +323,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 f => f.InvocationExpression(
                     f.IdentifierName("E")),
                 cs: "E()",
-                vb: "E()");
+                csSimple: "E()",
+                vb: "E()",
+                vbSimple: "E");
         }
 
         [Fact]
@@ -284,7 +336,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.IdentifierName("E"),
                     f.Argument(f.IdentifierName("a"))),
                 cs: "E(a)",
-                vb: "E(a)");
+                csSimple: "E(a)",
+                vb: "E(a)",
+                vbSimple: "E(a)");
         }
 
         [Fact]
@@ -295,7 +349,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.IdentifierName("E"),
                     f.Argument("n", RefKind.None, f.IdentifierName("a"))),
                 cs: "E(n: a)",
-                vb: "E(n:=a)");
+                csSimple: "E(n: a)",
+                vb: "E(n:=a)",
+                vbSimple: "E(n:=a)");
         }
 
         [Fact]
@@ -307,7 +363,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.Argument(null, RefKind.Out, f.IdentifierName("a")),
                     f.Argument(null, RefKind.Ref, f.IdentifierName("b"))),
                 cs: "E(out a, ref b)",
-                vb: "E(a, b)");
+                csSimple: "E(out a, ref b)",
+                vb: "E(a, b)",
+                vbSimple: "E(a, b)");
         }
 
         [Fact]
@@ -319,7 +377,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.Argument("n1", RefKind.Out, f.IdentifierName("a")),
                     f.Argument("n2", RefKind.Ref, f.IdentifierName("b"))),
                 cs: "E(n1: out a, n2: ref b)",
-                vb: "E(n1:=a, n2:=b)");
+                csSimple: "E(n1: out a, n2: ref b)",
+                vb: "E(n1:=a, n2:=b)",
+                vbSimple: "E(n1:=a, n2:=b)");
         }
 
         [Fact]
@@ -329,7 +389,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 f => f.ElementAccessExpression(
                     f.IdentifierName("E")),
                 cs: "E[]",
-                vb: "E()");
+                csSimple: "E[]",
+                vb: "E()",
+                vbSimple: "E");
         }
 
         [Fact]
@@ -340,7 +402,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.IdentifierName("E"),
                     f.Argument(f.IdentifierName("a"))),
                 cs: "E[a]",
-                vb: "E(a)");
+                csSimple: "E[a]",
+                vb: "E(a)",
+                vbSimple: "E(a)");
         }
 
         [Fact]
@@ -351,7 +415,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.IdentifierName("E"),
                     f.Argument("n", RefKind.None, f.IdentifierName("a"))),
                 cs: "E[n: a]",
-                vb: "E(n:=a)");
+                csSimple: "E[n: a]",
+                vb: "E(n:=a)",
+                vbSimple: "E(n:=a)");
         }
 
         [Fact]
@@ -363,7 +429,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.Argument(null, RefKind.Out, f.IdentifierName("a")),
                     f.Argument(null, RefKind.Ref, f.IdentifierName("b"))),
                 cs: "E[out a, ref b]",
-                vb: "E(a, b)");
+                csSimple: "E[out a, ref b]",
+                vb: "E(a, b)",
+                vbSimple: "E(a, b)");
         }
 
         [Fact]
@@ -375,60 +443,72 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.Argument("n1", RefKind.Out, f.IdentifierName("a")),
                     f.Argument("n2", RefKind.Ref, f.IdentifierName("b"))),
                 cs: "E[n1: out a, n2: ref b]",
-                vb: "E(n1:=a, n2:=b)");
+                csSimple: "E[n1: out a, n2: ref b]",
+                vb: "E(n1:=a, n2:=b)",
+                vbSimple: "E(n1:=a, n2:=b)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestIsExpression()
         {
             Test(
                 f => f.IsTypeExpression(
                     f.IdentifierName("a"),
                     CreateClass("SomeType")),
-                cs: "a is SomeType",
-                vb: "TypeOf a Is SomeType");
+                cs: "(a) is SomeType",
+                csSimple: "a is SomeType",
+                vb: "TypeOf (a) Is SomeType",
+                vbSimple: "TypeOf a Is SomeType");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestAsExpression()
         {
             Test(
                 f => f.TryCastExpression(
                     f.IdentifierName("a"),
                     CreateClass("SomeType")),
-                cs: "a as SomeType",
-                vb: "TryCast(a, SomeType)");
+                cs: "(a) as SomeType",
+                csSimple: "a as SomeType",
+                vb: "TryCast(a, SomeType)",
+                vbSimple: "TryCast(a, SomeType)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestNotExpression()
         {
             Test(
                 f => f.LogicalNotExpression(
                     f.IdentifierName("a")),
-                cs: "!a",
-                vb: "Not a");
+                cs: "!(a)",
+                csSimple: "!a",
+                vb: "Not (a)",
+                vbSimple: "Not a");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestCastExpression()
         {
             Test(
                 f => f.CastExpression(
                     CreateClass("SomeType"),
                     f.IdentifierName("a")),
-                cs: "(SomeType)a",
-                vb: "DirectCast(a, SomeType)");
+                cs: "(SomeType)(a)",
+                csSimple: "(SomeType)a",
+                vb: "DirectCast(a, SomeType)",
+                vbSimple: "DirectCast(a, SomeType)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestNegateExpression()
         {
             Test(
                 f => f.NegateExpression(
                     f.IdentifierName("a")),
-                cs: "-a",
-                vb: "-a");
+                cs: "-(a)",
+                csSimple: "-a",
+                vb: "-(a)",
+                vbSimple: "-a");
         }
     }
 }

--- a/src/EditorFeatures/Test/CodeGeneration/ExpressionPrecedenceGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/ExpressionPrecedenceGenerationTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
     [Trait(Traits.Feature, Traits.Features.CodeGeneration)]
     public class ExpressionPrecedenceGenerationTests : AbstractCodeGenerationTests
     {
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestAddMultiplyPrecedence1()
         {
             Test(
@@ -17,11 +17,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.LiteralExpression(3)),
-                cs: "(1 + 2) * 3",
-                vb: "(1 + 2) * 3");
+                cs: "((1) + (2)) * (3)",
+                csSimple: "(1 + 2) * 3",
+                vb: "((1) + (2)) * (3)",
+                vbSimple: "(1 + 2) * 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestAddMultiplyPrecedence2()
         {
             Test(
@@ -30,11 +32,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.LiteralExpression(3)),
-                cs: "1 * 2 + 3",
-                vb: "1 * 2 + 3");
+                cs: "((1) * (2)) + (3)",
+                csSimple: "1 * 2 + 3",
+                vb: "((1) * (2)) + (3)",
+                vbSimple: "1 * 2 + 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestAddMultiplyPrecedence3()
         {
             Test(
@@ -43,11 +47,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.AddExpression(
                         f.LiteralExpression(2),
                         f.LiteralExpression(3))),
-                cs: "1 * (2 + 3)",
-                vb: "1 * (2 + 3)");
+                cs: "(1) * ((2) + (3))",
+                csSimple: "1 * (2 + 3)",
+                vb: "(1) * ((2) + (3))",
+                vbSimple: "1 * (2 + 3)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestAddMultiplyPrecedence4()
         {
             Test(
@@ -56,11 +62,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.MultiplyExpression(
                         f.LiteralExpression(2),
                         f.LiteralExpression(3))),
-                cs: "1 + 2 * 3",
-                vb: "1 + 2 * 3");
+                cs: "(1) + ((2) * (3))",
+                csSimple: "1 + 2 * 3",
+                vb: "(1) + ((2) * (3))",
+                vbSimple: "1 + 2 * 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestBitwiseAndOrPrecedence1()
         {
             Test(
@@ -69,11 +77,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.LiteralExpression(3)),
-                cs: "(1 | 2) & 3",
-                vb: "(1 Or 2) And 3");
+                cs: "((1) | (2)) & (3)",
+                csSimple: "(1 | 2) & 3",
+                vb: "((1) Or (2)) And (3)",
+                vbSimple: "(1 Or 2) And 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestBitwiseAndOrPrecedence2()
         {
             Test(
@@ -82,11 +92,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.LiteralExpression(3)),
-                cs: "1 & 2 | 3",
-                vb: "1 And 2 Or 3");
+                cs: "((1) & (2)) | (3)",
+                csSimple: "1 & 2 | 3",
+                vb: "((1) And (2)) Or (3)",
+                vbSimple: "1 And 2 Or 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestBitwiseAndOrPrecedence3()
         {
             Test(
@@ -95,11 +107,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.BitwiseOrExpression(
                         f.LiteralExpression(2),
                         f.LiteralExpression(3))),
-                cs: "1 & (2 | 3)",
-                vb: "1 And (2 Or 3)");
+                cs: "(1) & ((2) | (3))",
+                csSimple: "1 & (2 | 3)",
+                vb: "(1) And ((2) Or (3))",
+                vbSimple: "1 And (2 Or 3)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestBitwiseAndOrPrecedence4()
         {
             Test(
@@ -108,11 +122,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.BitwiseAndExpression(
                         f.LiteralExpression(2),
                         f.LiteralExpression(3))),
-                cs: "1 | 2 & 3",
-                vb: "1 Or 2 And 3");
+                cs: "(1) | ((2) & (3))",
+                csSimple: "1 | 2 & 3",
+                vb: "(1) Or ((2) And (3))",
+                vbSimple: "1 Or 2 And 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestLogicalAndOrPrecedence1()
         {
             Test(
@@ -121,11 +137,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.LiteralExpression(3)),
-                cs: "(1 || 2) && 3",
-                vb: "(1 OrElse 2) AndAlso 3");
+                cs: "((1) || (2)) && (3)",
+                csSimple: "(1 || 2) && 3",
+                vb: "((1) OrElse (2)) AndAlso (3)",
+                vbSimple: "(1 OrElse 2) AndAlso 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestLogicalAndOrPrecedence2()
         {
             Test(
@@ -134,11 +152,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.LiteralExpression(3)),
-                cs: "1 && 2 || 3",
-                vb: "1 AndAlso 2 OrElse 3");
+                cs: "((1) && (2)) || (3)",
+                csSimple: "1 && 2 || 3",
+                vb: "((1) AndAlso (2)) OrElse (3)",
+                vbSimple: "1 AndAlso 2 OrElse 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestLogicalAndOrPrecedence3()
         {
             Test(
@@ -147,11 +167,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.LogicalOrExpression(
                         f.LiteralExpression(2),
                         f.LiteralExpression(3))),
-                cs: "1 && (2 || 3)",
-                vb: "1 AndAlso (2 OrElse 3)");
+                cs: "(1) && ((2) || (3))",
+                csSimple: "1 && (2 || 3)",
+                vb: "(1) AndAlso ((2) OrElse (3))",
+                vbSimple: "1 AndAlso (2 OrElse 3)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestLogicalAndOrPrecedence4()
         {
             Test(
@@ -160,11 +182,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.LogicalAndExpression(
                         f.LiteralExpression(2),
                         f.LiteralExpression(3))),
-                cs: "1 || 2 && 3",
-                vb: "1 OrElse 2 AndAlso 3");
+                cs: "(1) || ((2) && (3))",
+                csSimple: "1 || 2 && 3",
+                vb: "(1) OrElse ((2) AndAlso (3))",
+                vbSimple: "1 OrElse 2 AndAlso 3");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMemberAccessOffOfAdd1()
         {
             Test(
@@ -173,11 +197,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.IdentifierName("M")),
-                cs: "(1 + 2).M",
-                vb: "(1 + 2).M");
+                cs: "((1) + (2)).M",
+                csSimple: "(1 + 2).M",
+                vb: "((1) + (2)).M",
+                vbSimple: "(1 + 2).M");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestConditionalExpression1()
         {
             Test(
@@ -187,11 +213,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.IdentifierName("E2")),
                     f.IdentifierName("T"),
                     f.IdentifierName("F")),
-                cs: "(E1 = E2) ? T : F",
-                vb: null);
+                cs: "(E1 = (E2)) ? (T) : (F)",
+                csSimple: "(E1 = E2) ? T : F",
+                vb: null,
+                vbSimple: null);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestConditionalExpression2()
         {
             Test(
@@ -204,11 +232,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                             f.IdentifierName("E2"),
                             f.IdentifierName("T2"),
                             f.IdentifierName("F2"))),
-                cs: "(E1 ? T1 : F1) + (E2 ? T2 : F2)",
-                vb: null);
+                cs: "((E1) ? (T1) : (F1)) + ((E2) ? (T2) : (F2))",
+                csSimple: "(E1 ? T1 : F1) + (E2 ? T2 : F2)",
+                vb: null,
+                vbSimple: null);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMemberAccessOffOfElementAccess()
         {
             Test(
@@ -217,11 +247,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.LiteralExpression(1),
                         f.LiteralExpression(2)),
                     f.Argument(f.IdentifierName("M"))),
-                cs: "(1 + 2)[M]",
-                vb: "(1 + 2)(M)");
+                cs: "((1) + (2))[M]",
+                csSimple: "(1 + 2)[M]",
+                vb: "((1) + (2))(M)",
+                vbSimple: "(1 + 2)(M)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMemberAccessOffOfIsExpression()
         {
             Test(
@@ -230,11 +262,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.IdentifierName("a"),
                         CreateClass("SomeType")),
                     f.IdentifierName("M")),
-                cs: "(a is SomeType).M",
-                vb: "(TypeOf a Is SomeType).M");
+                cs: "((a) is SomeType).M",
+                csSimple: "(a is SomeType).M",
+                vb: "(TypeOf (a) Is SomeType).M",
+                vbSimple: "(TypeOf a Is SomeType).M");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestIsOfMemberAccessExpression()
         {
             Test(
@@ -243,11 +277,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.IdentifierName("a"),
                         f.IdentifierName("M")),
                     CreateClass("SomeType")),
-                cs: "a.M is SomeType",
-                vb: "TypeOf a.M Is SomeType");
+                cs: "(a.M) is SomeType",
+                csSimple: "a.M is SomeType",
+                vb: "TypeOf (a.M) Is SomeType",
+                vbSimple: "TypeOf a.M Is SomeType");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMemberAccessOffOfAsExpression()
         {
             Test(
@@ -256,11 +292,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         f.IdentifierName("a"),
                         CreateClass("SomeType")),
                     f.IdentifierName("M")),
-                cs: "(a as SomeType).M",
-                vb: "TryCast(a, SomeType).M");
+                cs: "((a) as SomeType).M",
+                csSimple: "(a as SomeType).M",
+                vb: "(TryCast(a, SomeType)).M",
+                vbSimple: "TryCast(a, SomeType).M");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestAsOfMemberAccessExpression()
         {
             Test(
@@ -269,11 +307,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                             f.IdentifierName("a"),
                             f.IdentifierName("M")),
                         CreateClass("SomeType")),
-                cs: "a.M as SomeType",
-                vb: "TryCast(a.M, SomeType)");
+                cs: "(a.M) as SomeType",
+                csSimple: "a.M as SomeType",
+                vb: "TryCast(a.M, SomeType)",
+                vbSimple: "TryCast(a.M, SomeType)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMemberAccessOffOfNotExpression()
         {
             Test(
@@ -281,11 +321,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.LogicalNotExpression(
                         f.IdentifierName("a")),
                     f.IdentifierName("M")),
-                cs: "(!a).M",
-                vb: "(Not a).M");
+                cs: "(!(a)).M",
+                csSimple: "(!a).M",
+                vb: "(Not (a)).M",
+                vbSimple: "(Not a).M");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestNotOfMemberAccessExpression()
         {
             Test(
@@ -293,11 +335,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.MemberAccessExpression(
                         f.IdentifierName("a"),
                         f.IdentifierName("M"))),
-                cs: "!a.M",
-                vb: "Not a.M");
+                cs: "!(a.M)",
+                csSimple: "!a.M",
+                vb: "Not (a.M)",
+                vbSimple: "Not a.M");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMemberAccessOffOfCastExpression()
         {
             Test(
@@ -306,11 +350,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         CreateClass("SomeType"),
                         f.IdentifierName("a")),
                     f.IdentifierName("M")),
-                cs: "((SomeType)a).M",
-                vb: "DirectCast(a, SomeType).M");
+                cs: "((SomeType)(a)).M",
+                csSimple: "((SomeType)a).M",
+                vb: "(DirectCast(a, SomeType)).M",
+                vbSimple: "DirectCast(a, SomeType).M");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestCastOfAddExpression()
         {
             Test(
@@ -319,11 +365,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.AddExpression(
                         f.IdentifierName("a"),
                         f.IdentifierName("b"))),
-                cs: "(SomeType)(a + b)",
-                vb: "DirectCast(a + b, SomeType)");
+                cs: "(SomeType)((a) + (b))",
+                csSimple: "(SomeType)(a + b)",
+                vb: "DirectCast((a) + (b), SomeType)",
+                vbSimple: "DirectCast(a + b, SomeType)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestNegateOfAddExpression()
         {
             Test(
@@ -331,11 +379,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.AddExpression(
                         f.IdentifierName("a"),
                         f.IdentifierName("b"))),
-                cs: "-(a + b)",
-                vb: "-(a + b)");
+                cs: "-((a) + (b))",
+                csSimple: "-(a + b)",
+                vb: "-((a) + (b))",
+                vbSimple: "-(a + b)");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestMemberAccessOffOfNegate()
         {
             Test(
@@ -343,11 +393,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.NegateExpression(
                         f.IdentifierName("a")),
                     f.IdentifierName("M")),
-                cs: "(-a).M",
-                vb: "(-a).M");
+                cs: "(-(a)).M",
+                csSimple: "(-a).M",
+                vb: "(-(a)).M",
+                vbSimple: "(-a).M");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
+        [Fact]
         public void TestNegateOfMemberAccess()
         {
             Test(f =>
@@ -355,8 +407,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     f.MemberAccessExpression(
                         f.IdentifierName("a"),
                         f.IdentifierName("M"))),
-                cs: "-a.M",
-                vb: "-a.M");
+                cs: "-(a.M)",
+                csSimple: "-a.M",
+                vb: "-(a.M)",
+                vbSimple: "-a.M");
         }
     }
 }

--- a/src/EditorFeatures/Test/CodeGeneration/NameGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/NameGenerationTests.cs
@@ -14,7 +14,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.IdentifierName("a"),
                 cs: "a",
-                vb: "a");
+                csSimple: "a",
+                vb: "a",
+                vbSimple: "a");
         }
 
         [Fact]
@@ -23,7 +25,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.IdentifierName("int"),
                 cs: "@int",
-                vb: "int");
+                csSimple: "@int",
+                vb: "int",
+                vbSimple: "int");
         }
 
         [Fact]
@@ -32,7 +36,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.IdentifierName("Integer"),
                 cs: "Integer",
-                vb: "[Integer]");
+                csSimple: "Integer",
+                vb: "[Integer]",
+                vbSimple: "[Integer]");
         }
 
         [Fact]
@@ -41,7 +47,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.GenericName("Outer", CreateClass("Inner1")),
                 cs: "Outer<Inner1>",
-                vb: "Outer(Of Inner1)");
+                csSimple: null,
+                vb: "Outer(Of Inner1)",
+                vbSimple: null);
         }
 
         [Fact]
@@ -50,7 +58,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.GenericName("Outer", CreateClass("Inner1"), CreateClass("Inner2")),
                 cs: "Outer<Inner1, Inner2>",
-                vb: "Outer(Of Inner1, Inner2)");
+                csSimple: null,
+                vb: "Outer(Of Inner1, Inner2)",
+                vbSimple: null);
         }
 
         [Fact]
@@ -59,7 +69,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.GenericName("int", CreateClass("string"), CreateClass("bool")),
                 cs: "@int<@string, @bool>",
-                vb: "int(Of [string], bool)");
+                csSimple: null,
+                vb: "int(Of [string], bool)",
+                vbSimple: null);
         }
 
         [Fact]
@@ -68,7 +80,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.GenericName("Integer", CreateClass("String"), CreateClass("Boolean")),
                 cs: "Integer<String, Boolean>",
-                vb: "[Integer](Of [String], [Boolean])");
+                csSimple: null,
+                vb: "[Integer](Of [String], [Boolean])",
+                vbSimple: null);
         }
 
         [Fact]
@@ -77,7 +91,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.QualifiedName(f.IdentifierName("Outer"), f.IdentifierName("Inner1")),
                 cs: "Outer.Inner1",
-                vb: "Outer.Inner1");
+                csSimple: "Outer.Inner1",
+                vb: "Outer.Inner1",
+                vbSimple: "Outer.Inner1");
         }
 
         [Fact]
@@ -86,7 +102,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.QualifiedName(f.IdentifierName("int"), f.IdentifierName("string")),
                 cs: "@int.@string",
-                vb: "int.[string]");
+                csSimple: "@int.@string",
+                vb: "int.[string]",
+                vbSimple: "int.string");
         }
 
         [Fact]
@@ -95,7 +113,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(
                 f => f.QualifiedName(f.IdentifierName("Integer"), f.IdentifierName("String")),
                 cs: "Integer.String",
-                vb: "[Integer].[String]");
+                csSimple: "Integer.String",
+                vb: "[Integer].[String]",
+                vbSimple: "Integer.String");
         }
 
         [Fact]
@@ -108,7 +128,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         CreateClass("Inner1"),
                         CreateClass("Inner2"))),
                 cs: "One.Outer<Inner1, Inner2>",
-                vb: "One.Outer(Of Inner1, Inner2)");
+                csSimple: "One.Outer<Inner1, Inner2>",
+                vb: "One.Outer(Of Inner1, Inner2)",
+                vbSimple: "One.Outer(Of Inner1, Inner2)");
         }
 
         [Fact]
@@ -121,7 +143,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                         CreateClass("Inner2")),
                     f.IdentifierName("One")),
                 cs: "Outer<Inner1, Inner2>.One",
-                vb: "Outer(Of Inner1, Inner2).One");
+                csSimple: "Outer<Inner1, Inner2>.One",
+                vb: "Outer(Of Inner1, Inner2).One",
+                vbSimple: "Outer(Of Inner1, Inner2).One");
         }
     }
 }

--- a/src/EditorFeatures/Test/CodeGeneration/StatementGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/StatementGenerationTests.cs
@@ -12,7 +12,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
         {
             Test(f => f.ThrowStatement(),
                 cs: "throw;",
-                vb: "Throw");
+                csSimple: null,
+                vb: "Throw",
+                vbSimple: null);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
@@ -21,7 +23,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(f => f.ThrowStatement(
                 f.IdentifierName("e")),
                 cs: "throw e;",
-                vb: "Throw e");
+                csSimple: null,
+                vb: "Throw e",
+                vbSimple: null);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
@@ -31,7 +35,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 f.ObjectCreationExpression(
                     CreateClass("NotImplementedException"))),
                 cs: "throw new NotImplementedException();",
-                vb: "Throw New NotImplementedException()");
+                csSimple: null,
+                vb: "Throw New NotImplementedException()",
+                vbSimple: null);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
@@ -39,7 +45,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
         {
             Test(f => f.ReturnStatement(),
                 cs: "return;",
-                vb: "Return");
+                csSimple: null,
+                vb: "Return",
+                vbSimple: null);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
@@ -48,7 +56,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Test(f => f.ReturnStatement(
                 f.IdentifierName("e")),
                 cs: "return e;",
-                vb: "Return e");
+                csSimple: null,
+                vb: "Return e",
+                vbSimple: null);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
@@ -58,7 +68,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 f.ObjectCreationExpression(
                     CreateClass("NotImplementedException"))),
                 cs: "return new NotImplementedException();",
-                vb: "Return New NotImplementedException()");
+                csSimple: null,
+                vb: "Return New NotImplementedException()",
+                vbSimple: null);
         }
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.vb
@@ -338,12 +338,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             ' Cases:
             '   (1 + 1) * 8
             '   (1 + 1).ToString
+            '   (1 + 1)()
             If TypeOf expression Is BinaryExpressionSyntax OrElse
                TypeOf expression Is UnaryExpressionSyntax Then
 
                 Dim parentExpression = TryCast(node.Parent, ExpressionSyntax)
                 If parentExpression IsNot Nothing Then
-                    If parentExpression.IsKind(SyntaxKind.SimpleMemberAccessExpression) Then
+                    If parentExpression.IsKind(SyntaxKind.SimpleMemberAccessExpression) OrElse
+                       parentExpression.IsKind(SyntaxKind.InvocationExpression) Then
                         Return False
                     End If
 


### PR DESCRIPTION
Adds a new test helper method that runs the expressions
through the simplifier to remove parenthesis.

New test helper wraps the expression under test in some boilerplate to make sure the simplifier works properly. Without the boilerplate the simplifier never did any work. Did I miss something maybe?

Included also is a fix for one of the `TestMemberAccessOffOfElementAccess` test where the VB simplifier removed parenthesis when it shouldn't. I'm not sure the fix is correct but I included it here to allow for discussion and to get some input on it.
I'm not sure about the template and could use some help filling it out if it's required :)

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes
#26586 

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact
PR only touches test code so low or no perf impact.

### Is this a regression from a previous update?
No
### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
