### PR TITLE
Add a workaround for long pipe path names

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -455,9 +455,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
             try
             {
+                var workingDir = CurrentDirectoryToUse();
+                string tempDir = BuildServerConnection.GetTempPath(workingDir);
+
                 if (!UseSharedCompilation ||
                     HasToolBeenOverridden ||
-                    !BuildServerConnection.IsCompilerServerSupported)
+                    !BuildServerConnection.IsCompilerServerSupported(tempDir))
                 {
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
@@ -475,13 +478,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     // we'll just print our own message that contains the real client location
                     Log.LogMessage(ErrorString.UsingSharedCompilation, clientDir);
 
-                    var workingDir = CurrentDirectoryToUse();
                     var buildPaths = new BuildPathsAlt(
                         clientDir: clientDir,
                         // MSBuild doesn't need the .NET SDK directory
                         sdkDir: null,
                         workingDir: workingDir,
-                        tempDir: BuildServerConnection.GetTempPath(workingDir));
+                        tempDir: tempDir);
 
                     // Note: using ToolArguments here (the property) since
                     // commandLineCommands (the parameter) may have been mucked with

--- a/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
@@ -123,10 +124,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
         }
 
-        internal static new int RunServer(string pipeName, IClientConnectionHost clientConnectionHost = null, IDiagnosticListener listener = null, TimeSpan? keepAlive = null, CancellationToken cancellationToken = default(CancellationToken))
+        internal static new int RunServer(
+            string pipeName,
+            string tempPath,
+            IClientConnectionHost clientConnectionHost = null,
+            IDiagnosticListener listener = null,
+            TimeSpan? keepAlive = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             BuildServerController controller = new DesktopBuildServerController(new NameValueCollection());
-            return controller.RunServer(pipeName, clientConnectionHost, listener, keepAlive, cancellationToken);
+            return controller.RunServer(pipeName, tempPath, clientConnectionHost, listener, keepAlive, cancellationToken);
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -12,6 +12,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using System.IO;
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
@@ -312,7 +313,11 @@ class Hello
                 try
                 {
                     var host = new Mock<IClientConnectionHost>(MockBehavior.Strict);
-                    var result = DesktopBuildServerController.RunServer(pipeName, host.Object, keepAlive: null);
+                    var result = DesktopBuildServerController.RunServer(
+                        pipeName,
+                        Path.GetTempPath(),
+                        host.Object,
+                        keepAlive: null);
                     Assert.Equal(CommonCompiler.Failed, result);
                 }
                 finally
@@ -364,7 +369,11 @@ class Hello
                     return new TaskCompletionSource<IClientConnection>().Task;
                 });
 
-            var result = DesktopBuildServerController.RunServer(pipeName, host.Object, keepAlive: TimeSpan.FromSeconds(1));
+            var result = DesktopBuildServerController.RunServer(
+                pipeName,
+                Path.GetTempPath(),
+                host.Object,
+                keepAlive: TimeSpan.FromSeconds(1));
             Assert.Equal(CommonCompiler.Succeeded, result);
         }
 

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -83,10 +83,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         internal static ServerData CreateServer(
             string pipeName = null,
             ICompilerServerHost compilerServerHost = null,
-            bool failingServer = false)
+            bool failingServer = false,
+            string tempPath = null)
         {
-            pipeName = pipeName ?? Guid.NewGuid().ToString();
+            // The total pipe path must be < 92 characters on Unix, so trim this down to 10 chars
+            pipeName = pipeName ?? Guid.NewGuid().ToString().Substring(0, 10);
             compilerServerHost = compilerServerHost ?? DesktopBuildServerController.CreateCompilerServerHost();
+            tempPath = tempPath ?? Path.GetTempPath();
             var clientConnectionHost = DesktopBuildServerController.CreateClientConnectionHostForServerHost(compilerServerHost, pipeName);
 
             if (failingServer)
@@ -106,6 +109,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 {
                     DesktopBuildServerController.RunServer(
                         pipeName,
+                        tempPath,
                         clientConnectionHost,
                         listener,
                         keepAlive: TimeSpan.FromMilliseconds(-1),

--- a/src/Compilers/Shared/DesktopBuildClient.cs
+++ b/src/Compilers/Shared/DesktopBuildClient.cs
@@ -61,28 +61,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             return RunServerCompilationCore(_language, arguments, buildPaths, sessionKey, keepAlive, libDirectory, TimeoutOverride, TryCreateServer, cancellationToken);
         }
 
-        public static Task<BuildResponse> RunServerCompilation(
-            RequestLanguage language,
-            List<string> arguments,
-            BuildPaths buildPaths,
-            string keepAlive,
-            string libEnvVariable,
-            CancellationToken cancellationToken)
-        {
-            var pipeNameOpt = BuildServerConnection.GetPipeNameForPathOpt(buildPaths.ClientDirectory);
-
-            return RunServerCompilationCore(
-                language,
-                arguments,
-                buildPaths,
-                pipeNameOpt,
-                keepAlive,
-                libEnvVariable,
-                timeoutOverride: null,
-                tryCreateServerFunc: BuildServerConnection.TryCreateServerCore,
-                cancellationToken: cancellationToken);
-        }
-
         private static Task<BuildResponse> RunServerCompilationCore(
             RequestLanguage language,
             List<string> arguments,


### PR DESCRIPTION

### Customer scenario

Sometimes, on MacOS, a build will cause the compiler server to never do any work, spinning forever in the background and consuming 100% CPU.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/24137

### Workarounds, if any

Disabling the compiler server works, but is not obvious and will slow down builds, that wouldn't hit this problem.

### Risk

This change only affects builds on CoreCLR on MacOS and Linux systems. The code should only affect usage of VBCSCompiler, so will not affect build correctness, only performance.

### Performance impact

Should have no change for users not previously hitting this bug. For users who do, this change should be a perf improvement, as VBCSCompiler was previously wasting CPU time and now would be disabled.

### Is this a regression from a previous update?

No.

### Root cause analysis

This is a non-deterministic property of how MacOS constructs its temp path, so the problem wasn't immediately apparent.

### How was the bug found?

User reported
