### PR TITLE
Warn for using ? in executable code but outside NonNullTypes(true) context

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -329,6 +329,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _next.GetImports(basesBeingResolved);
         }
 
+        protected virtual bool InExecutableBinder
+            => _next.InExecutableBinder;
+
         /// <summary>
         /// The type containing the binding context
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -338,11 +338,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case SyntaxKind.NullableType:
                     {
-                        TypeSyntax typeArgumentSyntax = ((NullableTypeSyntax)syntax).ElementType;
+                        var nullableSyntax = (NullableTypeSyntax)syntax;
+                        TypeSyntax typeArgumentSyntax = nullableSyntax.ElementType;
                         TypeSymbolWithAnnotations typeArgument = BindType(typeArgumentSyntax, diagnostics, basesBeingResolved);
                         TypeSymbolWithAnnotations constructedType;
                         if (Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking))
                         {
+                            if (InExecutableBinder)
+                            {
+                                // Inside a method body or other executable code, we can afford to pull on NonNullTypes symbol or question IsReferenceType without causing cycles.
+                                // Types created outside executable context should be check by the responsible symbol (the method symbol checks its return type, for instance).
+
+                                if (typeArgument.IsReferenceType && NonNullTypesContext.NonNullTypes != true)
+                                {
+                                    diagnostics.Add(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, nullableSyntax.QuestionToken.GetLocation());
+                                }
+                            }
+
                             constructedType = typeArgument.SetIsAnnotated(Compilation);
                             if (!ShouldCheckConstraints)
                             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -346,10 +346,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             if (InExecutableBinder)
                             {
-                                // Inside a method body or other executable code, we can afford to pull on NonNullTypes symbol or question IsReferenceType without causing cycles.
-                                // Types created outside executable context should be check by the responsible symbol (the method symbol checks its return type, for instance).
+                                // Inside a method body or other executable code, we can afford to pull on NonNullTypes symbol or question IsValueType without causing cycles.
+                                // Types created outside executable context should be checked by the responsible symbol (the method symbol checks its return type, for instance).
 
-                                if (typeArgument.IsReferenceType && NonNullTypesContext.NonNullTypes != true)
+                                if (!typeArgument.IsValueType && NonNullTypesContext.NonNullTypes != true)
                                 {
                                     diagnostics.Add(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, nullableSyntax.QuestionToken.GetLocation());
                                 }

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -20,41 +20,29 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override ImportChain ImportChain
-        {
-            get
-            {
-                return null;
-            }
-        }
+            => null;
 
         /// <summary>
         /// Get <see cref="QuickAttributeChecker"/> that can be used to quickly
         /// check for certain attribute applications in context of this binder.
         /// </summary>
         internal override QuickAttributeChecker QuickAttributeChecker
-        {
-            get
-            {
-                return QuickAttributeChecker.Predefined;
-            }
-        }
+            => QuickAttributeChecker.Predefined;
 
         internal override Imports GetImports(ConsList<Symbol> basesBeingResolved)
-        {
-            return Imports.Empty;
-        }
+            => Imports.Empty;
 
         protected override SourceLocalSymbol LookupLocal(SyntaxToken nameToken)
-        {
-            return null;
-        }
+            => null;
 
         protected override LocalFunctionSymbol LookupLocalFunction(SyntaxToken nameToken)
-        {
-            return null;
-        }
+            => null;
 
-        internal override uint LocalScopeDepth => Binder.ExternalScope;
+        internal override uint LocalScopeDepth
+            => Binder.ExternalScope;
+
+        protected override bool InExecutableBinder
+            => false;
 
         internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo> useSiteDiagnostics, ConsList<Symbol> basesBeingResolved)
         {

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -20,29 +20,43 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override ImportChain ImportChain
-            => null;
+        {
+            get
+            {
+                return null;
+            }
+        }
 
         /// <summary>
         /// Get <see cref="QuickAttributeChecker"/> that can be used to quickly
         /// check for certain attribute applications in context of this binder.
         /// </summary>
         internal override QuickAttributeChecker QuickAttributeChecker
-            => QuickAttributeChecker.Predefined;
+        {
+            get
+            {
+                return QuickAttributeChecker.Predefined;
+            }
+        }
 
         internal override Imports GetImports(ConsList<Symbol> basesBeingResolved)
-            => Imports.Empty;
+        {
+            return Imports.Empty;
+        }
 
         protected override SourceLocalSymbol LookupLocal(SyntaxToken nameToken)
-            => null;
+        {
+            return null;
+        }
 
         protected override LocalFunctionSymbol LookupLocalFunction(SyntaxToken nameToken)
-            => null;
+        {
+            return null;
+        }
 
-        internal override uint LocalScopeDepth
-            => Binder.ExternalScope;
+        internal override uint LocalScopeDepth => Binder.ExternalScope;
 
-        protected override bool InExecutableBinder
-            => false;
+        protected override bool InExecutableBinder => false;
 
         internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref HashSet<DiagnosticInfo> useSiteDiagnostics, ConsList<Symbol> basesBeingResolved)
         {

--- a/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
@@ -42,11 +42,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override Symbol ContainingMemberOrLambda
-        {
-            get { return _memberSymbol ?? Next.ContainingMemberOrLambda; }
-        }
+            => _memberSymbol ?? Next.ContainingMemberOrLambda;
 
-        internal Symbol MemberSymbol { get { return _memberSymbol; } }
+        internal Symbol MemberSymbol
+            => _memberSymbol;
+
+        protected override bool InExecutableBinder
+            => true;
 
         internal override Binder GetBinder(SyntaxNode node)
         {

--- a/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
@@ -42,13 +42,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override Symbol ContainingMemberOrLambda
-            => _memberSymbol ?? Next.ContainingMemberOrLambda;
-
-        internal Symbol MemberSymbol
-            => _memberSymbol;
+        {
+            get { return _memberSymbol ?? Next.ContainingMemberOrLambda; }
+        }
 
         protected override bool InExecutableBinder
             => true;
+
+        internal Symbol MemberSymbol { get { return _memberSymbol; } }
 
         internal override Binder GetBinder(SyntaxNode node)
         {

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -66,6 +66,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override uint LocalScopeDepth => Binder.TopLevelScope;
 
+        protected override bool InExecutableBinder => true;
+
         internal override Symbol ContainingMemberOrLambda
         {
             get

--- a/src/Compilers/CSharp/Portable/Binder/WithMethodTypeParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithMethodTypeParametersBinder.cs
@@ -20,13 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             _methodSymbol = methodSymbol;
         }
 
-        internal override Symbol ContainingMemberOrLambda
-        {
-            get
-            {
-                return _methodSymbol;
-            }
-        }
+        internal override Symbol ContainingMemberOrLambda => _methodSymbol;
+
+        protected override bool InExecutableBinder => false;
 
         protected override MultiDictionary<string, TypeParameterSymbol> TypeParameterMap
         {

--- a/src/Compilers/CSharp/Portable/Binder/WithMethodTypeParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithMethodTypeParametersBinder.cs
@@ -20,9 +20,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             _methodSymbol = methodSymbol;
         }
 
-        internal override Symbol ContainingMemberOrLambda => _methodSymbol;
-
         protected override bool InExecutableBinder => false;
+
+        internal override Symbol ContainingMemberOrLambda
+        {
+            get
+            {
+                return _methodSymbol;
+            }
+        }
 
         protected override MultiDictionary<string, TypeParameterSymbol> TypeParameterMap
         {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -13970,7 +13970,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context..
+        ///   Looks up a localized string similar to The suppression operator (!) should be used in code with a &apos;[NonNullTypes(true/false)]&apos; context..
         /// </summary>
         internal static string WRN_MissingNonNullTypesContext {
             get {
@@ -13979,11 +13979,29 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context..
+        ///   Looks up a localized string similar to The suppression operator (!) should be used in code with a &apos;[NonNullTypes(true/false)]&apos; context..
         /// </summary>
         internal static string WRN_MissingNonNullTypesContext_Title {
             get {
                 return ResourceManager.GetString("WRN_MissingNonNullTypesContext_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The annotation for nullable reference types should only be used in code within a &apos;[NonNullTypes(true)]&apos; context..
+        /// </summary>
+        internal static string WRN_MissingNonNullTypesContextForAnnotation {
+            get {
+                return ResourceManager.GetString("WRN_MissingNonNullTypesContextForAnnotation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The annotation for nullable reference types should only be used in code within a &apos;[NonNullTypes(true)]&apos; context..
+        /// </summary>
+        internal static string WRN_MissingNonNullTypesContextForAnnotation_Title {
+            get {
+                return ResourceManager.GetString("WRN_MissingNonNullTypesContextForAnnotation_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5370,10 +5370,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.</value>
   </data>
   <data name="WRN_MissingNonNullTypesContextForAnnotation" xml:space="preserve">
-    <value>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</value>
+    <value>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</value>
   </data>
   <data name="WRN_MissingNonNullTypesContextForAnnotation_Title" xml:space="preserve">
-    <value>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</value>
+    <value>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</value>
   </data>
   <data name="ERR_ExplicitNullableAttribute" xml:space="preserve">
     <value>Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.</value>
@@ -5388,10 +5388,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Please use language version {0} or greater to use the NonNullTypes attribute.</value>
   </data>
   <data name="WRN_MissingNonNullTypesContext" xml:space="preserve">
-    <value>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</value>
+    <value>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</value>
   </data>
   <data name="WRN_MissingNonNullTypesContext_Title" xml:space="preserve">
-    <value>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</value>
+    <value>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</value>
   </data>
   <data name="ERR_NonTaskMainCantBeAsync" xml:space="preserve">
     <value>A void or int returning entry point cannot be async</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5369,6 +5369,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_NullabilityMismatchInTypeParameterConstraint_Title" xml:space="preserve">
     <value>The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.</value>
   </data>
+  <data name="WRN_MissingNonNullTypesContextForAnnotation" xml:space="preserve">
+    <value>The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.</value>
+  </data>
+  <data name="WRN_MissingNonNullTypesContextForAnnotation_Title" xml:space="preserve">
+    <value>The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.</value>
+  </data>
   <data name="ERR_ExplicitNullableAttribute" xml:space="preserve">
     <value>Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5370,10 +5370,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.</value>
   </data>
   <data name="WRN_MissingNonNullTypesContextForAnnotation" xml:space="preserve">
-    <value>The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.</value>
+    <value>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</value>
   </data>
   <data name="WRN_MissingNonNullTypesContextForAnnotation_Title" xml:space="preserve">
-    <value>The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.</value>
+    <value>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</value>
   </data>
   <data name="ERR_ExplicitNullableAttribute" xml:space="preserve">
     <value>Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1616,6 +1616,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_MissingNonNullTypesContext = 8629,
         ERR_NonNullTypesNotAvailable = 8630,
         WRN_NullabilityMismatchInTypeParameterConstraint = 8631,
+        WRN_MissingNonNullTypesContextForAnnotation = 8632,
     }
     // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -348,6 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_TupleBinopLiteralNameMismatch:
                 case ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter:
                 case ErrorCode.WRN_MissingNonNullTypesContext:
+                case ErrorCode.WRN_MissingNonNullTypesContextForAnnotation:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -204,6 +204,7 @@
                 case ErrorCode.WRN_NoBestNullabilityConditionalExpression:
                 case ErrorCode.WRN_MissingNonNullTypesContext:
                 case ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint:
+                case ErrorCode.WRN_MissingNonNullTypesContextForAnnotation:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -964,7 +964,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return (AssociatedSymbol ?? ContainingType)?.NonNullTypes;
+                return (AssociatedSymbol ?? ContainingSymbol)?.NonNullTypes;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -407,6 +407,16 @@
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
+        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
         <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
         <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -403,23 +403,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation_Title">
-        <source>The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</source>
-        <target state="new">The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.</target>
+        <source>The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</source>
+        <target state="new">The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContext_Title">
-        <source>The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</source>
-        <target state="new">The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.</target>
+        <source>The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</source>
+        <target state="new">The suppression operator (!) should be used in code with a '[NonNullTypes(true/false)]' context.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_TypeParameterSameAsOuterMethodTypeParameter">

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -579,7 +579,7 @@ class Program
         new C<B2?>();
     }
 }";
-            var comp2 = CreateCompilation(source2, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
+            var comp2 = CreateCompilation(new[] { source2, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics();
 
             var type = comp2.GetMember<NamedTypeSymbol>("C");
@@ -681,10 +681,10 @@ public class C<T> where T : A<object>
         new C<object, string>();
     }
 }";
-            var comp2 = CreateCompilation(new[] { source, source2 }, parseOptions: TestOptions.Regular8);
+            var comp2 = CreateCompilation(new[] { source, source2, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp2.VerifyEmitDiagnostics();
 
-            comp2 = CreateCompilation(source2, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
+            comp2 = CreateCompilation(new[] { source2, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyEmitDiagnostics();
 
             var type = comp2.GetMember<NamedTypeSymbol>("C");
@@ -1292,7 +1292,7 @@ class C
         F((object? o) => { });
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (9,12): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //         F((object? o) => { });
@@ -1311,7 +1311,7 @@ class C
         L();
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (5,9): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //         object?[] L() => throw new System.NotImplementedException();
@@ -1330,7 +1330,7 @@ class C
         L(null, 2);
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (5,16): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //         void L(object? x, object y) { }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -37809,34 +37809,43 @@ class C
     void M1()
     {
         local(new C(), new C(), new C(), null);
-        void local<T, T2, T3>(T t, T2 t2, T3 t3, string? s) where T : C where T2 : C? where T3 : T? { }
+        void local<T, T2, T3>(T t, T2 t2, T3 t3, string? s) where T : C where T2 : C? where T3 : T?
+        {
+            T? x = t;
+            x!.ToString();
+        }
     }
     [System.Runtime.CompilerServices.NonNullTypes(false)]
     void M2()
     {
         local(new C(), new C(), new C(), null);
-        void local<T, T2, T3>(T t, T2 t2, T3 t3, string? s) where T : C where T2 : C? where T3 : T? { }
+        void local<T, T2, T3>(T t, T2 t2, T3 t3, string? s) where T : C where T2 : C? where T3 : T?
+        {
+            T? x = t; // warn 1
+            x!.ToString();
+        }
     }
     void M3()
     {
         local(new C(), new C(), new C(), null);
-        void local<T, T2, T3>(T t, T2 t2, T3 t3, string? s) where T : C where T2 : C? where T3 : T? { }
+        void local<T, T2, T3>(T t, T2 t2, T3 t3, string? s) where T : C where T2 : C? where T3 : T?
+        {
+            T? x = t; // warn 2
+            x!.ToString(); // warn 3
+        }
     }
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (14,45): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
-                //         void local<T, T2>(T t, T2 t2, string? s) where T : C where T2 : C? { }
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(14, 45),
-                // (14,74): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
-                //         void local<T, T2>(T t, T2 t2, string? s) where T : C where T2 : C? { }
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(14, 74),
-                // (19,45): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
-                //         void local<T, T2>(T t, T2 t2, string? s) where T : C where T2 : C? { }
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(19, 45),
-                // (19,74): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
-                //         void local<T, T2>(T t, T2 t2, string? s) where T : C where T2 : C? { }
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(19, 74)
+                // (20,14): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                //             T? x = t; // warn 1
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(20, 14),
+                // (29,14): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                //             T? x = t; // warn 2
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(29, 14),
+                // (30,13): warning CS8629: The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.
+                //             x!.ToString(); // warn 3
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContext, "x!").WithLocation(30, 13)
                 );
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -37808,19 +37808,19 @@ class C
     [System.Runtime.CompilerServices.NonNullTypes(true)]
     void M1()
     {
-        local(new C(), new C(), null);
-        void local<T, T2>(T t, T2 t2, string? s) where T : C where T2 : C? { }
+        local(new C(), new C(), new C(), null);
+        void local<T, T2, T3>(T t, T2 t2, T3 t3, string? s) where T : C where T2 : C? where T3 : T? { }
     }
     [System.Runtime.CompilerServices.NonNullTypes(false)]
     void M2()
     {
-        local(new C(), new C(), null);
-        void local<T, T2>(T t, T2 t2, string? s) where T : C where T2 : C? { }
+        local(new C(), new C(), new C(), null);
+        void local<T, T2, T3>(T t, T2 t2, T3 t3, string? s) where T : C where T2 : C? where T3 : T? { }
     }
     void M3()
     {
-        local(new C(), new C(), null);
-        void local<T, T2>(T t, T2 t2, string? s) where T : C where T2 : C? { }
+        local(new C(), new C(), new C(), null);
+        void local<T, T2, T3>(T t, T2 t2, T3 t3, string? s) where T : C where T2 : C? where T3 : T? { }
     }
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -229,25 +229,25 @@ class C
 
             // PROTOTYPE(NullableReferenceTypes): we need to warn on misuse of annotation every place a type could appear (not just in executable code)
             c.VerifyDiagnostics(
-                // (4,41): warning CS8628: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (4,41): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //     static string? field = M2(out string? x1); // warn 1
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(4, 41),
-                // (9,19): warning CS8628: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (9,19): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //             string? x2 = null; // warn 2
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(9, 19),
-                // (15,15): warning CS8628: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (15,15): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         string? x3 = local(); // warn 3
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(15, 15),
-                // (20,19): warning CS8628: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (20,19): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //             string? x4 = null; // warn 5
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(20, 19),
-                // (18,15): warning CS8628: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (18,15): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         string? local() // warn 4
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(18, 15),
-                // (26,27): warning CS8628: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (26,27): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         System.Func<string?> x5 = () =>  // warn 6
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(26, 27),
-                // (28,19): warning CS8628: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (28,19): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //             string? x6 = null; // warn 7
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(28, 19)
                 );
@@ -277,7 +277,7 @@ public class E<T> where T : struct
 
             // PROTOTYPE(NullableReferenceTypes): we need to warn on misuse of annotation every place a type could appear (not just in executable code)
             c.VerifyDiagnostics(
-                // (6,10): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (6,10): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         T? y1 = x1; // warn
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(6, 10)
                 );
@@ -2451,10 +2451,10 @@ class C
 
             compilation.VerifyTypes();
             compilation.VerifyDiagnostics(
-                // (14,24): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (14,24): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         foreach (string? ns in NCollection())
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(14, 24),
-                // (34,24): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (34,24): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         foreach (string? ns in FalseNCollection())
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(34, 24),
                 // (16,13): warning CS8602: Possible dereference of a null reference.
@@ -2618,10 +2618,10 @@ class C
 
             compilation.VerifyTypes();
             compilation.VerifyDiagnostics(
-                // (13,24): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (13,24): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         NOut(out string? ns2);
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(13, 24),
-                // (21,29): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (21,29): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         FalseNOut(out string? ns3);
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(21, 29),
                 // (14,9): warning CS8602: Possible dereference of a null reference.
@@ -2792,10 +2792,10 @@ public class Base
 
             compilation.VerifyTypes();
             compilation.VerifyDiagnostics(
-                // (13,15): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (13,15): warning CS8628: The annotation for nullable reference types should only be used in code with a '[NonNullTypes(true)]' context.
                 //         string? ns2 = NMethod();
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(13, 15),
-                // (21,15): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (21,15): warning CS8628: The annotation for nullable reference types should only be used in code with a '[NonNullTypes(true)]' context.
                 //         string? ns3 = FalseNMethod();
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(21, 15),
                 // (14,9): warning CS8602: Possible dereference of a null reference.
@@ -5065,10 +5065,10 @@ class B : A
                 // (18,31): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     public override string?[] M1()
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M1").WithLocation(18, 31),
-                // (20,26): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (20,26): warning CS8628: The annotation for nullable reference types should only be used in code with a '[NonNullTypes(true)]' context.
                 //         return new string?[] {};
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(20, 26),
-                // (26,21): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (26,21): warning CS8628: The annotation for nullable reference types should only be used in code with a '[NonNullTypes(true)]' context.
                 //         return new S?[] {};
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(26, 21)
                 );
@@ -5241,10 +5241,10 @@ class B : IA
                 // (11,18): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'string[] IA.M1()'.
                 //     string?[] IA.M1()
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M1").WithArguments("string[] IA.M1()").WithLocation(11, 18),
-                // (13,26): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (13,26): warning CS8628: The annotation for nullable reference types should only be used in code with a '[NonNullTypes(true)]' context.
                 //         return new string?[] {};
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(13, 26),
-                // (19,21): warning CS8628: The annotation for nullable reference types can only be used in code with a `[NonNullTypes(true)]` context.
+                // (19,21): warning CS8628: The annotation for nullable reference types should only be used in code with a '[NonNullTypes(true)]' context.
                 //         return new S?[] {};
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(19, 21)
                 );
@@ -37822,10 +37822,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (20,14): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (20,14): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //             T? x = t; // warn 1
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(20, 14),
-                // (29,14): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (29,14): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //             T? x = t; // warn 2
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(29, 14),
                 // (30,13): warning CS8629: The suppression operator (!) should be used in code with a `[NonNullTypes(true/false)]` context.
@@ -38372,13 +38372,13 @@ public class A6<T> where T : IEquatable<int?> { }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
             // PROTOTYPE(NullableReferenceTypes): Should report a warning for A0<string?>() and A2<string>().
             comp.VerifyDiagnostics(
-                // (5,22): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (5,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         new A0<string?>(); // warning
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(5, 22),
-                // (7,22): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (7,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         new A2<string?>();
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(7, 22),
-                // (9,22): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (9,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         new A5<string?>();
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(9, 22),
                 // (9,16): warning CS8631: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'A5<T>'. Nullability of type argument 'string?' doesn't match constraint type 'System.IEquatable<string?>'.
@@ -38399,13 +38399,13 @@ public class A6<T> where T : IEquatable<int?> { }";
             comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
             // PROTOTYPE(NullableReferenceTypes): Should report same warnings as other two cases.
             comp.VerifyDiagnostics(
-                // (5,22): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (5,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         new A0<string?>(); // warning
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(5, 22),
-                // (7,22): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (7,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         new A2<string?>();
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(7, 22),
-                // (9,22): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (9,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         new A5<string?>();
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(9, 22)
                 );
@@ -38423,13 +38423,13 @@ public class A6<T> where T : IEquatable<int?> { }";
             comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
             // PROTOTYPE(NullableReferenceTypes): Should report a warning for A0<string?>() and A2<string>().
             comp.VerifyDiagnostics(
-                // (5,22): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (5,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         new A0<string?>(); // warning
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(5, 22),
-                // (7,22): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (7,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         new A2<string?>();
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(7, 22),
-                // (9,22): warning CS8632: The annotation for nullable reference types can only be used in code within a '[NonNullTypes(true)]' context.
+                // (9,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //         new A5<string?>();
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(9, 22),
                 // (9,16): warning CS8631: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'A5<T>'. Nullability of type argument 'string?' doesn't match constraint type 'System.IEquatable<string?>'.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -161,7 +161,7 @@ class C
         }
 
         [Fact]
-        public void TestSuppressionWithoutNonNullTypes()
+        public void SuppressionWithoutNonNullTypes()
         {
             CSharpCompilation c = CreateCompilation(@"
 class C
@@ -189,7 +189,7 @@ class C
         }
 
         [Fact]
-        public void TestAnnotationWithoutNonNullTypes()
+        public void AnnotationWithoutNonNullTypes()
         {
             CSharpCompilation c = CreateCompilation(@"
 class C

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -303,9 +303,15 @@ class Client
     }
 }
 ";
-            // PROTOTYPE(NullableReferenceTypes): expecting warnings
-            var comp2 = CreateCompilation(client, references: new[] { c.EmitToImageReference() });
-            comp2.VerifyDiagnostics();
+            var comp2 = CreateCompilation(client, references: new[] { c.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
+            comp2.VerifyDiagnostics(
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         c.M("").ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, @"c.M("""")").WithLocation(6, 9),
+                // (7,9): warning CS8602: Possible dereference of a null reference.
+                //         d.M("").ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, @"d.M("""")").WithLocation(7, 9)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -254,7 +254,7 @@ class C
         }
 
         [Fact]
-        public void TestAnnotationWithoutNonNullTypes_GenericType()
+        public void AnnotationWithoutNonNullTypes_GenericType()
         {
             CSharpCompilation c = CreateCompilation(@"
 class C<T>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -257,25 +257,25 @@ class C
         public void AnnotationWithoutNonNullTypes_GenericType()
         {
             CSharpCompilation c = CreateCompilation(@"
-class C<T>
+public class C<T>
 {
-    T? M(T? x1)
+    public T? M(T? x1)
     {
         T? y1 = x1; // warn 1
         return y1;
     }
 }
-class D<T> where T : class
+public class D<T> where T : class
 {
-    T? M(T? x2)
+    public T? M(T? x2)
     {
         T? y2 = x2; // warn 2
         return y2;
     }
 }
-class E<T> where T : struct
+public class E<T> where T : struct
 {
-    T? M(T? x3)
+    public T? M(T? x3)
     {
         T? y3 = x3;
         return y3;
@@ -292,6 +292,20 @@ class E<T> where T : struct
                 //         T? y1 = x1; // warn 1
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(6, 10)
                 );
+
+            var client = @"
+class Client
+{
+    void M(C<string> c, D<string> d)
+    {
+        c.M("""").ToString();
+        d.M("""").ToString();
+    }
+}
+";
+            // PROTOTYPE(NullableReferenceTypes): expecting warnings
+            var comp2 = CreateCompilation(client, references: new[] { c.EmitToImageReference() });
+            comp2.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -385,7 +385,7 @@ namespace System.Runtime.CompilerServices
         P2 = new object?[] { o };
     }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -281,6 +281,7 @@ class X
                         case ErrorCode.WRN_NoBestNullabilityConditionalExpression:
                         case ErrorCode.WRN_MissingNonNullTypesContext:
                         case ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint:
+                        case ErrorCode.WRN_MissingNonNullTypesContextForAnnotation:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_InvalidVersionFormat:


### PR DESCRIPTION
LDM [agreed](https://github.com/dotnet/csharplang/blob/master/meetings/2018/LDM-2018-07-16.md#non-nullable-reference-type-feature-flag-follow-up) to warn on misuse of `?`, namely outside of a `NonNullTypes(true)` context.

Unfortunately, we can just perform this check whenever binding a type, because pulling on `IsReferenceType` or `NonNullTypes` causes cycles.
So we're going to divide the problem into three categories, each with their own solution:
- types in executable code: it's ok to pull on those properties in this case (since it doesn't affect binding the symbols and members declared), we can handle those in the binder.
- types in declarations: those will need to be checked by the declaration symbols themselves. For instance, `MethodChecks` will need to perform this validation on the return type, parameter types, etc.
- misc. scenarios that are already errors: we can get away with not checking those, as they would be cascading errors anyways.

Note to self: I'm working on a follow-up (to address types in declarations) in branch `string-question2`.