### PR TITLE
updating optprof data for expression evaluators

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -152,7 +152,7 @@
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62506-02</MicrosoftDiaSymReaderPdb2PdbVersion>
     <RestSharpVersion>105.2.3</RestSharpVersion>
     <RoslynBuildUtilVersion>0.9.8-beta</RoslynBuildUtilVersion>
-    <RoslynDependenciesOptimizationDataVersion>2.9.0-beta7-63018-03-01</RoslynDependenciesOptimizationDataVersion>
+    <RoslynDependenciesOptimizationDataVersion>2.11.0-beta1-63126-01</RoslynDependenciesOptimizationDataVersion>
     <RoslynToolsMicrosoftLocateVSVersion>0.2.4-beta</RoslynToolsMicrosoftLocateVSVersion>
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.4.0-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
     <RoslynToolsMSBuildVersion>0.5.0-alpha</RoslynToolsMSBuildVersion>


### PR DESCRIPTION
This PR adds new pgo training data for the following assemblies: 

 - Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ExpressionCompiler.dll
 - Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ResultProvider.dll
 - Microsoft.CodeAnalysis.ExpressionEvaluator.ExpressionCompiler.dll
 - Microsoft.CodeAnalysis.ExpressionEvaluator.ResultProvider.dll
 - Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ExpressionCompiler.dll
 - Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ResultProvider.dll

Scenarios used for training:
 - [C#](https://github.com/dotnet/roslyn-internal/blob/master/Closed/Hosting/RoslynTaoActions/IntegrationTests/CSharpDebuggerIntellisense.xml)
 - [VB](https://github.com/dotnet/roslyn-internal/blob/master/Closed/Hosting/RoslynTaoActions/IntegrationTests/BasicDebuggerIntellisense.xml)

### Customer scenario

loading Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ResultProvider.dll causes more VM to be used than in previous releases

### Bugs this fixes

- [VSO bug](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/632106)

### Workarounds, if any

None

### Risk

We will do an RPS run against this change to validate that it fixes the issue
- [RPS run](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=1892995)

### Performance impact

Should improve image load size.

### Is this a regression from a previous update?

Yes

### Root cause analysis

Its been over 6 months since expression evaluator training was done. In that time drift between the expression evaluator code and the training data caused a regression.

### How was the bug found?

RPS testing

