### PR TITLE
Disable icacls use on Helix

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -4975,6 +4975,14 @@ public class CS1698_a {}
                 {
                     return;
                 }
+
+                // The icacls command fails on our Helix machines and it appears to be related to the use of the $ in 
+                // the username. 
+                // https://github.com/dotnet/roslyn/issues/28836
+                if (StringComparer.OrdinalIgnoreCase.Equals(Environment.UserDomainName, "WORKGROUP"))
+                {
+                    return;
+                }
             }
 
             var folder = Temp.CreateDirectory();

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -6362,6 +6362,13 @@ End Module
         <WorkItem(5664, "https://github.com/dotnet/roslyn/issues/5664")>
         <ConditionalFact(GetType(IsEnglishLocal))>
         Public Sub Bug15538()
+            ' The icacls command fails on our Helix machines And it appears to be related to the use of the $ in 
+            ' the username. 
+            ' https://github.com/dotnet/roslyn/issues/28836
+            If StringComparer.OrdinalIgnoreCase.Equals(Environment.UserDomainName, "WORKGROUP") Then
+                Return
+            End If
+
             Dim folder = Temp.CreateDirectory()
             Dim source As String = folder.CreateFile("src.vb").WriteAllText("").Path
             Dim ref As String = folder.CreateFile("ref.dll").WriteAllText("").Path


### PR DESCRIPTION
The icacls command is failing on Helix hence disabling these tests there
for now

Related to #28836

