### PR TITLE
Ensure F# package is loaded

### DIFF
--- a/src/VisualStudio/Core/Def/Guids.cs
+++ b/src/VisualStudio/Core/Def/Guids.cs
@@ -85,6 +85,10 @@ namespace Microsoft.VisualStudio.LanguageServices
         public const string VisualBasicOptionPageNamingStyleIdString = "BCA454E0-95E4-4877-B4CB-B1D642B7BAFA";
         public const string VisualBasicOptionPageIntelliSenseIdString = "04460A3B-1B5F-4402-BC6D-89A4F6F0A8D7";
 
+        public const string FSharpPackageIdString = "871D2A70-12A2-4e42-9440-425DD92A4116";
+
+        public static readonly Guid FSharpPackageId = new Guid(FSharpPackageIdString);
+
         // from vscommon\inc\textmgruuids.h
         public const string TextManagerPackageString = "F5E7E720-1401-11D1-883B-0000F87579D2";
 

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -127,6 +127,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                 case LanguageNames.VisualBasic:
                     shell.LoadPackage(Guids.VisualBasicPackageId, out unused);
                     break;
+                case LanguageNames.FSharp:
+                    shell.LoadPackage(Guids.FSharpPackageId, out unused);
+                    break;
                 default:
                     // by default, load roslyn package for things like typescript and etc
                     shell.LoadPackage(Guids.RoslynPackageId, out unused);


### PR DESCRIPTION
This ensures the F# package is loaded for CPS only projects in a solution. Seems this was an oversight.

Independent of https://github.com/Microsoft/visualfsharp/pull/5391, ensuring the F# package load fixes this issue: https://github.com/Microsoft/visualfsharp/issues/5395 - and it probably fixes other issues that we haven't discovered as a result of not loading the package.