### PR TITLE
Delete Contract.* methods that are equivalent to Debug.Assert

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 else
                 {
                     // there must be trivia that contains or touch this position
-                    Contract.Assert(token.FullSpan.Contains(lastNonWhitespacePosition));
+                    Debug.Assert(token.FullSpan.Contains(lastNonWhitespacePosition));
 
                     // okay, now check whether the trivia is at the beginning of the line
                     var firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition();
@@ -162,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 if (token.IsSemicolonOfEmbeddedStatement() ||
                     token.IsCloseBraceOfEmbeddedBlock())
                 {
-                    Contract.Requires(
+                    Debug.Assert(
                         token.Parent != null &&
                         (token.Parent.Parent is StatementSyntax || token.Parent.Parent is ElseClauseSyntax));
 

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Composition;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -109,8 +110,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
             public override void AddIndentBlockOperations(List<IndentBlockOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<IndentBlockOperation> nextOperation)
             {
                 // these nodes should be from syntax tree from ITextSnapshot.
-                Contract.Requires(node.SyntaxTree != null);
-                Contract.Requires(node.SyntaxTree.GetText() != null);
+                Debug.Assert(node.SyntaxTree != null);
+                Debug.Assert(node.SyntaxTree.GetText() != null);
 
                 nextOperation.Invoke(list);
 

--- a/src/EditorFeatures/CSharp/NavigationBar/CSharpNavigationBarItemService.cs
+++ b/src/EditorFeatures/CSharp/NavigationBar/CSharpNavigationBarItemService.cs
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.NavigationBar
         [Conditional("DEBUG")]
         private static void ValidateSpanFromBounds(ITextSnapshot snapshot, int start, int end)
         {
-            Contract.Requires(start >= 0 && end <= snapshot.Length && start <= end);
+            Debug.Assert(start >= 0 && end <= snapshot.Length && start <= end);
         }
 
         [Conditional("DEBUG")]

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -242,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     // additions of "one" and "three").
                     var boundingIntersectionSpan = Span.FromBounds(intersectionSpans.First().Start, intersectionSpans.Last().End);
                     var trackingSpansTouched = GetEditableSpansForSnapshot(args.After).Where(ss => ss.IntersectsWith(boundingIntersectionSpan));
-                    Contract.Assert(trackingSpansTouched.Count() == 1);
+                    Debug.Assert(trackingSpansTouched.Count() == 1);
 
                     var singleTrackingSpanTouched = trackingSpansTouched.Single();
                     _activeSpan = _referenceSpanToLinkedRenameSpanMap.Where(kvp => kvp.Value.TrackingSpan.GetSpan(args.After).Contains(boundingIntersectionSpan)).Single().Key;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
@@ -563,7 +563,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
             else
             {
-                Contract.Assert(outcome.HasFlag(RenameLogMessage.UserActionOutcome.Canceled));
+                Debug.Assert(outcome.HasFlag(RenameLogMessage.UserActionOutcome.Canceled));
                 Logger.Log(FunctionId.Rename_InlineSession_Session, RenameLogMessage.Create(
                     _optionSet,
                     outcome,

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -548,7 +548,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         var priority = GetSuggestedActionSetPriority(group.Key);
 
                         // diagnostic from things like build shouldn't reach here since we don't support LB for those diagnostics
-                        Contract.Requires(diag.Item1.HasTextSpan);
+                        Debug.Assert(diag.Item1.HasTextSpan);
                         var category = GetFixCategory(diag.Item1.Severity);
                         sets.Add(new SuggestedActionSet(category, group, priority: priority, applicableToSpan: diag.Item1.TextSpan.ToSpan()));
                     }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSquiggleTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSquiggleTaggerProvider.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue;
@@ -51,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
         protected override IErrorTag CreateTag(DiagnosticData diagnostic)
         {
-            Contract.Requires(!string.IsNullOrWhiteSpace(diagnostic.Message));
+            Debug.Assert(!string.IsNullOrWhiteSpace(diagnostic.Message));
             var errorType = GetErrorTypeFromDiagnostic(diagnostic);
             if (errorType == null)
             {

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             }
 
             var lines = GetDocumentationCommentStubLines(targetMember);
-            Contract.Assume(lines.Count > 2);
+            Debug.Assert(lines.Count > 2);
 
             var newLine = options.GetOption(FormattingOptions.NewLine);
             AddLineBreaks(text, lines, newLine);
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             }
 
             var lines = GetDocumentationCommentStubLines(targetMember);
-            Contract.Assume(lines.Count > 2);
+            Debug.Assert(lines.Count > 2);
 
             var newLine = options.GetOption(FormattingOptions.NewLine);
             AddLineBreaks(text, lines, newLine);
@@ -411,17 +411,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
 
             var startPosition = targetMember.GetFirstToken().SpanStart;
             var line = text.Lines.GetLineFromPosition(startPosition);
-            Contract.Assume(!line.IsEmptyOrWhitespace());
+            Debug.Assert(!line.IsEmptyOrWhitespace());
 
             var lines = GetDocumentationCommentStubLines(targetMember);
-            Contract.Assume(lines.Count > 2);
+            Debug.Assert(lines.Count > 2);
 
             var newLine = options.GetOption(FormattingOptions.NewLine);
             AddLineBreaks(text, lines, newLine);
 
             // Add indents
             var lineOffset = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(options.GetOption(FormattingOptions.TabSize));
-            Contract.Assume(line.Start + lineOffset == startPosition);
+            Debug.Assert(line.Start + lineOffset == startPosition);
 
             var indentText = lineOffset.CreateIndentationString(options.GetOption(FormattingOptions.UseTabs), options.GetOption(FormattingOptions.TabSize));
             for (int i = 1; i < lines.Count; i++)

--- a/src/EditorFeatures/Core/Implementation/ForegroundNotification/ForegroundNotificationService.cs
+++ b/src/EditorFeatures/Core/Implementation/ForegroundNotification/ForegroundNotificationService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ForegroundNotification
 
         public void RegisterNotification(Action action, int delay, IAsyncToken asyncToken, CancellationToken cancellationToken = default)
         {
-            Contract.Requires(delay >= 0);
+            Debug.Assert(delay >= 0);
 
             if (cancellationToken.IsCancellationRequested)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ForegroundNotification
 
         public void RegisterNotification(Func<bool> action, int delay, IAsyncToken asyncToken, CancellationToken cancellationToken = default)
         {
-            Contract.Requires(delay >= 0);
+            Debug.Assert(delay >= 0);
 
             if (cancellationToken.IsCancellationRequested)
             {

--- a/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -198,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
             }
 
             // okay, it is an empty line with some whitespaces 
-            Contract.Requires(indentation <= lineInSubjectBuffer.Length);
+            Debug.Assert(indentation <= lineInSubjectBuffer.Length);
 
             var offset = GetOffsetFromIndentation(indentation, view.Options);
             view.TryMoveCaretToAndEnsureVisible(lineInSubjectBuffer.Start.Add(offset));

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_SetModelSelectedItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_SetModelSelectedItem.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Completion;
 using Roslyn.Utilities;
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
                 // Switch to hard selection.
                 var selectedItem = selector(model);
-                Contract.Assert(model.TotalItems.Contains(selectedItem) || model.SuggestionModeItem == selectedItem);
+                Debug.Assert(model.TotalItems.Contains(selectedItem) || model.SuggestionModeItem == selectedItem);
 
                 if (model.FilteredItems.Contains(selectedItem))
                 {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/SignatureHelpPresenter.SignatureHelpPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/SignatureHelpPresenter.SignatureHelpPresenterSession.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -95,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                     _editorSessionOpt.Recalculate();
 
                     // Now let the editor know what the currently selected item is.
-                    Contract.Requires(_signatureMap.ContainsKey(selectedItem));
+                    Debug.Assert(_signatureMap.ContainsKey(selectedItem));
                     Contract.ThrowIfNull(_signatureMap);
 
                     var defaultValue = _signatureMap.GetValueOrDefault(_selectedItem);

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCommitter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -189,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 var syntaxTreeWithOriginalName = syntaxTree.WithChangedText(newFullText);
                 var documentWithOriginalName = document.WithSyntaxRoot(syntaxTreeWithOriginalName.GetRoot(cancellationToken));
 
-                Contract.Requires(newFullText.ToString() == documentWithOriginalName.GetTextSynchronously(cancellationToken).ToString());
+                Debug.Assert(newFullText.ToString() == documentWithOriginalName.GetTextSynchronously(cancellationToken).ToString());
 #endif
 
                 // Apply the original name to all linked documents to construct a consistent solution

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
             protected bool HasPreprocessorCharacter(TextLine currentLine)
             {
                 var text = currentLine.ToString();
-                Contract.Requires(!string.IsNullOrWhiteSpace(text));
+                Debug.Assert(!string.IsNullOrWhiteSpace(text));
 
                 var trimmedText = text.Trim();
 

--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Common;
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
                 // check whether we can use the data as it is (can happen when re-using persisted data from previous VS session)
                 if (CheckVersions(document, textVersion, syntaxVersion, existingData))
                 {
-                    Contract.Requires(_workspace == document.Project.Solution.Workspace);
+                    Debug.Assert(_workspace == document.Project.Solution.Workspace);
                     RaiseTaskListUpdated(_workspace, document.Project.Solution, document.Id, existingData.Items);
                     return;
                 }
@@ -82,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
             // * NOTE * cancellation can't throw after this point.
             if (existingData == null || existingData.Items.Length > 0 || data.Items.Length > 0)
             {
-                Contract.Requires(_workspace == document.Project.Solution.Workspace);
+                Debug.Assert(_workspace == document.Project.Solution.Workspace);
                 RaiseTaskListUpdated(_workspace, document.Project.Solution, document.Id, data.Items);
             }
         }

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         public IList<ITagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
         {
             var snapshot = snapshotSpan.Snapshot;
-            Contract.Requires(snapshot.TextBuffer == _textBuffer);
+            Debug.Assert(snapshot.TextBuffer == _textBuffer);
 
             var introspector = new IntervalIntrospector(snapshot);
             var intersectingIntervals = _tree.GetIntervalsThatIntersectWith(snapshotSpan.Start, snapshotSpan.Length, introspector);

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 if (Workspace.TryGetWorkspace(container, out var dummy))
                 {
                     // if the buffer is part of our workspace, it must be the latest.
-                    Contract.Assert(snapshot.Version.Next == null, "should be on latest snapshot");
+                    Debug.Assert(snapshot.Version.Next == null, "should be on latest snapshot");
                 }
             }
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -173,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             string[] files,
             ExportProvider exportProvider)
         {
-            Contract.Requires(parseOptions == null || (files.Length == parseOptions.Length), "Please specify a parse option for each file.");
+            Debug.Assert(parseOptions == null || (files.Length == parseOptions.Length), "Please specify a parse option for each file.");
 
             var documentElements = new List<XElement>();
             var index = 0;

--- a/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
+++ b/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -432,7 +433,7 @@ namespace Microsoft.CodeAnalysis.Text
                     range = range.Accumulate(changes);
                 }
 
-                Contract.Requires(range.HasValue);
+                Debug.Assert(range.HasValue);
                 return range.Value;
             }
 

--- a/src/EditorFeatures/Text/Shared/Extensions/TextSpanExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/TextSpanExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         /// </summary>
         public static SnapshotSpan ToSnapshotSpan(this TextSpan textSpan, ITextSnapshot snapshot)
         {
-            Contract.Requires(snapshot != null);
+            Debug.Assert(snapshot != null);
             var span = textSpan.ToSpan();
             return new SnapshotSpan(snapshot, span);
         }

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                 If token.Span.End = lastNonWhitespacePosition + 1 Then
                     Return GetIndentationBasedOnToken(token)
                 Else
-                    Contract.Assert(token.FullSpan.Contains(lastNonWhitespacePosition))
+                    Debug.Assert(token.FullSpan.Contains(lastNonWhitespacePosition))
 
                     Dim trivia = Tree.GetRoot(CancellationToken).FindTrivia(lastNonWhitespacePosition)
 

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
         private VariableDeclaratorSyntax FindDeclarator(SyntaxNode node)
         {
             var annotatedNodesOrTokens = node.GetAnnotatedNodesAndTokens(DefinitionAnnotation).ToList();
-            Contract.Requires(annotatedNodesOrTokens.Count == 1, "Only a single variable declarator should have been annotated.");
+            Debug.Assert(annotatedNodesOrTokens.Count == 1, "Only a single variable declarator should have been annotated.");
 
             return (VariableDeclaratorSyntax)annotatedNodesOrTokens.First().AsNode();
         }

--- a/src/Features/CSharp/Portable/Organizing/Organizers/MemberDeclarationsOrganizer.cs
+++ b/src/Features/CSharp/Portable/Organizing/Organizers/MemberDeclarationsOrganizer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -36,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Organizing.Organizers
             IList<TSyntaxNode> originalList,
             IList<TSyntaxNode> finalList) where TSyntaxNode : SyntaxNode
         {
-            Contract.Requires(originalList.Count == finalList.Count);
+            Debug.Assert(originalList.Count == finalList.Count);
 
             if (originalList.Count >= 2)
             {

--- a/src/Features/CSharp/Portable/RemoveUnnecessaryImports/AbstractCSharpRemoveUnnecessaryImportsService.Rewriter.cs
+++ b/src/Features/CSharp/Portable/RemoveUnnecessaryImports/AbstractCSharpRemoveUnnecessaryImportsService.Rewriter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -73,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
                 SyntaxList<UsingDirectiveSyntax> oldUsings,
                 SyntaxList<UsingDirectiveSyntax> newUsings)
             {
-                Contract.Requires(oldUsings.Count == newUsings.Count);
+                Debug.Assert(oldUsings.Count == newUsings.Count);
 
                 var result = new HashSet<UsingDirectiveSyntax>();
                 for (int i = 0; i < oldUsings.Count; i++)

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -336,11 +336,11 @@ namespace Microsoft.CodeAnalysis.Completion
 
             foreach (var context in completionContexts)
             {
-                Contract.Assert(context != null);
+                Debug.Assert(context != null);
 
                 foreach (var item in context.Items)
                 {
-                    Contract.Assert(item != null);
+                    Debug.Assert(item != null);
                     AddToDisplayMap(item, displayNameToItemsMap);
                 }
 
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.Completion
             {
                 var existingItem = sameNamedItems[i];
 
-                Contract.Assert(item.DisplayText == existingItem.DisplayText);
+                Debug.Assert(item.DisplayText == existingItem.DisplayText);
 
                 if (ItemsMatch(item, existingItem))
                 {

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -88,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 var diagnostics = tree.GetDiagnostics(cancellationToken);
 
-                Contract.Requires(document.Project.Solution.Workspace == _workspace);
+                Debug.Assert(document.Project.Solution.Workspace == _workspace);
 
                 var diagnosticData = diagnostics == null ? ImmutableArray<DiagnosticData>.Empty : diagnostics.Select(d => DiagnosticData.Create(document, d)).ToImmutableArrayOrEmpty();
 
@@ -110,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var diagnostics = model.GetMethodBodyDiagnostics(span: null, cancellationToken: cancellationToken).Concat(
                                     model.GetDeclarationDiagnostics(span: null, cancellationToken: cancellationToken));
 
-                Contract.Requires(document.Project.Solution.Workspace == _workspace);
+                Debug.Assert(document.Project.Solution.Workspace == _workspace);
 
                 var diagnosticData = diagnostics == null ? ImmutableArray<DiagnosticData>.Empty : diagnostics.Select(d => DiagnosticData.Create(document, d)).ToImmutableArrayOrEmpty();
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticCustomTags.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticCustomTags.cs
@@ -44,11 +44,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         [Conditional("DEBUG")]
         private static void Assert(string[] customTags, params string[] tags)
         {
-            Contract.Requires(customTags.Length == tags.Length);
+            Debug.Assert(customTags.Length == tags.Length);
 
             for (int i = 0; i < tags.Length; i++)
             {
-                Contract.Requires(customTags[i] == tags[i]);
+                Debug.Assert(customTags[i] == tags[i]);
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // we expect source who uses this ability to have small number of diagnostics.
             lock (_gate)
             {
-                Contract.Requires(_updateSources.Contains(source));
+                Debug.Assert(_updateSources.Contains(source));
 
                 // check cheap early bail out
                 if (args.Diagnostics.Length == 0 && !_map.ContainsKey(source))
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     using (var pool = SharedPools.Default<List<Data>>().GetPooledObject())
                     {
                         AppendMatchingData(source, workspace, projectId, documentId, id, pool.Object);
-                        Contract.Requires(pool.Object.Count == 0 || pool.Object.Count == 1);
+                        Debug.Assert(pool.Object.Count == 0 || pool.Object.Count == 1);
 
                         if (pool.Object.Count == 1)
                         {
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             if (obj == null)
             {
-                Contract.Requires(false, "who returns invalid data?");
+                Debug.Assert(false, "who returns invalid data?");
             }
         }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -477,13 +478,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         var diagnostics = await analyzerDriverOpt.GetAnalyzerSyntaxDiagnosticsAsync(tree, oneAnalyzers, cancellationToken).ConfigureAwait(false);
                         LogSyntaxInfo(document, analyzer, diagnostics, tree);
 
-                        Contract.Requires(diagnostics.Count() == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, analyzerDriverOpt.Compilation).Count());
+                        Debug.Assert(diagnostics.Count() == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, analyzerDriverOpt.Compilation).Count());
                         return diagnostics.ToImmutableArrayOrEmpty();
                     case AnalysisKind.Semantic:
                         var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                         diagnostics = await analyzerDriverOpt.GetAnalyzerSemanticDiagnosticsAsync(model, spanOpt, oneAnalyzers, cancellationToken).ConfigureAwait(false);
 
-                        Contract.Requires(diagnostics.Count() == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, analyzerDriverOpt.Compilation).Count());
+                        Debug.Assert(diagnostics.Count() == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, analyzerDriverOpt.Compilation).Count());
                         return diagnostics.ToImmutableArrayOrEmpty();
                     default:
                         return Contract.FailWithReturn<ImmutableArray<Diagnostic>>("shouldn't reach here");

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -95,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                     if (!await TryDeserializeDocumentAsync(serializer, document, builder, cancellationToken).ConfigureAwait(false))
                     {
-                        Contract.Requires(lastResult.Version == VersionStamp.Default);
+                        Debug.Assert(lastResult.Version == VersionStamp.Default);
 
                         // this can happen if we merged back active file diagnostics back to project state but
                         // project state didn't have diagnostics for the file yet. (since project state was staled)
@@ -144,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 if (!await TryDeserializeDocumentAsync(serializer, document, builder, cancellationToken).ConfigureAwait(false))
                 {
-                    Contract.Requires(lastResult.Version == VersionStamp.Default);
+                    Debug.Assert(lastResult.Version == VersionStamp.Default);
 
                     // this can happen if we merged back active file diagnostics back to project state but
                     // project state didn't have diagnostics for the file yet. (since project state was staled)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         return;
                     }
 
-                    Contract.Requires(!entry.AnalyzerReferences.Equals(project.AnalyzerReferences));
+                    Debug.Assert(!entry.AnalyzerReferences.Equals(project.AnalyzerReferences));
 
                     // there has been change. find out what has changed
                     var addedStates = DiffStateSets(project.AnalyzerReferences.Except(entry.AnalyzerReferences), newMapPerReference, newMap);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // errors from build shouldn't have any span set.
                 // this is debug check since it gets data from us only not from third party unlike one in compiler
                 // that checks span for third party reported diagnostics
-                Contract.Requires(!diagnostic.HasTextSpan);
+                Debug.Assert(!diagnostic.HasTextSpan);
             }
         }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             var list = new List<DiagnosticData>();
             var result = await getter.TryGetAsync(list, cancellationToken).ConfigureAwait(false);
-            Contract.Requires(result);
+            Debug.Assert(result);
 
             return list;
         }
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     }
 
                     // if we are blocked for data, then we should always have full result.
-                    Contract.Requires(!_blockForData || containsFullResult);
+                    Debug.Assert(!_blockForData || containsFullResult);
                     return containsFullResult;
                 }
                 catch (Exception e) when (FatalError.ReportUnlessCanceled(e))

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -91,7 +92,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
         private async Task<Result> SingleEncapsulateFieldResultAsync(Document document, TextSpan span, int index, bool updateReferences, CancellationToken cancellationToken)
         {
             var fields = (await GetFieldsAsync(document, span, cancellationToken).ConfigureAwait(false)).ToImmutableArrayOrEmpty();
-            Contract.Requires(fields.Length > index);
+            Debug.Assert(fields.Length > index);
 
             var field = fields[index];
             var result = await EncapsulateFieldAsync(field, document, updateReferences, cancellationToken).ConfigureAwait(false);
@@ -109,7 +110,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
             var failedFieldSymbols = new List<IFieldSymbol>();
 
             var fields = await GetFieldsAsync(document, span, cancellationToken).ConfigureAwait(false);
-            Contract.Requires(fields.Any());
+            Debug.Assert(fields.Any());
 
             // For now, build up the multiple field case by encapsulating one at a time.
             Result result = null;

--- a/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.cs
+++ b/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         {
             Contract.ThrowIfNull(root);
             Contract.ThrowIfTrue(textSpan.IsEmpty);
-            Contract.Requires(Enum.GetNames(typeof(TriviaLocation)).Length == TriviaLocationsCount);
+            Debug.Assert(Enum.GetNames(typeof(TriviaLocation)).Length == TriviaLocationsCount);
 
             var tokens = GetTokensAtEdges(root, textSpan);
 

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.SymbolResult.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.SymbolResult.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -36,8 +37,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
 
             public int CompareTo(SymbolResult other)
             {
-                Contract.Requires(this.Symbol is INamespaceSymbol || !((INamedTypeSymbol)this.Symbol).IsGenericType);
-                Contract.Requires(other.Symbol is INamespaceSymbol || !((INamedTypeSymbol)other.Symbol).IsGenericType);
+                Debug.Assert(this.Symbol is INamespaceSymbol || !((INamedTypeSymbol)this.Symbol).IsGenericType);
+                Debug.Assert(other.Symbol is INamespaceSymbol || !((INamedTypeSymbol)other.Symbol).IsGenericType);
 
                 var diff = this.Weight - other.Weight;
                 if (diff != 0)

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 // If the target Project is VB then we have to check if the RootNamespace of the VB project is the parent most namespace of the type being generated
                 // True, Remove the RootNamespace
                 // False, Add Global to the Namespace
-                Contract.Assert(targetProject.Language == LanguageNames.VisualBasic);
+                Debug.Assert(targetProject.Language == LanguageNames.VisualBasic);
                 IGenerateTypeService targetLanguageService = null;
                 if (_semanticDocument.Project.Language == LanguageNames.VisualBasic)
                 {
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                         }
                     }
 
-                    Contract.Assert(includeUsingsOrImports != null);
+                    Debug.Assert(includeUsingsOrImports != null);
                 }
 
                 return (containers, includeUsingsOrImports);

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -536,7 +537,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 string memberName,
                 ISymbol baseMember)
             {
-                Contract.Requires(memberName == baseMember.Name);
+                Debug.Assert(memberName == baseMember.Name);
 
                 if (member.Kind == SymbolKind.Method && baseMember.Kind == SymbolKind.Method)
                 {

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
                 // the tree, a source symbol is defined in, doesn't exist in universe
                 // how this can happen?
-                Contract.Requires(false, "How?");
+                Debug.Assert(false, "How?");
                 return null;
             }
 

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -230,13 +230,13 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                     if (IsDefaultProvider(lazyProvider.Metadata))
                     {
-                        Contract.Requires(set.Add(Default));
+                        Debug.Assert(set.Add(Default));
                         continue;
                     }
 
                     foreach (var kind in lazyProvider.Metadata.WorkspaceKinds)
                     {
-                        Contract.Requires(set.Add(kind));
+                        Debug.Assert(set.Add(kind));
                     }
                 }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Roslyn.Utilities;
@@ -101,7 +102,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         documentMap.TryGetValue(key, out var existingWorkItem))
                     {
                         // TODO: should I care about language when replace it?
-                        Contract.Requires(existingWorkItem.Language == item.Language);
+                        Debug.Assert(existingWorkItem.Language == item.Language);
 
                         // replace it
                         documentMap[key] = existingWorkItem.With(item.InvocationReasons, item.ActiveMember, item.Analyzers, item.IsRetry, item.AsyncToken);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -219,7 +220,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 protected CancellationTokenSource GetNewCancellationSource_NoLock(object key)
                 {
-                    Contract.Requires(!_cancellationMap.ContainsKey(key));
+                    Debug.Assert(!_cancellationMap.ContainsKey(key));
 
                     var source = new CancellationTokenSource();
                     _cancellationMap.Add(key, source);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
@@ -395,7 +396,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         try
                         {
 #if DEBUG
-                            Contract.Requires(!workItem.InvocationReasons.Contains(PredefinedInvocationReasons.Reanalyze) || workItem.Analyzers.Count > 0);
+                            Debug.Assert(!workItem.InvocationReasons.Contains(PredefinedInvocationReasons.Reanalyze) || workItem.Analyzers.Count > 0);
 #endif
 
                             // no-reanalyze request or we already have a request to re-analyze every thing

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -184,7 +185,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                     foreach (var location in locations)
                     {
-                        Contract.Requires(location.IsInSource);
+                        Debug.Assert(location.IsInSource);
 
                         var document = solution.GetDocument(location.SourceTree, projectId);
                         if (document == null || thisDocument == document)
@@ -290,7 +291,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         // this is only one that removes data from the queue. so, it should always succeed
                         var result = map.Remove(first.Key);
-                        Contract.Requires(result);
+                        Debug.Assert(result);
 
                         return first.Value;
                     }

--- a/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
+++ b/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -53,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Host
                     }
                 }
 
-                Contract.Requires(oldIndex >= 0);
+                Debug.Assert(oldIndex >= 0);
                 _nodes[oldIndex] = new Node(instance, DateTime.UtcNow);
             }
 

--- a/src/Features/VisualBasic/Portable/ConvertForEachToFor/VisualBasicConvertForEachToForCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertForEachToFor/VisualBasicConvertForEachToForCodeRefactoringProvider.vb
@@ -100,7 +100,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertForEachToFor
             Dim nextStatement = forEachBlock.NextStatement
 
             If nextStatement.ControlVariables.Count > 0 Then
-                Contract.Requires(nextStatement.ControlVariables.Count = 1)
+                Debug.Assert(nextStatement.ControlVariables.Count = 1)
 
                 Dim controlVariable As SyntaxNode = nextStatement.ControlVariables(0)
                 controlVariable = generator.IdentifierName(

--- a/src/Features/VisualBasic/Portable/Organizing/Organizers/MemberDeclarationsOrganizer.vb
+++ b/src/Features/VisualBasic/Portable/Organizing/Organizers/MemberDeclarationsOrganizer.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Organizing.Organizers
         Private Shared Sub TransferTrivia(Of TSyntaxNode As SyntaxNode)(
             originalList As IList(Of TSyntaxNode),
             finalList As IList(Of TSyntaxNode))
-            Contract.Requires(originalList.Count = finalList.Count)
+            Debug.Assert(originalList.Count = finalList.Count)
 
             If originalList.Count >= 2 Then
                 ' Ok, we wanted to reorder the list.  But we're definitely not done right now. While

--- a/src/Interactive/EditorFeatures/Core/Completion/AbstractDirectivePathCompletionProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Completion/AbstractDirectivePathCompletionProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Scripting;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Editor.Completion.FileSystem
 {
@@ -151,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Editor.Completion.FileSystem
             if (!PathUtilities.IsAbsolute(result))
             {
                 result = environmentOpt?.BaseDirectory;
-                Contract.Requires(result == null || PathUtilities.IsAbsolute(result));
+                Debug.Assert(result == null || PathUtilities.IsAbsolute(result));
             }
 
             return result;

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
 
         internal VsENCRebuildableProjectImpl(AbstractProject project)
         {
-            Contract.Requires(project != null);
+            Debug.Assert(project != null);
 
             _vsProject = project;
 
@@ -113,12 +113,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             _moduleMetadataProvider = componentModel.GetService<IDebuggeeModuleMetadataProvider>();
             _encService = _debuggingService.EditAndContinueServiceOpt;
 
-            Contract.Requires(_debugEncNotify != null);
-            Contract.Requires(_encService != null);
-            Contract.Requires(_trackingService != null);
-            Contract.Requires(_diagnosticProvider != null);
-            Contract.Requires(_editorAdaptersFactoryService != null);
-            Contract.Requires(_moduleMetadataProvider != null);
+            Debug.Assert(_debugEncNotify != null);
+            Debug.Assert(_encService != null);
+            Debug.Assert(_trackingService != null);
+            Debug.Assert(_diagnosticProvider != null);
+            Debug.Assert(_editorAdaptersFactoryService != null);
+            Debug.Assert(_moduleMetadataProvider != null);
         }
 
         // called from an edit filter if an edit of a read-only buffer is attempted:

--- a/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialogViewModel.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security;
@@ -81,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
         {
             get
             {
-                Contract.Assert(_accessListMap.ContainsKey(SelectedAccessibilityString), "The Accessibility Key String not present");
+                Debug.Assert(_accessListMap.ContainsKey(SelectedAccessibilityString), "The Accessibility Key String not present");
                 return _accessListMap[SelectedAccessibilityString];
             }
         }
@@ -132,7 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
         {
             get
             {
-                Contract.Assert(_typeKindMap.ContainsKey(SelectedTypeKindString), "The TypeKind Key String not present");
+                Debug.Assert(_typeKindMap.ContainsKey(SelectedTypeKindString), "The TypeKind Key String not present");
                 return _typeKindMap[SelectedTypeKindString];
             }
         }
@@ -165,7 +166,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
             }
             else
             {
-                Contract.Assert(languageName == LanguageNames.VisualBasic, "Currently only C# and VB are supported");
+                Debug.Assert(languageName == LanguageNames.VisualBasic, "Currently only C# and VB are supported");
                 _visualBasicAccessList.Add(key);
             }
 
@@ -198,7 +199,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
 
         private void PopulateTypeKind()
         {
-            Contract.Assert(_generateTypeDialogOptions.TypeKindOptions != TypeKindOptions.None);
+            Debug.Assert(_generateTypeDialogOptions.TypeKindOptions != TypeKindOptions.None);
 
             if (TypeKindOptionsHelper.IsClass(_generateTypeDialogOptions.TypeKindOptions))
             {
@@ -439,7 +440,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
                         // 3 in the list represent the Public. 1-based array.
                         this.AccessSelectIndex = this.AccessList.IndexOf("public") == -1 ?
                             this.AccessList.IndexOf("Public") : this.AccessList.IndexOf("public");
-                        Contract.Assert(this.AccessSelectIndex != -1);
+                        Debug.Assert(this.AccessSelectIndex != -1);
                         this.IsAccessListEnabled = false;
                     }
                     else

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -230,7 +231,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             var wpfTextView = EditorAdaptersFactoryService.GetWpfTextView(textView);
             Contract.ThrowIfNull(wpfTextView, "Could not get IWpfTextView for IVsTextView");
 
-            Contract.Assert(!wpfTextView.Properties.ContainsProperty(typeof(AbstractVsTextViewFilter<TPackage, TLanguageService>)));
+            Debug.Assert(!wpfTextView.Properties.ContainsProperty(typeof(AbstractVsTextViewFilter<TPackage, TLanguageService>)));
 
             var commandHandlerFactory = Package.ComponentModel.GetService<ICommandHandlerServiceFactory>();
             var workspace = Package.ComponentModel.GetService<VisualStudioWorkspace>();

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -505,7 +505,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private static string GetAssemblyNameFromPath(string outputPath)
         {
-            Contract.Requires(outputPath != null);
+            Debug.Assert(outputPath != null);
 
             // dev11 sometimes gives us output path w/o extension, so removing extension becomes problematic
             if (outputPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ||

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/ProjectExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/ProjectExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using EnvDTE;
 using Roslyn.Utilities;
@@ -12,7 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.E
     {
         public static ProjectItem FindOrCreateFolder(this EnvDTE.Project project, IEnumerable<string> containers)
         {
-            Contract.Requires(containers.Any());
+            Debug.Assert(containers.Any());
 
             var currentItems = project.ProjectItems;
             foreach (var container in containers)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             internal Snapshot(VisualStudioMetadataReferenceManager provider, MetadataReferenceProperties properties, string fullPath, FileChangeTracker fileChangeTrackerOpt)
                 : base(properties, fullPath)
             {
-                Contract.Requires(Properties.Kind == MetadataImageKind.Assembly);
+                Debug.Assert(Properties.Kind == MetadataImageKind.Assembly);
                 _provider = provider;
                 _fileChangeTrackerOpt = fileChangeTrackerOpt;
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -254,7 +254,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return null;
             }
 
-            Contract.Requires(pImage != IntPtr.Zero, "Base address should not be zero if GetFileFlatMapping call succeeded.");
+            Debug.Assert(pImage != IntPtr.Zero, "Base address should not be zero if GetFileFlatMapping call succeeded.");
 
             var metadata = ModuleMetadata.CreateFromImage(pImage, (int)length);
             s_lifetimeMap.Add(metadata, info);

--- a/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
@@ -27,9 +27,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         public JsonRpcEx(Workspace workspace, TraceSource logger, Stream stream, object callbackTarget, bool useThisAsCallback)
         {
-            Contract.Requires(workspace != null);
-            Contract.Requires(logger != null);
-            Contract.Requires(stream != null);
+            Debug.Assert(workspace != null);
+            Debug.Assert(logger != null);
+            Debug.Assert(stream != null);
 
             var target = useThisAsCallback ? this : callbackTarget;
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Windows;
@@ -190,7 +191,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 if (diagnostic == null)
                 {
                     // guard us from wrong provider that gives null diagnostic
-                    Contract.Requires(false, "Let's see who does this");
+                    Debug.Assert(false, "Let's see who does this");
                     return false;
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -175,7 +176,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     return;
                 }
 
-                Contract.Requires(e.DocumentId != null);
+                Debug.Assert(e.DocumentId != null);
 
                 if (e.TodoItems.Length == 0)
                 {

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,7 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             IAsynchronousOperationListenerProvider listenerProvider) :
                 this(workspace, diagnosticService, registrationService, listenerProvider.GetListener(FeatureAttribute.ErrorList))
         {
-            Contract.Requires(!KnownUIContexts.SolutionBuildingContext.IsActive);
+            Debug.Assert(!KnownUIContexts.SolutionBuildingContext.IsActive);
             KnownUIContexts.SolutionBuildingContext.UIContextChanged += OnSolutionBuild;
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -803,7 +803,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             }
 
             var originalText = document.GetTextSynchronously(CancellationToken.None);
-            Contract.Requires(object.ReferenceEquals(originalText, snapshot.AsText()));
+            Debug.Assert(object.ReferenceEquals(originalText, snapshot.AsText()));
 
             var root = document.GetSyntaxRootSynchronously(CancellationToken.None);
 

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/GlobalUndoServiceFactory.WorkspaceGlobalUndoTransaction.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/GlobalUndoServiceFactory.WorkspaceGlobalUndoTransaction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -124,7 +125,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             ~WorkspaceUndoTransaction()
             {
                 // make sure we closed it correctly
-                Contract.Requires(!_transactionAlive);
+                Debug.Assert(!_transactionAlive);
             }
 #endif
 #pragma warning restore CA1821 // Remove empty Finalizers

--- a/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -104,7 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
         {
             if (!_pendingScopes.TryRemove(blockId, out var value))
             {
-                Contract.Requires(false, "when can this happen?");
+                Debug.Assert(false, "when can this happen?");
                 return;
             }
 

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -169,7 +169,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
         Public Function AdviseBuildStatusCallback(pIVbBuildStatusCallback As IVbBuildStatusCallback) As UInteger Implements IVbCompilerProject.AdviseBuildStatusCallback
             Try
-                Contract.Requires(_buildStatusCallback Is Nothing, "IVbBuildStatusCallback already set")
+                Debug.Assert(_buildStatusCallback Is Nothing, "IVbBuildStatusCallback already set")
 
                 _buildStatusCallback = pIVbBuildStatusCallback
 
@@ -187,7 +187,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
         End Function
 
         Public Sub UnadviseBuildStatusCallback(dwCookie As UInteger) Implements IVbCompilerProject.UnadviseBuildStatusCallback
-            Contract.Requires(dwCookie = 0, "Bad cookie")
+            Debug.Assert(dwCookie = 0, "Bad cookie")
 
             _buildStatusCallback = Nothing
         End Sub

--- a/src/Workspaces/CSharp/Portable/Extensions/DirectiveSyntaxExtensions.DirectiveWalker.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/DirectiveSyntaxExtensions.DirectiveWalker.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
@@ -135,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                 // #If should be the first one in sorted order
                 var ifDirective = condDirectives.First();
-                Contract.Assert(
+                Debug.Assert(
                     ifDirective.Kind() == SyntaxKind.IfDirectiveTrivia ||
                     ifDirective.Kind() == SyntaxKind.ElifDirectiveTrivia ||
                     ifDirective.Kind() == SyntaxKind.ElseDirectiveTrivia);

--- a/src/Workspaces/CSharp/Portable/Extensions/SeparatedSyntaxListExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SeparatedSyntaxListExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -15,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     {
         private static Tuple<List<T>, List<SyntaxToken>> GetNodesAndSeparators<T>(this SeparatedSyntaxList<T> separatedList) where T : SyntaxNode
         {
-            Contract.Requires(separatedList.Count == separatedList.SeparatorCount ||
+            Debug.Assert(separatedList.Count == separatedList.SeparatorCount ||
                               separatedList.Count == separatedList.SeparatorCount + 1);
 
             var nodes = new List<T>(separatedList.Count);

--- a/src/Workspaces/CSharp/Portable/Extensions/SimpleNameSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SimpleNameSyntaxExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
 
@@ -9,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     {
         public static ExpressionSyntax GetLeftSideOfDot(this SimpleNameSyntax name)
         {
-            Contract.Requires(name.IsMemberAccessExpressionName() || name.IsRightSideOfQualifiedName() || name.IsParentKind(SyntaxKind.NameMemberCref));
+            Debug.Assert(name.IsMemberAccessExpressionName() || name.IsRightSideOfQualifiedName() || name.IsParentKind(SyntaxKind.NameMemberCref));
             if (name.IsMemberAccessExpressionName())
             {
                 var conditionalAccess = name.GetParentConditionalAccessExpression();

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -154,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public bool TryGetSpeculativeSemanticModel(SemanticModel oldSemanticModel, SyntaxNode oldNode, SyntaxNode newNode, out SemanticModel speculativeModel)
         {
-            Contract.Requires(oldNode.Kind() == newNode.Kind());
+            Debug.Assert(oldNode.Kind() == newNode.Kind());
 
             var model = oldSemanticModel;
 

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1115,7 +1115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public int GetMethodLevelMemberId(SyntaxNode root, SyntaxNode node)
         {
-            Contract.Requires(root.SyntaxTree == node.SyntaxTree);
+            Debug.Assert(root.SyntaxTree == node.SyntaxTree);
 
             int currentId = 0;
             Contract.ThrowIfFalse(TryGetMethodLevelMember(root, (n, i) => n == node, ref currentId, out var currentNode));

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -1175,7 +1175,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private IEnumerable<TypeInferenceInfo> InferTypeInPropertyDeclaration(PropertyDeclarationSyntax propertyDeclaration)
             {
-                Contract.Assert(propertyDeclaration?.Type != null, "Property type should never be null");
+                Debug.Assert(propertyDeclaration?.Type != null, "Property type should never be null");
 
                 var typeInfo = SemanticModel.GetTypeInfo(propertyDeclaration.Type);
                 return typeInfo.Type != null

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
@@ -191,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
         // Is the tuple on either side of a deconstruction (top-level or nested)?
         private static bool IsTupleInDeconstruction(SyntaxNode tuple)
         {
-            Contract.Assert(tuple.IsKind(SyntaxKind.TupleExpression));
+            Debug.Assert(tuple.IsKind(SyntaxKind.TupleExpression));
             var currentTuple = tuple;
             do
             {

--- a/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesDirectiveComparer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesDirectiveComparer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
 
@@ -23,8 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             IComparer<NameSyntax> nameComparer,
             IComparer<SyntaxToken> tokenComparer)
         {
-            Contract.Requires(nameComparer != null);
-            Contract.Requires(tokenComparer != null);
+            Debug.Assert(nameComparer != null);
+            Debug.Assert(tokenComparer != null);
             _nameComparer = nameComparer;
             _tokenComparer = tokenComparer;
         }

--- a/src/Workspaces/Core/Desktop/Workspace/Host/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedInfo.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Runtime;
@@ -118,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Host
                         _weakReadAccessor = new ReferenceCountedDisposable<MemoryMappedViewAccessor>.WeakReference(streamAccessor);
                     }
 
-                    Contract.Assert(streamAccessor.Target.CanRead);
+                    Debug.Assert(streamAccessor.Target.CanRead);
                     return new SharedReadableStream(this, streamAccessor, Size);
                 }
             }

--- a/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
                 }
 
                 var syntaxFactsService = document.GetLanguageService<ISyntaxFactsService>();
-                Contract.Requires(syntaxFactsService != null);
+                Debug.Assert(syntaxFactsService != null);
 
                 // We need to track spans between cleaners. Annotate the tree with the provided spans.
                 var newNodeAndAnnotations = AnnotateNodeForTextSpans(syntaxFactsService, root, normalizedSpan, cancellationToken);
@@ -91,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
                 }
 
                 var syntaxFactsService = workspace.Services.GetLanguageServices(root.Language).GetService<ISyntaxFactsService>();
-                Contract.Requires(syntaxFactsService != null);
+                Debug.Assert(syntaxFactsService != null);
 
                 // We need to track spans between cleaners. Annotate the tree with the provided spans.
                 var newNodeAndAnnotations = AnnotateNodeForTextSpans(syntaxFactsService, root, normalizedSpan, cancellationToken);

--- a/src/Workspaces/Core/Portable/CodeCleanup/Providers/SimpleCodeCleanupProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/Providers/SimpleCodeCleanupProvider.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
             Func<Document, ImmutableArray<TextSpan>, CancellationToken, Task<Document>> documentDelegatee = null,
             Func<SyntaxNode, ImmutableArray<TextSpan>, Workspace, CancellationToken, SyntaxNode> syntaxDelegatee = null)
         {
-            Contract.Requires(documentDelegatee != null || syntaxDelegatee != null);
+            Debug.Assert(documentDelegatee != null || syntaxDelegatee != null);
 
             this.Name = name;
             _documentDelegatee = documentDelegatee;

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Utilities;
@@ -139,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             AddDiagnostics(ref dummy, tree: null, diagnostics: diagnostics);
 
             // dummy should be always null
-            Contract.Requires(dummy == null);
+            Debug.Assert(dummy == null);
         }
 
         private void AddDiagnostics(

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -331,7 +332,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public static DiagnosticData Create(Workspace workspace, Diagnostic diagnostic)
         {
-            Contract.Requires(diagnostic.Location == null || !diagnostic.Location.IsInSource);
+            Debug.Assert(diagnostic.Location == null || !diagnostic.Location.IsInSource);
 
             return new DiagnosticData(
                 diagnostic.Id,
@@ -354,7 +355,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public static DiagnosticData Create(Project project, Diagnostic diagnostic)
         {
-            Contract.Requires(diagnostic.Location == null || !diagnostic.Location.IsInSource);
+            Debug.Assert(diagnostic.Location == null || !diagnostic.Location.IsInSource);
 
             return new DiagnosticData(
                 diagnostic.Id,

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -185,7 +186,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     if (diagnosticsByAnalyzerMap.TryGetValue(analyzer, out diagnostics))
                     {
-                        Contract.Requires(diagnostics.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, compilation).Count());
+                        Debug.Assert(diagnostics.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, compilation).Count());
                         result.AddSyntaxDiagnostics(tree, diagnostics);
                     }
                 }
@@ -194,14 +195,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     if (diagnosticsByAnalyzerMap.TryGetValue(analyzer, out diagnostics))
                     {
-                        Contract.Requires(diagnostics.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, compilation).Count());
+                        Debug.Assert(diagnostics.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, compilation).Count());
                         result.AddSemanticDiagnostics(tree, diagnostics);
                     }
                 }
 
                 if (analysisResult.CompilationDiagnostics.TryGetValue(analyzer, out diagnostics))
                 {
-                    Contract.Requires(diagnostics.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, compilation).Count());
+                    Debug.Assert(diagnostics.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, compilation).Count());
                     result.AddCompilationDiagnostics(diagnostics);
                 }
 

--- a/src/Workspaces/Core/Portable/Execution/AssetStorages.cs
+++ b/src/Workspaces/Core/Portable/Execution/AssetStorages.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Roslyn.Utilities;
 
@@ -117,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Execution
                 if (result.Count == numberOfChecksumsToSearch)
                 {
                     // no checksum left to find
-                    Contract.Requires(searchingChecksumsLeft.Object.Count == 0);
+                    Debug.Assert(searchingChecksumsLeft.Object.Count == 0);
                     return result;
                 }
 
@@ -134,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Execution
                         if (result.Count == numberOfChecksumsToSearch)
                         {
                             // no checksum left to find
-                            Contract.Requires(searchingChecksumsLeft.Object.Count == 0);
+                            Debug.Assert(searchingChecksumsLeft.Object.Count == 0);
                             return result;
                         }
                     }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -215,7 +216,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         public static void Start(SemanticModel model)
         {
-            Contract.Requires(model != null);
+            Debug.Assert(model != null);
 
             using (s_gate.DisposableWrite())
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                     foreach (var finder in documentToFinderList.Value)
                     {
-                        Contract.Requires(set.Add(finder));
+                        Debug.Assert(set.Add(finder));
                     }
                 }
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
@@ -591,7 +592,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // compilation from definition project must already exist.
             if (!definitionProject.TryGetCompilation(out definingCompilation))
             {
-                Contract.Requires(false, "How can compilation not exist?");
+                Debug.Assert(false, "How can compilation not exist?");
                 return false;
             }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,7 +36,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         public static async Task PrecalculateAsync(Document document, CancellationToken cancellationToken)
         {
-            Contract.Requires(document.IsFromPrimaryBranch());
+            Debug.Assert(document.IsFromPrimaryBranch());
 
             var checksum = await GetChecksumAsync(document, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -233,32 +234,32 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                 identifiers = SharedPools.StringIgnoreCaseHashSet.AllocateAndClear();
                 escapedIdentifiers = SharedPools.StringIgnoreCaseHashSet.AllocateAndClear();
 
-                Contract.Requires(identifiers.Comparer == StringComparer.OrdinalIgnoreCase);
-                Contract.Requires(escapedIdentifiers.Comparer == StringComparer.OrdinalIgnoreCase);
+                Debug.Assert(identifiers.Comparer == StringComparer.OrdinalIgnoreCase);
+                Debug.Assert(escapedIdentifiers.Comparer == StringComparer.OrdinalIgnoreCase);
                 return;
             }
 
             identifiers = SharedPools.StringHashSet.AllocateAndClear();
             escapedIdentifiers = SharedPools.StringHashSet.AllocateAndClear();
 
-            Contract.Requires(identifiers.Comparer == StringComparer.Ordinal);
-            Contract.Requires(escapedIdentifiers.Comparer == StringComparer.Ordinal);
+            Debug.Assert(identifiers.Comparer == StringComparer.Ordinal);
+            Debug.Assert(escapedIdentifiers.Comparer == StringComparer.Ordinal);
         }
 
         private static void Free(bool ignoreCase, HashSet<string> identifiers, HashSet<string> escapedIdentifiers)
         {
             if (ignoreCase)
             {
-                Contract.Requires(identifiers.Comparer == StringComparer.OrdinalIgnoreCase);
-                Contract.Requires(escapedIdentifiers.Comparer == StringComparer.OrdinalIgnoreCase);
+                Debug.Assert(identifiers.Comparer == StringComparer.OrdinalIgnoreCase);
+                Debug.Assert(escapedIdentifiers.Comparer == StringComparer.OrdinalIgnoreCase);
 
                 SharedPools.StringIgnoreCaseHashSet.ClearAndFree(identifiers);
                 SharedPools.StringIgnoreCaseHashSet.ClearAndFree(escapedIdentifiers);
                 return;
             }
 
-            Contract.Requires(identifiers.Comparer == StringComparer.Ordinal);
-            Contract.Requires(escapedIdentifiers.Comparer == StringComparer.Ordinal);
+            Debug.Assert(identifiers.Comparer == StringComparer.Ordinal);
+            Debug.Assert(escapedIdentifiers.Comparer == StringComparer.Ordinal);
 
             SharedPools.StringHashSet.ClearAndFree(identifiers);
             SharedPools.StringHashSet.ClearAndFree(escapedIdentifiers);

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TokenData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TokenData.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -106,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             // this is expansive check. but there is no other way to check.
             var commonRoot = this.Token.GetCommonRoot(other.Token);
-            Contract.Requires(commonRoot != null);
+            Debug.Assert(commonRoot != null);
 
             var tokens = commonRoot.DescendantTokens();
 

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TokenStream.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TokenStream.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 _tokens = new List<SyntaxToken>(sizeOfList);
                 _tokens.AddRange(_treeData.GetApplicableTokens(spanToFormat));
 
-                Contract.Requires(this.TokenCount > 0);
+                Debug.Assert(this.TokenCount > 0);
 
                 // initialize trivia related info
                 _cachedOriginalTriviaInfo = new TriviaData[this.TokenCount - 1];
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             for (int i = 1; i < _tokens.Count; i++)
             {
                 var currentToken = _tokens[i];
-                Contract.Requires(previousToken.FullSpan.End <= currentToken.FullSpan.Start);
+                Debug.Assert(previousToken.FullSpan.End <= currentToken.FullSpan.Start);
 
                 previousToken = currentToken;
             }
@@ -397,9 +397,9 @@ namespace Microsoft.CodeAnalysis.Formatting
             }
 
             // normal cases
-            Contract.Requires(token1.Token.Span.End <= token2.Token.SpanStart);
-            Contract.Requires(token1.IndexInStream < 0 || token2.IndexInStream < 0 || (token1.IndexInStream + 1 == token2.IndexInStream));
-            Contract.Requires((token1.IndexInStream >= 0 && token2.IndexInStream >= 0) || token1.Token.Equals(token2.Token.GetPreviousToken(includeZeroWidth: true)) || token2.Token.LeadingTrivia.Span.Contains(token1.Token.Span));
+            Debug.Assert(token1.Token.Span.End <= token2.Token.SpanStart);
+            Debug.Assert(token1.IndexInStream < 0 || token2.IndexInStream < 0 || (token1.IndexInStream + 1 == token2.IndexInStream));
+            Debug.Assert((token1.IndexInStream >= 0 && token2.IndexInStream >= 0) || token1.Token.Equals(token2.Token.GetPreviousToken(includeZeroWidth: true)) || token2.Token.LeadingTrivia.Span.Contains(token1.Token.Span));
 
             // one of token is out side of cached token stream
             if (token1.IndexInStream < 0 || token2.IndexInStream < 0)
@@ -422,9 +422,9 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return _factory.CreateTrailingTrivia(token1.Token);
             }
 
-            Contract.Requires(token1.Token.Span.End <= token2.Token.SpanStart);
-            Contract.Requires(token1.IndexInStream < 0 || token2.IndexInStream < 0 || (token1.IndexInStream + 1 == token2.IndexInStream));
-            Contract.Requires((token1.IndexInStream >= 0 && token2.IndexInStream >= 0) || token1.Token.Equals(token2.Token.GetPreviousToken(includeZeroWidth: true)) || token2.Token.LeadingTrivia.Span.Contains(token1.Token.Span));
+            Debug.Assert(token1.Token.Span.End <= token2.Token.SpanStart);
+            Debug.Assert(token1.IndexInStream < 0 || token2.IndexInStream < 0 || (token1.IndexInStream + 1 == token2.IndexInStream));
+            Debug.Assert((token1.IndexInStream >= 0 && token2.IndexInStream >= 0) || token1.Token.Equals(token2.Token.GetPreviousToken(includeZeroWidth: true)) || token2.Token.LeadingTrivia.Span.Contains(token1.Token.Span));
 
             if (token1.IndexInStream < 0 || token2.IndexInStream < 0)
             {
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return data;
             }
 
-            Contract.Requires(_treeData.IsFirstToken(this.FirstTokenInStream.Token));
+            Debug.Assert(_treeData.IsFirstToken(this.FirstTokenInStream.Token));
             return GetOriginalTriviaData(default, this.FirstTokenInStream);
         }
 
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return data;
             }
 
-            Contract.Requires(_treeData.IsLastToken(this.LastTokenInStream.Token));
+            Debug.Assert(_treeData.IsLastToken(this.LastTokenInStream.Token));
             return GetOriginalTriviaData(this.LastTokenInStream, default);
         }
 
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return true;
             }
 
-            Contract.Requires(tokenData2 == tokenData1.GetNextTokenData());
+            Debug.Assert(tokenData2 == tokenData1.GetNextTokenData());
 
             // see if there are changes for a given token pair
             return this.GetTriviaData(tokenData1, tokenData2).SecondTokenIsFirstTokenOnLine;

--- a/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
@@ -845,7 +845,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             LineColumnDelta whitespaceBetween,
             SyntaxTrivia trivia2)
         {
-            Contract.Requires(IsWhitespaceOrEndOfLine(trivia2));
+            Debug.Assert(IsWhitespaceOrEndOfLine(trivia2));
 
             // treat elastic as new line as long as its previous trivia is not elastic or
             // it has line break right before it

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared;
@@ -482,8 +483,8 @@ namespace Microsoft.CodeAnalysis.PatternMatching
                 // Let's consider our termination cases
                 if (currentPatternHump == patternHumpCount)
                 {
-                    Contract.Requires(firstMatch.HasValue);
-                    Contract.Requires(contiguous.HasValue);
+                    Debug.Assert(firstMatch.HasValue);
+                    Debug.Assert(contiguous.HasValue);
 
                     var matchCount = matchSpans.Count;
                     matchedSpans = _includeMatchedSpans

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -139,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 // when that happen, we don't want to crash VS, so this is debug only check
                 if (!Environment.HasShutdownStarted)
                 {
-                    Contract.Requires(false, 
+                    Debug.Assert(false, 
                         $"Unless OOP process (RoslynCodeAnalysisService) is explicitly killed, this should have been disposed!\r\n {_creationCallStack}");
                 }
             }

--- a/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
@@ -510,7 +510,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelWorkspaceService
                 private static void ValidateTreeMap(ImmutableDictionary<DocumentId, SyntaxTree> actual, Project project, Compilation compilation)
                 {
                     var expected = ImmutableDictionary.CreateRange(GetNewTreeMap(project, compilation));
-                    Contract.Requires(actual.SetEquals(expected));
+                    Debug.Assert(actual.SetEquals(expected));
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Shared/Collections/IntervalTree`1.cs
+++ b/src/Workspaces/Core/Portable/Shared/Collections/IntervalTree`1.cs
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
                 }
                 else
                 {
-                    Contract.Requires(rightBalance == 1);
+                    Debug.Assert(rightBalance == 1);
                     return node.InnerRightOuterLeftRotation(introspector);
                 }
             }
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
                 }
                 else
                 {
-                    Contract.Requires(leftBalance == -1);
+                    Debug.Assert(leftBalance == -1);
                     return node.InnerLeftOuterRightRotation(introspector);
                 }
             }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions
@@ -84,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             Contract.ThrowIfNull(symbol);
             Contract.ThrowIfNull(within);
-            Contract.Requires(within is INamedTypeSymbol || within is IAssemblySymbol);
+            Debug.Assert(within is INamedTypeSymbol || within is IAssemblySymbol);
 
             failedThroughTypeCheck = false;
             switch (symbol.Kind)
@@ -156,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         // an assembly.
         private static bool IsNamedTypeAccessible(INamedTypeSymbol type, ISymbol within)
         {
-            Contract.Requires(within is INamedTypeSymbol || within is IAssemblySymbol);
+            Debug.Assert(within is INamedTypeSymbol || within is IAssemblySymbol);
             Contract.ThrowIfNull(type);
 
             if (type.IsErrorType())
@@ -195,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             Accessibility declaredAccessibility,
             ISymbol within)
         {
-            Contract.Requires(within is INamedTypeSymbol || within is IAssemblySymbol);
+            Debug.Assert(within is INamedTypeSymbol || within is IAssemblySymbol);
             Contract.ThrowIfNull(assembly);
             var withinAssembly = (within as IAssemblySymbol) ?? ((INamedTypeSymbol)within).ContainingAssembly;
 
@@ -232,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             ITypeSymbol throughTypeOpt,
             out bool failedThroughTypeCheck)
         {
-            Contract.Requires(within is INamedTypeSymbol || within is IAssemblySymbol);
+            Debug.Assert(within is INamedTypeSymbol || within is IAssemblySymbol);
             Contract.ThrowIfNull(containingType);
 
             failedThroughTypeCheck = false;
@@ -357,7 +358,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 var originalThroughTypeOpt = throughTypeOpt == null ? null : throughTypeOpt.OriginalDefinition;
                 while (current != null)
                 {
-                    Contract.Requires(current.IsDefinition);
+                    Debug.Assert(current.IsDefinition);
 
                     if (current.InheritsFromOrEqualsIgnoringConstruction(originalContainingType))
                     {
@@ -391,7 +392,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             ISymbol within,
             INamedTypeSymbol originalContainingType)
         {
-            Contract.Requires(within is INamedTypeSymbol || within is IAssemblySymbol);
+            Debug.Assert(within is INamedTypeSymbol || within is IAssemblySymbol);
 
             var withinType = within as INamedTypeSymbol;
             if (withinType == null)
@@ -418,7 +419,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var current = withinType.OriginalDefinition;
             while (current != null)
             {
-                Contract.Requires(current.IsDefinition);
+                Debug.Assert(current.IsDefinition);
                 if (current.Equals(originalContainingType))
                 {
                     return true;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/StringExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/StringExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions
@@ -47,8 +48,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static int ConvertTabToSpace(this string textSnippet, int tabSize, int initialColumn, int endPosition)
         {
-            Contract.Requires(tabSize > 0);
-            Contract.Requires(endPosition >= 0 && endPosition <= textSnippet.Length);
+            Debug.Assert(tabSize > 0);
+            Debug.Assert(endPosition >= 0 && endPosition <= textSnippet.Length);
 
             int column = initialColumn;
 
@@ -224,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             builder.Add(alias);
 
             var caseSensitive = builder.KeyComparer == StringComparer.Ordinal;
-            Contract.Requires(builder.KeyComparer == StringComparer.Ordinal || builder.KeyComparer == StringComparer.OrdinalIgnoreCase);
+            Debug.Assert(builder.KeyComparer == StringComparer.Ordinal || builder.KeyComparer == StringComparer.OrdinalIgnoreCase);
             if (alias.TryGetWithoutAttributeSuffix(caseSensitive, out var aliasWithoutAttribute))
             {
                 builder.Add(aliasWithoutAttribute);

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             private bool AreEquivalentWorker(ISymbol x, ISymbol y, SymbolKind k, Dictionary<INamedTypeSymbol, INamedTypeSymbol> equivalentTypesWithDifferingAssemblies)
             {
-                Contract.Requires(x.Kind == y.Kind && x.Kind == k);
+                Debug.Assert(x.Kind == y.Kind && x.Kind == k);
                 switch (k)
                 {
                     case SymbolKind.ArrayType:
@@ -558,11 +558,11 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             private bool TypeParametersAreEquivalent(ITypeParameterSymbol x, ITypeParameterSymbol y, Dictionary<INamedTypeSymbol, INamedTypeSymbol> equivalentTypesWithDifferingAssemblies)
             {
-                Contract.Requires(
+                Debug.Assert(
                     (x.TypeParameterKind == TypeParameterKind.Method && IsConstructedFromSelf(x.DeclaringMethod)) ||
                     (x.TypeParameterKind == TypeParameterKind.Type && IsConstructedFromSelf(x.ContainingType)) ||
                     x.TypeParameterKind == TypeParameterKind.Cref);
-                Contract.Requires(
+                Debug.Assert(
                     (y.TypeParameterKind == TypeParameterKind.Method && IsConstructedFromSelf(y.DeclaringMethod)) ||
                     (y.TypeParameterKind == TypeParameterKind.Type && IsConstructedFromSelf(y.ContainingType)) ||
                     y.TypeParameterKind == TypeParameterKind.Cref);

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.GetHashCodeVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.GetHashCodeVisitor.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -281,7 +282,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             public int CombineHashCodes(ITypeParameterSymbol x, int currentHash)
             {
-                Contract.Requires(
+                Debug.Assert(
                     (x.TypeParameterKind == TypeParameterKind.Method && IsConstructedFromSelf(x.DeclaringMethod)) ||
                     (x.TypeParameterKind == TypeParameterKind.Type && IsConstructedFromSelf(x.ContainingType)) ||
                     x.TypeParameterKind == TypeParameterKind.Cref);

--- a/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
+++ b/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Simplification
 
                 // Chaining of the Speculative SemanticModel (i.e. Generating a speculative SemanticModel from an existing Speculative SemanticModel) is not supported
                 // Hence make sure we always start working off of the actual SemanticModel instead of a speculative SemanticModel.
-                Contract.Assert(!semanticModel.IsSpeculativeSemanticModel);
+                Debug.Assert(!semanticModel.IsSpeculativeSemanticModel);
 
                 var root = await semanticModel.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Core/Portable/Utilities/BidirectionalMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/BidirectionalMap.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Roslyn.Utilities
@@ -93,7 +94,7 @@ namespace Roslyn.Utilities
         {
             get
             {
-                Contract.Requires(_forwardMap.Count == _backwardMap.Count);
+                Debug.Assert(_forwardMap.Count == _backwardMap.Count);
                 return _backwardMap.Count;
             }
         }

--- a/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/ImmutableHashMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/ImmutableHashMap.cs
@@ -50,9 +50,9 @@ namespace Roslyn.Collections.Immutable
         private ImmutableHashMap(Bucket root, IEqualityComparer<TKey> comparer, IEqualityComparer<TValue> valueComparer)
             : this(comparer, valueComparer)
         {
-            Contract.Requires(root != null);
-            Contract.Requires(comparer != null);
-            Contract.Requires(valueComparer != null);
+            Debug.Assert(root != null);
+            Debug.Assert(comparer != null);
+            Debug.Assert(valueComparer != null);
 
             _root = root;
         }
@@ -539,7 +539,7 @@ namespace Roslyn.Collections.Immutable
         [Pure]
         private ImmutableHashMap<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs, bool overwriteOnCollision, bool avoidToHashMap)
         {
-            Contract.Requires(pairs != null);
+            Debug.Assert(pairs != null);
             Contract.Ensures(Contract.Result<ImmutableHashMap<TKey, TValue>>() != null);
 
             // Some optimizations may apply if we're an empty list.
@@ -713,8 +713,8 @@ namespace Roslyn.Collections.Immutable
             internal ListBucket(ValueBucket[] buckets)
                 : base(buckets[0].Hash)
             {
-                Contract.Requires(buckets != null);
-                Contract.Requires(buckets.Length >= 2);
+                Debug.Assert(buckets != null);
+                Debug.Assert(buckets.Length >= 2);
                 _buckets = buckets;
             }
 
@@ -829,8 +829,8 @@ namespace Roslyn.Collections.Immutable
             /// <param name="count">The count.</param>
             private HashBucket(int hashRoll, uint used, Bucket[] buckets, int count)
             {
-                Contract.Requires(buckets != null);
-                Contract.Requires(buckets.Length == CountBits(used));
+                Debug.Assert(buckets != null);
+                Debug.Assert(buckets.Length == CountBits(used));
 
                 _hashRoll = hashRoll & 31;
                 _used = used;
@@ -846,9 +846,9 @@ namespace Roslyn.Collections.Immutable
             /// <param name="bucket2">The bucket2.</param>
             internal HashBucket(int suggestedHashRoll, ValueOrListBucket bucket1, ValueOrListBucket bucket2)
             {
-                Contract.Requires(bucket1 != null);
-                Contract.Requires(bucket2 != null);
-                Contract.Requires(bucket1.Hash != bucket2.Hash);
+                Debug.Assert(bucket1 != null);
+                Debug.Assert(bucket2 != null);
+                Debug.Assert(bucket1.Hash != bucket2.Hash);
 
                 // find next hashRoll that causes these two to be slotted in different buckets
                 var h1 = bucket1.Hash;
@@ -971,7 +971,7 @@ namespace Roslyn.Collections.Immutable
             [Pure]
             private static uint RotateRight(uint v, int n)
             {
-                Contract.Requires(n >= 0 && n < 32);
+                Debug.Assert(n >= 0 && n < 32);
                 if (n == 0)
                 {
                     return v;
@@ -982,7 +982,7 @@ namespace Roslyn.Collections.Immutable
 
             private int ComputePhysicalSlot(int logicalSlot)
             {
-                Contract.Requires(logicalSlot >= 0 && logicalSlot < 32);
+                Debug.Assert(logicalSlot >= 0 && logicalSlot < 32);
                 Contract.Ensures(Contract.Result<int>() >= 0);
                 if (_buckets.Length == 32)
                 {
@@ -1012,14 +1012,14 @@ namespace Roslyn.Collections.Immutable
             [Pure]
             private static uint InsertBit(int position, uint bits)
             {
-                Contract.Requires(0 == (bits & (1u << position)));
+                Debug.Assert(0 == (bits & (1u << position)));
                 return bits | (1u << position);
             }
 
             [Pure]
             private static uint RemoveBit(int position, uint bits)
             {
-                Contract.Requires(0 != (bits & (1u << position)));
+                Debug.Assert(0 != (bits & (1u << position)));
                 return bits & ~(1u << position);
             }
         }

--- a/src/Workspaces/Core/Portable/Utilities/Contract.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Contract.cs
@@ -8,60 +8,6 @@ namespace Roslyn.Utilities
     internal static class Contract
     {
         /// <summary>
-        /// Equivalent to Debug.Assert.  
-        ///
-        /// DevDiv 867813 covers removing this completely at a future date
-        /// </summary>
-        [Conditional("DEBUG")]
-        [DebuggerHidden]
-        public static void Requires(bool condition, string message = null)
-        {
-            Assert(condition, message);
-        }
-
-        /// <summary>
-        /// Equivalent to Debug.Assert.  
-        ///
-        /// DevDiv 867813 covers removing this completely at a future date
-        /// </summary>
-        [Conditional("DEBUG")]
-        [DebuggerHidden]
-        public static void Assert(bool condition, string message = null)
-        {
-            if (condition)
-            {
-                return;
-            }
-
-            if (string.IsNullOrEmpty(message))
-            {
-                Debug.Assert(condition);
-            }
-            else
-            {
-                Debug.Assert(condition, message);
-            }
-        }
-
-        /// <summary>
-        /// Equivalent to Debug.Assert.  
-        ///
-        /// DevDiv 867813 covers removing this completely at a future date
-        /// </summary>
-        [Conditional("DEBUG")]
-        public static void Assume(bool condition, string message = null)
-        {
-            if (string.IsNullOrEmpty(message))
-            {
-                Debug.Assert(condition);
-            }
-            else
-            {
-                Debug.Assert(condition, message);
-            }
-        }
-
-        /// <summary>
         /// Throws a non-accessible exception if the provided value is null.  This method executes in
         /// all builds
         /// </summary>

--- a/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Threading;
@@ -158,7 +159,7 @@ So we suppress this error until the reporting for CA3053 has been updated to acc
             public FileBasedXmlDocumentationProvider(string filePath)
             {
                 Contract.ThrowIfNull(filePath);
-                Contract.Requires(PathUtilities.IsAbsolute(filePath));
+                Debug.Assert(PathUtilities.IsAbsolute(filePath));
 
                 _filePath = filePath;
             }

--- a/src/Workspaces/Core/Portable/Utilities/LazyInitialization.cs
+++ b/src/Workspaces/Core/Portable/Utilities/LazyInitialization.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 
 namespace Roslyn.Utilities
@@ -9,7 +10,7 @@ namespace Roslyn.Utilities
     {
         internal static T InterlockedStore<T>(ref T target, T value) where T : class
         {
-            Contract.Assert(value != null);
+            Debug.Assert(value != null);
             return Interlocked.CompareExchange(ref target, value, null) ?? value;
         }
 

--- a/src/Workspaces/Core/Portable/Utilities/NonReentrantLock.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NonReentrantLock.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.Internal.Log;
 
@@ -198,7 +199,7 @@ namespace Roslyn.Utilities
         /// </summary>
         private void TakeOwnership()
         {
-            Contract.Assert(!this.IsLocked);
+            Debug.Assert(!this.IsLocked);
             _owningThreadId = Environment.CurrentManagedThreadId;
         }
 
@@ -207,7 +208,7 @@ namespace Roslyn.Utilities
         /// </summary>
         private void ReleaseOwnership()
         {
-            Contract.Assert(this.IsOwnedByMe);
+            Debug.Assert(this.IsOwnedByMe);
             _owningThreadId = 0;
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -473,7 +473,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState AddProjectReference(ProjectReference projectReference)
         {
-            Contract.Requires(!this.ProjectReferences.Contains(projectReference));
+            Debug.Assert(!this.ProjectReferences.Contains(projectReference));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithProjectReferences(this.ProjectReferences.ToImmutableArray().Add(projectReference)).WithVersion(this.Version.GetNewerVersion()));
@@ -481,7 +481,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState RemoveProjectReference(ProjectReference projectReference)
         {
-            Contract.Requires(this.ProjectReferences.Contains(projectReference));
+            Debug.Assert(this.ProjectReferences.Contains(projectReference));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithProjectReferences(this.ProjectReferences.ToImmutableArray().Remove(projectReference)).WithVersion(this.Version.GetNewerVersion()));
@@ -492,7 +492,7 @@ namespace Microsoft.CodeAnalysis
             var newProjectRefs = this.ProjectReferences;
             foreach (var projectReference in projectReferences)
             {
-                Contract.Requires(!newProjectRefs.Contains(projectReference));
+                Debug.Assert(!newProjectRefs.Contains(projectReference));
                 newProjectRefs = newProjectRefs.ToImmutableArray().Add(projectReference);
             }
 
@@ -508,7 +508,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState AddMetadataReference(MetadataReference toMetadata)
         {
-            Contract.Requires(!this.MetadataReferences.Contains(toMetadata));
+            Debug.Assert(!this.MetadataReferences.Contains(toMetadata));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithMetadataReferences(this.MetadataReferences.ToImmutableArray().Add(toMetadata)).WithVersion(this.Version.GetNewerVersion()));
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState RemoveMetadataReference(MetadataReference toMetadata)
         {
-            Contract.Requires(this.MetadataReferences.Contains(toMetadata));
+            Debug.Assert(this.MetadataReferences.Contains(toMetadata));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithMetadataReferences(this.MetadataReferences.ToImmutableArray().Remove(toMetadata)).WithVersion(this.Version.GetNewerVersion()));
@@ -527,7 +527,7 @@ namespace Microsoft.CodeAnalysis
             var newMetaRefs = this.MetadataReferences;
             foreach (var metadataReference in metadataReferences)
             {
-                Contract.Requires(!newMetaRefs.Contains(metadataReference));
+                Debug.Assert(!newMetaRefs.Contains(metadataReference));
                 newMetaRefs = newMetaRefs.ToImmutableArray().Add(metadataReference);
             }
 
@@ -543,7 +543,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState AddAnalyzerReference(AnalyzerReference analyzerReference)
         {
-            Contract.Requires(!this.AnalyzerReferences.Contains(analyzerReference));
+            Debug.Assert(!this.AnalyzerReferences.Contains(analyzerReference));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithAnalyzerReferences(this.AnalyzerReferences.ToImmutableArray().Add(analyzerReference)).WithVersion(this.Version.GetNewerVersion()));
@@ -551,7 +551,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState RemoveAnalyzerReference(AnalyzerReference analyzerReference)
         {
-            Contract.Requires(this.AnalyzerReferences.Contains(analyzerReference));
+            Debug.Assert(this.AnalyzerReferences.Contains(analyzerReference));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithAnalyzerReferences(this.AnalyzerReferences.ToImmutableArray().Remove(analyzerReference)).WithVersion(this.Version.GetNewerVersion()));
@@ -562,7 +562,7 @@ namespace Microsoft.CodeAnalysis
             var newAnalyzerReferences = this.AnalyzerReferences;
             foreach (var analyzerReference in analyzerReferences)
             {
-                Contract.Requires(!newAnalyzerReferences.Contains(analyzerReference));
+                Debug.Assert(!newAnalyzerReferences.Contains(analyzerReference));
                 newAnalyzerReferences = newAnalyzerReferences.ToImmutableArray().Add(analyzerReference);
             }
 
@@ -578,7 +578,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState AddDocument(DocumentState document)
         {
-            Contract.Requires(!this.DocumentStates.ContainsKey(document.Id));
+            Debug.Assert(!this.DocumentStates.ContainsKey(document.Id));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
@@ -588,7 +588,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState AddAdditionalDocument(TextDocumentState document)
         {
-            Contract.Requires(!this.AdditionalDocumentStates.ContainsKey(document.Id));
+            Debug.Assert(!this.AdditionalDocumentStates.ContainsKey(document.Id));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
@@ -598,7 +598,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState RemoveDocument(DocumentId documentId)
         {
-            Contract.Requires(this.DocumentStates.ContainsKey(documentId));
+            Debug.Assert(this.DocumentStates.ContainsKey(documentId));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
@@ -608,7 +608,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState RemoveAdditionalDocument(DocumentId documentId)
         {
-            Contract.Requires(this.AdditionalDocumentStates.ContainsKey(documentId));
+            Debug.Assert(this.AdditionalDocumentStates.ContainsKey(documentId));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
@@ -626,7 +626,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState UpdateDocument(DocumentState newDocument, bool textChanged, bool recalculateDependentVersions)
         {
-            Contract.Requires(this.ContainsDocument(newDocument.Id));
+            Debug.Assert(this.ContainsDocument(newDocument.Id));
 
             var oldDocument = this.GetDocumentState(newDocument.Id);
             if (oldDocument == newDocument)
@@ -647,7 +647,7 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState UpdateAdditionalDocument(TextDocumentState newDocument, bool textChanged, bool recalculateDependentVersions)
         {
-            Contract.Requires(this.ContainsAdditionalDocument(newDocument.Id));
+            Debug.Assert(this.ContainsAdditionalDocument(newDocument.Id));
 
             var oldDocument = this.GetAdditionalDocumentState(newDocument.Id);
             if (oldDocument == newDocument)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis
             {
                 try
                 {
-                    Contract.Requires(inProgressCompilation != null);
+                    Debug.Assert(inProgressCompilation != null);
                     var intermediateProjects = state.IntermediateProjects;
 
                     while (intermediateProjects.Length > 0)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -691,7 +692,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(projectId));
             }
 
-            Contract.Requires(this.ContainsProject(projectId));
+            Debug.Assert(this.ContainsProject(projectId));
 
             var oldProject = this.GetProjectState(projectId);
             var newProject = oldProject.UpdateParseOptions(options);
@@ -726,7 +727,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(projectId));
             }
 
-            Contract.Requires(this.ContainsProject(projectId));
+            Debug.Assert(this.ContainsProject(projectId));
 
             return ForkProject(GetProjectState(projectId));
         }
@@ -742,7 +743,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(projectId));
             }
 
-            Contract.Requires(this.ContainsProject(projectId));
+            Debug.Assert(this.ContainsProject(projectId));
 
             var oldProject = this.GetProjectState(projectId);
             var newProject = oldProject.UpdateHasAllInformation(hasAllInformation);
@@ -1400,7 +1401,7 @@ namespace Microsoft.CodeAnalysis
 
         private SolutionState TouchDocument(DocumentId documentId, Func<ProjectState, ProjectState> touchProject)
         {
-            Contract.Requires(this.ContainsDocument(documentId));
+            Debug.Assert(this.ContainsDocument(documentId));
 
             var oldProject = this.GetProjectState(documentId.ProjectId);
             var newProject = touchProject(oldProject);
@@ -1898,7 +1899,7 @@ namespace Microsoft.CodeAnalysis
 
         private void CheckNotContainsDocument(DocumentId documentId)
         {
-            Contract.Requires(!this.ContainsDocument(documentId));
+            Debug.Assert(!this.ContainsDocument(documentId));
 
             if (this.ContainsDocument(documentId))
             {
@@ -1908,7 +1909,7 @@ namespace Microsoft.CodeAnalysis
 
         private void CheckNotContainsAdditionalDocument(DocumentId documentId)
         {
-            Contract.Requires(!this.ContainsAdditionalDocument(documentId));
+            Debug.Assert(!this.ContainsAdditionalDocument(documentId));
 
             if (this.ContainsAdditionalDocument(documentId))
             {
@@ -1918,7 +1919,7 @@ namespace Microsoft.CodeAnalysis
 
         private void CheckContainsDocument(DocumentId documentId)
         {
-            Contract.Requires(this.ContainsDocument(documentId));
+            Debug.Assert(this.ContainsDocument(documentId));
 
             if (!this.ContainsDocument(documentId))
             {
@@ -1928,7 +1929,7 @@ namespace Microsoft.CodeAnalysis
 
         private void CheckContainsAdditionalDocument(DocumentId documentId)
         {
-            Contract.Requires(this.ContainsAdditionalDocument(documentId));
+            Debug.Assert(this.ContainsAdditionalDocument(documentId));
 
             if (!this.ContainsAdditionalDocument(documentId))
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using Roslyn.Utilities;
 
@@ -122,7 +123,7 @@ namespace Microsoft.CodeAnalysis
         public VersionStamp GetNewerVersion()
         {
             // global version can't be moved to newer version
-            Contract.Requires(_globalIncrement != GlobalVersionMarker);
+            Debug.Assert(_globalIncrement != GlobalVersionMarker);
 
             var now = DateTime.UtcNow;
             var incr = (now == _utcLastModified) ? _localIncrement + 1 : 0;

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Remote.DebugUtil;
 using Roslyn.Utilities;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -630,7 +631,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 return;
             }
 
-            Contract.Requires(false, "checksum not same");
+            Debug.Assert(false, "checksum not same");
 
             var map = solution.GetAssetMap();
             await RemoveDuplicateChecksumsAsync(givenSolutionChecksum, map).ConfigureAwait(false);

--- a/src/Workspaces/Remote/Core/TestUtils.cs
+++ b/src/Workspaces/Remote/Core/TestUtils.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Remote.DebugUtil
         {
             if (!project.State.TryGetStateChecksums(out var projectChecksums))
             {
-                Contract.Requires(!RemoteSupportedLanguages.IsSupported(project.Language));
+                Debug.Assert(!RemoteSupportedLanguages.IsSupported(project.Language));
                 return;
             }
 

--- a/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CaseCorrection
                             Dim name = preprocessingSymbolInfo.Symbol.Name
                             If Not String.IsNullOrEmpty(name) AndAlso name <> token.ValueText Then
                                 ' Name should differ only in case
-                                Contract.Requires(name.Equals(token.ValueText, StringComparison.OrdinalIgnoreCase))
+                                Debug.Assert(name.Equals(token.ValueText, StringComparison.OrdinalIgnoreCase))
 
                                 Return GetIdentifierWithCorrectedName(name, newToken)
                             End If
@@ -115,7 +115,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CaseCorrection
                                         ordinal = ordinal + 1
                                     Next
 
-                                    Contract.Requires(otherPartOfPartial.Parameters.Length > ordinal)
+                                    Debug.Assert(otherPartOfPartial.Parameters.Length > ordinal)
                                     Dim otherPartParam = otherPartOfPartial.Parameters(ordinal)
 
                                     ' We don't want to rename the parameter if names are not equal ignoring case.

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/AsyncOrIteratorFunctionReturnTypeFixer.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/AsyncOrIteratorFunctionReturnTypeFixer.vb
@@ -149,10 +149,10 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup
                                              ByRef asClauseOpt As SimpleAsClauseSyntax,
                                              semanticModel As SemanticModel,
                                              position As Integer)
-            Contract.Requires(type IsNot Nothing)
-            Contract.Requires(parameterListOpt IsNot Nothing)
-            Contract.Requires(asClauseOpt Is Nothing)
-            Contract.Requires(semanticModel IsNot Nothing)
+            Debug.Assert(type IsNot Nothing)
+            Debug.Assert(parameterListOpt IsNot Nothing)
+            Debug.Assert(asClauseOpt Is Nothing)
+            Debug.Assert(semanticModel IsNot Nothing)
 
             Dim typeSyntax = SyntaxFactory.ParseTypeName(type.ToMinimalDisplayString(semanticModel, position))
             asClauseOpt = SyntaxFactory.SimpleAsClause(typeSyntax).NormalizeWhitespace()
@@ -173,9 +173,9 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup
 
         ' Pretty list the function with return type "T" to return "genericTypeName(Of T)"
         Private Sub RewriteFunctionAsClause(genericType As INamedTypeSymbol, ByRef asClauseOpt As SimpleAsClauseSyntax, semanticModel As SemanticModel, position As Integer)
-            Contract.Requires(genericType.IsGenericType)
-            Contract.Requires(asClauseOpt IsNot Nothing AndAlso Not asClauseOpt.IsMissing)
-            Contract.Requires(semanticModel IsNot Nothing)
+            Debug.Assert(genericType.IsGenericType)
+            Debug.Assert(asClauseOpt IsNot Nothing AndAlso Not asClauseOpt.IsMissing)
+            Debug.Assert(semanticModel IsNot Nothing)
 
             ' Move the leading and trailing trivia from the existing typeSyntax node to the new AsClause.
             Dim typeSyntax = asClauseOpt.Type

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.vb
@@ -117,7 +117,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
         Friend Function IsDeclarationContextWithinTypeBlocks(
             syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, allowAfterModifiersOrDim As Boolean, cancellationToken As CancellationToken, ParamArray allowedParentBlocks As SyntaxKind()) As Boolean
 
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
             If targetToken.Kind = SyntaxKind.None OrElse targetToken.Parent Is Nothing Then
                 ' We're at the root, so we're acceptable if we allow us to be in the root
                 Return allowedParentBlocks.Contains(SyntaxKind.CompilationUnit)
@@ -206,7 +206,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension>
         Friend Function IsFieldNameDeclarationContext(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, cancellationToken As CancellationToken) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
             If targetToken.FollowsEndOfStatement(position) Then
                 Return False
             End If
@@ -262,7 +262,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension()>
         Friend Function IsLabelContext(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, cancellationToken As CancellationToken) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
             If targetToken.FollowsEndOfStatement(position) Then
                 Return False
             End If
@@ -307,7 +307,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension()>
         Public Function IsDelegateCreationContext(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
 
             If targetToken.FollowsEndOfStatement(position) Then
                 Return False
@@ -339,7 +339,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
         Friend Function IsExpressionContext(
             syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, cancellationToken As CancellationToken, Optional semanticModelOpt As SemanticModel = Nothing) As Boolean
 
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
 
             ' Tuple elements are in expression context if the tuple is in expression context
             PositionOutsideTupleIfApplicable(syntaxTree, position, targetToken, cancellationToken)
@@ -445,8 +445,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension()>
         Public Function IsAttributeNameContext(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, cancellationToken As CancellationToken) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
-            Contract.Requires(Not (targetToken.IntersectsWith(position) AndAlso IsWord(targetToken)))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(Not (targetToken.IntersectsWith(position) AndAlso IsWord(targetToken)))
 
             If targetToken.IsChildToken(Function(a As AttributeTargetSyntax) a.ColonToken) OrElse
                targetToken.IsChildToken(Function(a As AttributeListSyntax) a.LessThanToken) OrElse
@@ -474,7 +474,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 Return False
             End If
 
-            Contract.Requires(token = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(token = syntaxTree.GetTargetToken(position, cancellationToken))
 
             ' Tuple elements are in type context if the tuple is in type context
             PositionOutsideTupleIfApplicable(syntaxTree, position, token, cancellationToken)
@@ -574,7 +574,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 Return True
             End If
 
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
             If targetToken.FollowsEndOfStatement(position) Then
                 Return False
             End If
@@ -622,7 +622,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 Return False
             End If
 
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
             If targetToken.Kind = SyntaxKind.None Then
                 Return False
             End If
@@ -656,7 +656,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
         ''' </summary>
         <Extension()>
         Friend Function IsAfterStatementOfKind(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, cancellationToken As CancellationToken, ParamArray kinds As SyntaxKind()) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
             If targetToken.Kind = SyntaxKind.None OrElse targetToken.Parent Is Nothing Then
                 Return False
             End If
@@ -670,7 +670,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension()>
         Friend Function IsInStatementBlockOfKind(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, cancellationToken As CancellationToken, ParamArray kinds As SyntaxKind()) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
             Dim ancestor = targetToken.Parent
 
             Do While ancestor IsNot Nothing
@@ -702,7 +702,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension()>
         Public Function IsQueryIntoClauseContext(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, cancellationToken As CancellationToken) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
             If targetToken.Kind = SyntaxKind.None Then
                 Return False
             End If
@@ -736,7 +736,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension()>
         Public Function IsRaiseEventContext(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, cancellationToken As CancellationToken) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
             Return Not targetToken.FollowsEndOfStatement(position) AndAlso targetToken.Kind = SyntaxKind.RaiseEventKeyword
         End Function
 
@@ -748,7 +748,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension()>
         Public Function IsObjectCreationTypeContext(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, cancellationToken As CancellationToken) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
 
             If Not targetToken.FollowsEndOfStatement(position) AndAlso targetToken.Kind = SyntaxKind.NewKeyword Then
                 Return syntaxTree.IsTypeContext(position, targetToken, cancellationToken) OrElse
@@ -761,7 +761,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
         <Extension>
         Friend Function IsEnumTypeMemberAccessContext(syntaxTree As SyntaxTree, position As Integer, targetToken As SyntaxToken, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Boolean
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
 
             If Not targetToken.IsKind(SyntaxKind.DotToken) OrElse
                Not targetToken.Parent.IsKind(SyntaxKind.SimpleMemberAccessExpression) Then
@@ -804,7 +804,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
             Optional allowImplicitLineContinuation As Boolean = True
         ) As Boolean
 
-            Contract.Requires(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(targetToken = syntaxTree.GetTargetToken(position, cancellationToken))
 
             ' Check if our position begins a new statement
             If targetToken.MustBeginNewStatement(position) OrElse

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SimpleNameSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SimpleNameSyntaxExtensions.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
     Friend Module SimpleNameSyntaxExtensions
         <Extension()>
         Public Function GetLeftSideOfDot(name As SimpleNameSyntax) As ExpressionSyntax
-            Contract.Requires(IsMemberAccessExpressionName(name) OrElse IsRightSideOfQualifiedName(name))
+            Debug.Assert(IsMemberAccessExpressionName(name) OrElse IsRightSideOfQualifiedName(name))
             If IsMemberAccessExpressionName(name) Then
                 Return DirectCast(name.Parent, MemberAccessExpressionSyntax).Expression
             Else

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -174,7 +174,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         Public Function TryGetSpeculativeSemanticModel(oldSemanticModel As SemanticModel, oldNode As SyntaxNode, newNode As SyntaxNode, <Out> ByRef speculativeModel As SemanticModel) As Boolean Implements ISemanticFactsService.TryGetSpeculativeSemanticModel
-            Contract.Requires(oldNode.Kind = newNode.Kind)
+            Debug.Assert(oldNode.Kind = newNode.Kind)
 
             Dim model = oldSemanticModel
 

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -945,12 +945,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetSyntaxListSpan(Of T As SyntaxNode)(list As SyntaxList(Of T)) As TextSpan
-            Contract.Requires(list.Count > 0)
+            Debug.Assert(list.Count > 0)
             Return TextSpan.FromBounds(list.First.SpanStart, list.Last.Span.End)
         End Function
 
         Private Function GetSeparatedSyntaxListSpan(Of T As SyntaxNode)(list As SeparatedSyntaxList(Of T)) As TextSpan
-            Contract.Requires(list.Count > 0)
+            Debug.Assert(list.Count > 0)
             Return TextSpan.FromBounds(list.First.SpanStart, list.Last.Span.End)
         End Function
 
@@ -1115,7 +1115,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Public Function GetMethodLevelMemberId(root As SyntaxNode, node As SyntaxNode) As Integer Implements ISyntaxFactsService.GetMethodLevelMemberId
-            Contract.Requires(root.SyntaxTree Is node.SyntaxTree)
+            Debug.Assert(root.SyntaxTree Is node.SyntaxTree)
 
             Dim currentId As Integer = Nothing
             Dim currentNode As SyntaxNode = Nothing

--- a/src/Workspaces/VisualBasic/Portable/LinkedFiles/BasicLinkedFileMergeConflictCommentAdditionService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LinkedFiles/BasicLinkedFileMergeConflictCommentAdditionService.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim newlines = Regex.Matches(text, "\r\n|\r|\n")
-            Contract.Assert(newlines.Count = lines.Length - 1)
+            Debug.Assert(newlines.Count = lines.Length - 1)
 
             Dim builder = New StringBuilder()
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/DirectiveWalker.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/DirectiveWalker.vb
@@ -99,9 +99,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
 
             ' #If should be the first one in sorted order
             Dim ifDirective = condDirectives.First()
-            Contract.Assert(ifDirective.Kind = SyntaxKind.IfDirectiveTrivia OrElse
-                            ifDirective.Kind = SyntaxKind.ElseIfDirectiveTrivia OrElse
-                            ifDirective.Kind = SyntaxKind.ElseDirectiveTrivia)
+            Debug.Assert(ifDirective.Kind = SyntaxKind.IfDirectiveTrivia OrElse
+                         ifDirective.Kind = SyntaxKind.ElseIfDirectiveTrivia OrElse
+                         ifDirective.Kind = SyntaxKind.ElseDirectiveTrivia)
 
             If directiveOpt IsNot Nothing Then
                 _startEndMap.Add(directiveOpt, ifDirective)

--- a/src/Workspaces/VisualBasic/Portable/Utilities/ImportsStatementComparer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/ImportsStatementComparer.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
         Private ReadOnly _nameComparer As IComparer(Of NameSyntax)
 
         Private Sub New(nameComparer As IComparer(Of NameSyntax))
-            Contract.Requires(nameComparer IsNot Nothing)
+            Debug.Assert(nameComparer IsNot Nothing)
             Me._nameComparer = nameComparer
         End Sub
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/ModifierCollectionFacts.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/ModifierCollectionFacts.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
         Private ReadOnly _declarationTypes As PossibleDeclarationTypes
 
         Public Sub New(syntaxTree As SyntaxTree, position As Integer, token As SyntaxToken, cancellationToken As CancellationToken)
-            Contract.Requires(token = syntaxTree.GetTargetToken(position, cancellationToken))
+            Debug.Assert(token = syntaxTree.GetTargetToken(position, cancellationToken))
 
             Dim targetToken = token
 


### PR DESCRIPTION
These can be very confusing, since other methods on Contract actually throw exceptions. Since we have endless amounts of code directly calling Debug.Assert, let's just use it everywhere.