### PR TITLE
Don't fire IDE0009 incorrectly in List initializers

### DIFF
--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -198,6 +198,30 @@ class Derived : Base
 CodeStyleOptions.QualifyFieldAccess);
         }
 
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyFieldAccess_InObjectInitializer()
+        {
+            await TestAsyncWithOption(
+@"class C
+{
+    int i = 1;
+    void M()
+    {
+        var test = new System.Collections.Generic.List<int> { [|i|] };
+    }
+}",
+@"class C
+{
+    int i = 1;
+    void M()
+    {
+        var test = new System.Collections.Generic.List<int> { this.i };
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
         [WorkItem(7065, "https://github.com/dotnet/roslyn/issues/7065")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
         public async Task QualifyFieldAccess_NotSuggestedOnInstance()
@@ -228,6 +252,22 @@ CodeStyleOptions.QualifyFieldAccess);
     void M()
     {
         [|i|] = 1;
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyFieldAccess_NotSuggestedOnLocalVarInObjectInitializer()
+        {
+            await TestMissingAsyncWithOption(
+@"class C
+{
+    void M()
+    {
+         var foo = 1;
+         var test = new System.Collections.Generic.List<int> { [|foo|] };
     }
 }",
 CodeStyleOptions.QualifyFieldAccess);
@@ -636,6 +676,54 @@ CodeStyleOptions.QualifyMethodAccess);
     void M()
     {
         [|Method|]();
+    }
+}",
+CodeStyleOptions.QualifyMethodAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyMethodAccess_NotSuggestedOnObjectInitializer()
+        {
+            await TestMissingAsyncWithOption(
+@"class C
+{
+    void M()
+    {
+         var foo = 1;
+         var test = new System.Collections.Generic.List<int> { [|foo|] };
+    }
+}",
+CodeStyleOptions.QualifyMethodAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyLocalMethodAccess_NotSuggestedOnObjectInitializer()
+        {
+            await TestMissingAsyncWithOption(
+@"class C
+{
+    void M()
+    {
+        int Local() => 1;
+        var test = new System.Collections.Generic.List<int> { [|Local()|] };
+    }
+}",
+CodeStyleOptions.QualifyMethodAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyLocalMethodAccess_NotSuggestedInMethodCall()
+        {
+            await TestMissingAsyncWithOption(
+@"class C
+{
+    void M()
+    {
+        int Local() => 1;
+        [|Local|]();
     }
 }",
 CodeStyleOptions.QualifyMethodAccess);
@@ -1247,6 +1335,30 @@ CodeStyleOptions.QualifyPropertyAccess);
 {
     public string Foo { get; set; }
     public string Bar { get { return Foo; } => this.Foo; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_InObjectInitializer()
+        {
+            await TestAsyncWithOption(
+@"class C
+{
+    public int Foo { get; set }
+    void M()
+    {
+        var test = new System.Collections.Generic.List<int> { [|Foo|] };
+    }
+}",
+@"class C
+{
+    public int Foo { get; set }
+    void M()
+    {
+        var test = new System.Collections.Generic.List<int> { this.Foo };
+    }
 }",
 CodeStyleOptions.QualifyPropertyAccess);
         }

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -115,6 +115,28 @@ End Class
 CodeStyleOptions.QualifyFieldAccess)
         End Function
 
+        <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function QualifyFieldAccess_InObjectInitializer() As Task
+            Await TestAsyncWithOption("
+Class C
+    Protected i As Integer = 1
+    Sub M()
+        Dim test = New System.Collections.Generic.List(Of Integer) With { [|i|] }
+    End Sub
+End Class
+",
+"
+Class C
+    Protected i As Integer = 1
+    Sub M()
+        Dim test = New System.Collections.Generic.List(Of Integer) With { Me.i }
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
+
         <WorkItem(7065, "https://github.com/dotnet/roslyn/issues/7065")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
         Public Async Function QualifyFieldAccess_NotSuggestedOnInstance() As Task
@@ -144,6 +166,19 @@ CodeStyleOptions.QualifyFieldAccess)
         Public Async Function QualifyFieldAccess_NotSuggestedInModule() As Task
             Await TestMissingAsyncWithOption(
 "Module C : Dim i As Integer : Sub M() : [|i|] = 1 : End Sub : End Module",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
+
+        <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function QualifyFieldAccess_NotSuggestedOnLocalVarInObjectInitializer() As Task
+            Await TestMissingAsyncWithOption(
+"Class C
+    Sub M()
+        Dim i = 1
+        Dim test = New System.Collections.Generic.List(Of Integer) With { [|i|] }
+    End Sub
+End Module",
 CodeStyleOptions.QualifyFieldAccess)
         End Function
 
@@ -214,6 +249,28 @@ Class Derived
     Inherits Base
     Sub M()
         Me.i = 1
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
+
+        <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function QualifyPropertyAccess_InObjectInitializer() As Task
+            Await TestAsyncWithOption("
+Class C
+    Protected Property i As Integer
+    Sub M()
+        Dim test = New System.Collections.Generic.List(Of Integer) With { [|i|] }
+    End Sub
+End Class
+",
+"
+Class C
+    Protected Property i As Integer
+    Sub M()
+        Dim test = New System.Collections.Generic.List(Of Integer) With { Me.i }
     End Sub
 End Class
 ",
@@ -350,6 +407,19 @@ CodeStyleOptions.QualifyMethodAccess)
         Public Async Function QualifyMethodAccess_NotSuggestedOnShared() As Task
             Await TestMissingAsyncWithOption(
 "Class C : Shared Sub Method() : End Sub : Sub M() : [|Method|]() : End Sub : End Class",
+CodeStyleOptions.QualifyMethodAccess)
+        End Function
+
+        <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function QualifyMethodAccess_NotSuggestedOnLocalVarInObjectInitializer() As Task
+            Await TestMissingAsyncWithOption(
+"Class C
+    Sub M()
+        Dim i = 1
+        Dim test = New System.Collections.Generic.List(Of Integer) With { [|i|] }
+    End Sub
+End Module",
 CodeStyleOptions.QualifyMethodAccess)
         End Function
 

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -90,6 +90,14 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                 return;
             }
 
+            // Initializer lists are IInvocationOperation which if passed to GetApplicableOptionFromSymbolKind
+            // will incorrectly fetch the options for method call.
+            // We still want to handle InstanceReferenceKind.ContainingTypeInstance
+            if ((instanceOperation as IInstanceReferenceOperation)?.ReferenceKind == InstanceReferenceKind.ImplicitReceiver)
+            {
+                return;
+            }
+
             // If we can't be qualified (e.g., because we're already qualified with `base.`), we're done.
             if (!CanMemberAccessBeQualified(context.ContainingSymbol, instanceOperation.Syntax))
             {


### PR DESCRIPTION
When analyzing Invocation expressions, don't check `InstanceReferenceKind.ImplicitReceiver` as it shouldn't be qualified.
Because it's an invocation expression when it's used to determine which qualifier setting to use it tries to use the setting for methods.

Added test cases that I believe covers the relevant scenarios for the future.
See #28509, and this also solves #28091