### PR TITLE
Create AddAwait refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/AddAwait/AddAwaitTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/AddAwait/AddAwaitTests.cs
@@ -37,6 +37,42 @@ class Program
         }
 
         [Fact]
+        public async Task InArgument()
+        {
+            await TestInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync(int argument)
+    {
+        var x = GetNumberAsync(arg[||]ument);
+    }
+}", @"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync(int argument)
+    {
+        var x = await GetNumberAsync(argument);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task AlreadyAwaited()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = await GetNumberAsync()[||];
+    }
+}");
+        }
+
+        [Fact]
         public async Task SimpleWithTrivia()
         {
             await TestInRegularAndScriptAsync(@"
@@ -56,6 +92,28 @@ class Program
     {
         var x = // comment
             await GetNumberAsync()[||] /* comment */
+    }
+}");
+        }
+
+        [Fact]
+        public async Task SimpleWithTrivia2()
+        {
+            await TestInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = /* comment */ GetNumberAsync()[||] // comment
+    }
+}", @"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = /* comment */ await GetNumberAsync()[||] // comment
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/AddAwait/AddAwaitTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/AddAwait/AddAwaitTests.cs
@@ -37,6 +37,28 @@ class Program
         }
 
         [Fact]
+        public async Task SimpleWithConfigureAwait()
+        {
+            await TestInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = GetNumberAsync()[||];
+    }
+}", @"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = await GetNumberAsync().ConfigureAwait(false);
+    }
+}", index: 1);
+        }
+
+        [Fact]
         public async Task InArgument()
         {
             await TestInRegularAndScriptAsync(@"
@@ -116,6 +138,52 @@ class Program
         var x = /* comment */ await GetNumberAsync()[||] // comment
     }
 }");
+        }
+
+        [Fact]
+        public async Task SimpleWithTriviaWithConfigureAwait()
+        {
+            await TestInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = // comment
+            GetNumberAsync()[||] /* comment */
+    }
+}", @"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = // comment
+            await GetNumberAsync().ConfigureAwait(false) /* comment */
+    }
+}", index: 1);
+        }
+
+        [Fact]
+        public async Task SimpleWithTrivia2WithConfigureAwait()
+        {
+            await TestInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = /* comment */ GetNumberAsync()[||] // comment
+    }
+}", @"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = /* comment */ await GetNumberAsync().ConfigureAwait(false) // comment
+    }
+}", index: 1);
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/CodeActions/AddAwait/AddAwaitTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/AddAwait/AddAwaitTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.AddAwait;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.AddAwait
+{
+    [Trait(Traits.Feature, Traits.Features.AddAwait)]
+    public class AddAwaitTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new CSharpAddAwaitCodeRefactoringProvider();
+
+        [Fact]
+        public async Task Simple()
+        {
+            await TestInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = GetNumberAsync()[||];
+    }
+}", @"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = await GetNumberAsync();
+    }
+}");
+        }
+
+        [Fact]
+        public async Task SimpleWithTrivia()
+        {
+            await TestInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = // comment
+            GetNumberAsync()[||] /* comment */
+    }
+}", @"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = // comment
+            await GetNumberAsync()[||] /* comment */
+    }
+}");
+        }
+
+        [Fact]
+        public async Task MissingOnSemiColon()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    async Task<int> GetNumberAsync()
+    {
+        var x = GetNumberAsync();[||]
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ChainedInvocation()
+        {
+            await TestInRegularAndScriptAsync(@"
+using System.Threading.Tasks;
+class Program
+{
+    Task<int> GetNumberAsync() => throw null;
+    async void M()
+    {
+        var x = GetNumberAsync()[||].ToString();
+    }
+}", @"
+using System.Threading.Tasks;
+class Program
+{
+    Task<int> GetNumberAsync() => throw null;
+    async void M()
+    {
+        var x = (await GetNumberAsync()).ToString();
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/AddAwait/AddAwaitTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/AddAwait/AddAwaitTests.vb
@@ -1,0 +1,157 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Option Strict Off
+Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.AddAwait
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.AddAwait
+    <Trait(Traits.Feature, Traits.Features.AddAwait)>
+    Public Class AddAwaitTests
+        Inherits AbstractVisualBasicCodeActionTest
+
+        Protected Overrides Function CreateCodeRefactoringProvider(workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
+            Return New VisualBasicAddAwaitCodeRefactoringProvider()
+        End Function
+
+        <Fact>
+        Public Async Function Simple() As Task
+            Dim markup =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = GetNumberAsync()[||]
+    End Function
+End Module
+</File>
+
+            Dim expected =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = Await GetNumberAsync()
+    End Function
+End Module
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact>
+        Public Async Function SimpleWithConfigureAwait() As Task
+            Dim markup =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = GetNumberAsync()[||]
+    End Function
+End Module
+</File>
+
+            Dim expected =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = Await GetNumberAsync().ConfigureAwait(False)
+    End Function
+End Module
+</File>
+
+            Await TestAsync(markup, expected, index:=1)
+        End Function
+
+        <Fact>
+        Public Async Function AlreadyAwaited() As Task
+            Dim markup =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = Await GetNumberAsync()[||]
+    End Function
+End Module
+</File>
+
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact>
+        Public Async Function SimpleWithTrivia() As Task
+            Dim markup =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = GetNumberAsync()[||] ' Comment
+    End Function
+End Module
+</File>
+
+            Dim expected =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = Await GetNumberAsync() ' Comment
+    End Function
+End Module
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact>
+        Public Async Function SimpleWithTriviaAndConfigureAwait() As Task
+            Dim markup =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = GetNumberAsync()[||] ' Comment
+    End Function
+End Module
+</File>
+
+            Dim expected =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = Await GetNumberAsync().ConfigureAwait(False) ' Comment
+    End Function
+End Module
+</File>
+
+            Await TestAsync(markup, expected, index:=1)
+        End Function
+
+        <Fact>
+        Public Async Function ChainedInvocation() As Task
+            Dim markup =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = GetNumberAsync()[||].ToString()
+    End Function
+End Module
+</File>
+
+            Dim expected =
+<File>
+Imports System.Threading.Tasks
+Module Program
+    Async Function GetNumberAsync() As Task(Of Integer)
+        Dim x = (Await GetNumberAsync()).ToString()
+    End Function
+End Module
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
+
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -89,6 +89,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add await and ConfigureAwait(false).
+        /// </summary>
+        internal static string Add_await_and_ConfigureAwaitFalse {
+            get {
+                return ResourceManager.GetString("Add_await_and_ConfigureAwaitFalse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add parentheses.
         /// </summary>
         internal static string Add_parentheses_around_conditional_expression_in_interpolated_string {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -91,9 +91,9 @@ namespace Microsoft.CodeAnalysis.CSharp {
         /// <summary>
         ///   Looks up a localized string similar to Add await and ConfigureAwait(false).
         /// </summary>
-        internal static string Add_await_and_ConfigureAwaitFalse {
+        internal static string Add_Await_and_ConfigureAwaitFalse {
             get {
-                return ResourceManager.GetString("Add_await_and_ConfigureAwaitFalse", resourceCulture);
+                return ResourceManager.GetString("Add_Await_and_ConfigureAwaitFalse", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -80,6 +80,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add await.
+        /// </summary>
+        internal static string Add_await {
+            get {
+                return ResourceManager.GetString("Add_await", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add parentheses.
         /// </summary>
         internal static string Add_parentheses_around_conditional_expression_in_interpolated_string {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -129,7 +129,7 @@
   <data name="Add_await" xml:space="preserve">
     <value>Add await</value>
   </data>
-  <data name="Add_await_and_ConfigureAwaitFalse" xml:space="preserve">
+  <data name="Add_Await_and_ConfigureAwaitFalse" xml:space="preserve">
     <value>Add await and ConfigureAwait(false)</value>
   </data>
   <data name="Simplify_lambda_expression" xml:space="preserve">

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -129,6 +129,9 @@
   <data name="Add_await" xml:space="preserve">
     <value>Add await</value>
   </data>
+  <data name="Add_await_and_ConfigureAwaitFalse" xml:space="preserve">
+    <value>Add await and ConfigureAwait(false)</value>
+  </data>
   <data name="Simplify_lambda_expression" xml:space="preserve">
     <value>Simplify lambda expression</value>
   </data>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -126,6 +126,9 @@
   <data name="Invert_if" xml:space="preserve">
     <value>Invert if</value>
   </data>
+  <data name="Add_await" xml:space="preserve">
+    <value>Add await</value>
+  </data>
   <data name="Simplify_lambda_expression" xml:space="preserve">
     <value>Simplify lambda expression</value>
   </data>

--- a/src/Features/CSharp/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.AddAwait
+{
+    /// <summary>
+    /// This refactoring complements the AddAwait fixer. It allows adding `await` even there is no compiler error to trigger the fixer.
+    /// </summary>
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.AddAwait), Shared]
+    internal partial class CSharpAddAwaitCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var textSpan = context.Span;
+            var cancellationToken = context.CancellationToken;
+
+            if (!textSpan.IsEmpty)
+            {
+                return;
+            }
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var token = root.FindTokenOnLeftOfPosition(textSpan.Start);
+
+            var model = await document.GetSemanticModelAsync(cancellationToken);
+            var awaitable = GetAwaitableExpression(textSpan, token, model, cancellationToken);
+            if (awaitable == null)
+            {
+                return;
+            }
+
+            if (awaitable.OverlapsHiddenPosition(cancellationToken))
+            {
+                return;
+            }
+
+            context.RegisterRefactoring(
+                new MyCodeAction(
+                    CSharpFeaturesResources.Add_await,
+                    c => AddAwaitAsync(document, awaitable, c)));
+        }
+
+        private ExpressionSyntax GetAwaitableExpression(TextSpan textSpan, SyntaxToken token, SemanticModel model, CancellationToken cancellationToken)
+        {
+            var invocation = token.GetAncestor<InvocationExpressionSyntax>();
+            if (invocation is null)
+            {
+                return null;
+            }
+
+            var type = model.GetTypeInfo(invocation).Type;
+            if (type?.IsAwaitableNonDynamic(model, token.SpanStart) == true)
+            {
+                return invocation;
+            }
+            return null;
+        }
+
+        private async Task<Document> AddAwaitAsync(
+            Document document,
+            ExpressionSyntax invocation,
+            CancellationToken cancellationToken)
+        {
+            var awaitExpression = SyntaxFactory.AwaitExpression(invocation)
+                .Parenthesize()
+                .WithTriviaFrom(invocation);
+            return await document.ReplaceNodeAsync(invocation, awaitExpression, cancellationToken);
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
+                base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
@@ -23,19 +23,5 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.AddAwait
 
         protected override bool IsAlreadyAwaited(InvocationExpressionSyntax invocation)
             => invocation.IsParentKind(SyntaxKind.AwaitExpression);
-
-        protected override ExpressionSyntax WithAwait(ExpressionSyntax expression, ExpressionSyntax originalExpression)
-        {
-            return SyntaxFactory.AwaitExpression(expression)
-                .Parenthesize()
-                .WithTriviaFrom(originalExpression);
-        }
-
-        protected override ExpressionSyntax WithConfigureAwait(ExpressionSyntax expression)
-        {
-            return SyntaxFactory.InvocationExpression(
-                SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, SyntaxFactory.IdentifierName(nameof(Task.ConfigureAwait))),
-                SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[] { SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)) })));
-        }
     }
 }

--- a/src/Features/CSharp/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
@@ -62,11 +62,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.AddAwait
                 return null;
             }
 
+            if (invocation.IsParentKind(SyntaxKind.AwaitExpression))
+            {
+                return null;
+            }
+
             var type = model.GetTypeInfo(invocation).Type;
             if (type?.IsAwaitableNonDynamic(model, token.SpanStart) == true)
             {
                 return invocation;
             }
+
             return null;
         }
 
@@ -75,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.AddAwait
             ExpressionSyntax invocation,
             CancellationToken cancellationToken)
         {
-            var awaitExpression = SyntaxFactory.AwaitExpression(invocation)
+            var awaitExpression = SyntaxFactory.AwaitExpression(invocation.WithoutTrivia())
                 .Parenthesize()
                 .WithTriviaFrom(invocation);
             return await document.ReplaceNodeAsync(invocation, awaitExpression, cancellationToken);

--- a/src/Features/CSharp/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
@@ -13,15 +13,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.AddAwait
     /// This refactoring complements the AddAwait fixer. It allows adding `await` and `await ... .ConfigureAwait(false)` even there is no compiler error to trigger the fixer.
     /// </summary>
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.AddAwait), Shared]
-    internal partial class CSharpAddAwaitCodeRefactoringProvider : AddAwaitCodeRefactoringProvider<ExpressionSyntax, InvocationExpressionSyntax>
+    internal partial class CSharpAddAwaitCodeRefactoringProvider : AbstractAddAwaitCodeRefactoringProvider<ExpressionSyntax, InvocationExpressionSyntax>
     {
         protected override string GetTitle()
             => CSharpFeaturesResources.Add_await;
 
         protected override string GetTitleWithConfigureAwait()
-            => CSharpFeaturesResources.Add_await_and_ConfigureAwaitFalse;
-
-        protected override bool IsAlreadyAwaited(InvocationExpressionSyntax invocation)
-            => invocation.IsParentKind(SyntaxKind.AwaitExpression);
+            => CSharpFeaturesResources.Add_Await_and_ConfigureAwaitFalse;
     }
 }

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Přidat modifikátory dostupnosti</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Přidat/odebrat složené závorky pro řídicí příkazy na jeden řádek</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">Přidat modifikátory dostupnosti</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Přidat/odebrat složené závorky pro řídicí příkazy na jeden řádek</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">Zugriffsmodifizierer hinzufügen</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Zugriffsmodifizierer hinzufügen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Geschweifte Klammern für einzeilige Steuerungsanweisungen hinzufügen/entfernen</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Geschweifte Klammern für einzeilige Steuerungsanweisungen hinzufügen/entfernen</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">Agregar modificadores de accesibilidad</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Agregar modificadores de accesibilidad</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Agregar o quitar llaves para instrucciones de control de una línea</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Agregar o quitar llaves para instrucciones de control de una línea</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Ajouter/supprimer des accolades pour les instructions de contrôle sur une seule ligne</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">Ajouter des modificateurs d'accessibilité</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Ajouter des modificateurs d'accessibilité</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Ajouter/supprimer des accolades pour les instructions de contrôle sur une seule ligne</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">Aggiungi modificatori di accessibilità</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aggiungi modificatori di accessibilità</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Aggiungi/rimuovi le parentesi graffe per le istruzioni di controllo a riga singola</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Aggiungi/rimuovi le parentesi graffe per le istruzioni di controllo a riga singola</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">単一行のコントロール ステートメントに対する波かっこの追加/削除を行います</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">アクセシビリティ修飾子を追加します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">単一行のコントロール ステートメントに対する波かっこの追加/削除を行います</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">アクセシビリティ修飾子を追加します</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">한 줄 제어문에 대해 중괄호 추가/제거</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">접근성 한정자 추가</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">한 줄 제어문에 대해 중괄호 추가/제거</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">접근성 한정자 추가</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Dodaj modyfikatory dostępności</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Dodaj/usuń nawiasy klamrowe w przypadku jednowierszowych instrukcji sterowania</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Dodaj/usuń nawiasy klamrowe w przypadku jednowierszowych instrukcji sterowania</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">Dodaj modyfikatory dostępności</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">Adicionar modificadores de acessibilidade</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Adicionar modificadores de acessibilidade</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Adicionar/remover as chaves das instruções de controle de linha única</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Adicionar/remover as chaves das instruções de controle de linha única</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Добавьте модификаторы доступности</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Добавлять или удалять фигурные скобки для однострочных операторов управления</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Добавлять или удалять фигурные скобки для однострочных операторов управления</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">Добавьте модификаторы доступности</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Tek satır denetim deyimleri için küme ayracı ekle/küme ayraçlarını kaldır</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">Erişilebilirlik değiştiricileri ekle</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Erişilebilirlik değiştiricileri ekle</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">Tek satır denetim deyimleri için küme ayracı ekle/küme ayraçlarını kaldır</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">添加可访问性修饰符</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">添加可访问性修饰符</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">添加/删除单行控制语句的括号</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">添加/删除单行控制语句的括号</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="new">Add await</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">新增/移除單行控制項陳述式的括弧</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CSharpFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add await and ConfigureAwait(false)</source>
+        <target state="new">Add await and ConfigureAwait(false)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_accessibility_modifiers">
         <source>Add accessibility modifiers</source>
         <target state="translated">新增協助工具修飾詞</target>
@@ -10,11 +15,6 @@
       <trans-unit id="Add_await">
         <source>Add await</source>
         <target state="new">Add await</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Add_await_and_ConfigureAwaitFalse">
-        <source>Add await and ConfigureAwait(false)</source>
-        <target state="new">Add await and ConfigureAwait(false)</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">新增協助工具修飾詞</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_await">
+        <source>Add await</source>
+        <target state="new">Add await</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_remove_braces_for_single_line_control_statements">
         <source>Add/remove braces for single-line control statements</source>
         <target state="translated">新增/移除單行控制項陳述式的括弧</target>

--- a/src/Features/Core/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CodeRefactorings.AddAwait
+{
+    /// <summary>
+    /// Refactor:
+    ///     var x = GetAsync();
+    /// 
+    /// Into:
+    ///     var x = await GetAsync();
+    /// 
+    /// Or:
+    ///     var x = await GetAsync().ConfigureAwait(false);
+    /// </summary>
+    internal abstract class AddAwaitCodeRefactoringProvider<TExpressionSyntax, TInvocationExpressionSyntax> : CodeRefactoringProvider
+        where TExpressionSyntax : SyntaxNode
+        where TInvocationExpressionSyntax : TExpressionSyntax
+    {
+        protected abstract string GetTitle();
+        protected abstract string GetTitleWithConfigureAwait();
+        protected abstract bool IsAlreadyAwaited(TInvocationExpressionSyntax invocation);
+
+        /// <summary>
+        /// Add `.ConfigureAwait(false)`
+        /// </summary>
+        protected abstract TExpressionSyntax WithConfigureAwait(TExpressionSyntax expression);
+
+        /// <summary>
+        /// Add `await` and trivia
+        /// </summary>
+        protected abstract TExpressionSyntax WithAwait(TExpressionSyntax expression, TExpressionSyntax originalExpression);
+
+        public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var textSpan = context.Span;
+            var cancellationToken = context.CancellationToken;
+
+            if (!textSpan.IsEmpty)
+            {
+                return;
+            }
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var token = root.FindTokenOnLeftOfPosition(textSpan.Start);
+
+            var model = await document.GetSemanticModelAsync(cancellationToken);
+            var awaitable = GetAwaitableExpression(textSpan, token, model, cancellationToken);
+            if (awaitable == null)
+            {
+                return;
+            }
+
+            if (awaitable.OverlapsHiddenPosition(cancellationToken))
+            {
+                return;
+            }
+
+            context.RegisterRefactoring(
+                new MyCodeAction(
+                    GetTitle(),
+                    c => AddAwaitAsync(document, awaitable, withConfigureAwait: false, c)));
+
+
+            context.RegisterRefactoring(
+                new MyCodeAction(
+                    GetTitleWithConfigureAwait(),
+                    c => AddAwaitAsync(document, awaitable, withConfigureAwait: true, c)));
+        }
+
+        private TExpressionSyntax GetAwaitableExpression(TextSpan textSpan, SyntaxToken token, SemanticModel model, CancellationToken cancellationToken)
+        {
+            var invocation = token.GetAncestor<TInvocationExpressionSyntax>();
+            if (invocation is null)
+            {
+                return null;
+            }
+
+            if (IsAlreadyAwaited(invocation))
+            {
+                return null;
+            }
+
+            var type = model.GetTypeInfo(invocation).Type;
+            if (type?.IsAwaitableNonDynamic(model, token.SpanStart) == true)
+            {
+                return invocation;
+            }
+
+            return null;
+        }
+
+        private async Task<Document> AddAwaitAsync(
+            Document document,
+            TExpressionSyntax invocation,
+            bool withConfigureAwait,
+            CancellationToken cancellationToken)
+        {
+            var withoutTrivia = invocation.WithoutTrivia();
+            if (withConfigureAwait)
+            {
+                withoutTrivia = WithConfigureAwait(withoutTrivia);
+            }
+
+            var awaitExpression = WithAwait(withoutTrivia, invocation);
+
+            return await document.ReplaceNodeAsync(invocation, awaitExpression, cancellationToken);
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
+                base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
@@ -4,6 +4,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 {
     internal static class PredefinedCodeRefactoringProviderNames
     {
+        public const string AddAwait = "Add Await Code Action Provider";
         public const string AddFileBanner = "Add Banner To File Code Action Provider";
         public const string AddConstructorParametersFromMembers = "Add Parameters From Members Code Action Provider";
         public const string ChangeSignature = "Change Signature Code Action Provider";

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.vb
@@ -22,19 +22,5 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.AddAwait
             Return invocation.IsParentKind(SyntaxKind.AwaitExpression)
         End Function
 
-        Protected Overrides Function WithAwait(expression As ExpressionSyntax, originalExpression As ExpressionSyntax) As ExpressionSyntax
-            Return SyntaxFactory.AwaitExpression(expression).Parenthesize().WithTriviaFrom(originalExpression)
-        End Function
-
-        Protected Overrides Function WithConfigureAwait(expression As ExpressionSyntax) As ExpressionSyntax
-            Dim falseLiteral = SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression, SyntaxFactory.Token(SyntaxKind.FalseKeyword))
-
-            Return SyntaxFactory.InvocationExpression(
-                SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                     expression,
-                                                     SyntaxFactory.Token(SyntaxKind.DotToken),
-                                                     SyntaxFactory.IdentifierName(NameOf(Task.ConfigureAwait))),
-                SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList({DirectCast(SyntaxFactory.SimpleArgument(falseLiteral), ArgumentSyntax)})))
-        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/AddAwait/AddAwaitCodeRefactoringProvider.vb
@@ -8,19 +8,14 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.AddAwait
     <ExportCodeRefactoringProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeRefactoringProviderNames.AddAwait), [Shared]>
     Friend Class VisualBasicAddAwaitCodeRefactoringProvider
-        Inherits AddAwaitCodeRefactoringProvider(Of ExpressionSyntax, InvocationExpressionSyntax)
+        Inherits AbstractAddAwaitCodeRefactoringProvider(Of ExpressionSyntax, InvocationExpressionSyntax)
 
         Protected Overrides Function GetTitle() As String
             Return VBFeaturesResources.Add_Await
         End Function
 
         Protected Overrides Function GetTitleWithConfigureAwait() As String
-            Return VBFeaturesResources.Add_await_and_ConfigureAwaitFalse
+            Return VBFeaturesResources.Add_Await_and_ConfigureAwaitFalse
         End Function
-
-        Protected Overrides Function IsAlreadyAwaited(invocation As InvocationExpressionSyntax) As Boolean
-            Return invocation.IsParentKind(SyntaxKind.AwaitExpression)
-        End Function
-
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
@@ -94,6 +94,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Add Await.
+        '''</summary>
+        Friend ReadOnly Property Add_Await() As String
+            Get
+                Return ResourceManager.GetString("Add_Await", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Add Await and &apos;ConfigureAwait(false)&apos;.
+        '''</summary>
+        Friend ReadOnly Property Add_Await_and_ConfigureAwaitFalse() As String
+            Get
+                Return ResourceManager.GetString("Add_Await_and_ConfigureAwaitFalse", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Add &apos;Me.&apos;.
         '''</summary>
         Friend ReadOnly Property Add_Me() As String

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
@@ -141,6 +141,12 @@
   <data name="Invert_If" xml:space="preserve">
     <value>Invert If</value>
   </data>
+  <data name="Add_Await" xml:space="preserve">
+    <value>Add Await</value>
+  </data>
+  <data name="Add_Await_and_ConfigureAwaitFalse" xml:space="preserve">
+    <value>Add Await and 'ConfigureAwait(false)'</value>
+  </data>
   <data name="Move_the_0_statement_to_line_1" xml:space="preserve">
     <value>Move the '{0}' statement to line {1}.</value>
   </data>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.cs.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">Příkaz if lze zjednodušit.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.de.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">Die If-Anweisung kann vereinfacht werden.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.es.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">La instrucción "if" se puede simplificar</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.fr.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">L'instruction 'If' peut être simplifiée</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.it.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">L'istruzione 'If' può essere semplificata</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ja.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">'if' ステートメントは簡素化できます</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ko.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">'if' 문을 간단하게 줄일 수 있습니다.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pl.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">Instrukcja „if” może zostać uproszczona</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pt-BR.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">A instrução 'If' pode ser simplificada</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ru.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">Оператор if можно упростить</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.tr.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">'If' deyimi basitleştirilebilir</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hans.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">可简化“If”语句</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hant.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../VBFeaturesResources.resx">
     <body>
+      <trans-unit id="Add_Await">
+        <source>Add Await</source>
+        <target state="new">Add Await</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Add_Await_and_ConfigureAwaitFalse">
+        <source>Add Await and 'ConfigureAwait(false)'</source>
+        <target state="new">Add Await and 'ConfigureAwait(false)'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="If_statement_can_be_simplified">
         <source>'If' statement can be simplified</source>
         <target state="translated">'If' 陳述式可簡化</target>

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -162,6 +162,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string ErrorSquiggles = nameof(ErrorSquiggles);
             public const string EventHookup = nameof(EventHookup);
             public const string Expansion = nameof(Expansion);
+            public const string AddAwait = "Refactoring.AddAwait";
             public const string ExtractInterface = "Refactoring.ExtractInterface";
             public const string ExtractMethod = "Refactoring.ExtractMethod";
             public const string F1Help = nameof(F1Help);

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3766,6 +3766,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return DefaultExpression(type.GenerateTypeSyntax());
         }
 
+        internal override SyntaxNode AddParentheses(SyntaxNode expression)
+        {
+            return Parenthesize(expression);
+        }
+
         private static ExpressionSyntax Parenthesize(SyntaxNode expression)
         {
             return ((ExpressionSyntax)expression).Parenthesize();

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -2216,6 +2216,11 @@ namespace Microsoft.CodeAnalysis.Editing
         public abstract SyntaxNode AwaitExpression(SyntaxNode expression);
 
         /// <summary>
+        /// Wraps with parens.
+        /// </summary>
+        internal abstract SyntaxNode AddParentheses(SyntaxNode expression);
+
+        /// <summary>
         /// Creates an nameof expression.
         /// </summary>
         public abstract SyntaxNode NameOfExpression(SyntaxNode expression);

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -54,6 +54,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Return SyntaxFactory.TupleExpression(SyntaxFactory.SeparatedList(arguments.Select(AddressOf AsSimpleArgument)))
         End Function
 
+        Friend Overrides Function AddParentheses(expression As SyntaxNode) As SyntaxNode
+            Return Parenthesize(expression)
+        End Function
+
         Private Function Parenthesize(expression As SyntaxNode) As ParenthesizedExpressionSyntax
             Return DirectCast(expression, ExpressionSyntax).Parenthesize()
         End Function


### PR DESCRIPTION
We have an AddAwait fixer. It is triggered by compiler errors. For instance, when you try to return a `Task<int>` from an `async Task<int>` method (but you should be returning an `int` instead).

But it leaves off a common scenario (demonstrated in @kuhlenh's recent talk on Roslyn) where you forgot to type `await`, but there is no compiler error. 
For instance, you are typing `var x = GetNumberAsync()`. 

This PR offers a refactoring that streamlines this edit operation.

![image](https://user-images.githubusercontent.com/12466233/43363974-bd3d025c-92c5-11e8-8258-ce306c6d5754.png)
