### PR TITLE
Use struct for TypeSymbolWithAnnotations

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -9,21 +9,23 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         internal struct NamespaceOrTypeOrAliasSymbolWithAnnotations
         {
-            private readonly object _symbolOrTypeSymbolWithAnnotations;
+            private readonly TypeSymbolWithAnnotations _type;
+            private readonly Symbol _symbol;
 
-            private NamespaceOrTypeOrAliasSymbolWithAnnotations(object symbolOrTypeSymbolWithAnnotations)
+            private NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type, Symbol symbol)
             {
-                Debug.Assert(symbolOrTypeSymbolWithAnnotations != null);
-                Debug.Assert(!(symbolOrTypeSymbolWithAnnotations is TypeSymbol));
-                _symbolOrTypeSymbolWithAnnotations = symbolOrTypeSymbolWithAnnotations;
+                Debug.Assert(type == null != (symbol is null));
+                Debug.Assert(!(symbol is TypeSymbol));
+                _type = type;
+                _symbol = symbol;
             }
 
-            internal TypeSymbolWithAnnotations Type => _symbolOrTypeSymbolWithAnnotations as TypeSymbolWithAnnotations;
-            internal Symbol Symbol => _symbolOrTypeSymbolWithAnnotations as Symbol ?? Type?.TypeSymbol;
-            internal bool IsType => !(Type is null);
-            internal bool IsAlias => (_symbolOrTypeSymbolWithAnnotations as Symbol)?.Kind == SymbolKind.Alias;
+            internal TypeSymbolWithAnnotations Type => _type;
+            internal Symbol Symbol => _symbol ?? Type.TypeSymbol;
+            internal bool IsType => _type != null;
+            internal bool IsAlias => _symbol?.Kind == SymbolKind.Alias;
             internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => Symbol as NamespaceOrTypeSymbol;
-            internal bool IsDefault => _symbolOrTypeSymbolWithAnnotations is null;
+            internal bool IsDefault => _type == null && _symbol is null;
 
             internal static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateUnannotated(INonNullTypesContext nonNullTypesContext, Symbol symbol)
             {
@@ -32,16 +34,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return default;
                 }
                 var type = symbol as TypeSymbol;
-                if (type is null)
-                {
-                    return new NamespaceOrTypeOrAliasSymbolWithAnnotations(symbol);
-                }
-                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext, type));
+                return type is null ?
+                    new NamespaceOrTypeOrAliasSymbolWithAnnotations(default, symbol) :
+                    new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext, type), null);
             }
 
             public static implicit operator NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type)
             {
-                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(type);
+                return new NamespaceOrTypeOrAliasSymbolWithAnnotations(type, null);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type, Symbol symbol)
             {
-                Debug.Assert(type == null != (symbol is null));
+                Debug.Assert(type.IsNull != (symbol is null));
                 Debug.Assert(!(symbol is TypeSymbol));
                 _type = type;
                 _symbol = symbol;
@@ -22,10 +22,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             internal TypeSymbolWithAnnotations Type => _type;
             internal Symbol Symbol => _symbol ?? Type.TypeSymbol;
-            internal bool IsType => _type != null;
+            internal bool IsType => !_type.IsNull;
             internal bool IsAlias => _symbol?.Kind == SymbolKind.Alias;
             internal NamespaceOrTypeSymbol NamespaceOrTypeSymbol => Symbol as NamespaceOrTypeSymbol;
-            internal bool IsDefault => _type == null && _symbol is null;
+            internal bool IsDefault => _type.IsNull && _symbol is null;
 
             internal static NamespaceOrTypeOrAliasSymbolWithAnnotations CreateUnannotated(INonNullTypesContext nonNullTypesContext, Symbol symbol)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -916,7 +916,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // change from Dev10 which reports this error for struct types only,
                     // not for type parameters constrained to "struct".
 
-                    Debug.Assert((object)propertySymbol.Type != null);
+                    Debug.Assert(propertySymbol.Type != null);
                     Error(diagnostics, ErrorCode.ERR_ReturnNotLValue, expr.Syntax, propertySymbol);
                 }
                 else
@@ -1622,7 +1622,7 @@ moreArguments:
         {
             Debug.Assert((object)field != null);
             Debug.Assert(RequiresAssignableVariable(kind));
-            Debug.Assert((object)field.Type != null);
+            Debug.Assert(field.Type != null);
 
             // It's clearer to say that the address can't be taken than to say that the field can't be modified
             // (even though the latter message gives more explanation of why).

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -916,7 +916,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // change from Dev10 which reports this error for struct types only,
                     // not for type parameters constrained to "struct".
 
-                    Debug.Assert(propertySymbol.Type != null);
+                    Debug.Assert(!propertySymbol.Type.IsNull);
                     Error(diagnostics, ErrorCode.ERR_ReturnNotLValue, expr.Syntax, propertySymbol);
                 }
                 else
@@ -1622,7 +1622,7 @@ moreArguments:
         {
             Debug.Assert((object)field != null);
             Debug.Assert(RequiresAssignableVariable(kind));
-            Debug.Assert(field.Type != null);
+            Debug.Assert(!field.Type.IsNull);
 
             // It's clearer to say that the address can't be taken than to say that the field can't be modified
             // (even though the latter message gives more explanation of why).

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var parameter in parameters)
             {
                 var paramType = parameter.Type;
-                Debug.Assert(paramType != null);
+                Debug.Assert(!paramType.IsNull);
 
                 if (!paramType.TypeSymbol.IsValidAttributeParameterType(Compilation))
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var parameter in parameters)
             {
                 var paramType = parameter.Type;
-                Debug.Assert((object)paramType != null);
+                Debug.Assert(paramType != null);
 
                 if (!paramType.TypeSymbol.IsValidAttributeParameterType(Compilation))
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -740,7 +740,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 containingType: null,
                                 name: null,
                                 refKind: RefKind.None,
-                                returnType: null,
+                                returnType: default,
                                 refCustomModifiers: ImmutableArray<CustomModifier>.Empty,
                                 explicitInterfaceImplementations: ImmutableArray<MethodSymbol>.Empty);
                             break;
@@ -755,7 +755,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 containingType: null,
                                 name: null,
                                 refKind: RefKind.None,
-                                type: null,
+                                type: default,
                                 refCustomModifiers: ImmutableArray<CustomModifier>.Empty,
                                 isStatic: false,
                                 explicitInterfaceImplementations: ImmutableArray<PropertySymbol>.Empty);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -726,7 +726,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         bool isConst = false;
                         AliasSymbol alias;
                         var declType = BindVariableType(component.Designation, diagnostics, component.Type, ref isConst, out isVar, out alias);
-                        Debug.Assert(isVar == ((object)declType == null));
+                        Debug.Assert(isVar == (declType == null));
                         if (component.Designation.Kind() == SyntaxKind.ParenthesizedVariableDesignation && !isVar)
                         {
                             // An explicit is not allowed with a parenthesized designation
@@ -800,7 +800,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxNode syntax,
             TypeSymbolWithAnnotations declType)
         {
-            return new BoundDiscardExpression(syntax, declType?.TypeSymbol);
+            return new BoundDiscardExpression(syntax, declType.TypeSymbol);
         }
 
         /// <summary>
@@ -824,7 +824,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // might own nested scope.
                 var hasErrors = localSymbol.ScopeBinder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
-                if ((object)declType != null)
+                if (declType != null)
                 {
                     return new BoundLocal(syntax, localSymbol, BoundLocalDeclarationKind.WithExplicitType, constantValueOpt: null, isNullableUnknown: false, type: declType.TypeSymbol, hasErrors: hasErrors);
                 }
@@ -844,7 +844,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundThisReference receiver = ThisReference(designation, this.ContainingType, hasErrors: false,
                                             wasCompilerGenerated: true);
 
-            if ((object)declType != null)
+            if (declType != null)
             {
                 var fieldType = field.GetFieldType(this.FieldsBeingBound);
                 Debug.Assert(declType.TypeSymbol == fieldType.TypeSymbol);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -726,7 +726,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         bool isConst = false;
                         AliasSymbol alias;
                         var declType = BindVariableType(component.Designation, diagnostics, component.Type, ref isConst, out isVar, out alias);
-                        Debug.Assert(isVar == (declType == null));
+                        Debug.Assert(isVar == declType.IsNull);
                         if (component.Designation.Kind() == SyntaxKind.ParenthesizedVariableDesignation && !isVar)
                         {
                             // An explicit is not allowed with a parenthesized designation
@@ -824,7 +824,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // might own nested scope.
                 var hasErrors = localSymbol.ScopeBinder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
-                if (declType != null)
+                if (!declType.IsNull)
                 {
                     return new BoundLocal(syntax, localSymbol, BoundLocalDeclarationKind.WithExplicitType, constantValueOpt: null, isNullableUnknown: false, type: declType.TypeSymbol, hasErrors: hasErrors);
                 }
@@ -844,7 +844,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundThisReference receiver = ThisReference(designation, this.ContainingType, hasErrors: false,
                                             wasCompilerGenerated: true);
 
-            if (declType != null)
+            if (!declType.IsNull)
             {
                 var fieldType = field.GetFieldType(this.FieldsBeingBound);
                 Debug.Assert(declType.TypeSymbol == fieldType.TypeSymbol);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -676,7 +676,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression BindDeclarationVariables(TypeSymbolWithAnnotations declType, VariableDesignationSyntax node, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
-            declType = declType ?? TypeSymbolWithAnnotations.Create(CreateErrorType("var"));
+            declType = declType == null ? TypeSymbolWithAnnotations.Create(CreateErrorType("var")) : declType;
             switch (node.Kind())
             {
                 case SyntaxKind.SingleVariableDesignation:
@@ -783,7 +783,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var elementType = boundArgument.GetTypeAndNullability(includeNullability);
                 elementTypes.Add(elementType);
 
-                if ((object)elementType == null)
+                if (elementType == null)
                 {
                     hasNaturalType = false;
                 }
@@ -2056,7 +2056,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression BindExplicitNullableCastFromNonNullable(ExpressionSyntax node, BoundExpression operand, TypeSymbolWithAnnotations targetType, DiagnosticBag diagnostics)
         {
-            Debug.Assert((object)targetType != null && targetType.IsNullableType());
+            Debug.Assert(targetType != null && targetType.IsNullableType());
             Debug.Assert(operand.Type != null && !operand.Type.IsNullableType());
 
             // Section 6.2.3 of the spec only applies when the non-null version of the types involved have a
@@ -2310,9 +2310,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         bool isConst = false;
                         AliasSymbol alias;
                         var declType = BindVariableType(designation, diagnostics, typeSyntax, ref isConst, out isVar, out alias);
-                        Debug.Assert(isVar == ((object)declType == null));
+                        Debug.Assert(isVar == (declType == null));
 
-                        return new BoundDiscardExpression(declarationExpression, declType?.TypeSymbol);
+                        return new BoundDiscardExpression(declarationExpression, declType.TypeSymbol);
                     }
                 case SyntaxKind.SingleVariableDesignation:
                     return BindOutVariableDeclarationArgument(declarationExpression, diagnostics);
@@ -2563,7 +2563,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (argument.Kind == BoundKind.DiscardExpression && !argument.HasExpressionType())
                 {
                     TypeSymbolWithAnnotations parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
-                    Debug.Assert((object)parameterType != null);
+                    Debug.Assert(parameterType != null);
                     arguments[arg] = ((BoundDiscardExpression)argument).SetInferredType(parameterType);
                 }
             }
@@ -2711,7 +2711,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 useSiteDiagnostics: ref useSiteDiagnostics);
             diagnostics.Add(node, useSiteDiagnostics);
 
-            if ((object)bestType == null || bestType.SpecialType == SpecialType.System_Void) // Dev10 also reports ERR_ImplicitlyTypedArrayNoBestType for void.
+            if (bestType == null || bestType.SpecialType == SpecialType.System_Void) // Dev10 also reports ERR_ImplicitlyTypedArrayNoBestType for void.
             {
                 Error(diagnostics, ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, node);
                 bestType = TypeSymbolWithAnnotations.Create(CreateErrorType());
@@ -2737,7 +2737,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbolWithAnnotations bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, out bool hadMultipleCandidates, ref useSiteDiagnostics);
             diagnostics.Add(node, useSiteDiagnostics);
 
-            if ((object)bestType == null || bestType.SpecialType == SpecialType.System_Void)
+            if (bestType == null || bestType.SpecialType == SpecialType.System_Void)
             {
                 Error(diagnostics, ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, node);
                 bestType = TypeSymbolWithAnnotations.Create(CreateErrorType());

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -676,7 +676,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression BindDeclarationVariables(TypeSymbolWithAnnotations declType, VariableDesignationSyntax node, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
-            declType = declType == null ? TypeSymbolWithAnnotations.Create(CreateErrorType("var")) : declType;
+            declType = declType.IsNull ? TypeSymbolWithAnnotations.Create(CreateErrorType("var")) : declType;
             switch (node.Kind())
             {
                 case SyntaxKind.SingleVariableDesignation:
@@ -783,7 +783,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var elementType = boundArgument.GetTypeAndNullability(includeNullability);
                 elementTypes.Add(elementType);
 
-                if (elementType == null)
+                if (elementType.IsNull)
                 {
                     hasNaturalType = false;
                 }
@@ -2056,7 +2056,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression BindExplicitNullableCastFromNonNullable(ExpressionSyntax node, BoundExpression operand, TypeSymbolWithAnnotations targetType, DiagnosticBag diagnostics)
         {
-            Debug.Assert(targetType != null && targetType.IsNullableType());
+            Debug.Assert(!targetType.IsNull && targetType.IsNullableType());
             Debug.Assert(operand.Type != null && !operand.Type.IsNullableType());
 
             // Section 6.2.3 of the spec only applies when the non-null version of the types involved have a
@@ -2310,7 +2310,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         bool isConst = false;
                         AliasSymbol alias;
                         var declType = BindVariableType(designation, diagnostics, typeSyntax, ref isConst, out isVar, out alias);
-                        Debug.Assert(isVar == (declType == null));
+                        Debug.Assert(isVar == declType.IsNull);
 
                         return new BoundDiscardExpression(declarationExpression, declType.TypeSymbol);
                     }
@@ -2563,7 +2563,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (argument.Kind == BoundKind.DiscardExpression && !argument.HasExpressionType())
                 {
                     TypeSymbolWithAnnotations parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
-                    Debug.Assert(parameterType != null);
+                    Debug.Assert(!parameterType.IsNull);
                     arguments[arg] = ((BoundDiscardExpression)argument).SetInferredType(parameterType);
                 }
             }
@@ -2711,7 +2711,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 useSiteDiagnostics: ref useSiteDiagnostics);
             diagnostics.Add(node, useSiteDiagnostics);
 
-            if (bestType == null || bestType.SpecialType == SpecialType.System_Void) // Dev10 also reports ERR_ImplicitlyTypedArrayNoBestType for void.
+            if (bestType.IsNull || bestType.SpecialType == SpecialType.System_Void) // Dev10 also reports ERR_ImplicitlyTypedArrayNoBestType for void.
             {
                 Error(diagnostics, ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, node);
                 bestType = TypeSymbolWithAnnotations.Create(CreateErrorType());
@@ -2737,7 +2737,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbolWithAnnotations bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, out bool hadMultipleCandidates, ref useSiteDiagnostics);
             diagnostics.Add(node, useSiteDiagnostics);
 
-            if (bestType == null || bestType.SpecialType == SpecialType.System_Void)
+            if (bestType.IsNull || bestType.SpecialType == SpecialType.System_Void)
             {
                 Error(diagnostics, ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, node);
                 bestType = TypeSymbolWithAnnotations.Create(CreateErrorType());

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var type in types)
                 {
                     // UNDONE: Where do we report improper use of pointer types?
-                    if (type != null && type.IsStatic)
+                    if (!type.IsNull && type.IsStatic)
                     {
                         Error(diagnostics, ErrorCode.ERR_ParameterIsStaticClass, syntax, type.TypeSymbol);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     var typeSyntax = p.Type;
-                    TypeSymbolWithAnnotations type = null;
+                    TypeSymbolWithAnnotations type = default;
                     var refKind = RefKind.None;
 
                     if (typeSyntax == null)
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var type in types)
                 {
                     // UNDONE: Where do we report improper use of pointer types?
-                    if ((object)type != null && type.IsStatic)
+                    if (type != null && type.IsStatic)
                     {
                         Error(diagnostics, ErrorCode.ERR_ParameterIsStaticClass, syntax, type.TypeSymbol);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3645,7 +3645,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     useSiteDiagnostics: ref useSiteDiagnostics);
                 diagnostics.Add(node, useSiteDiagnostics);
 
-                if (bestType == null)
+                if (bestType.IsNull)
                 {
                     // CONSIDER: Dev10 suppresses ERR_InvalidQM unless the following is true for both trueType and falseType
                     // (!T->type->IsErrorType() || T->type->AsErrorType()->HasTypeParent() || T->type->AsErrorType()->HasNSParent())

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3645,7 +3645,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     useSiteDiagnostics: ref useSiteDiagnostics);
                 diagnostics.Add(node, useSiteDiagnostics);
 
-                if ((object)bestType == null)
+                if (bestType == null)
                 {
                     // CONSIDER: Dev10 suppresses ERR_InvalidQM unless the following is true for both trueType and falseType
                     // (!T->type->IsErrorType() || T->type->AsErrorType()->HasTypeParent() || T->type->AsErrorType()->HasNSParent())

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 declType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, operandType);
             }
 
-            if (declType == (object)null)
+            if (declType == null)
             {
                 Debug.Assert(hasErrors);
                 declType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, this.CreateErrorType("var"));

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 declType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, operandType);
             }
 
-            if (declType == null)
+            if (declType.IsNull)
             {
                 Debug.Assert(hasErrors);
                 declType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, this.CreateErrorType("var"));

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -664,7 +664,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we want to treat the declaration as an explicitly typed declaration.
 
             TypeSymbolWithAnnotations declType = BindTypeOrVarKeyword(typeSyntax.SkipRef(out _), diagnostics, out isVar, out alias);
-            Debug.Assert(declType != null || isVar);
+            Debug.Assert(!declType.IsNull || isVar);
 
             if (isVar)
             {
@@ -851,7 +851,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             CSharpSyntaxNode associatedSyntaxNode = null)
         {
             Debug.Assert(declarator != null);
-            Debug.Assert(declTypeOpt != null || isVar);
+            Debug.Assert(!declTypeOpt.IsNull || isVar);
             Debug.Assert(typeSyntax != null);
 
             var localDiagnostics = DiagnosticBag.GetInstance();
@@ -934,7 +934,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            Debug.Assert(declTypeOpt != null);
+            Debug.Assert(!declTypeOpt.IsNull);
             
             if (kind == LocalDeclarationKind.FixedVariable)
             {
@@ -2336,7 +2336,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isVar;
             TypeSymbolWithAnnotations declType = BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar, out alias);
 
-            Debug.Assert(declType != null || isVar);
+            Debug.Assert(!declType.IsNull || isVar);
 
             var variables = nodeOpt.Variables;
             int count = variables.Count;
@@ -2475,7 +2475,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 TypeSymbolWithAnnotations returnType = symbol.ReturnType;
 
-                if (returnType == null || (object)returnType.TypeSymbol == LambdaSymbol.ReturnTypeIsBeingInferred)
+                if (returnType.IsNull || (object)returnType.TypeSymbol == LambdaSymbol.ReturnTypeIsBeingInferred)
                 {
                     return null;
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -664,7 +664,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we want to treat the declaration as an explicitly typed declaration.
 
             TypeSymbolWithAnnotations declType = BindTypeOrVarKeyword(typeSyntax.SkipRef(out _), diagnostics, out isVar, out alias);
-            Debug.Assert((object)declType != null || isVar);
+            Debug.Assert(declType != null || isVar);
 
             if (isVar)
             {
@@ -851,7 +851,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             CSharpSyntaxNode associatedSyntaxNode = null)
         {
             Debug.Assert(declarator != null);
-            Debug.Assert((object)declTypeOpt != null || isVar);
+            Debug.Assert(declTypeOpt != null || isVar);
             Debug.Assert(typeSyntax != null);
 
             var localDiagnostics = DiagnosticBag.GetInstance();
@@ -934,7 +934,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            Debug.Assert((object)declTypeOpt != null);
+            Debug.Assert(declTypeOpt != null);
             
             if (kind == LocalDeclarationKind.FixedVariable)
             {
@@ -2336,7 +2336,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isVar;
             TypeSymbolWithAnnotations declType = BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar, out alias);
 
-            Debug.Assert((object)declType != null || isVar);
+            Debug.Assert(declType != null || isVar);
 
             var variables = nodeOpt.Variables;
             int count = variables.Count;
@@ -2475,7 +2475,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 TypeSymbolWithAnnotations returnType = symbol.ReturnType;
 
-                if ((object)returnType == null || (object)returnType == LambdaSymbol.ReturnTypeIsBeingInferred)
+                if (returnType == null || (object)returnType.TypeSymbol == LambdaSymbol.ReturnTypeIsBeingInferred)
                 {
                     return null;
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var symbol = BindTypeOrAliasOrVarKeyword(syntax, diagnostics, out isVar);
             Debug.Assert(isVar == symbol.IsDefault);
-            return isVar ? null : UnwrapAlias(symbol, diagnostics, syntax).Type;
+            return isVar ? default : UnwrapAlias(symbol, diagnostics, syntax).Type;
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var symbol = BindTypeOrAliasOrUnmanagedKeyword(syntax, diagnostics, out isUnmanaged);
             Debug.Assert(isUnmanaged == symbol.IsDefault);
-            return isUnmanaged ? null : UnwrapAlias(symbol, diagnostics, syntax).Type;
+            return isUnmanaged ? default : UnwrapAlias(symbol, diagnostics, syntax).Type;
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (isVar)
             {
                 alias = null;
-                return null;
+                return default;
             }
             else
             {
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal NamespaceOrTypeOrAliasSymbolWithAnnotations BindNamespaceOrTypeSymbol(ExpressionSyntax syntax, DiagnosticBag diagnostics, ConsList<Symbol> basesBeingResolved, bool suppressUseSiteDiagnostics)
         {
             var result = BindNamespaceOrTypeOrAliasSymbol(syntax, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics);
-            Debug.Assert((object)result != null);
+            Debug.Assert(!result.IsDefault);
 
             return UnwrapAlias(result, diagnostics, syntax, basesBeingResolved);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -386,7 +386,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // placeholder bound nodes with the proper types are sufficient to bind the element-wise binary operators
             TypeSymbol tupleType = expr.Type.StrippedType();
             ImmutableArray<BoundExpression> placeholders = tupleType.TupleElementTypes
-                .SelectAsArray((t, s) => (BoundExpression)new BoundTupleOperandPlaceholder(s, t?.TypeSymbol), expr.Syntax);
+                .SelectAsArray((t, s) => (BoundExpression)new BoundTupleOperandPlaceholder(s, t.TypeSymbol), expr.Syntax);
 
             return (placeholders, tupleType.TupleElementNames);
         }

--- a/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BinderFlags location)
         {
             Debug.Assert((object)collectionType != null, "Field 'collectionType' cannot be null");
-            Debug.Assert((object)elementType != null, "Field 'elementType' cannot be null");
+            Debug.Assert(elementType != null, "Field 'elementType' cannot be null");
             Debug.Assert((object)getEnumeratorMethod != null, "Field 'getEnumeratorMethod' cannot be null");
             Debug.Assert((object)currentPropertyGetter != null, "Field 'currentPropertyGetter' cannot be null");
             Debug.Assert((object)moveNextMethod != null, "Field 'moveNextMethod' cannot be null");

--- a/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BinderFlags location)
         {
             Debug.Assert((object)collectionType != null, "Field 'collectionType' cannot be null");
-            Debug.Assert(elementType != null, "Field 'elementType' cannot be null");
+            Debug.Assert(!elementType.IsNull, "Field 'elementType' cannot be null");
             Debug.Assert((object)getEnumeratorMethod != null, "Field 'getEnumeratorMethod' cannot be null");
             Debug.Assert((object)currentPropertyGetter != null, "Field 'currentPropertyGetter' cannot be null");
             Debug.Assert((object)moveNextMethod != null, "Field 'moveNextMethod' cannot be null");

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ExpressionSyntax variables = ((ForEachVariableStatementSyntax)_syntax).Variable;
 
             // Tracking narrowest safe-to-escape scope by default, the proper val escape will be set when doing full binding of the foreach statement
-            var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, this.LocalScopeDepth, inferredType?.TypeSymbol ?? CreateErrorType("var"));
+            var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, this.LocalScopeDepth, inferredType.TypeSymbol ?? CreateErrorType("var"));
 
             DeclarationExpressionSyntax declaration = null;
             ExpressionSyntax expression = null;
@@ -226,11 +226,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (isVar)
                         {
-                            declType = inferredType ?? TypeSymbolWithAnnotations.Create(CreateErrorType("var"), isNullableIfReferenceType: null);
+                            declType = inferredType == null ? TypeSymbolWithAnnotations.Create(CreateErrorType("var"), isNullableIfReferenceType: null) : inferredType;
                         }
                         else
                         {
-                            Debug.Assert((object)declType != null);
+                            Debug.Assert(declType != null);
                         }
 
                         iterationVariableType = declType.TypeSymbol;
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.ForEachVariableStatement:
                     {
                         var node = (ForEachVariableStatementSyntax)_syntax;
-                        iterationVariableType = inferredType?.TypeSymbol ?? CreateErrorType("var");
+                        iterationVariableType = inferredType.TypeSymbol ?? CreateErrorType("var");
 
                         var variables = node.Variable;
                         if (variables.IsDeconstructionLeft())
@@ -492,7 +492,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!gotInfo)
             {
-                inferredType = null;
+                inferredType = default;
             }
             else if (collectionExpr.HasDynamicType())
             {

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -226,11 +226,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (isVar)
                         {
-                            declType = inferredType == null ? TypeSymbolWithAnnotations.Create(CreateErrorType("var"), isNullableIfReferenceType: null) : inferredType;
+                            declType = inferredType.IsNull ? TypeSymbolWithAnnotations.Create(CreateErrorType("var"), isNullableIfReferenceType: null) : inferredType;
                         }
                         else
                         {
-                            Debug.Assert(declType != null);
+                            Debug.Assert(!declType.IsNull);
                         }
 
                         iterationVariableType = declType.TypeSymbol;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool? isNullable = false;
             foreach (var type in types)
             {
-                if (type is null)
+                if (type == null)
                 {
                     // PROTOTYPE(NullableReferenceTypes): Should ignore untyped
                     // expressions such as unbound lambdas and typeless tuples.
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var type = expr.GetTypeAndNullability(includeNullability);
 
-                if ((object)type != null)
+                if (type != null)
                 {
                     if (type.IsErrorType())
                     {
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var type1 = expr1.GetTypeAndNullability(includeNullability);
 
-            if ((object)type1 != null)
+            if (type1 != null)
             {
                 if (type1.IsErrorType())
                 {
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var type2 = expr2.GetTypeAndNullability(includeNullability);
 
-            if ((object)type2 != null)
+            if (type2 != null)
             {
                 if (type2.IsErrorType())
                 {
@@ -156,19 +156,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Short-circuit some common cases.
             if (types.IsEmpty)
             {
-                return null;
+                return default;
             }
             else if (types.Length == 1)
             {
                 return types[0];
             }
 
-            TypeSymbolWithAnnotations best = null;
+            TypeSymbolWithAnnotations best = default;
             int bestIndex = -1;
             for(int i = 0; i < types.Length; i++)
             {
                 var type = types[i];
-                if ((object)best == null)
+                if (best == null)
                 {
                     best = type;
                     bestIndex = i;
@@ -177,11 +177,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var better = Better(best, type, conversions, ref useSiteDiagnostics);
 
-                    if ((object)better == null)
+                    if (better == null)
                     {
-                        best = null;
+                        best = default;
                     }
-                    else if ((object)better != (object)best)
+                    else
                     {
                         best = better;
                         bestIndex = i;
@@ -189,9 +189,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if ((object)best == null)
+            if (best == null)
             {
-                return null;
+                return default;
             }
 
             // We have actually only determined that every type *after* best was worse. Now check
@@ -201,9 +201,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TypeSymbolWithAnnotations type = types[i];
                 TypeSymbolWithAnnotations better = Better(best, type, conversions, ref useSiteDiagnostics);
 
-                if (!best.Equals(better, TypeCompareKind.ConsiderEverything))
+                if (better == null || !best.Equals(better, TypeCompareKind.ConsiderEverything))
                 {
-                    return null;
+                    return default;
                 }
             }
 
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return type2;
             }
 
-            if ((object)type2 == null || type2.IsErrorType())
+            if (type2 == null || type2.IsErrorType())
             {
                 return type1;
             }
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return MethodTypeInferrer.Merge(type1, type2, conversions.CorLibrary);
                 }
 
-                return null;
+                return default;
             }
 
             if (t1tot2)
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return type1;
             }
 
-            return null;
+            return default;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool? isNullable = false;
             foreach (var type in types)
             {
-                if (type == null)
+                if (type.IsNull)
                 {
                     // PROTOTYPE(NullableReferenceTypes): Should ignore untyped
                     // expressions such as unbound lambdas and typeless tuples.
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var type = expr.GetTypeAndNullability(includeNullability);
 
-                if (type != null)
+                if (!type.IsNull)
                 {
                     if (type.IsErrorType())
                     {
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var type1 = expr1.GetTypeAndNullability(includeNullability);
 
-            if (type1 != null)
+            if (!type1.IsNull)
             {
                 if (type1.IsErrorType())
                 {
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var type2 = expr2.GetTypeAndNullability(includeNullability);
 
-            if (type2 != null)
+            if (!type2.IsNull)
             {
                 if (type2.IsErrorType())
                 {
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for(int i = 0; i < types.Length; i++)
             {
                 var type = types[i];
-                if (best == null)
+                if (best.IsNull)
                 {
                     best = type;
                     bestIndex = i;
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var better = Better(best, type, conversions, ref useSiteDiagnostics);
 
-                    if (better == null)
+                    if (better.IsNull)
                     {
                         best = default;
                     }
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if (best == null)
+            if (best.IsNull)
             {
                 return default;
             }
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TypeSymbolWithAnnotations type = types[i];
                 TypeSymbolWithAnnotations better = Better(best, type, conversions, ref useSiteDiagnostics);
 
-                if (better == null || !best.Equals(better, TypeCompareKind.ConsiderEverything))
+                if (better.IsNull || !best.Equals(better, TypeCompareKind.ConsiderEverything))
                 {
                     return default;
                 }
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return type2;
             }
 
-            if (type2 == null || type2.IsErrorType())
+            if (type2.IsNull || type2.IsErrorType())
             {
                 return type1;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -958,7 +958,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     sub.Add(new TreeDumperNode("method", self.Method.ToDisplayString(), null));
                 }
 
-                if ((object)self.DeconstructionInfo != null)
+                if (!self.DeconstructionInfo.IsDefault)
                 {
                     sub.Add(new TreeDumperNode("deconstructionInfo", null,
                         new[] { BoundTreeDumperNodeProducer.MakeTree(self.DeconstructionInfo.Invocation)}));

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/INonNullTypesContext.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/INonNullTypesContext.cs
@@ -26,4 +26,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static readonly INonNullTypesContext Instance = new NonNullTypesFalseContext();
         public bool? NonNullTypes => false;
     }
+
+    internal sealed class NonNullTypesUnusedContext : INonNullTypesContext
+    {
+        public static readonly INonNullTypesContext Instance = new NonNullTypesUnusedContext();
+        public bool? NonNullTypes => throw ExceptionUtilities.Unreachable;
+    }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -332,7 +332,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var fixedType = _fixedResults[i];
 
-                if ((object)fixedType == null)
+                if (fixedType == null)
                 {
                     sb.Append("UNFIXED ");
                 }
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             for (int i = 0; i < _methodTypeParameters.Length; i++)
             {
-                if ((object)_fixedResults[i] != null)
+                if (_fixedResults[i] != null)
                 {
                     if (!_fixedResults[i].IsErrorType())
                     {
@@ -405,12 +405,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool IsUnfixed(int methodTypeParameterIndex)
         {
             Debug.Assert(ValidIndex(methodTypeParameterIndex));
-            return (object)_fixedResults[methodTypeParameterIndex] == null;
+            return _fixedResults[methodTypeParameterIndex] == null;
         }
 
         private bool IsUnfixedTypeParameter(TypeSymbolWithAnnotations type)
         {
-            Debug.Assert((object)type != null);
+            Debug.Assert(type != null);
 
             if (type.TypeKind != TypeKind.TypeParameter) return false;
 
@@ -1217,7 +1217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void OutputTypeInference(Binder binder, BoundExpression expression, bool? isNullable, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(expression != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(target != null);
             // SPEC: An output type inference is made from an expression E to a type T
             // SPEC: in the following way:
 
@@ -1240,7 +1240,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * Otherwise, if E is an expression with type U then a lower-bound
             // SPEC:   inference is made from U to T.
             var sourceType = TypeSymbolWithAnnotations.Create(expression.Type, isNullable);
-            if ((object)sourceType != null)
+            if (sourceType != null)
             {
                 LowerBoundInference(sourceType, target, ref useSiteDiagnostics);
             }
@@ -1250,7 +1250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool InferredReturnTypeInference(BoundExpression source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(target != null);
             // SPEC: * If E is an anonymous function with inferred return type U and
             // SPEC:   T is a delegate type or expression tree with return type Tb
             // SPEC:   then a lower bound inference is made from U to Tb.
@@ -1266,13 +1266,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)delegateType.DelegateInvokeMethod != null && !delegateType.DelegateInvokeMethod.HasUseSiteError,
                          "This method should only be called for valid delegate types.");
             var returnType = delegateType.DelegateInvokeMethod.ReturnType;
-            if ((object)returnType == null || returnType.SpecialType == SpecialType.System_Void)
+            if (returnType == null || returnType.SpecialType == SpecialType.System_Void)
             {
                 return false;
             }
 
             var inferredReturnType = InferReturnType(source, delegateType, ref useSiteDiagnostics);
-            if ((object)inferredReturnType == null)
+            if (inferredReturnType == null)
             {
                 return false;
             }
@@ -1309,7 +1309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                          "This method should only be called for valid delegate types");
 
             TypeSymbolWithAnnotations delegateReturnType = delegateInvokeMethod.ReturnType;
-            if ((object)delegateReturnType == null || delegateReturnType.SpecialType == SpecialType.System_Void)
+            if (delegateReturnType == null || delegateReturnType.SpecialType == SpecialType.System_Void)
             {
                 return false;
             }
@@ -1372,7 +1372,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void ExplicitParameterTypeInference(BoundExpression source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(target != null);
 
             // SPEC: An explicit type parameter type inference is made from an expression
             // SPEC: E to a type T in the following way.
@@ -1430,8 +1430,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         private void ExactInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             // SPEC: An exact inference from a type U to a type V is made as follows:
 
@@ -1482,8 +1482,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactTypeParameterInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             // SPEC: * If V is one of the unfixed Xi then U is added to the set of bounds
             // SPEC:   for Xi.
@@ -1497,8 +1497,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactArrayInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             // SPEC: * Otherwise, if U is an array type UE[...] and V is an array type VE[...]
             // SPEC:   of the same rank then an exact inference from UE to VE is made.
@@ -1543,8 +1543,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactOrBoundsNullableInference(ExactOrBoundsKind kind, TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             if (source.IsNullableType() && target.IsNullableType())
             {
@@ -1568,8 +1568,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactOrBoundsTupleInference(ExactOrBoundsKind kind, TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             // NOTE: we are losing tuple element names when unwrapping tuple types to underlying types.
             //       that is ok, because we are inferring type parameters used in the matching elements, 
@@ -1600,8 +1600,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactConstructedInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             // SPEC: * Otherwise, if V is a constructed type C<V1...Vk> and U is a constructed
             // SPEC:   type C<U1...Uk> then an exact inference 
@@ -1668,8 +1668,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         private void LowerBoundInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             // SPEC: A lower-bound inference from a type U to a type V is made as follows:
 
@@ -1750,8 +1750,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool LowerBoundTypeParameterInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             // SPEC: * If V is one of the unfixed Xi then U is added to the set of bounds
             // SPEC:   for Xi.
@@ -1774,7 +1774,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var arrayTarget = (ArrayTypeSymbol)target;
                 if (!arrayTarget.HasSameShapeAs(source))
                 {
-                    return null;
+                    return default;
                 }
                 return arrayTarget.ElementType;
             }
@@ -1783,7 +1783,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!source.IsSZArray)
             {
-                return null;
+                return default;
             }
 
             // Arrays are specified as being convertible to IEnumerable<T>, ICollection<T> and
@@ -1792,7 +1792,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!target.IsPossibleArrayGenericInterface())
             {
-                return null;
+                return default;
             }
 
             return ((NamedTypeSymbol)target).TypeArgumentWithDefinitionUseSiteDiagnostics(0, ref useSiteDiagnostics);
@@ -1819,7 +1819,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var arraySource = (ArrayTypeSymbol)source;
             var elementSource = arraySource.ElementType;
             var elementTarget = GetMatchingElementType(arraySource, target, ref useSiteDiagnostics);
-            if ((object)elementTarget == null)
+            if (elementTarget == null)
             {
                 return false;
             }
@@ -2062,8 +2062,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         private void UpperBoundInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             // SPEC: An upper-bound inference from a type U to a type V is made as follows:
 
@@ -2118,8 +2118,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool UpperBoundTypeParameterInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
             // SPEC: * If V is one of the unfixed Xi then U is added to the set of upper bounds
             // SPEC:   for Xi.
             if (IsUnfixedTypeParameter(target))
@@ -2132,8 +2132,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool UpperBoundArrayInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
 
             // SPEC: * Otherwise, if V is an array type Ve[...] and U is an array
             // SPEC:   type Ue[...] of the same rank, or if V is a one-dimensional array
@@ -2150,7 +2150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var arrayTarget = (ArrayTypeSymbol)target.TypeSymbol;
             var elementTarget = arrayTarget.ElementType;
             var elementSource = GetMatchingElementType(arrayTarget, source.TypeSymbol, ref useSiteDiagnostics);
-            if ((object)elementSource == null)
+            if (elementSource == null)
             {
                 return false;
             }
@@ -2174,8 +2174,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool UpperBoundConstructedInference(TypeSymbolWithAnnotations sourceWithAnnotations, TypeSymbolWithAnnotations targetWithAnnotations, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)sourceWithAnnotations != null);
-            Debug.Assert((object)targetWithAnnotations != null);
+            Debug.Assert(sourceWithAnnotations != null);
+            Debug.Assert(targetWithAnnotations != null);
             var source = sourceWithAnnotations.TypeSymbol.TupleUnderlyingTypeOrSelf();
             var target = targetWithAnnotations.TypeSymbol.TupleUnderlyingTypeOrSelf();
 
@@ -2371,7 +2371,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var withoutNullability = Fix(exact, lower, upper, ref useSiteDiagnostics, _conversions, includeNullability: false);
 
             var best = withNullability;
-            if ((object)best == null)
+            if (best == null)
             {
                 best = withoutNullability;
             }
@@ -2391,7 +2391,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if ((object)best == null)
+            if (best == null)
             {
                 return false;
             }
@@ -2442,13 +2442,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 candidates.AddAll(exact, conversions);
                 if (candidates.Count >= 2)
                 {
-                    return null;
+                    return default;
                 }
             }
 
             if (candidates.Count == 0)
             {
-                return null;
+                return default;
             }
 
             // Don't mutate the collection as we're iterating it.
@@ -2510,7 +2510,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * If among the remaining candidate types there is a unique type V to
             // SPEC:   which there is an implicit conversion from all the other candidate
             // SPEC:   types, then the parameter is fixed to V.
-            TypeSymbolWithAnnotations best = null;
+            TypeSymbolWithAnnotations best = default;
             foreach (var candidate in initialCandidates)
             {
                 foreach (var candidate2 in initialCandidates)
@@ -2522,7 +2522,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                if ((object)best == null)
+                if (best == null)
                 {
                     best = candidate;
                 }
@@ -2542,7 +2542,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     // best candidate is not unique
-                    best = null;
+                    best = default;
                     break;
                 }
 
@@ -2706,7 +2706,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (source.Kind != BoundKind.UnboundLambda)
             {
-                return null;
+                return default;
             }
 
             var anonymousFunction = (UnboundLambda)source;
@@ -2723,12 +2723,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var originalDelegateParameters = target.DelegateParameters();
                 if (originalDelegateParameters.IsDefault)
                 {
-                    return null;
+                    return default;
                 }
 
                 if (originalDelegateParameters.Length != anonymousFunction.ParameterCount)
                 {
-                    return null;
+                    return default;
                 }
             }
 
@@ -2745,12 +2745,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (!anonymousFunction.ParameterType(p).TypeSymbol.Equals(fixedDelegateParameters[p].Type.TypeSymbol, TypeCompareKind.IgnoreDynamicAndTupleNames))
                     {
-                        return null;
+                        return default;
                     }
                 }
             }
 
-            // Future optimization: We could return null if the delegate has out or ref parameters
+            // Future optimization: We could return default if the delegate has out or ref parameters
             // and the anonymous function is an implicitly typed lambda. It will not be applicable.
 
             // We have an entirely fixed delegate parameter list, which is of the same arity as
@@ -2781,7 +2781,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else if (matchingInterface != currentInterface)
                     {
                         // Not unique. Bail out.
-                        return null;
+                        return default;
                     }
                 }
             }
@@ -2894,7 +2894,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var builder = ArrayBuilder<TypeSymbol>.GetInstance();
             foreach (var fixedResult in _fixedResults)
             {
-                builder.Add(fixedResult?.TypeSymbol);
+                builder.Add(fixedResult.TypeSymbol);
             }
             return builder.ToImmutableAndFree();
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -332,7 +332,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var fixedType = _fixedResults[i];
 
-                if (fixedType == null)
+                if (fixedType.IsNull)
                 {
                     sb.Append("UNFIXED ");
                 }
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             for (int i = 0; i < _methodTypeParameters.Length; i++)
             {
-                if (_fixedResults[i] != null)
+                if (!_fixedResults[i].IsNull)
                 {
                     if (!_fixedResults[i].IsErrorType())
                     {
@@ -405,12 +405,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool IsUnfixed(int methodTypeParameterIndex)
         {
             Debug.Assert(ValidIndex(methodTypeParameterIndex));
-            return _fixedResults[methodTypeParameterIndex] == null;
+            return _fixedResults[methodTypeParameterIndex].IsNull;
         }
 
         private bool IsUnfixedTypeParameter(TypeSymbolWithAnnotations type)
         {
-            Debug.Assert(type != null);
+            Debug.Assert(!type.IsNull);
 
             if (type.TypeKind != TypeKind.TypeParameter) return false;
 
@@ -1217,7 +1217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void OutputTypeInference(Binder binder, BoundExpression expression, bool? isNullable, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(expression != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!target.IsNull);
             // SPEC: An output type inference is made from an expression E to a type T
             // SPEC: in the following way:
 
@@ -1240,7 +1240,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * Otherwise, if E is an expression with type U then a lower-bound
             // SPEC:   inference is made from U to T.
             var sourceType = TypeSymbolWithAnnotations.Create(expression.Type, isNullable);
-            if (sourceType != null)
+            if (!sourceType.IsNull)
             {
                 LowerBoundInference(sourceType, target, ref useSiteDiagnostics);
             }
@@ -1250,7 +1250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool InferredReturnTypeInference(BoundExpression source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!target.IsNull);
             // SPEC: * If E is an anonymous function with inferred return type U and
             // SPEC:   T is a delegate type or expression tree with return type Tb
             // SPEC:   then a lower bound inference is made from U to Tb.
@@ -1266,13 +1266,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)delegateType.DelegateInvokeMethod != null && !delegateType.DelegateInvokeMethod.HasUseSiteError,
                          "This method should only be called for valid delegate types.");
             var returnType = delegateType.DelegateInvokeMethod.ReturnType;
-            if (returnType == null || returnType.SpecialType == SpecialType.System_Void)
+            if (returnType.IsNull || returnType.SpecialType == SpecialType.System_Void)
             {
                 return false;
             }
 
             var inferredReturnType = InferReturnType(source, delegateType, ref useSiteDiagnostics);
-            if (inferredReturnType == null)
+            if (inferredReturnType.IsNull)
             {
                 return false;
             }
@@ -1309,7 +1309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                          "This method should only be called for valid delegate types");
 
             TypeSymbolWithAnnotations delegateReturnType = delegateInvokeMethod.ReturnType;
-            if (delegateReturnType == null || delegateReturnType.SpecialType == SpecialType.System_Void)
+            if (delegateReturnType.IsNull || delegateReturnType.SpecialType == SpecialType.System_Void)
             {
                 return false;
             }
@@ -1372,7 +1372,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void ExplicitParameterTypeInference(BoundExpression source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!target.IsNull);
 
             // SPEC: An explicit type parameter type inference is made from an expression
             // SPEC: E to a type T in the following way.
@@ -1430,8 +1430,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         private void ExactInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             // SPEC: An exact inference from a type U to a type V is made as follows:
 
@@ -1482,8 +1482,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactTypeParameterInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             // SPEC: * If V is one of the unfixed Xi then U is added to the set of bounds
             // SPEC:   for Xi.
@@ -1497,8 +1497,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactArrayInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             // SPEC: * Otherwise, if U is an array type UE[...] and V is an array type VE[...]
             // SPEC:   of the same rank then an exact inference from UE to VE is made.
@@ -1543,8 +1543,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactOrBoundsNullableInference(ExactOrBoundsKind kind, TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             if (source.IsNullableType() && target.IsNullableType())
             {
@@ -1568,8 +1568,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactOrBoundsTupleInference(ExactOrBoundsKind kind, TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             // NOTE: we are losing tuple element names when unwrapping tuple types to underlying types.
             //       that is ok, because we are inferring type parameters used in the matching elements, 
@@ -1600,8 +1600,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ExactConstructedInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             // SPEC: * Otherwise, if V is a constructed type C<V1...Vk> and U is a constructed
             // SPEC:   type C<U1...Uk> then an exact inference 
@@ -1668,8 +1668,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         private void LowerBoundInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             // SPEC: A lower-bound inference from a type U to a type V is made as follows:
 
@@ -1750,8 +1750,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool LowerBoundTypeParameterInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             // SPEC: * If V is one of the unfixed Xi then U is added to the set of bounds
             // SPEC:   for Xi.
@@ -1819,7 +1819,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var arraySource = (ArrayTypeSymbol)source;
             var elementSource = arraySource.ElementType;
             var elementTarget = GetMatchingElementType(arraySource, target, ref useSiteDiagnostics);
-            if (elementTarget == null)
+            if (elementTarget.IsNull)
             {
                 return false;
             }
@@ -2062,8 +2062,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         private void UpperBoundInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             // SPEC: An upper-bound inference from a type U to a type V is made as follows:
 
@@ -2118,8 +2118,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool UpperBoundTypeParameterInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
             // SPEC: * If V is one of the unfixed Xi then U is added to the set of upper bounds
             // SPEC:   for Xi.
             if (IsUnfixedTypeParameter(target))
@@ -2132,8 +2132,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool UpperBoundArrayInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(target != null);
+            Debug.Assert(!source.IsNull);
+            Debug.Assert(!target.IsNull);
 
             // SPEC: * Otherwise, if V is an array type Ve[...] and U is an array
             // SPEC:   type Ue[...] of the same rank, or if V is a one-dimensional array
@@ -2150,7 +2150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var arrayTarget = (ArrayTypeSymbol)target.TypeSymbol;
             var elementTarget = arrayTarget.ElementType;
             var elementSource = GetMatchingElementType(arrayTarget, source.TypeSymbol, ref useSiteDiagnostics);
-            if (elementSource == null)
+            if (elementSource.IsNull)
             {
                 return false;
             }
@@ -2174,8 +2174,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool UpperBoundConstructedInference(TypeSymbolWithAnnotations sourceWithAnnotations, TypeSymbolWithAnnotations targetWithAnnotations, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(sourceWithAnnotations != null);
-            Debug.Assert(targetWithAnnotations != null);
+            Debug.Assert(!sourceWithAnnotations.IsNull);
+            Debug.Assert(!targetWithAnnotations.IsNull);
             var source = sourceWithAnnotations.TypeSymbol.TupleUnderlyingTypeOrSelf();
             var target = targetWithAnnotations.TypeSymbol.TupleUnderlyingTypeOrSelf();
 
@@ -2371,7 +2371,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var withoutNullability = Fix(exact, lower, upper, ref useSiteDiagnostics, _conversions, includeNullability: false);
 
             var best = withNullability;
-            if (best == null)
+            if (best.IsNull)
             {
                 best = withoutNullability;
             }
@@ -2391,7 +2391,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if (best == null)
+            if (best.IsNull)
             {
                 return false;
             }
@@ -2522,7 +2522,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                if (best == null)
+                if (best.IsNull)
                 {
                     best = candidate;
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2229,7 +2229,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // - an inferred return type X exists for E in the context of the parameter list of D(§7.5.2.12), and an identity conversion exists from X to Y
                 var x = lambda.GetInferredReturnType(ref useSiteDiagnostics);
-                if (x != null && Conversions.HasIdentityConversion(x.TypeSymbol, y))
+                if (!x.IsNull && Conversions.HasIdentityConversion(x.TypeSymbol, y))
                 {
                     return true;
                 }
@@ -2654,7 +2654,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         var x = lambda.InferReturnType(d1, ref useSiteDiagnostics);
-                        if (x == null)
+                        if (x.IsNull)
                         {
                             return true;
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2229,7 +2229,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // - an inferred return type X exists for E in the context of the parameter list of D(§7.5.2.12), and an identity conversion exists from X to Y
                 var x = lambda.GetInferredReturnType(ref useSiteDiagnostics);
-                if ((object)x != null && Conversions.HasIdentityConversion(x.TypeSymbol, y))
+                if (x != null && Conversions.HasIdentityConversion(x.TypeSymbol, y))
                 {
                     return true;
                 }
@@ -2654,7 +2654,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         var x = lambda.InferReturnType(d1, ref useSiteDiagnostics);
-                        if ((object)x == null)
+                        if (x == null)
                         {
                             return true;
                         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public BoundExpression SetInferredType(TypeSymbolWithAnnotations type)
         {
-            Debug.Assert((object)Type == null && (object)type != null);
+            Debug.Assert((object)Type == null && type != null);
             // PROTOTYPE(NullableReferenceTypes): we're dropping the annotation
             return this.Update(type.TypeSymbol);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public BoundExpression SetInferredType(TypeSymbolWithAnnotations type)
         {
-            Debug.Assert((object)Type == null && type != null);
+            Debug.Assert((object)Type == null && !type.IsNull);
             // PROTOTYPE(NullableReferenceTypes): we're dropping the annotation
             return this.Update(type.TypeSymbol);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var type = expr.Type;
             if ((object)type == null)
             {
-                return null;
+                return default;
             }
             // PROTOTYPE(NullableReferenceTypes): Could we track nullability always,
             // even in C#7, but only report warnings when the feature is enabled?
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.Call:
                     return ((BoundCall)expr).Method.ReturnType.IsNullable;
                 case BoundKind.Conversion:
-                    return ((BoundConversion)expr).ConversionGroupOpt?.ExplicitType?.IsNullable == true ? (bool?)true : null;
+                    return ((BoundConversion)expr).ConversionGroupOpt?.ExplicitType.IsNullable == true ? (bool?)true : null;
                 case BoundKind.BinaryOperator:
                     return ((BoundBinaryOperator)expr).MethodOpt?.ReturnType.IsNullable;
                 case BoundKind.NullCoalescingOperator:

--- a/src/Compilers/CSharp/Portable/BoundTree/ConversionGroup.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/ConversionGroup.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     internal sealed class ConversionGroup
     {
-        internal ConversionGroup(Conversion conversion, TypeSymbolWithAnnotations explicitType = null)
+        internal ConversionGroup(Conversion conversion, TypeSymbolWithAnnotations explicitType = default)
         {
             Conversion = conversion;
             ExplicitType = explicitType;
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// True if the conversion is an explicit conversion.
         /// </summary>
-        internal bool IsExplicitConversion => (object)ExplicitType != null;
+        internal bool IsExplicitConversion => ExplicitType != null;
 
         /// <summary>
         /// The conversion (from Conversions.ClassifyConversionFromExpression for
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal string GetDebuggerDisplay()
         {
             var str = $"#{_id} {Conversion}";
-            if ((object)ExplicitType != null)
+            if (ExplicitType != null)
             {
                 str += $" ({ExplicitType})";
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/ConversionGroup.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/ConversionGroup.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// True if the conversion is an explicit conversion.
         /// </summary>
-        internal bool IsExplicitConversion => ExplicitType != null;
+        internal bool IsExplicitConversion => !ExplicitType.IsNull;
 
         /// <summary>
         /// The conversion (from Conversions.ClassifyConversionFromExpression for
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal string GetDebuggerDisplay()
         {
             var str = $"#{_id} {Conversion}";
-            if (ExplicitType != null)
+            if (!ExplicitType.IsNull)
             {
                 str += $" ({ExplicitType})";
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return TypeSymbolWithAnnotations.Create(resultType);
             }
 
-            if (bestResultType == null || bestResultType.SpecialType == SpecialType.System_Void)
+            if (bestResultType.IsNull || bestResultType.SpecialType == SpecialType.System_Void)
             {
                 // If the best type was 'void', ERR_CantReturnVoid is reported while binding the "return void"
                 // statement(s).
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var lambda in _returnInferenceCache.Values)
             {
                 var type = lambda.InferredReturnType.Type;
-                if (type != null)
+                if (!type.IsNull)
                 {
                     any = true;
                     yield return type.TypeSymbol;
@@ -388,7 +388,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!any)
             {
                 var type = BindForErrorRecovery().InferredReturnType.Type;
-                if (type != null)
+                if (!type.IsNull)
                 {
                     yield return type.TypeSymbol;
                 }
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var lambdaParameters = lambdaSymbol.Parameters;
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(lambdaParameters, diagnostics, modifyCompilation: false);
 
-            if (returnType != null)
+            if (!returnType.IsNull)
             {
                 returnType.ReportAnnotatedUnconstrainedTypeParameterIfAny(lambdaSymbol.DiagnosticLocation, diagnostics);
                 if (returnType.ContainsNullableReferenceTypes())
@@ -513,7 +513,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (IsAsync && !ErrorFacts.PreventsSuccessfulDelegateConversion(diagnostics))
             {
-                if (returnType != null && // Can be null if "delegateType" is not actually a delegate type.
+                if (!returnType.IsNull && // Can be null if "delegateType" is not actually a delegate type.
                     returnType.SpecialType != SpecialType.System_Void &&
                     !returnType.TypeSymbol.IsNonGenericTaskType(binder.Compilation) &&
                     !returnType.TypeSymbol.IsGenericTaskType(binder.Compilation))
@@ -583,7 +583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // TODO: Should InferredReturnType.UseSiteDiagnostics be merged into BoundLambda.Diagnostics?
             var returnType = inferredReturnType.Type;
-            if (returnType == null)
+            if (!returnType.IsNull)
             {
                 returnType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, LambdaSymbol.InferenceFailureReturnType);
             }
@@ -792,7 +792,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 builder.Builder.Append(parameter.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
             }
 
-            if (lambda.ReturnType != null)
+            if (!lambda.ReturnType.IsNull)
             {
                 builder.Builder.Append(lambda.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -585,7 +585,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var returnType = inferredReturnType.Type;
             if (returnType.IsNull)
             {
-                returnType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, LambdaSymbol.InferenceFailureReturnType);
+                returnType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesFalseContext.Instance, LambdaSymbol.InferenceFailureReturnType);
             }
             lambdaSymbol.SetInferredReturnType(inferredReturnType.RefKind, returnType);
 

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -583,7 +583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // TODO: Should InferredReturnType.UseSiteDiagnostics be merged into BoundLambda.Diagnostics?
             var returnType = inferredReturnType.Type;
-            if (!returnType.IsNull)
+            if (returnType.IsNull)
             {
                 returnType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, LambdaSymbol.InferenceFailureReturnType);
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var expression = node.ExpressionOpt;
                 var type = (expression is null) ?
-                    TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesFalseContext.Instance, NoReturnExpression) :
+                    TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, NoReturnExpression) :
                     TypeSymbolWithAnnotations.Create(expression.Type?.SetUnknownNullabilityForReferenceTypes());
                 _builder.Add((node.RefKind, type));
                 return null;
@@ -585,7 +585,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var returnType = inferredReturnType.Type;
             if (returnType == null)
             {
-                returnType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesFalseContext.Instance, LambdaSymbol.InferenceFailureReturnType);
+                returnType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, LambdaSymbol.InferenceFailureReturnType);
             }
             lambdaSymbol.SetInferredReturnType(inferredReturnType.RefKind, returnType);
 

--- a/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
@@ -22,19 +22,19 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         internal BoundExpression SetInferredType(TypeSymbolWithAnnotations type, DiagnosticBag diagnosticsOpt)
         {
-            Debug.Assert(type != null);
+            Debug.Assert(!type.IsNull);
 
             return SetInferredType(type, null, diagnosticsOpt);
         }
 
         internal BoundExpression SetInferredType(TypeSymbolWithAnnotations type, Binder binderOpt, DiagnosticBag diagnosticsOpt)
         {
-            Debug.Assert(binderOpt != null || type != null);
+            Debug.Assert(binderOpt != null || !type.IsNull);
             Debug.Assert(this.Syntax.Kind() == SyntaxKind.SingleVariableDesignation ||
                 (this.Syntax.Kind() == SyntaxKind.DeclarationExpression &&
                     ((DeclarationExpressionSyntax)this.Syntax).Designation.Kind() == SyntaxKind.SingleVariableDesignation));
 
-            bool inferenceFailed = (type == null);
+            bool inferenceFailed = type.IsNull;
 
             if (inferenceFailed)
             {

--- a/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
@@ -22,19 +22,19 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         internal BoundExpression SetInferredType(TypeSymbolWithAnnotations type, DiagnosticBag diagnosticsOpt)
         {
-            Debug.Assert((object)type != null);
+            Debug.Assert(type != null);
 
             return SetInferredType(type, null, diagnosticsOpt);
         }
 
         internal BoundExpression SetInferredType(TypeSymbolWithAnnotations type, Binder binderOpt, DiagnosticBag diagnosticsOpt)
         {
-            Debug.Assert(binderOpt != null || (object)type != null);
+            Debug.Assert(binderOpt != null || type != null);
             Debug.Assert(this.Syntax.Kind() == SyntaxKind.SingleVariableDesignation ||
                 (this.Syntax.Kind() == SyntaxKind.DeclarationExpression &&
                     ((DeclarationExpressionSyntax)this.Syntax).Designation.Kind() == SyntaxKind.SingleVariableDesignation));
 
-            bool inferenceFailed = ((object)type == null);
+            bool inferenceFailed = (type == null);
 
             if (inferenceFailed)
             {
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal BoundExpression FailInference(Binder binder, DiagnosticBag diagnosticsOpt)
         {
-            return this.SetInferredType(null, binder, diagnosticsOpt);
+            return this.SetInferredType(default, binder, diagnosticsOpt);
         }
 
         private void ReportInferenceFailure(DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // fields we need to record each field assignment separately,
             // since some fields may be assigned when this read is replayed
             VariableIdentifier id = variableBySlot[slot];
-            var type = VariableType(id.Symbol)?.TypeSymbol;
+            var type = VariableType(id.Symbol).TypeSymbol;
 
             Debug.Assert(!_emptyStructTypeCache.IsEmptyStructType(type));
             

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -883,7 +883,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // We've already reported the use of a local before its declaration.  No need to emit
                 // another diagnostic for the same issue.
             }
-            else if (!_alreadyReported[slot] && VariableType(symbol)?.IsErrorType() != true)
+            else if (!_alreadyReported[slot] && VariableType(symbol).IsErrorType() != true)
             {
                 // CONSIDER: could suppress this diagnostic in cases where the local was declared in a using
                 // or fixed statement because there's a special error code for not initializing those.
@@ -1197,7 +1197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(containingSlot != -1);
             Debug.Assert(!state.IsAssigned(containingSlot));
             VariableIdentifier variable = variableBySlot[containingSlot];
-            NamedTypeSymbol structType = (NamedTypeSymbol)VariableType(variable.Symbol)?.TypeSymbol;
+            NamedTypeSymbol structType = (NamedTypeSymbol)VariableType(variable.Symbol).TypeSymbol;
             foreach (var field in _emptyStructTypeCache.GetStructInstanceFields(structType))
             {
                 if (_emptyStructTypeCache.IsEmptyStructType(field.Type.TypeSymbol)) continue;
@@ -1225,7 +1225,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (slot < 0) return;
             VariableIdentifier id = variableBySlot[slot];
-            TypeSymbol type = VariableType(id.Symbol)?.TypeSymbol;
+            TypeSymbol type = VariableType(id.Symbol).TypeSymbol;
             Debug.Assert(!_emptyStructTypeCache.IsEmptyStructType(type));
             if (slot >= state.Assigned.Capacity) Normalize(ref state);
             if (state.IsAssigned(slot)) return; // was already fully assigned.
@@ -1261,7 +1261,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (slot < 0) return;
             VariableIdentifier id = variableBySlot[slot];
-            TypeSymbol type = VariableType(id.Symbol)?.TypeSymbol;
+            TypeSymbol type = VariableType(id.Symbol).TypeSymbol;
             Debug.Assert(!_emptyStructTypeCache.IsEmptyStructType(type));
             if (!state.IsAssigned(slot)) return; // was already unassigned
             state.Unassign(slot);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -883,7 +883,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // We've already reported the use of a local before its declaration.  No need to emit
                 // another diagnostic for the same issue.
             }
-            else if (!_alreadyReported[slot] && VariableType(symbol).IsErrorType() != true)
+            else if (!_alreadyReported[slot] && !VariableType(symbol).IsErrorType())
             {
                 // CONSIDER: could suppress this diagnostic in cases where the local was declared in a using
                 // or fixed statement because there's a special error code for not initializing those.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Since analysis may proceed in multiple passes, it is possible the slot is already assigned.
             if (!_variableSlot.TryGetValue(identifier, out slot))
             {
-                var variableType = VariableType(symbol)?.TypeSymbol;
+                var variableType = VariableType(symbol).TypeSymbol;
                  if (_emptyStructTypeCache.IsEmptyStructType(variableType))
                 {
                     return -1;
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return ((ParameterSymbol)s).Type;
                 case SymbolKind.Method:
                     Debug.Assert(((MethodSymbol)s).MethodKind == MethodKind.LocalFunction);
-                    return null;
+                    return default;
                 case SymbolKind.Property:
                     return ((PropertySymbol)s).Type;
                 case SymbolKind.Event:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(value != null);
             Debug.Assert(!IsConditionalState);
 
-            if (targetType == null || valueType == null)
+            if (targetType.IsNull || valueType.IsNull)
             {
                 return false;
             }
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (this.State.Reachable)
             {
-                if (targetType == null || valueType == null)
+                if (targetType.IsNull || valueType.IsNull)
                 {
                     return;
                 }
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (this.State.Reachable)
             {
-                if (targetType == null)
+                if (targetType.IsNull)
                 {
                     return;
                 }
@@ -847,7 +847,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // PROTOTYPE(NullableReferenceTypes): We should only report such
             // diagnostics for locals that are set or checked explicitly within this method.
-            if (expressionResultType != null && expressionResultType.IsNullable == false && isNull == true)
+            if (!expressionResultType.IsNull && expressionResultType.IsNullable == false && isNull == true)
             {
                 ReportStaticNullCheckingDiagnostics(ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse, pattern.Syntax);
             }
@@ -926,12 +926,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static bool IsNullable(TypeSymbolWithAnnotations typeOpt)
         {
-            return typeOpt != null && typeOpt.IsNullable == true;
+            return !typeOpt.IsNull && typeOpt.IsNullable == true;
         }
 
         private static bool IsNonNullable(TypeSymbolWithAnnotations typeOpt)
         {
-            return typeOpt != null && typeOpt.IsNullable == false && typeOpt.IsReferenceType;
+            return !typeOpt.IsNull && typeOpt.IsNullable == false && typeOpt.IsReferenceType;
         }
 
         private static bool IsUnconstrainedTypeParameter(TypeSymbol typeOpt)
@@ -980,7 +980,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.DeclaredType.InferredType)
             {
                 Debug.Assert(conversion.IsIdentity);
-                if (valueType == null)
+                if (valueType.IsNull)
                 {
                     Debug.Assert(type.IsErrorType());
                     valueType = type;
@@ -1282,22 +1282,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Should do the same here.
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 // If there are error types, use the first error type. (Matches InferBestType(ImmutableArray<BoundExpression>, ...).)
-                var bestType = resultTypes.FirstOrDefault(t => t != null && t.IsErrorType());
-                if (bestType == null)
+                var bestType = resultTypes.FirstOrDefault(t => !t.IsNull && t.IsErrorType());
+                if (bestType.IsNull)
                 {
                     bestType = BestTypeInferrer.InferBestType(resultTypes, _conversions, useSiteDiagnostics: ref useSiteDiagnostics);
                 }
                 // PROTOTYPE(NullableReferenceTypes): Report a special ErrorCode.WRN_NoBestNullabilityArrayElements
                 // when InferBestType fails, and avoid reporting conversion warnings for each element in those cases.
                 // (See similar code for conditional expressions: ErrorCode.WRN_NoBestNullabilityConditionalExpression.)
-                if (bestType != null)
+                if (!bestType.IsNull)
                 {
                     elementType = bestType;
                 }
                 arrayType = arrayType.WithElementType(elementType);
             }
 
-            if (elementType != null)
+            if (!elementType.IsNull)
             {
                 bool elementTypeIsReferenceType = elementType.IsReferenceType == true;
                 for (int i = 0; i < n; i++)
@@ -1465,7 +1465,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // PROTOTYPE(NullableReferenceTypes): This check is incorrect since it compares declared
                         // nullability rather than tracked nullability. Moreover, we should only report such
                         // diagnostics for locals that are set or checked explicitly within this method.
-                        if (operandComparedToNullType != null && operandComparedToNullType.IsNullable == false)
+                        if (!operandComparedToNullType.IsNull && operandComparedToNullType.IsNullable == false)
                         {
                             ReportStaticNullCheckingDiagnostics(op == BinaryOperatorKind.Equal ?
                                                                     ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse :
@@ -1668,7 +1668,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _resultType = TypeSymbolWithAnnotations.Create(resultType, resultIsNullable);
             return null;
 
-            bool? getIsNullable(BoundExpression e, TypeSymbolWithAnnotations t) => t == null ? e.IsNullable() : t.IsNullable;
+            bool? getIsNullable(BoundExpression e, TypeSymbolWithAnnotations t) => t.IsNull ? e.IsNullable() : t.IsNullable;
             TypeSymbol getLeftResultType(TypeSymbol leftType, TypeSymbol rightType)
             {
                 // If there was an identity conversion between the two operands (in short, if there
@@ -1788,7 +1788,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _conversions,
                     out _,
                     ref useSiteDiagnostics);
-                if (resultType == null)
+                if (resultType.IsNull)
                 {
                     ReportStaticNullCheckingDiagnostics(
                         ErrorCode.WRN_NoBestNullabilityConditionalExpression,
@@ -1804,7 +1804,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool? getIsNullableIfReferenceType(BoundExpression expr, TypeSymbolWithAnnotations type)
             {
-                if (type != null)
+                if (!type.IsNull)
                 {
                     return type.IsNullable;
                 }
@@ -1817,7 +1817,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression createPlaceholderIfNecessary(BoundExpression expr, TypeSymbolWithAnnotations type)
             {
-                return type == null ?
+                return type.IsNull ?
                     expr :
                     new BoundValuePlaceholder(expr.Syntax, type.IsNullable, type.TypeSymbol);
             }
@@ -2519,7 +2519,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // to re-bind lambdas in MethodTypeInferrer.
                     return GetUnboundLambda((BoundLambda)argument, GetVariableState());
                 }
-                if (argumentType == null)
+                if (argumentType.IsNull)
                 {
                     return argument;
                 }
@@ -2739,7 +2739,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Visit(operand);
             TypeSymbolWithAnnotations operandType = _resultType;
             TypeSymbolWithAnnotations explicitType = node.ConversionGroupOpt?.ExplicitType ?? default;
-            bool fromExplicitCast = explicitType != null;
+            bool fromExplicitCast = !explicitType.IsNull;
             TypeSymbolWithAnnotations resultType = ApplyConversion(node, operand, conversion, explicitType.TypeSymbol ?? node.Type, operandType, checkConversion: !fromExplicitCast, fromExplicitCast: fromExplicitCast, out bool _);
 
             if (fromExplicitCast && explicitType.IsNullable == false)
@@ -2912,7 +2912,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             out bool canConvertNestedNullability)
         {
             Debug.Assert(node != null);
-            Debug.Assert(operandOpt != null || operandType != null);
+            Debug.Assert(operandOpt != null || !operandType.IsNull);
             Debug.Assert((object)targetType != null);
 
             bool? isNullableIfReferenceType = null;
@@ -2999,7 +2999,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case ConversionKind.ExplicitDynamic:
                 case ConversionKind.ImplicitDynamic:
-                    isNullableIfReferenceType = operandType == null ? null : operandType.IsNullable;
+                    isNullableIfReferenceType = operandType.IsNull ? null : operandType.IsNullable;
                     break;
 
                 case ConversionKind.Unboxing:
@@ -3007,19 +3007,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case ConversionKind.Boxing:
-                    if (operandType != null && operandType.IsValueType)
+                    if (!operandType.IsNull && operandType.IsValueType)
                     {
                         // PROTOTYPE(NullableReferenceTypes): Should we worry about a pathological case of boxing nullable value known to be not null?
                         //       For example, new int?(0)
                         isNullableIfReferenceType = operandType.IsNullableType();
                     }
-                    else if (operandType != null && IsUnconstrainedTypeParameter(operandType.TypeSymbol))
+                    else if (!operandType.IsNull && IsUnconstrainedTypeParameter(operandType.TypeSymbol))
                     {
                         isNullableIfReferenceType = true;
                     }
                     else
                     {
-                        Debug.Assert(operandType == null ||
+                        Debug.Assert(operandType.IsNull ||
                             !operandType.IsReferenceType ||
                             operandType.SpecialType == SpecialType.System_ValueType ||
                             operandType.TypeKind == TypeKind.Interface ||
@@ -3035,7 +3035,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.Identity:
                 case ConversionKind.ImplicitReference:
                 case ConversionKind.ExplicitReference:
-                    if (operandType == null && operandOpt.IsLiteralNullOrDefault())
+                    if (operandType.IsNull && operandOpt.IsLiteralNullOrDefault())
                     {
                         isNullableIfReferenceType = true;
                     }
@@ -3048,7 +3048,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             conversion = GenerateConversion(_conversions, operandOpt, operandType.TypeSymbol, targetType, fromExplicitCast);
                             canConvertNestedNullability = conversion.Exists;
                         }
-                        isNullableIfReferenceType = operandType == null ? null : operandType.IsNullable;
+                        isNullableIfReferenceType = operandType.IsNull ? null : operandType.IsNullable;
                     }
                     break;
 
@@ -3414,7 +3414,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ReportNullReferenceArgumentIfNecessary(argument, argumentType, parameter, paramType);
 
-            if (argumentType != null && IsNullabilityMismatch(paramType.TypeSymbol, argumentType.TypeSymbol))
+            if (!argumentType.IsNull && IsNullabilityMismatch(paramType.TypeSymbol, argumentType.TypeSymbol))
             {
                 ReportNullabilityMismatchInArgument(argument, argumentType.TypeSymbol, parameter, paramType.TypeSymbol);
             }
@@ -3529,7 +3529,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int slot = GetOrCreateSlot(iterationVariable);
                 TypeSymbolWithAnnotations sourceType = node.EnumeratorInfoOpt?.ElementType ?? default;
                 bool? isNullableIfReferenceType = null;
-                if (sourceType != null)
+                if (!sourceType.IsNull)
                 {
                     TypeSymbolWithAnnotations destinationType = iterationVariable.Type;
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
@@ -3599,7 +3599,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            _resultType = resultType == null ? TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: null) : resultType;
+            _resultType = resultType.IsNull ? TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: null) : resultType;
             return null;
         }
 
@@ -3856,7 +3856,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             //if (this.State.Reachable) // PROTOTYPE(NullableReferenceTypes): Consider reachability?
             {
-                _resultType = _resultType == null ? default : _resultType.WithTopLevelNonNullabilityForReferenceTypes();
+                _resultType = _resultType.IsNull ? default : _resultType.WithTopLevelNonNullabilityForReferenceTypes();
             }
 
             return null;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1465,7 +1465,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // PROTOTYPE(NullableReferenceTypes): This check is incorrect since it compares declared
                         // nullability rather than tracked nullability. Moreover, we should only report such
                         // diagnostics for locals that are set or checked explicitly within this method.
-                        if (operandComparedToNullType.IsNullable == false)
+                        if (operandComparedToNullType != null && operandComparedToNullType.IsNullable == false)
                         {
                             ReportStaticNullCheckingDiagnostics(op == BinaryOperatorKind.Equal ?
                                                                     ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse :

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(value != null);
             Debug.Assert(!IsConditionalState);
 
-            if (targetType is null || valueType is null)
+            if (targetType == null || valueType == null)
             {
                 return false;
             }
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (this.State.Reachable)
             {
-                if (targetType is null || valueType is null)
+                if (targetType == null || valueType == null)
                 {
                     return;
                 }
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (this.State.Reachable)
             {
-                if ((object)targetType == null)
+                if (targetType == null)
                 {
                     return;
                 }
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Since reference can point to the heap, we cannot assume the value is not null after this assignment,
                     // regardless of what value is being assigned.
                     (targetType.IsNullable == true) ? (bool?)false : null :
-                    !valueType?.IsNullable;
+                    !valueType.IsNullable;
 
                 // PROTOTYPE(NullableReferenceTypes): Might this clear state that
                 // should be copied in InheritNullableStateOfTrackableType?
@@ -571,7 +571,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // }
                     // For now, we copy a limited set of BoundNode types that shouldn't contain cycles.
                     if ((value.Kind == BoundKind.ObjectCreationExpression || value.Kind == BoundKind.AnonymousObjectCreationExpression || value.Kind == BoundKind.DynamicObjectCreationExpression || targetType.TypeSymbol.IsAnonymousType) &&
-                        targetType.TypeSymbol.Equals(valueType?.TypeSymbol, TypeCompareKind.ConsiderEverything)) // PROTOTYPE(NullableReferenceTypes): Allow assignment to base type.
+                        targetType.TypeSymbol.Equals(valueType.TypeSymbol, TypeCompareKind.ConsiderEverything)) // PROTOTYPE(NullableReferenceTypes): Allow assignment to base type.
                     {
                         if (valueSlot > 0)
                         {
@@ -580,7 +580,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
                 else if (EmptyStructTypeCache.IsTrackableStructType(targetType.TypeSymbol) &&
-                        targetType.TypeSymbol.Equals(valueType?.TypeSymbol, TypeCompareKind.ConsiderEverything))
+                        targetType.TypeSymbol.Equals(valueType.TypeSymbol, TypeCompareKind.ConsiderEverything))
                 {
                     InheritNullableStateOfTrackableStruct(targetType.TypeSymbol, targetSlot, valueSlot, IsByRefTarget(targetSlot), slotWatermark: GetSlotWatermark());
                 }
@@ -847,7 +847,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // PROTOTYPE(NullableReferenceTypes): We should only report such
             // diagnostics for locals that are set or checked explicitly within this method.
-            if (expressionResultType?.IsNullable == false && isNull == true)
+            if (expressionResultType != null && expressionResultType.IsNullable == false && isNull == true)
             {
                 ReportStaticNullCheckingDiagnostics(ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse, pattern.Syntax);
             }
@@ -891,7 +891,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbolWithAnnotations resultType = ApplyConversion(expr, expr, conversion, returnType.TypeSymbol, result, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
             if (!canConvertNestedNullability)
             {
-                ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInAssignment, expr.Syntax, GetTypeAsDiagnosticArgument(result?.TypeSymbol), returnType.TypeSymbol);
+                ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInAssignment, expr.Syntax, GetTypeAsDiagnosticArgument(result.TypeSymbol), returnType.TypeSymbol);
             }
 
             bool returnTypeIsNonNullable = IsNonNullable(returnType);
@@ -905,7 +905,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!reportedNullable)
             {
                 if (IsNullable(resultType) && (returnTypeIsNonNullable || returnTypeIsUnconstrainedTypeParameter) ||
-                    IsUnconstrainedTypeParameter(resultType?.TypeSymbol) && returnTypeIsNonNullable)
+                    IsUnconstrainedTypeParameter(resultType.TypeSymbol) && returnTypeIsNonNullable)
                 {
                     ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullReferenceReturn, node.ExpressionOpt.Syntax);
                 }
@@ -918,7 +918,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var method = (MethodSymbol)_member;
             var returnType = (_useMethodSignatureReturnType ? _methodSignatureOpt : method).ReturnType;
-            Debug.Assert((object)returnType != LambdaSymbol.ReturnTypeIsBeingInferred);
+            Debug.Assert((object)returnType.TypeSymbol != LambdaSymbol.ReturnTypeIsBeingInferred);
             return method.IsGenericTaskReturningAsync(compilation) ?
                 ((NamedTypeSymbol)returnType.TypeSymbol).TypeArgumentsNoUseSiteDiagnostics.Single() :
                 returnType;
@@ -926,12 +926,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static bool IsNullable(TypeSymbolWithAnnotations typeOpt)
         {
-            return typeOpt?.IsNullable == true;
+            return typeOpt != null && typeOpt.IsNullable == true;
         }
 
         private static bool IsNonNullable(TypeSymbolWithAnnotations typeOpt)
         {
-            return typeOpt?.IsNullable == false && typeOpt.IsReferenceType;
+            return typeOpt != null && typeOpt.IsNullable == false && typeOpt.IsReferenceType;
         }
 
         private static bool IsUnconstrainedTypeParameter(TypeSymbol typeOpt)
@@ -980,7 +980,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.DeclaredType.InferredType)
             {
                 Debug.Assert(conversion.IsIdentity);
-                if (valueType is null)
+                if (valueType == null)
                 {
                     Debug.Assert(type.IsErrorType());
                     valueType = type;
@@ -996,7 +996,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ReportNullReferenceAssignmentIfNecessary(initializer, type, valueType, useLegacyWarnings: true);
                 if (!canConvertNestedNullability)
                 {
-                    ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInAssignment, initializer.Syntax, GetTypeAsDiagnosticArgument(unconvertedType?.TypeSymbol), type.TypeSymbol);
+                    ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInAssignment, initializer.Syntax, GetTypeAsDiagnosticArgument(unconvertedType.TypeSymbol), type.TypeSymbol);
                 }
             }
 
@@ -1012,8 +1012,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
             // Verify Visit method set _result.
             TypeSymbolWithAnnotations resultType = _resultType;
-            Debug.Assert((object)resultType != _invalidType);
-            Debug.Assert(AreCloseEnough(resultType?.TypeSymbol, node.Type));
+            Debug.Assert((object)resultType.TypeSymbol != _invalidType.TypeSymbol);
+            Debug.Assert(AreCloseEnough(resultType.TypeSymbol, node.Type));
 #endif
             if (_callbackOpt != null)
             {
@@ -1282,19 +1282,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Should do the same here.
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 // If there are error types, use the first error type. (Matches InferBestType(ImmutableArray<BoundExpression>, ...).)
-                var bestType = resultTypes.FirstOrDefault(t => t?.IsErrorType() == true) ??
-                    BestTypeInferrer.InferBestType(resultTypes, _conversions, useSiteDiagnostics: ref useSiteDiagnostics);
+                var bestType = resultTypes.FirstOrDefault(t => t != null && t.IsErrorType());
+                if (bestType == null)
+                {
+                    bestType = BestTypeInferrer.InferBestType(resultTypes, _conversions, useSiteDiagnostics: ref useSiteDiagnostics);
+                }
                 // PROTOTYPE(NullableReferenceTypes): Report a special ErrorCode.WRN_NoBestNullabilityArrayElements
                 // when InferBestType fails, and avoid reporting conversion warnings for each element in those cases.
                 // (See similar code for conditional expressions: ErrorCode.WRN_NoBestNullabilityConditionalExpression.)
-                if ((object)bestType != null)
+                if (bestType != null)
                 {
                     elementType = bestType;
                 }
                 arrayType = arrayType.WithElementType(elementType);
             }
 
-            if ((object)elementType != null)
+            if (elementType != null)
             {
                 bool elementTypeIsReferenceType = elementType.IsReferenceType == true;
                 for (int i = 0; i < n; i++)
@@ -1302,7 +1305,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var conversion = conversionBuilder[i];
                     var element = elementBuilder[i];
                     var resultType = resultBuilder[i];
-                    var sourceType = resultType?.TypeSymbol;
+                    var sourceType = resultType.TypeSymbol;
                     if (elementTypeIsReferenceType)
                     {
                         resultType = ApplyConversion(element, element, conversion, elementType.TypeSymbol, resultType, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
@@ -1347,14 +1350,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node.Expression.Type.IsReferenceType);
             CheckPossibleNullReceiver(node.Expression, checkType: false);
 
-            var type = _resultType?.TypeSymbol as ArrayTypeSymbol;
+            var type = _resultType.TypeSymbol as ArrayTypeSymbol;
 
             foreach (var i in node.Indices)
             {
                 VisitRvalue(i);
             }
 
-            _resultType = type?.ElementType;
+            _resultType = type?.ElementType ?? default;
             return null;
         }
 
@@ -1385,8 +1388,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     case BinaryOperatorKind.DelegateCombination:
                         {
-                            bool? leftIsNullable = leftType?.IsNullable;
-                            bool? rightIsNullable = rightType?.IsNullable;
+                            bool? leftIsNullable = leftType.IsNullable;
+                            bool? rightIsNullable = rightType.IsNullable;
                             if (leftIsNullable == false || rightIsNullable == false)
                             {
                                 isNullable = false;
@@ -1444,7 +1447,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (op == BinaryOperatorKind.Equal || op == BinaryOperatorKind.NotEqual)
                 {
                     BoundExpression operandComparedToNull = null;
-                    TypeSymbolWithAnnotations operandComparedToNullType = null;
+                    TypeSymbolWithAnnotations operandComparedToNullType = default;
 
                     if (binary.Right.ConstantValue?.IsNull == true)
                     {
@@ -1462,7 +1465,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // PROTOTYPE(NullableReferenceTypes): This check is incorrect since it compares declared
                         // nullability rather than tracked nullability. Moreover, we should only report such
                         // diagnostics for locals that are set or checked explicitly within this method.
-                        if (operandComparedToNullType?.IsNullable == false)
+                        if (operandComparedToNullType.IsNullable == false)
                         {
                             ReportStaticNullCheckingDiagnostics(op == BinaryOperatorKind.Equal ?
                                                                     ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse :
@@ -1619,7 +1622,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var leftState = this.State.Clone();
-            if (leftResult?.IsNullable == false)
+            if (leftResult.IsNullable == false)
             {
                 ReportStaticNullCheckingDiagnostics(ErrorCode.HDN_ExpressionIsProbablyNeverNull, leftOperand.Syntax);
             }
@@ -1635,8 +1638,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             rightResult = VisitRvalueWithResult(rightOperand);
             IntersectWith(ref this.State, ref leftState);
             TypeSymbol resultType;
-            var leftResultType = leftResult?.TypeSymbol;
-            var rightResultType = rightResult?.TypeSymbol;
+            var leftResultType = leftResult.TypeSymbol;
+            var rightResultType = rightResult.TypeSymbol;
             switch (node.OperatorResultKind)
             {
                 case BoundNullCoalescingOperatorResultKind.NoCommonType:
@@ -1665,7 +1668,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _resultType = TypeSymbolWithAnnotations.Create(resultType, resultIsNullable);
             return null;
 
-            bool? getIsNullable(BoundExpression e, TypeSymbolWithAnnotations t) => (t is null) ? e.IsNullable() : t.IsNullable;
+            bool? getIsNullable(BoundExpression e, TypeSymbolWithAnnotations t) => t == null ? e.IsNullable() : t.IsNullable;
             TypeSymbol getLeftResultType(TypeSymbol leftType, TypeSymbol rightType)
             {
                 // If there was an identity conversion between the two operands (in short, if there
@@ -1699,7 +1702,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (receiver.Type?.IsReferenceType == true)
             {
-                if (receiverType?.IsNullable == false)
+                if (receiverType.IsNullable == false)
                 {
                     ReportStaticNullCheckingDiagnostics(ErrorCode.HDN_ExpressionIsProbablyNeverNull, receiver.Syntax);
                 }
@@ -1722,7 +1725,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // PROTOTYPE(NullableReferenceTypes): Use flow analysis type rather than node.Type
             // so that nested nullability is inferred from flow analysis. See VisitConditionalOperator.
-            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: receiverType?.IsNullable | _resultType?.IsNullable);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: receiverType.IsNullable | _resultType.IsNullable);
             // PROTOTYPE(NullableReferenceTypes): Report conversion warnings.
             return null;
         }
@@ -1766,7 +1769,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbolWithAnnotations resultType;
             if (node.HasErrors)
             {
-                resultType = null;
+                resultType = default;
             }
             else
             {
@@ -1785,23 +1788,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _conversions,
                     out _,
                     ref useSiteDiagnostics);
-                if (resultType is null)
+                if (resultType == null)
                 {
                     ReportStaticNullCheckingDiagnostics(
                         ErrorCode.WRN_NoBestNullabilityConditionalExpression,
                         node.Syntax,
-                        GetTypeAsDiagnosticArgument(consequenceResult?.TypeSymbol),
-                        GetTypeAsDiagnosticArgument(alternativeResult?.TypeSymbol));
+                        GetTypeAsDiagnosticArgument(consequenceResult.TypeSymbol),
+                        GetTypeAsDiagnosticArgument(alternativeResult.TypeSymbol));
                 }
             }
-            resultType = TypeSymbolWithAnnotations.Create(resultType?.TypeSymbol ?? node.Type.SetUnknownNullabilityForReferenceTypes(), isNullableIfReferenceType);
+            resultType = TypeSymbolWithAnnotations.Create(resultType.TypeSymbol ?? node.Type.SetUnknownNullabilityForReferenceTypes(), isNullableIfReferenceType);
 
             _resultType = resultType;
             return null;
 
             bool? getIsNullableIfReferenceType(BoundExpression expr, TypeSymbolWithAnnotations type)
             {
-                if ((object)type != null)
+                if (type != null)
                 {
                     return type.IsNullable;
                 }
@@ -1814,7 +1817,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression createPlaceholderIfNecessary(BoundExpression expr, TypeSymbolWithAnnotations type)
             {
-                return type is null ?
+                return type == null ?
                     expr :
                     new BoundValuePlaceholder(expr.Syntax, type.IsNullable, type.TypeSymbol);
             }
@@ -2268,7 +2271,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbolWithAnnotations parameterType,
             TypeSymbolWithAnnotations resultType)
         {
-            var argumentType = resultType?.TypeSymbol;
+            var argumentType = resultType.TypeSymbol;
             switch (refKind)
             {
                 case RefKind.None:
@@ -2395,7 +2398,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (parameters.IsDefault)
             {
-                return (null, null);
+                return (default, default);
             }
 
             int n = parameters.Length;
@@ -2434,7 +2437,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (parameter is null)
             {
                 Debug.Assert(!expanded);
-                return (null, null);
+                return (default, default);
             }
 
             var type = parameter.Type;
@@ -2516,7 +2519,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // to re-bind lambdas in MethodTypeInferrer.
                     return GetUnboundLambda((BoundLambda)argument, GetVariableState());
                 }
-                if (argumentType is null)
+                if (argumentType == null)
                 {
                     return argument;
                 }
@@ -2649,7 +2652,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private Symbol AsMemberOfResultType(Symbol symbol)
         {
-            var containingType = _resultType?.TypeSymbol as NamedTypeSymbol;
+            var containingType = _resultType.TypeSymbol as NamedTypeSymbol;
             if ((object)containingType == null || containingType.IsErrorType())
             {
                 return symbol;
@@ -2735,20 +2738,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Visit(operand);
             TypeSymbolWithAnnotations operandType = _resultType;
-            TypeSymbolWithAnnotations explicitType = node.ConversionGroupOpt?.ExplicitType;
-            bool fromExplicitCast = (object)explicitType != null;
-            TypeSymbolWithAnnotations resultType = ApplyConversion(node, operand, conversion, explicitType?.TypeSymbol ?? node.Type, operandType, checkConversion: !fromExplicitCast, fromExplicitCast: fromExplicitCast, out bool _);
+            TypeSymbolWithAnnotations explicitType = node.ConversionGroupOpt?.ExplicitType ?? default;
+            bool fromExplicitCast = explicitType != null;
+            TypeSymbolWithAnnotations resultType = ApplyConversion(node, operand, conversion, explicitType.TypeSymbol ?? node.Type, operandType, checkConversion: !fromExplicitCast, fromExplicitCast: fromExplicitCast, out bool _);
 
             if (fromExplicitCast && explicitType.IsNullable == false)
             {
                 TypeSymbol targetType = explicitType.TypeSymbol;
                 bool reportNullable = false;
-                if (targetType.IsReferenceType && IsUnconstrainedTypeParameter(resultType?.TypeSymbol))
+                if (targetType.IsReferenceType && IsUnconstrainedTypeParameter(resultType.TypeSymbol))
                 {
                     reportNullable = true;
                 }
                 else if ((targetType.IsReferenceType || IsUnconstrainedTypeParameter(targetType)) &&
-                    resultType?.IsNullable == true)
+                    resultType.IsNullable == true)
                 {
                     reportNullable = true;
                 }
@@ -2780,7 +2783,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeSymbolWithAnnotations> elementTypes = arguments.SelectAsArray((a, w) => w.VisitRvalueWithResult(a), this);
             var tupleOpt = (TupleTypeSymbol)node.Type;
             _resultType = (tupleOpt is null) ?
-                null :
+                default :
                 TypeSymbolWithAnnotations.Create(tupleOpt.WithElementTypes(elementTypes));
         }
 
@@ -2909,7 +2912,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             out bool canConvertNestedNullability)
         {
             Debug.Assert(node != null);
-            Debug.Assert(operandOpt != null || (object)operandType != null);
+            Debug.Assert(operandOpt != null || operandType != null);
             Debug.Assert((object)targetType != null);
 
             bool? isNullableIfReferenceType = null;
@@ -2996,7 +2999,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case ConversionKind.ExplicitDynamic:
                 case ConversionKind.ImplicitDynamic:
-                    isNullableIfReferenceType = operandType?.IsNullable;
+                    isNullableIfReferenceType = operandType == null ? null : operandType.IsNullable;
                     break;
 
                 case ConversionKind.Unboxing:
@@ -3004,19 +3007,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case ConversionKind.Boxing:
-                    if (operandType?.IsValueType == true)
+                    if (operandType != null && operandType.IsValueType)
                     {
                         // PROTOTYPE(NullableReferenceTypes): Should we worry about a pathological case of boxing nullable value known to be not null?
                         //       For example, new int?(0)
                         isNullableIfReferenceType = operandType.IsNullableType();
                     }
-                    else if (IsUnconstrainedTypeParameter(operandType?.TypeSymbol))
+                    else if (operandType != null && IsUnconstrainedTypeParameter(operandType.TypeSymbol))
                     {
                         isNullableIfReferenceType = true;
                     }
                     else
                     {
-                        Debug.Assert(operandType?.IsReferenceType != true ||
+                        Debug.Assert(operandType == null ||
+                            !operandType.IsReferenceType ||
                             operandType.SpecialType == SpecialType.System_ValueType ||
                             operandType.TypeKind == TypeKind.Interface ||
                             operandType.TypeKind == TypeKind.Dynamic);
@@ -3031,7 +3035,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.Identity:
                 case ConversionKind.ImplicitReference:
                 case ConversionKind.ExplicitReference:
-                    if (operandType is null && operandOpt.IsLiteralNullOrDefault())
+                    if (operandType == null && operandOpt.IsLiteralNullOrDefault())
                     {
                         isNullableIfReferenceType = true;
                     }
@@ -3041,10 +3045,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (checkConversion)
                         {
                             // PROTOTYPE(NullableReferenceTypes): Assert conversion is similar to original.
-                            conversion = GenerateConversion(_conversions, operandOpt, operandType?.TypeSymbol, targetType, fromExplicitCast);
+                            conversion = GenerateConversion(_conversions, operandOpt, operandType.TypeSymbol, targetType, fromExplicitCast);
                             canConvertNestedNullability = conversion.Exists;
                         }
-                        isNullableIfReferenceType = operandType?.IsNullable;
+                        isNullableIfReferenceType = operandType == null ? null : operandType.IsNullable;
                     }
                     break;
 
@@ -3105,7 +3109,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             //if (this.State.Reachable) // PROTOTYPE(NullableReferenceTypes): Consider reachability?
             {
-                _resultType = null;
+                _resultType = default;
             }
 
             return null;
@@ -3194,7 +3198,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ReportNullReferenceAssignmentIfNecessary(right, leftType, rightType, UseLegacyWarnings(left));
                 if (!canConvertNestedNullability)
                 {
-                    ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInAssignment, right.Syntax, GetTypeAsDiagnosticArgument(rightResult?.TypeSymbol), leftType.TypeSymbol);
+                    ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullabilityMismatchInAssignment, right.Syntax, GetTypeAsDiagnosticArgument(rightResult.TypeSymbol), leftType.TypeSymbol);
                 }
                 TrackNullableStateForAssignment(right, leftType, MakeSlot(left), rightType, MakeSlot(right));
                 // PROTOTYPE(NullableReferenceTypes): Check node.Type.IsErrorType() instead?
@@ -3325,7 +3329,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    leftOnRightType = null;
+                    leftOnRightType = default;
                 }
 
                 VisitRvalue(node.Right);
@@ -3388,7 +3392,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private bool ReportNullReferenceArgumentIfNecessary(BoundExpression argument, TypeSymbolWithAnnotations argumentType, ParameterSymbol parameter, TypeSymbolWithAnnotations paramType)
         {
-            if (argumentType?.IsNullable == true)
+            if (argumentType.IsNullable == true)
             {
                 if (paramType.IsReferenceType && paramType.IsNullable == false)
                 {
@@ -3410,7 +3414,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ReportNullReferenceArgumentIfNecessary(argument, argumentType, parameter, paramType);
 
-            if ((object)argumentType != null && IsNullabilityMismatch(paramType.TypeSymbol, argumentType.TypeSymbol))
+            if (argumentType != null && IsNullabilityMismatch(paramType.TypeSymbol, argumentType.TypeSymbol))
             {
                 ReportNullabilityMismatchInArgument(argument, argumentType.TypeSymbol, parameter, paramType.TypeSymbol);
             }
@@ -3523,9 +3527,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var iterationVariable in node.IterationVariables)
             {
                 int slot = GetOrCreateSlot(iterationVariable);
-                TypeSymbolWithAnnotations sourceType = node.EnumeratorInfoOpt?.ElementType;
+                TypeSymbolWithAnnotations sourceType = node.EnumeratorInfoOpt?.ElementType ?? default;
                 bool? isNullableIfReferenceType = null;
-                if ((object)sourceType != null)
+                if (sourceType != null)
                 {
                     TypeSymbolWithAnnotations destinationType = iterationVariable.Type;
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
@@ -3579,7 +3583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!IsConditionalState);
 
             var result = base.VisitUnaryOperator(node);
-            TypeSymbolWithAnnotations resultType = null;
+            TypeSymbolWithAnnotations resultType = default;
 
             // PROTOTYPE(NullableReferenceTypes): Update method based on inferred operand type.
             if (node.OperatorKind.IsUserDefined())
@@ -3595,7 +3599,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            _resultType = resultType ?? TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: null);
+            _resultType = resultType == null ? TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: null) : resultType;
             return null;
         }
 
@@ -3648,7 +3652,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return null;
+                return default;
             }
         }
 
@@ -3764,9 +3768,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDefaultExpression(BoundDefaultExpression node)
         {
             var result = base.VisitDefaultExpression(node);
-            _resultType = (object)node.Type == null ?
-                null :
-                TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: true);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: true);
             return result;
         }
 
@@ -3813,7 +3815,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         case ConversionKind.Identity:
                         case ConversionKind.ImplicitReference:
                             // Inherit nullability from the operand
-                            isNullable = _resultType?.IsNullable;
+                            isNullable = _resultType.IsNullable;
                             break;
 
                         case ConversionKind.Boxing:
@@ -3848,7 +3850,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             //if (this.State.Reachable) // PROTOTYPE(NullableReferenceTypes): Consider reachability?
             {
-                _resultType = _resultType?.WithTopLevelNonNullabilityForReferenceTypes();
+                _resultType = _resultType == null ? default : _resultType.WithTopLevelNonNullabilityForReferenceTypes();
             }
 
             return null;
@@ -4042,7 +4044,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void SetUnknownResultNullability()
         {
-            _resultType = null;
+            _resultType = default;
         }
 
         public override BoundNode VisitStackAllocArrayCreation(BoundStackAllocArrayCreation node)
@@ -4075,12 +4077,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (receiverOpt != null && this.State.Reachable)
             {
 #if DEBUG
-                Debug.Assert(receiverOpt.Type is null || _resultType?.TypeSymbol is null || AreCloseEnough(receiverOpt.Type, _resultType.TypeSymbol));
+                Debug.Assert(receiverOpt.Type is null || _resultType.TypeSymbol is null || AreCloseEnough(receiverOpt.Type, _resultType.TypeSymbol));
 #endif
-                TypeSymbol receiverType = receiverOpt.Type ?? _resultType?.TypeSymbol;
+                TypeSymbol receiverType = receiverOpt.Type ?? _resultType.TypeSymbol;
                 if ((object)receiverType != null &&
                     (!checkType || receiverType.IsReferenceType || receiverType.IsUnconstrainedTypeParameter()) &&
-                    (_resultType?.IsNullable == true || receiverType.IsUnconstrainedTypeParameter()))
+                    (_resultType.IsNullable == true || receiverType.IsUnconstrainedTypeParameter()))
                 {
                     ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullReferenceReceiver, receiverOpt.Syntax);
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                    isReadOnly: false,
                    isStatic: false)
         {
-            Debug.Assert(type != null);
+            Debug.Assert(!type.IsNull);
 
             // lifted fields do not need to have the CompilerGeneratedAttribute attached to it, the closure is already 
             // marked as being compiler generated.

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                    isReadOnly: false,
                    isStatic: false)
         {
-            Debug.Assert((object)type != null);
+            Debug.Assert(type != null);
 
             // lifted fields do not need to have the CompilerGeneratedAttribute attached to it, the closure is already 
             // marked as being compiler generated.

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override TypeSymbol VisitType(TypeSymbol type)
         {
-            return TypeMap.SubstituteType(type)?.TypeSymbol;
+            return TypeMap.SubstituteType(type).TypeSymbol;
         }
 
         public override BoundNode VisitMethodInfo(BoundMethodInfo node)

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (_iteratorElementType == null)
                 {
-                    _iteratorElementType = TypeMap.SubstituteType(BaseMethod.IteratorElementType)?.TypeSymbol;
+                    _iteratorElementType = TypeMap.SubstituteType(BaseMethod.IteratorElementType).TypeSymbol;
                 }
                 return _iteratorElementType;
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 underlyingNonArrayType = ((IArrayTypeSymbol)underlyingNonArrayType).ElementType;
             }
 
-            if (underlyingNonArrayTypeWithAnnotations != null)
+            if (!underlyingNonArrayTypeWithAnnotations.IsNull)
             {
                 VisitTypeSymbolWithAnnotations(underlyingNonArrayTypeWithAnnotations);
             }
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void AddNullableAnnotations(TypeSymbolWithAnnotations? typeOpt)
         {
-            if (typeOpt == null)
+            if (!typeOpt.HasValue)
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             VisitArrayType(symbol, typeOpt: null);
         }
 
-        private void VisitArrayType(IArrayTypeSymbol symbol, TypeSymbolWithAnnotations typeOpt)
+        private void VisitArrayType(IArrayTypeSymbol symbol, TypeSymbolWithAnnotations? typeOpt)
         {
             if (TryAddAlias(symbol, builder))
             {
@@ -57,15 +57,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            TypeSymbolWithAnnotations underlyingNonArrayTypeWithAnnotations = (symbol as ArrayTypeSymbol)?.ElementType;
+            TypeSymbolWithAnnotations underlyingNonArrayTypeWithAnnotations = (symbol as ArrayTypeSymbol)?.ElementType ?? default;
             var underlyingNonArrayType = symbol.ElementType;
             while (underlyingNonArrayType.Kind == SymbolKind.ArrayType)
             {
-                underlyingNonArrayTypeWithAnnotations = (underlyingNonArrayType as ArrayTypeSymbol)?.ElementType;
+                underlyingNonArrayTypeWithAnnotations = (underlyingNonArrayType as ArrayTypeSymbol)?.ElementType ?? default;
                 underlyingNonArrayType = ((IArrayTypeSymbol)underlyingNonArrayType).ElementType;
             }
 
-            if ((object)underlyingNonArrayTypeWithAnnotations != null)
+            if (underlyingNonArrayTypeWithAnnotations != null)
             {
                 VisitTypeSymbolWithAnnotations(underlyingNonArrayTypeWithAnnotations);
             }
@@ -90,22 +90,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddNullableAnnotations(TypeSymbolWithAnnotations typeOpt)
+        private void AddNullableAnnotations(TypeSymbolWithAnnotations? typeOpt)
         {
-            if (ReferenceEquals(typeOpt, null))
+            if (typeOpt == null)
             {
                 return;
             }
 
+            var type = typeOpt.Value;
             if (format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier) &&
-                !typeOpt.IsNullableType() &&
-                typeOpt.IsAnnotated)
+                !type.IsNullableType() &&
+                type.IsAnnotated)
             {
                 AddPunctuation(SyntaxKind.QuestionToken);
             }
             else if (format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier) &&
-                !typeOpt.IsValueType &&
-                typeOpt.IsNullable == false)
+                !type.IsValueType &&
+                type.IsNullable == false)
             {
                 AddPunctuation(SyntaxKind.ExclamationToken);
             }
@@ -731,7 +732,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         visitor = this.NotFirstVisitorNamespaceOrType;
                     }
 
-                    if ((object)typeArgumentsWithAnnotations == null)
+                    if (typeArgumentsWithAnnotations == null)
                     {
                         typeArg.Accept(visitor);
                     }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -29,10 +29,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitArrayType(IArrayTypeSymbol symbol)
         {
-            VisitArrayType(symbol, typeOpt: null);
+            VisitArrayType(symbol, typeOpt: default);
         }
 
-        private void VisitArrayType(IArrayTypeSymbol symbol, TypeSymbolWithAnnotations? typeOpt)
+        private void VisitArrayType(IArrayTypeSymbol symbol, TypeSymbolWithAnnotations typeOpt)
         {
             if (TryAddAlias(symbol, builder))
             {
@@ -85,28 +85,27 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AddArrayRank(arrayType);
                 AddNullableAnnotations(typeOpt);
 
-                typeOpt = (arrayType as ArrayTypeSymbol)?.ElementType;
+                typeOpt = (arrayType as ArrayTypeSymbol)?.ElementType ?? default;
                 arrayType = arrayType.ElementType as IArrayTypeSymbol;
             }
         }
 
-        private void AddNullableAnnotations(TypeSymbolWithAnnotations? typeOpt)
+        private void AddNullableAnnotations(TypeSymbolWithAnnotations typeOpt)
         {
-            if (!typeOpt.HasValue)
+            if (typeOpt.IsNull)
             {
                 return;
             }
 
-            var type = typeOpt.Value;
             if (format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier) &&
-                !type.IsNullableType() &&
-                type.IsAnnotated)
+                !typeOpt.IsNullableType() &&
+                typeOpt.IsAnnotated)
             {
                 AddPunctuation(SyntaxKind.QuestionToken);
             }
             else if (format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier) &&
-                !type.IsValueType &&
-                type.IsNullable == false)
+                !typeOpt.IsValueType &&
+                typeOpt.IsNullable == false)
             {
                 AddPunctuation(SyntaxKind.ExclamationToken);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var oldArgument = oldTypeArguments[i];
                 var newArgument = oldArgument.SubstituteTypeWithTupleUnification(this);
 
-                if (!changed && (object)oldArgument != newArgument)
+                if (!changed && oldArgument != newArgument)
                 {
                     changed = true;
                 }
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var oldElement = t.ElementType;
             TypeSymbolWithAnnotations element = oldElement.SubstituteTypeWithTupleUnification(this);
-            if ((object)element == oldElement)
+            if (element == oldElement)
             {
                 return t;
             }
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var oldPointedAtType = t.PointedAtType;
             var pointedAtType = oldPointedAtType.SubstituteTypeWithTupleUnification(this);
-            if ((object)pointedAtType == oldPointedAtType)
+            if (pointedAtType == oldPointedAtType)
             {
                 return t;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var oldArgument = oldTypeArguments[i];
                 var newArgument = oldArgument.SubstituteTypeWithTupleUnification(this);
 
-                if (!changed && oldArgument != newArgument)
+                if (!changed && oldArgument.IsSameAs(newArgument))
                 {
                     changed = true;
                 }
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var oldElement = t.ElementType;
             TypeSymbolWithAnnotations element = oldElement.SubstituteTypeWithTupleUnification(this);
-            if (element == oldElement)
+            if (element.IsSameAs(oldElement))
             {
                 return t;
             }
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var oldPointedAtType = t.PointedAtType;
             var pointedAtType = oldPointedAtType.SubstituteTypeWithTupleUnification(this);
-            if (pointedAtType == oldPointedAtType)
+            if (pointedAtType.IsSameAs(oldPointedAtType))
             {
                 return t;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var oldArgument = oldTypeArguments[i];
                 var newArgument = oldArgument.SubstituteTypeWithTupleUnification(this);
 
-                if (!changed && oldArgument.IsSameAs(newArgument))
+                if (!changed && !oldArgument.IsSameAs(newArgument))
                 {
                     changed = true;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeField.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeField.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         [Conditional("DEBUG")]
         internal void AssertIsGood()
         {
-            Debug.Assert(this.Name != null && this.Location != null && (object)this.Type != null);
+            Debug.Assert(this.Name != null && this.Location != null && this.Type != null);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeField.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeField.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         [Conditional("DEBUG")]
         internal void AssertIsGood()
         {
-            Debug.Assert(this.Name != null && this.Location != null && this.Type != null);
+            Debug.Assert(this.Name != null && this.Location != null && !this.Type.IsNull);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private AnonymousTypeTemplateSymbol CreatePlaceholderTemplate(Microsoft.CodeAnalysis.Emit.AnonymousTypeKey key)
         {
-            var fields = key.Fields.SelectAsArray(f => new AnonymousTypeField(f.Name, Location.None, (TypeSymbolWithAnnotations)null));
+            var fields = key.Fields.SelectAsArray(f => new AnonymousTypeField(f.Name, Location.None, default));
             var typeDescr = new AnonymousTypeDescriptor(fields, Location.None);
             return new AnonymousTypeTemplateSymbol(this, typeDescr);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbolWithAnnotations elementType,
             NamedTypeSymbol array)
         {
-            Debug.Assert(elementType != null);
+            Debug.Assert(!elementType.IsNull);
             Debug.Assert((object)array != null);
 
             _elementType = elementType;
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false; 
             }
 
-            if (oldElementType == newElementType)
+            if (oldElementType.IsSameAs(newElementType))
             {
                 result = this;
             }
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbolWithAnnotations oldElementType = ElementType;
             TypeSymbolWithAnnotations newElementType = oldElementType.SetUnknownNullabilityForReferenceTypes();
 
-            if (oldElementType == newElementType)
+            if (oldElementType.IsSameAs(newElementType))
             {
                 return this;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbolWithAnnotations elementType,
             NamedTypeSymbol array)
         {
-            Debug.Assert((object)elementType != null);
+            Debug.Assert(elementType != null);
             Debug.Assert((object)array != null);
 
             _elementType = elementType;
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false; 
             }
 
-            if ((object)oldElementType == newElementType)
+            if (oldElementType == newElementType)
             {
                 result = this;
             }
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbolWithAnnotations oldElementType = ElementType;
             TypeSymbolWithAnnotations newElementType = oldElementType.SetUnknownNullabilityForReferenceTypes();
 
-            if ((object)oldElementType == newElementType)
+            if (oldElementType == newElementType)
             {
                 return this;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (members.Length == 1 && members[0].Kind == SymbolKind.Property)
             {
                 var property = (PropertySymbol)members[0];
-                if (property.Type != null && property.Type.SpecialType == SpecialType.System_String &&
+                if (!property.Type.IsNull && property.Type.SpecialType == SpecialType.System_String &&
                     property.DeclaredAccessibility == Accessibility.Public && property.GetMemberArity() == 0 &&
                     (object)property.SetMethod != null && property.SetMethod.DeclaredAccessibility == Accessibility.Public)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (members.Length == 1 && members[0].Kind == SymbolKind.Property)
             {
                 var property = (PropertySymbol)members[0];
-                if ((object)property.Type != null && property.Type.SpecialType == SpecialType.System_String &&
+                if (property.Type != null && property.Type.SpecialType == SpecialType.System_String &&
                     property.DeclaredAccessibility == Accessibility.Public && property.GetMemberArity() == 0 &&
                     (object)property.SetMethod != null && property.SetMethod.DeclaredAccessibility == Accessibility.Public)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -514,7 +514,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (_considerReturnType && member.GetMemberArity() == 0 && 
                     (_typeComparison & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) == 0) // If it is generic, then type argument might be in return type.
                 {
-                    hash = Hash.Combine(member.GetTypeOrReturnType(), hash);
+                    // PROTOTYPE(NullableReferenceTypes): TypeSymbolWithAnnotations.GetHashCode()
+                    // throws ExceptionUtilities.Unreachable.
+                    hash = Hash.Combine(member.GetTypeOrReturnType().GetHashCode(), hash);
                 }
 
                 // CONSIDER: modify hash for constraints?

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             EntityHandle targetSymbolToken,
             PEModuleSymbol containingModule)
         {
-            Debug.Assert(metadataType != null);
+            Debug.Assert(!metadataType.IsNull);
 
             ImmutableArray<bool> nullableTransformFlags;
             containingModule.Module.HasNullableAttribute(targetSymbolToken, out nullableTransformFlags);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             EntityHandle targetSymbolToken,
             PEModuleSymbol containingModule)
         {
-            Debug.Assert((object)metadataType != null);
+            Debug.Assert(metadataType != null);
 
             ImmutableArray<bool> nullableTransformFlags;
             containingModule.Module.HasNullableAttribute(targetSymbolToken, out nullableTransformFlags);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
 
             TypeSymbol originalEventType = _eventType.TypeSymbol;
-            if (_eventType == null)
+            if (_eventType.IsNull)
             {
                 var metadataDecoder = new MetadataDecoder(moduleSymbol, containingType);
                 originalEventType = metadataDecoder.GetTypeOfToken(eventType);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -88,8 +88,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
             }
 
-            TypeSymbol originalEventType = _eventType?.TypeSymbol;
-            if ((object)_eventType == null)
+            TypeSymbol originalEventType = _eventType.TypeSymbol;
+            if (_eventType == null)
             {
                 var metadataDecoder = new MetadataDecoder(moduleSymbol, containingType);
                 originalEventType = metadataDecoder.GetTypeOfToken(eventType);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private ObsoleteAttributeData _lazyObsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
 
-        private TypeSymbolWithAnnotationsBuilder _lazyType;
+        private TypeSymbolWithAnnotations.Builder _lazyType;
         private int _lazyFixedSize;
         private NamedTypeSymbol _lazyFixedImplementationType;
         private PEEventSymbol _associatedEventOpt;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private ObsoleteAttributeData _lazyObsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
 
-        private TypeSymbolWithAnnotations _lazyType;
+        private TypeSymbolWithAnnotationsBuilder _lazyType;
         private int _lazyFixedSize;
         private NamedTypeSymbol _lazyFixedImplementationType;
         private PEEventSymbol _associatedEventOpt;
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private void EnsureSignatureIsLoaded()
         {
-            if ((object)_lazyType == null)
+            if (_lazyType.IsNull)
             {
                 var moduleSymbol = _containingType.ContainingPEModule;
                 bool isVolatile;
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     type = TypeSymbolWithAnnotations.Create(new PointerTypeSymbol(TypeSymbolWithAnnotations.Create(fixedElementType)));
                 }
 
-                Interlocked.CompareExchange(ref _lazyType, type, null);
+                _lazyType.InterlockedInitialize(type);
             }
         }
 
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         internal override TypeSymbolWithAnnotations GetFieldType(ConsList<FieldSymbol> fieldsBeingBound)
         {
             EnsureSignatureIsLoaded();
-            return _lazyType;
+            return _lazyType.ToType();
         }
 
         public override bool IsFixed

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             Debug.Assert((object)moduleSymbol != null);
             Debug.Assert((object)containingSymbol != null);
             Debug.Assert(ordinal >= 0);
-            Debug.Assert((object)type != null);
+            Debug.Assert(type != null);
 
             isBad = false;
             _moduleSymbol = moduleSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             Debug.Assert((object)moduleSymbol != null);
             Debug.Assert((object)containingSymbol != null);
             Debug.Assert(ordinal >= 0);
-            Debug.Assert(type != null);
+            Debug.Assert(!type.IsNull);
 
             isBad = false;
             _moduleSymbol = moduleSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 TypeSymbolWithAnnotations typeArg = typeArgs[i];
                 TypeSymbolWithAnnotations decoded = DecodeTypeInternal(typeArg);
-                anyDecoded |= !ReferenceEquals(decoded, typeArg);
+                anyDecoded |= !decoded.IsSameAs(typeArg);
                 decodedArgs.Add(decoded);
             }
 
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             TypeSymbolWithAnnotations elementType = type.ElementType;
             TypeSymbolWithAnnotations decodedElementType = DecodeTypeInternal(elementType);
-            return ReferenceEquals(decodedElementType, elementType)
+            return decodedElementType.IsSameAs(elementType)
                 ? type
                 : type.WithElementType(decodedElementType);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -756,7 +756,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <returns></returns>
         public MethodSymbol Construct(ImmutableArray<TypeSymbol> typeArguments)
         {
-            return Construct(typeArguments.SelectAsArray(a => (object)a == null ? null : TypeSymbolWithAnnotations.Create(a)));
+            return Construct(typeArguments.SelectAsArray(a => TypeSymbolWithAnnotations.Create(a)));
         }
 
         internal MethodSymbol Construct(ImmutableArray<TypeSymbolWithAnnotations> typeArguments)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var typeArgsForConstraintsCheck = typeArgs.SelectAsArray(a => TypeSymbolWithAnnotations.Create(a));
             for (int i = 0; i < typeArgsForConstraintsCheck.Length; i++)
             {
-                if (typeArgsForConstraintsCheck[i] == null)
+                if (typeArgsForConstraintsCheck[i].IsNull)
                 {
                     firstNullInTypeArgs = i;
                     var builder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     for (; i < typeArgsForConstraintsCheck.Length; i++)
                     {
                         var typeArg = typeArgsForConstraintsCheck[i];
-                        if (typeArg == null)
+                        if (typeArg.IsNull)
                         {
                             notInferredTypeParameters.Add(typeParams[i]);
                             builder.Add(TypeSymbolWithAnnotations.Create(ErrorTypeSymbol.UnknownResultType));

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -81,10 +81,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // This prevents constraint checking from failing for corresponding type parameters. 
             var notInferredTypeParameters = PooledHashSet<TypeParameterSymbol>.GetInstance();
             var typeParams = method.TypeParameters;
-            var typeArgsForConstraintsCheck = typeArgs.SelectAsArray(a => (object)a == null ? null : TypeSymbolWithAnnotations.Create(a));
+            var typeArgsForConstraintsCheck = typeArgs.SelectAsArray(a => TypeSymbolWithAnnotations.Create(a));
             for (int i = 0; i < typeArgsForConstraintsCheck.Length; i++)
             {
-                if ((object)typeArgsForConstraintsCheck[i] == null)
+                if (typeArgsForConstraintsCheck[i] == null)
                 {
                     firstNullInTypeArgs = i;
                     var builder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     for (; i < typeArgsForConstraintsCheck.Length; i++)
                     {
                         var typeArg = typeArgsForConstraintsCheck[i];
-                        if ((object)typeArg == null)
+                        if (typeArg == null)
                         {
                             notInferredTypeParameters.Add(typeParams[i]);
                             builder.Add(TypeSymbolWithAnnotations.Create(ErrorTypeSymbol.UnknownResultType));

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -777,7 +777,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     result = this;
                     return false;
                 }
-                else if (oldTypeArgument != newTypeArgument)
+                else if (!oldTypeArgument.IsSameAs(newTypeArgument))
                 {
                     allTypeArguments[i] = newTypeArgument;
                     haveChanges = true;
@@ -815,7 +815,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 TypeSymbolWithAnnotations oldTypeArgument = allTypeArguments[i];
                 TypeSymbolWithAnnotations newTypeArgument = oldTypeArgument.SetUnknownNullabilityForReferenceTypes();
-                if (oldTypeArgument != newTypeArgument)
+                if (!oldTypeArgument.IsSameAs(newTypeArgument))
                 {
                     allTypeArguments[i] = newTypeArgument;
                     haveChanges = true;
@@ -901,9 +901,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool HasCodeAnalysisEmbeddedAttribute { get; }
 
-        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsNullFunction = type => type == null;
+        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsNullFunction = type => type.IsNull;
 
-        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsErrorType = type => type != null && type.IsErrorType();
+        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsErrorType = type => !type.IsNull && type.IsErrorType();
 
         private NamedTypeSymbol ConstructWithoutModifiers(ImmutableArray<TypeSymbol> typeArguments, bool unbound, INonNullTypesContext nonNullTypesContext)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -915,7 +915,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else
             {
-                modifiedArguments = typeArguments.SelectAsArray((t, c) => TypeSymbolWithAnnotations.Create(c, t), nonNullTypesContext);
+                modifiedArguments = typeArguments.SelectAsArray((t, c) => t == null ? default : TypeSymbolWithAnnotations.Create(c, t), nonNullTypesContext);
             }
 
             return Construct(modifiedArguments, unbound);

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -777,7 +777,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     result = this;
                     return false;
                 }
-                else if ((object)oldTypeArgument != newTypeArgument)
+                else if (oldTypeArgument != newTypeArgument)
                 {
                     allTypeArguments[i] = newTypeArgument;
                     haveChanges = true;
@@ -815,7 +815,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 TypeSymbolWithAnnotations oldTypeArgument = allTypeArguments[i];
                 TypeSymbolWithAnnotations newTypeArgument = oldTypeArgument.SetUnknownNullabilityForReferenceTypes();
-                if ((object)oldTypeArgument != newTypeArgument)
+                if (oldTypeArgument != newTypeArgument)
                 {
                     allTypeArguments[i] = newTypeArgument;
                     haveChanges = true;
@@ -901,9 +901,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool HasCodeAnalysisEmbeddedAttribute { get; }
 
-        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsNullFunction = type => (object)type == null;
+        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsNullFunction = type => type == null;
 
-        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsErrorType = type => (object)type != null && type.IsErrorType();
+        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsErrorType = type => type != null && type.IsErrorType();
 
         private NamedTypeSymbol ConstructWithoutModifiers(ImmutableArray<TypeSymbol> typeArguments, bool unbound, INonNullTypesContext nonNullTypesContext)
         {
@@ -913,19 +913,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 modifiedArguments = default(ImmutableArray<TypeSymbolWithAnnotations>);
             }
-            else if (typeArguments.IsEmpty)
-            {
-                modifiedArguments = ImmutableArray<TypeSymbolWithAnnotations>.Empty;
-            }
             else
             {
-                var builder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(typeArguments.Length);
-                foreach (TypeSymbol t in typeArguments)
-                {
-                    builder.Add((object)t == null ? null : TypeSymbolWithAnnotations.Create(nonNullTypesContext, t));
-                }
-
-                modifiedArguments = builder.ToImmutableAndFree();
+                modifiedArguments = typeArguments.SelectAsArray((t, c) => TypeSymbolWithAnnotations.Create(c, t), nonNullTypesContext);
             }
 
             return Construct(modifiedArguments, unbound);

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="pointedAtType">The type being pointed at.</param>
         internal PointerTypeSymbol(TypeSymbolWithAnnotations pointedAtType)
         {
-            Debug.Assert(pointedAtType != null);
+            Debug.Assert(!pointedAtType.IsNull);
 
             _pointedAtType = pointedAtType;
         }
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            if (oldPointedAtType == newPointedAtType)
+            if (oldPointedAtType.IsSameAs(newPointedAtType))
             {
                 result = this;
             }
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbolWithAnnotations oldPointedAtType = PointedAtType;
             TypeSymbolWithAnnotations newPointedAtType = oldPointedAtType.SetUnknownNullabilityForReferenceTypes();
 
-            if (oldPointedAtType == newPointedAtType)
+            if (oldPointedAtType.IsSameAs(newPointedAtType))
             {
                 return this;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="pointedAtType">The type being pointed at.</param>
         internal PointerTypeSymbol(TypeSymbolWithAnnotations pointedAtType)
         {
-            Debug.Assert((object)pointedAtType != null);
+            Debug.Assert(pointedAtType != null);
 
             _pointedAtType = pointedAtType;
         }
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            if ((object)oldPointedAtType == newPointedAtType)
+            if (oldPointedAtType == newPointedAtType)
             {
                 result = this;
             }
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbolWithAnnotations oldPointedAtType = PointedAtType;
             TypeSymbolWithAnnotations newPointedAtType = oldPointedAtType.SetUnknownNullabilityForReferenceTypes();
 
-            if ((object)oldPointedAtType == newPointedAtType)
+            if (oldPointedAtType == newPointedAtType)
             {
                 return this;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get
             {
-                if ((object)_lazyReturnType == null)
+                if (_lazyReturnType == null)
                 {
                     _lazyReturnType = this.RetargetingTranslator.Retarget(_underlyingMethod.ReturnType, RetargetOptions.RetargetPrimitiveTypesByTypeCode, this.ContainingType);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get
             {
-                if (_lazyReturnType == null)
+                if (_lazyReturnType.IsNull)
                 {
                     _lazyReturnType = this.RetargetingTranslator.Retarget(_underlyingMethod.ReturnType, RetargetOptions.RetargetPrimitiveTypesByTypeCode, this.ContainingType);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get
             {
-                if (_lazyType == null)
+                if (_lazyType.IsNull)
                 {
                     var type = this.RetargetingTranslator.Retarget(_underlyingProperty.Type, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
                     if (type.TypeSymbol.TryAsDynamicIfNoPia(this.ContainingType, out TypeSymbol asDynamic))

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get
             {
-                if ((object)_lazyType == null)
+                if (_lazyType == null)
                 {
                     var type = this.RetargetingTranslator.Retarget(_underlyingProperty.Type, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
                     if (type.TypeSymbol.TryAsDynamicIfNoPia(this.ContainingType, out TypeSymbol asDynamic))

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -515,7 +515,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 {
                     var newArg = Retarget(arg, RetargetOptions.RetargetPrimitiveTypesByTypeCode); // generic instantiation is a signature
 
-                    if (!anythingRetargeted && ((object)newArg != arg))
+                    if (!anythingRetargeted && (newArg != arg))
                     {
                         anythingRetargeted = true;
                     }
@@ -680,7 +680,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 TypeSymbolWithAnnotations oldElement = type.ElementType;
                 TypeSymbolWithAnnotations newElement = Retarget(oldElement, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
 
-                if ((object)oldElement == newElement)
+                if (oldElement == newElement)
                 {
                     return type;
                 }
@@ -730,7 +730,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 TypeSymbolWithAnnotations oldPointed = type.PointedAtType;
                 TypeSymbolWithAnnotations newPointed = Retarget(oldPointed, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
 
-                if ((object)oldPointed == newPointed)
+                if (oldPointed == newPointed)
                 {
                     return type;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -515,7 +515,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 {
                     var newArg = Retarget(arg, RetargetOptions.RetargetPrimitiveTypesByTypeCode); // generic instantiation is a signature
 
-                    if (!anythingRetargeted && (newArg != arg))
+                    if (!anythingRetargeted && !newArg.IsSameAs(arg))
                     {
                         anythingRetargeted = true;
                     }
@@ -680,7 +680,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 TypeSymbolWithAnnotations oldElement = type.ElementType;
                 TypeSymbolWithAnnotations newElement = Retarget(oldElement, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
 
-                if (oldElement == newElement)
+                if (oldElement.IsSameAs(newElement))
                 {
                     return type;
                 }
@@ -730,7 +730,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 TypeSymbolWithAnnotations oldPointed = type.PointedAtType;
                 TypeSymbolWithAnnotations newPointed = Retarget(oldPointed, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
 
-                if (oldPointed == newPointed)
+                if (oldPointed.IsSameAs(newPointed))
                 {
                     return type;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal class GlobalExpressionVariable : SourceMemberFieldSymbol
     {
-        private TypeSymbolWithAnnotationsBuilder _lazyType;
+        private TypeSymbolWithAnnotations.Builder _lazyType;
         private SyntaxReference _typeSyntax;
 
         internal GlobalExpressionVariable(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool isVar;
             TypeSymbolWithAnnotations type = binder.BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar);
 
-            Debug.Assert(type != null || isVar);
+            Debug.Assert(!type.IsNull || isVar);
 
             if (isVar && !fieldsBeingBound.ContainsReference(this))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _messageID = unboundLambda.Data.MessageID;
             _syntax = unboundLambda.Syntax;
             _refKind = refKind;
-            _returnType = returnType == null ? TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesFalseContext.Instance, ReturnTypeIsBeingInferred) : returnType;
+            _returnType = returnType == null ? TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, ReturnTypeIsBeingInferred) : returnType;
             _isSynthesized = unboundLambda.WasCompilerGenerated;
             _isAsync = unboundLambda.IsAsync;
             // No point in making this lazy. We are always going to need these soon after creation of the symbol.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _messageID = unboundLambda.Data.MessageID;
             _syntax = unboundLambda.Syntax;
             _refKind = refKind;
-            _returnType = returnType == null ? TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, ReturnTypeIsBeingInferred) : returnType;
+            _returnType = returnType.IsNull ? TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, ReturnTypeIsBeingInferred) : returnType;
             _isSynthesized = unboundLambda.WasCompilerGenerated;
             _isAsync = unboundLambda.IsAsync;
             // No point in making this lazy. We are always going to need these soon after creation of the symbol.
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool ReturnsVoid
         {
-            get { return this.ReturnType != null && this.ReturnType.SpecialType == SpecialType.System_Void; }
+            get { return !this.ReturnType.IsNull && this.ReturnType.SpecialType == SpecialType.System_Void; }
         }
 
         public override RefKind RefKind
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // IDE might inspect the symbol and want to know the return type.
         internal void SetInferredReturnType(RefKind refKind, TypeSymbolWithAnnotations inferredReturnType)
         {
-            Debug.Assert(inferredReturnType != null);
+            Debug.Assert(!inferredReturnType.IsNull);
             Debug.Assert((object)_returnType.TypeSymbol == ReturnTypeIsBeingInferred);
             _refKind = refKind;
             _returnType = inferredReturnType;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -24,12 +24,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// This symbol is used as the return type of a LambdaSymbol when we are interpreting
         /// lambda's body in order to infer its return type.
         /// </summary>
-        internal static readonly TypeSymbolWithAnnotations ReturnTypeIsBeingInferred = TypeSymbolWithAnnotations.Create(new UnsupportedMetadataTypeSymbol());
+        internal static readonly TypeSymbol ReturnTypeIsBeingInferred = new UnsupportedMetadataTypeSymbol();
 
         /// <summary>
         /// This symbol is used as the return type of a LambdaSymbol when we failed to infer its return type.
         /// </summary>
-        internal static readonly TypeSymbolWithAnnotations InferenceFailureReturnType = TypeSymbolWithAnnotations.Create(new UnsupportedMetadataTypeSymbol());
+        internal static readonly TypeSymbol InferenceFailureReturnType = new UnsupportedMetadataTypeSymbol();
 
         private static readonly TypeSymbolWithAnnotations UnknownReturnType = TypeSymbolWithAnnotations.Create(ErrorTypeSymbol.UnknownResultType);
 
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _messageID = unboundLambda.Data.MessageID;
             _syntax = unboundLambda.Syntax;
             _refKind = refKind;
-            _returnType = returnType ?? ReturnTypeIsBeingInferred;
+            _returnType = returnType == null ? TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesFalseContext.Instance, ReturnTypeIsBeingInferred) : returnType;
             _isSynthesized = unboundLambda.WasCompilerGenerated;
             _isAsync = unboundLambda.IsAsync;
             // No point in making this lazy. We are always going to need these soon after creation of the symbol.
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool ReturnsVoid
         {
-            get { return (object)this.ReturnType != null && this.ReturnType.SpecialType == SpecialType.System_Void; }
+            get { return this.ReturnType != null && this.ReturnType.SpecialType == SpecialType.System_Void; }
         }
 
         public override RefKind RefKind
@@ -185,8 +185,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // IDE might inspect the symbol and want to know the return type.
         internal void SetInferredReturnType(RefKind refKind, TypeSymbolWithAnnotations inferredReturnType)
         {
-            Debug.Assert((object)inferredReturnType != null);
-            Debug.Assert((object)_returnType == ReturnTypeIsBeingInferred);
+            Debug.Assert(inferredReturnType != null);
+            Debug.Assert((object)_returnType.TypeSymbol == ReturnTypeIsBeingInferred);
             _refKind = refKind;
             _returnType = inferredReturnType;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         
         internal void ComputeReturnType()
         {
-            if (_lazyReturnType != null)
+            if (!_lazyReturnType.IsNull)
             {
                 return;
             }
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             lock (_declarationDiagnostics)
             {
-                if (_lazyReturnType != null)
+                if (!_lazyReturnType.IsNull)
                 {
                     diagnostics.Free();
                     return;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         
         internal void ComputeReturnType()
         {
-            if ((object)_lazyReturnType != null)
+            if (_lazyReturnType != null)
             {
                 return;
             }
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             lock (_declarationDiagnostics)
             {
-                if ((object)_lazyReturnType != null)
+                if (_lazyReturnType != null)
                 {
                     diagnostics.Free();
                     return;
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override bool ReturnsVoid => ReturnType?.SpecialType == SpecialType.System_Void;
+        public override bool ReturnsVoid => ReturnType.SpecialType == SpecialType.System_Void;
 
         public override int Arity => TypeParameters.Length;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -40,14 +40,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected sealed override void MethodChecks(DiagnosticBag diagnostics)
         {
-            Debug.Assert(_lazyParameters.IsDefault == (_lazyReturnType == null));
+            Debug.Assert(_lazyParameters.IsDefault == _lazyReturnType.IsNull);
 
             // CONSIDER: currently, we're copying the custom modifiers of the event overridden
             // by this method's associated event (by using the associated event's type, which is
             // copied from the overridden event).  It would be more correct to copy them from
             // the specific accessor that this method is overriding (as in SourceMemberMethodSymbol).
 
-            if (_lazyReturnType == null)
+            if (_lazyReturnType.IsNull)
             {
                 CSharpCompilation compilation = this.DeclaringCompilation;
                 Debug.Assert(compilation != null);
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 LazyMethodChecks();
-                Debug.Assert(_lazyReturnType != null);
+                Debug.Assert(!_lazyReturnType.IsNull);
                 return base.ReturnsVoid;
             }
         }
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 LazyMethodChecks();
-                Debug.Assert(_lazyReturnType != null);
+                Debug.Assert(!_lazyReturnType.IsNull);
                 return _lazyReturnType;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -40,14 +40,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected sealed override void MethodChecks(DiagnosticBag diagnostics)
         {
-            Debug.Assert(_lazyParameters.IsDefault == ((object)_lazyReturnType == null));
+            Debug.Assert(_lazyParameters.IsDefault == (_lazyReturnType == null));
 
             // CONSIDER: currently, we're copying the custom modifiers of the event overridden
             // by this method's associated event (by using the associated event's type, which is
             // copied from the overridden event).  It would be more correct to copy them from
             // the specific accessor that this method is overriding (as in SourceMemberMethodSymbol).
 
-            if ((object)_lazyReturnType == null)
+            if (_lazyReturnType == null)
             {
                 CSharpCompilation compilation = this.DeclaringCompilation;
                 Debug.Assert(compilation != null);
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 LazyMethodChecks();
-                Debug.Assert((object)_lazyReturnType != null);
+                Debug.Assert(_lazyReturnType != null);
                 return base.ReturnsVoid;
             }
         }
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 LazyMethodChecks();
-                Debug.Assert((object)_lazyReturnType != null);
+                Debug.Assert(_lazyReturnType != null);
                 return _lazyReturnType;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 // If we got a valid result that was not void then use the inferred type
                 // else create an error type.
-                if (inferredType != null &&
+                if (!inferredType.IsNull &&
                     inferredType.SpecialType != SpecialType.System_Void)
                 {
                     declType = inferredType;
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            Debug.Assert(declType != null);
+            Debug.Assert(!declType.IsNull);
 
             //
             // Note that we drop the diagnostics on the floor! That is because this code is invoked mainly in

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly RefKind _refKind;
         private readonly TypeSyntax _typeSyntax;
         private readonly LocalDeclarationKind _declarationKind;
-        private TypeSymbolWithAnnotationsBuilder _type;
+        private TypeSymbolWithAnnotations.Builder _type;
 
         /// <summary>
         /// Scope to which the local can "escape" via aliasing/ref assignment.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                if (_lazyType.IsNull)
+                if (!_lazyType.IsNull)
                 {
                     Debug.Assert(_lazyType.DefaultType.IsPointerType() ==
                         IsPointerFieldSyntactically());

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly bool _hasInitializer;
 
-        private TypeSymbolWithAnnotationsBuilder _lazyType;
+        private TypeSymbolWithAnnotations.Builder _lazyType;
 
         // Non-zero if the type of the field has been inferred from the type of its initializer expression
         // and the errors of binding the initializer have been or are being reported to compilation diagnostics.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -439,7 +439,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     bool isVar;
                     type = binder.BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar);
 
-                    Debug.Assert(type != null || isVar);
+                    Debug.Assert(!type.IsNull || isVar);
 
                     if (isVar)
                     {
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                         }
 
-                        if (type == null)
+                        if (type.IsNull)
                         {
                             type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, binder.CreateErrorType("var"));
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private SymbolCompletionState _state;
         private ImmutableArray<ParameterSymbol> _lazyParameters;
-        private TypeSymbolWithAnnotationsBuilder _lazyType;
+        private TypeSymbolWithAnnotations.Builder _lazyType;
 
         /// <summary>
         /// Set in constructor, might be changed while decoding <see cref="IndexerNameAttribute"/>.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -495,7 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                if (_lazyType.IsNull)
+                if (!_lazyType.IsNull)
                 {
                     return _lazyType.DefaultType.IsPointerType();
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private SymbolCompletionState _state;
         private ImmutableArray<ParameterSymbol> _lazyParameters;
-        private TypeSymbolWithAnnotations _lazyType;
+        private TypeSymbolWithAnnotationsBuilder _lazyType;
 
         /// <summary>
         /// Set in constructor, might be changed while decoding <see cref="IndexerNameAttribute"/>.
@@ -238,7 +238,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // lazily since the property name depends on the metadata name of the base property,
                 // and the property name is required to add the property to the containing type, and
                 // the type and parameters are required to determine the override or implementation.
-                _lazyType = this.ComputeType(bodyBinder, syntax, diagnostics);
+                var type = this.ComputeType(bodyBinder, syntax, diagnostics);
+                _lazyType.InterlockedInitialize(type);
                 _lazyParameters = this.ComputeParameters(bodyBinder, syntax, diagnostics);
 
                 bool isOverride = false;
@@ -270,11 +271,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // We do an extra check before copying the type to handle the case where the overriding
                     // property (incorrectly) has a different type than the overridden property.  In such cases,
                     // we want to retain the original (incorrect) type to avoid hiding the type given in source.
-                    if (_lazyType.TypeSymbol.Equals(overriddenPropertyType.TypeSymbol, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
+                    if (type.TypeSymbol.Equals(overriddenPropertyType.TypeSymbol, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
                     {
-                        _lazyType = _lazyType.WithTypeAndModifiers(
-                            CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType.TypeSymbol, _lazyType.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: this),
+                        type = type.WithTypeAndModifiers(
+                            CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType.TypeSymbol, type.TypeSymbol, this.ContainingAssembly, nonNullTypesContext: this),
                             overriddenPropertyType.CustomModifiers);
+                        _lazyType = default;
+                        _lazyType.InterlockedInitialize(type);
                     }
 
                     _lazyParameters = CustomModifierUtils.CopyParameterCustomModifiers(overriddenOrImplementedProperty.Parameters, _lazyParameters, alsoCopyParamsModifier: isOverride);
@@ -471,20 +474,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                if ((object)_lazyType == null)
+                if (_lazyType.IsNull)
                 {
                     var diagnostics = DiagnosticBag.GetInstance();
                     var binder = this.CreateBinderForTypeAndParameters();
                     var syntax = (BasePropertyDeclarationSyntax)_syntaxRef.GetSyntax();
                     var result = this.ComputeType(binder, syntax, diagnostics);
-                    if ((object)Interlocked.CompareExchange(ref _lazyType, result, null) == null)
+                    if (_lazyType.InterlockedInitialize(result))
                     {
                         this.AddDeclarationDiagnostics(diagnostics);
                     }
                     diagnostics.Free();
                 }
 
-                return _lazyType;
+                return _lazyType.ToType();
             }
         }
 
@@ -492,9 +495,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                if ((object)_lazyType != null)
+                if (_lazyType.IsNull)
                 {
-                    return _lazyType.IsPointerType();
+                    return _lazyType.DefaultType.IsPointerType();
                 }
 
                 var syntax = (BasePropertyDeclarationSyntax)_syntaxRef.GetSyntax();

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedEventSymbol.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly SubstitutedNamedTypeSymbol _containingType;
 
-        private TypeSymbolWithAnnotations _lazyType;
+        private TypeSymbolWithAnnotationsBuilder _lazyType;
 
         internal SubstitutedEventSymbol(SubstitutedNamedTypeSymbol containingType, EventSymbol originalDefinition)
             : base(originalDefinition)
@@ -23,12 +23,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                if ((object)_lazyType == null)
+                if (_lazyType.IsNull)
                 {
-                    Interlocked.CompareExchange(ref _lazyType, _containingType.TypeSubstitution.SubstituteTypeWithTupleUnification(OriginalDefinition.Type), null);
+                    _lazyType.InterlockedInitialize(_containingType.TypeSubstitution.SubstituteTypeWithTupleUnification(OriginalDefinition.Type));
                 }
 
-                return _lazyType;
+                return _lazyType.ToType();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedEventSymbol.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly SubstitutedNamedTypeSymbol _containingType;
 
-        private TypeSymbolWithAnnotationsBuilder _lazyType;
+        private TypeSymbolWithAnnotations.Builder _lazyType;
 
         internal SubstitutedEventSymbol(SubstitutedNamedTypeSymbol containingType, EventSymbol originalDefinition)
             : base(originalDefinition)

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedFieldSymbol.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly SubstitutedNamedTypeSymbol _containingType;
 
-        private TypeSymbolWithAnnotationsBuilder _lazyType;
+        private TypeSymbolWithAnnotations.Builder _lazyType;
 
         internal SubstitutedFieldSymbol(SubstitutedNamedTypeSymbol containingType, FieldSymbol substitutedFrom)
             : base((FieldSymbol)substitutedFrom.OriginalDefinition)

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedFieldSymbol.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly SubstitutedNamedTypeSymbol _containingType;
 
-        private TypeSymbolWithAnnotations _lazyType;
+        private TypeSymbolWithAnnotationsBuilder _lazyType;
 
         internal SubstitutedFieldSymbol(SubstitutedNamedTypeSymbol containingType, FieldSymbol substitutedFrom)
             : base((FieldSymbol)substitutedFrom.OriginalDefinition)
@@ -22,12 +22,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override TypeSymbolWithAnnotations GetFieldType(ConsList<FieldSymbol> fieldsBeingBound)
         {
-            if ((object)_lazyType == null)
+            if (_lazyType.IsNull)
             {
-                Interlocked.CompareExchange(ref _lazyType, _containingType.TypeSubstitution.SubstituteTypeWithTupleUnification(OriginalDefinition.GetFieldType(fieldsBeingBound)), null);
+                _lazyType.InterlockedInitialize(_containingType.TypeSubstitution.SubstituteTypeWithTupleUnification(OriginalDefinition.GetFieldType(fieldsBeingBound)));
             }
 
-            return _lazyType;
+            return _lazyType.ToType();
         }
 
         public override Symbol ContainingSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly TypeMap _inputMap;
         private readonly MethodSymbol _constructedFrom;
 
-        private TypeSymbolWithAnnotations _lazyReturnType;
+        private TypeSymbolWithAnnotationsBuilder _lazyReturnType;
         private ImmutableArray<ParameterSymbol> _lazyParameters;
         private TypeMap _lazyMap;
         private ImmutableArray<TypeParameterSymbol> _lazyTypeParameters;
@@ -230,14 +230,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                var returnType = _lazyReturnType;
-                if ((object)returnType != null)
+                if (_lazyReturnType.IsNull)
                 {
-                    return returnType;
+                    var returnType = Map.SubstituteTypeWithTupleUnification(OriginalDefinition.ReturnType);
+                    _lazyReturnType.InterlockedInitialize(returnType);
                 }
-
-                returnType = Map.SubstituteTypeWithTupleUnification(OriginalDefinition.ReturnType);
-                return Interlocked.CompareExchange(ref _lazyReturnType, returnType, null) ?? returnType;
+                return _lazyReturnType.ToType();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly TypeMap _inputMap;
         private readonly MethodSymbol _constructedFrom;
 
-        private TypeSymbolWithAnnotationsBuilder _lazyReturnType;
+        private TypeSymbolWithAnnotations.Builder _lazyReturnType;
         private ImmutableArray<ParameterSymbol> _lazyParameters;
         private TypeMap _lazyMap;
         private ImmutableArray<TypeParameterSymbol> _lazyTypeParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedParameterSymbol.cs
@@ -45,24 +45,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var mapOrType = _mapOrType;
-                var type = mapOrType as TypeSymbolWithAnnotations;
-                if ((object)type != null)
+                if (mapOrType is TypeSymbolWithAnnotations)
                 {
-                    return type;
+                    return (TypeSymbolWithAnnotations)mapOrType;
                 }
 
                 TypeSymbolWithAnnotations substituted = ((TypeMap)mapOrType).SubstituteTypeWithTupleUnification(this._underlyingParameter.Type);
-
-                type = substituted;
 
                 if (substituted.CustomModifiers.IsEmpty && 
                     this._underlyingParameter.Type.CustomModifiers.IsEmpty &&
                     this._underlyingParameter.RefCustomModifiers.IsEmpty)
                 {
-                    _mapOrType = type;
+                    _mapOrType = substituted;
                 }
 
-                return type;
+                return substituted;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedParameterSymbol.cs
@@ -45,9 +45,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var mapOrType = _mapOrType;
-                if (mapOrType is TypeSymbolWithAnnotations)
+                if (mapOrType is TypeSymbolWithAnnotations type)
                 {
-                    return (TypeSymbolWithAnnotations)mapOrType;
+                    return type;
                 }
 
                 TypeSymbolWithAnnotations substituted = ((TypeMap)mapOrType).SubstituteTypeWithTupleUnification(this._underlyingParameter.Type);

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedPropertySymbol.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly SubstitutedNamedTypeSymbol _containingType;
 
-        private TypeSymbolWithAnnotations _lazyType;
+        private TypeSymbolWithAnnotationsBuilder _lazyType;
         private ImmutableArray<ParameterSymbol> _lazyParameters;
 
         internal SubstitutedPropertySymbol(SubstitutedNamedTypeSymbol containingType, PropertySymbol originalDefinition)
@@ -23,12 +23,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                if ((object)_lazyType == null)
+                if (_lazyType.IsNull)
                 {
-                    Interlocked.CompareExchange(ref _lazyType, _containingType.TypeSubstitution.SubstituteTypeWithTupleUnification(OriginalDefinition.Type), null);
+                    _lazyType.InterlockedInitialize(_containingType.TypeSubstitution.SubstituteTypeWithTupleUnification(OriginalDefinition.Type));
                 }
 
-                return _lazyType;
+                return _lazyType.ToType();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedPropertySymbol.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly SubstitutedNamedTypeSymbol _containingType;
 
-        private TypeSymbolWithAnnotationsBuilder _lazyType;
+        private TypeSymbolWithAnnotations.Builder _lazyType;
         private ImmutableArray<ParameterSymbol> _lazyParameters;
 
         internal SubstitutedPropertySymbol(SubstitutedNamedTypeSymbol containingType, PropertySymbol originalDefinition)

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             for (int i = 0, n = array.Length; i < n; i++)
             {
                 var item = array[i];
-                if (item != null && item.Kind == kind)
+                if (!item.IsNull && item.Kind == kind)
                 {
                     return true;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             for (int i = 0, n = array.Length; i < n; i++)
             {
                 var item = array[i];
-                if ((object)item != null && item.Kind == kind)
+                if (item != null && item.Kind == kind)
                 {
                     return true;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -217,6 +217,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return CreateNonLazyType(typeSymbol, nonNullTypesContext, isAnnotated: isAnnotated, customModifiers);
         }
 
+        /// <summary>
+        /// True if the fields are unset.
+        /// </summary>
+        internal bool IsNull => _defaultType is null;
+
         public TypeSymbolWithAnnotations SetIsAnnotated(CSharpCompilation compilation)
         {
             Debug.Assert(compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking));
@@ -247,8 +252,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public TypeSymbolWithAnnotations AsNullableReferenceType() => _extensions.AsNullableReferenceType(this);
         public TypeSymbolWithAnnotations AsNotNullableReferenceType() => _extensions.AsNotNullableReferenceType(this);
 
-        public TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers) => _extensions.WithModifiers(this, customModifiers);
-        public TypeSymbolWithAnnotations WithNonNullTypesContext(INonNullTypesContext nonNullTypesContext) => _extensions.WithNonNullTypesContext(this, nonNullTypesContext);
+        public TypeSymbolWithAnnotations WithModifiers(ImmutableArray<CustomModifier> customModifiers) =>
+            _extensions.WithModifiers(this, customModifiers);
+        public TypeSymbolWithAnnotations WithNonNullTypesContext(INonNullTypesContext nonNullTypesContext) =>
+            _extensions.WithNonNullTypesContext(this, nonNullTypesContext);
 
         public TypeSymbol TypeSymbol => _extensions?.GetResolvedType(_defaultType);
         public TypeSymbol NullableUnderlyingTypeOrSelf => _extensions.GetNullableUnderlyingTypeOrSelf(_defaultType);
@@ -334,7 +341,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public bool IsDynamic() => TypeSymbol.IsDynamic();
         public bool IsObjectType() => TypeSymbol.IsObjectType();
         public bool IsArray() => TypeSymbol.IsArray();
-        public bool IsRestrictedType(bool ignoreSpanLikeTypes = false) => _extensions.IsRestrictedType(_defaultType, ignoreSpanLikeTypes);
+        public bool IsRestrictedType(bool ignoreSpanLikeTypes = false) =>
+            _extensions.IsRestrictedType(_defaultType, ignoreSpanLikeTypes);
         public bool IsPointerType() => TypeSymbol.IsPointerType();
         public bool IsErrorType() => TypeSymbol.IsErrorType();
         public bool IsUnsafe() => TypeSymbol.IsUnsafe();
@@ -342,10 +350,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public bool IsNullableTypeOrTypeParameter() => TypeSymbol.IsNullableTypeOrTypeParameter();
         public bool IsVoid => _extensions.IsVoid(_defaultType);
         public bool IsSZArray() => _extensions.IsSZArray(_defaultType);
-        public TypeSymbolWithAnnotations GetNullableUnderlyingType() => TypeSymbol.GetNullableUnderlyingTypeWithAnnotations();
+        public TypeSymbolWithAnnotations GetNullableUnderlyingType() =>
+            TypeSymbol.GetNullableUnderlyingTypeWithAnnotations();
 
-        internal bool GetIsReferenceType(ConsList<TypeParameterSymbol> inProgress) => _extensions.GetIsReferenceType(_defaultType, inProgress);
-        internal bool GetIsValueType(ConsList<TypeParameterSymbol> inProgress) => _extensions.GetIsValueType(_defaultType, inProgress);
+        internal bool GetIsReferenceType(ConsList<TypeParameterSymbol> inProgress) =>
+            _extensions.GetIsReferenceType(_defaultType, inProgress);
+        internal bool GetIsValueType(ConsList<TypeParameterSymbol> inProgress) =>
+            _extensions.GetIsValueType(_defaultType, inProgress);
 
         public string ToDisplayString(SymbolDisplayFormat format = null)
         {
@@ -443,7 +454,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal bool TypeSymbolEquals(TypeSymbolWithAnnotations other, TypeCompareKind comparison) => _extensions.TypeSymbolEquals(this, other, comparison);
+        internal bool TypeSymbolEquals(TypeSymbolWithAnnotations other, TypeCompareKind comparison) =>
+            _extensions.TypeSymbolEquals(this, other, comparison);
 
         public bool GetUnificationUseSiteDiagnosticRecursive(ref DiagnosticInfo result, Symbol owner, ref HashSet<TypeSymbol> checkedTypes)
         {
@@ -462,8 +474,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return NullableUnderlyingTypeOrSelf.IsAtLeastAsVisibleAs(sym, ref useSiteDiagnostics);
         }
 
-        public TypeSymbolWithAnnotations SubstituteType(AbstractTypeMap typeMap) => _extensions.SubstituteType(this, typeMap, withTupleUnification: false);
-        public TypeSymbolWithAnnotations SubstituteTypeWithTupleUnification(AbstractTypeMap typeMap) => _extensions.SubstituteType(this, typeMap, withTupleUnification: true);
+        public TypeSymbolWithAnnotations SubstituteType(AbstractTypeMap typeMap) =>
+            _extensions.SubstituteType(this, typeMap, withTupleUnification: false);
+        public TypeSymbolWithAnnotations SubstituteTypeWithTupleUnification(AbstractTypeMap typeMap) =>
+            _extensions.SubstituteType(this, typeMap, withTupleUnification: true);
 
         internal TypeSymbolWithAnnotations SubstituteTypeCore(AbstractTypeMap typeMap, bool withTupleUnification)
         {
@@ -501,7 +515,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 newCustomModifiers.Concat(newTypeWithModifiers.CustomModifiers));
         }
 
-        public void ReportDiagnosticsIfObsolete(Binder binder, SyntaxNode syntax, DiagnosticBag diagnostics) => _extensions.ReportDiagnosticsIfObsolete(this, binder, syntax, diagnostics);
+        public void ReportDiagnosticsIfObsolete(Binder binder, SyntaxNode syntax, DiagnosticBag diagnostics) =>
+            _extensions.ReportDiagnosticsIfObsolete(this, binder, syntax, diagnostics);
 
         internal bool TypeSymbolEqualsCore(TypeSymbolWithAnnotations other, TypeCompareKind comparison)
         {
@@ -524,7 +539,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public bool Is(TypeParameterSymbol other) => _extensions.Is(_defaultType, other);
 
-        public TypeSymbolWithAnnotations WithTypeAndModifiers(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers) => _extensions.WithTypeAndModifiers(this, typeSymbol, customModifiers);
+        public TypeSymbolWithAnnotations WithTypeAndModifiers(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers) =>
+            _extensions.WithTypeAndModifiers(this, typeSymbol, customModifiers);
 
         public bool ContainsNullableReferenceTypes()
         {
@@ -726,29 +742,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return new LazyNullableTypeParameter(compilation, underlying);
             }
 
-            public abstract TypeSymbol GetResolvedType(TypeSymbol defaultType);
-            public abstract ImmutableArray<CustomModifier> CustomModifiers { get; }
+            internal abstract TypeSymbol GetResolvedType(TypeSymbol defaultType);
+            internal abstract ImmutableArray<CustomModifier> CustomModifiers { get; }
 
-            public abstract TypeSymbolWithAnnotations AsNullableReferenceType(TypeSymbolWithAnnotations type);
-            public abstract TypeSymbolWithAnnotations AsNotNullableReferenceType(TypeSymbolWithAnnotations type);
+            internal abstract TypeSymbolWithAnnotations AsNullableReferenceType(TypeSymbolWithAnnotations type);
+            internal abstract TypeSymbolWithAnnotations AsNotNullableReferenceType(TypeSymbolWithAnnotations type);
 
-            public abstract TypeSymbolWithAnnotations WithModifiers(TypeSymbolWithAnnotations type, ImmutableArray<CustomModifier> customModifiers);
-            public abstract TypeSymbolWithAnnotations WithNonNullTypesContext(TypeSymbolWithAnnotations type, INonNullTypesContext nonNullTypesContext);
+            internal abstract TypeSymbolWithAnnotations WithModifiers(TypeSymbolWithAnnotations type, ImmutableArray<CustomModifier> customModifiers);
+            internal abstract TypeSymbolWithAnnotations WithNonNullTypesContext(TypeSymbolWithAnnotations type, INonNullTypesContext nonNullTypesContext);
 
-            public abstract TypeSymbol GetNullableUnderlyingTypeOrSelf(TypeSymbol typeSymbol);
+            internal abstract TypeSymbol GetNullableUnderlyingTypeOrSelf(TypeSymbol typeSymbol);
 
             internal abstract bool GetIsReferenceType(TypeSymbol typeSymbol, ConsList<TypeParameterSymbol> inProgress);
             internal abstract bool GetIsValueType(TypeSymbol typeSymbol, ConsList<TypeParameterSymbol> inProgress);
 
-            public abstract TypeSymbol AsTypeSymbolOnly(TypeSymbol typeSymbol);
+            internal abstract TypeSymbol AsTypeSymbolOnly(TypeSymbol typeSymbol);
 
-            public abstract SpecialType GetSpecialType(TypeSymbol typeSymbol);
-            public abstract bool IsRestrictedType(TypeSymbol typeSymbol, bool ignoreSpanLikeTypes);
-            public abstract bool IsStatic(TypeSymbol typeSymbol);
-            public abstract bool IsVoid(TypeSymbol typeSymbol);
-            public abstract bool IsSZArray(TypeSymbol typeSymbol);
+            internal abstract SpecialType GetSpecialType(TypeSymbol typeSymbol);
+            internal abstract bool IsRestrictedType(TypeSymbol typeSymbol, bool ignoreSpanLikeTypes);
+            internal abstract bool IsStatic(TypeSymbol typeSymbol);
+            internal abstract bool IsVoid(TypeSymbol typeSymbol);
+            internal abstract bool IsSZArray(TypeSymbol typeSymbol);
 
-            public abstract bool Is(TypeSymbol typeSymbol, TypeParameterSymbol other);
+            internal abstract bool Is(TypeSymbol typeSymbol, TypeParameterSymbol other);
 
             internal abstract TypeSymbolWithAnnotations WithTypeAndModifiers(TypeSymbolWithAnnotations type, TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers);
 
@@ -767,16 +783,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _customModifiers = customModifiers;
             }
 
-            public override TypeSymbol GetResolvedType(TypeSymbol defaultType) => defaultType;
-            public override ImmutableArray<CustomModifier> CustomModifiers => _customModifiers;
+            internal override TypeSymbol GetResolvedType(TypeSymbol defaultType) => defaultType;
+            internal override ImmutableArray<CustomModifier> CustomModifiers => _customModifiers;
 
-            public override SpecialType GetSpecialType(TypeSymbol typeSymbol) => typeSymbol.SpecialType;
-            public override bool IsRestrictedType(TypeSymbol typeSymbol, bool ignoreSpanLikeTypes) => typeSymbol.IsRestrictedType(ignoreSpanLikeTypes);
-            public override bool IsStatic(TypeSymbol typeSymbol) => typeSymbol.IsStatic;
-            public override bool IsVoid(TypeSymbol typeSymbol) => typeSymbol.SpecialType == SpecialType.System_Void;
-            public override bool IsSZArray(TypeSymbol typeSymbol) => typeSymbol.IsSZArray();
+            internal override SpecialType GetSpecialType(TypeSymbol typeSymbol) => typeSymbol.SpecialType;
+            internal override bool IsRestrictedType(TypeSymbol typeSymbol, bool ignoreSpanLikeTypes) => typeSymbol.IsRestrictedType(ignoreSpanLikeTypes);
+            internal override bool IsStatic(TypeSymbol typeSymbol) => typeSymbol.IsStatic;
+            internal override bool IsVoid(TypeSymbol typeSymbol) => typeSymbol.SpecialType == SpecialType.System_Void;
+            internal override bool IsSZArray(TypeSymbol typeSymbol) => typeSymbol.IsSZArray();
 
-            public override TypeSymbol GetNullableUnderlyingTypeOrSelf(TypeSymbol typeSymbol) => typeSymbol.StrippedType();
+            internal override TypeSymbol GetNullableUnderlyingTypeOrSelf(TypeSymbol typeSymbol) => typeSymbol.StrippedType();
 
             internal override bool GetIsReferenceType(TypeSymbol typeSymbol, ConsList<TypeParameterSymbol> inProgress)
             {
@@ -796,34 +812,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return typeSymbol.IsValueType;
             }
 
-            public override TypeSymbolWithAnnotations WithModifiers(TypeSymbolWithAnnotations type, ImmutableArray<CustomModifier> customModifiers)
+            internal override TypeSymbolWithAnnotations WithModifiers(TypeSymbolWithAnnotations type, ImmutableArray<CustomModifier> customModifiers)
             {
                 return TypeSymbolWithAnnotations.CreateNonLazyType(type._defaultType, type.NonNullTypesContext, type.IsAnnotated, customModifiers);
             }
 
-            public override TypeSymbolWithAnnotations WithNonNullTypesContext(TypeSymbolWithAnnotations type, INonNullTypesContext nonNullTypesContext)
+            internal override TypeSymbolWithAnnotations WithNonNullTypesContext(TypeSymbolWithAnnotations type, INonNullTypesContext nonNullTypesContext)
             {
                 Debug.Assert(nonNullTypesContext != null);
                 return TypeSymbolWithAnnotations.CreateNonLazyType(type._defaultType, nonNullTypesContext, type.IsAnnotated, _customModifiers);
             }
 
-            public override TypeSymbol AsTypeSymbolOnly(TypeSymbol typeSymbol) => typeSymbol;
+            internal override TypeSymbol AsTypeSymbolOnly(TypeSymbol typeSymbol) => typeSymbol;
 
             // PROTOTYPE(NullableReferenceTypes): Use WithCustomModifiers.Is() => false
             // and set IsNullable=null always for GetTypeParametersAsTypeArguments.
-            public override bool Is(TypeSymbol typeSymbol, TypeParameterSymbol other) => typeSymbol.Equals(other, TypeCompareKind.CompareNullableModifiersForReferenceTypes) && _customModifiers.IsEmpty;
+            internal override bool Is(TypeSymbol typeSymbol, TypeParameterSymbol other) =>
+                typeSymbol.Equals(other, TypeCompareKind.CompareNullableModifiersForReferenceTypes) && _customModifiers.IsEmpty;
 
             internal override TypeSymbolWithAnnotations WithTypeAndModifiers(TypeSymbolWithAnnotations type, TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
             {
                 return TypeSymbolWithAnnotations.CreateNonLazyType(typeSymbol, type.NonNullTypesContext, type.IsAnnotated, customModifiers);
             }
 
-            public override TypeSymbolWithAnnotations AsNullableReferenceType(TypeSymbolWithAnnotations type)
+            internal override TypeSymbolWithAnnotations AsNullableReferenceType(TypeSymbolWithAnnotations type)
             {
                 return TypeSymbolWithAnnotations.CreateNonLazyType(type._defaultType, type.NonNullTypesContext, isAnnotated: true, _customModifiers);
             }
 
-            public override TypeSymbolWithAnnotations AsNotNullableReferenceType(TypeSymbolWithAnnotations type)
+            internal override TypeSymbolWithAnnotations AsNotNullableReferenceType(TypeSymbolWithAnnotations type)
             {
                 var defaultType = type._defaultType;
                 return TypeSymbolWithAnnotations.CreateNonLazyType(defaultType, type.NonNullTypesContext, isAnnotated: defaultType.IsNullableType(), _customModifiers);
@@ -865,9 +882,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _underlying = underlying;
             }
 
-            public override bool IsVoid(TypeSymbol typeSymbol) => false;
-            public override bool IsSZArray(TypeSymbol typeSymbol) => false;
-            public override bool IsStatic(TypeSymbol typeSymbol) => false;
+            internal override bool IsVoid(TypeSymbol typeSymbol) => false;
+            internal override bool IsSZArray(TypeSymbol typeSymbol) => false;
+            internal override bool IsStatic(TypeSymbol typeSymbol) => false;
 
             private TypeSymbol GetResolvedType()
             {
@@ -898,17 +915,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return _underlying.GetIsValueType(inProgress);
             }
 
-            public override TypeSymbol GetNullableUnderlyingTypeOrSelf(TypeSymbol typeSymbol) => _underlying.TypeSymbol;
+            internal override TypeSymbol GetNullableUnderlyingTypeOrSelf(TypeSymbol typeSymbol) => _underlying.TypeSymbol;
 
-            public override SpecialType GetSpecialType(TypeSymbol typeSymbol)
+            internal override SpecialType GetSpecialType(TypeSymbol typeSymbol)
             {
                 var specialType = _underlying.SpecialType;
                 return specialType.IsValueType() ? SpecialType.None : specialType;
             }
 
-            public override bool IsRestrictedType(TypeSymbol typeSymbol, bool ignoreSpanLikeTypes) => _underlying.IsRestrictedType(ignoreSpanLikeTypes);
+            internal override bool IsRestrictedType(TypeSymbol typeSymbol, bool ignoreSpanLikeTypes) => _underlying.IsRestrictedType(ignoreSpanLikeTypes);
 
-            public override TypeSymbol AsTypeSymbolOnly(TypeSymbol typeSymbol)
+            internal override TypeSymbol AsTypeSymbolOnly(TypeSymbol typeSymbol)
             {
                 var resolvedType = GetResolvedType();
                 Debug.Assert(resolvedType.IsNullableType() && CustomModifiers.IsEmpty);
@@ -917,7 +934,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // PROTOTYPE(NullableReferenceTypes): This implementation looks
             // incorrect since a type parameter cannot be Nullable<T>.
-            public override bool Is(TypeSymbol typeSymbol, TypeParameterSymbol other)
+            internal override bool Is(TypeSymbol typeSymbol, TypeParameterSymbol other)
             {
                 if (!other.IsNullableType())
                 {
@@ -928,10 +945,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return resolvedType.Equals(other, TypeCompareKind.CompareNullableModifiersForReferenceTypes);
             }
 
-            public override TypeSymbol GetResolvedType(TypeSymbol defaultType) => GetResolvedType();
-            public override ImmutableArray<CustomModifier> CustomModifiers => ImmutableArray<CustomModifier>.Empty;
+            internal override TypeSymbol GetResolvedType(TypeSymbol defaultType) => GetResolvedType();
+            internal override ImmutableArray<CustomModifier> CustomModifiers => ImmutableArray<CustomModifier>.Empty;
 
-            public override TypeSymbolWithAnnotations WithModifiers(TypeSymbolWithAnnotations type, ImmutableArray<CustomModifier> customModifiers)
+            internal override TypeSymbolWithAnnotations WithModifiers(TypeSymbolWithAnnotations type, ImmutableArray<CustomModifier> customModifiers)
             {
                 if (customModifiers.IsEmpty)
                 {
@@ -947,7 +964,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return TypeSymbolWithAnnotations.CreateNonLazyType(resolvedType, type.NonNullTypesContext, isAnnotated: true, customModifiers);
             }
 
-            public override TypeSymbolWithAnnotations WithNonNullTypesContext(TypeSymbolWithAnnotations type, INonNullTypesContext nonNullTypesContext)
+            internal override TypeSymbolWithAnnotations WithNonNullTypesContext(TypeSymbolWithAnnotations type, INonNullTypesContext nonNullTypesContext)
             {
                 return TypeSymbolWithAnnotations.CreateLazyNullableType(_compilation, _underlying.WithNonNullTypesContext(nonNullTypesContext));
             }
@@ -962,12 +979,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return TypeSymbolWithAnnotations.CreateNonLazyType(typeSymbol, type.NonNullTypesContext, isAnnotated: true, customModifiers);
             }
 
-            public override TypeSymbolWithAnnotations AsNullableReferenceType(TypeSymbolWithAnnotations type)
+            internal override TypeSymbolWithAnnotations AsNullableReferenceType(TypeSymbolWithAnnotations type)
             {
                 return type;
             }
 
-            public override TypeSymbolWithAnnotations AsNotNullableReferenceType(TypeSymbolWithAnnotations type)
+            internal override TypeSymbolWithAnnotations AsNotNullableReferenceType(TypeSymbolWithAnnotations type)
             {
                 if (!_underlying.TypeSymbol.IsValueType)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -28,10 +28,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private bool _isAnnotated;
             private Extensions _extensions;
 
+            /// <summary>
+            /// The underlying type, unless overridden by _extensions.
+            /// </summary>
             internal TypeSymbol DefaultType => _defaultType;
 
+            /// <summary>
+            /// True if the fields of the builder are unset.
+            /// </summary>
             internal bool IsNull => _defaultType is null;
 
+            /// <summary>
+            /// Set the fields of the builder.
+            /// </summary>
             internal bool InterlockedInitialize(TypeSymbolWithAnnotations type)
             {
                 if ((object)_defaultType != null)
@@ -44,6 +53,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return (object)Interlocked.CompareExchange(ref _defaultType, type._defaultType, null) == null;
             }
 
+            /// <summary>
+            /// Create immutable TypeSymbolWithAnnotations instance.
+            /// </summary>
             internal TypeSymbolWithAnnotations ToType()
             {
                 return (object)_defaultType == null ?

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -46,7 +46,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal TypeSymbolWithAnnotations ToType()
             {
-                return new TypeSymbolWithAnnotations(_defaultType, _nonNullTypesContext, _isAnnotated, _extensions);
+                return (object)_defaultType == null ?
+                    default :
+                    new TypeSymbolWithAnnotations(_defaultType, _nonNullTypesContext, _isAnnotated, _extensions);
             }
 
             internal string GetDebuggerDisplay() => ToType().GetDebuggerDisplay();

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -280,6 +280,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
+                if (_defaultType is null)
+                {
+                    return null;
+                }
                 if (IsAnnotated)
                 {
                     return true;
@@ -311,13 +315,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
+                if (_defaultType is null)
+                {
+                    return null;
+                }
                 if (IsAnnotated)
                 {
                     return true;
                 }
-
                 // A null NonNullTypes (ie. no attribute) means the same as NonNullTypes(false).
-                return NonNullTypesContext.NonNullTypes == true ? false : (bool?)null;
+                if (NonNullTypesContext.NonNullTypes == true)
+                {
+                    return false;
+                }
+                return null;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public bool Equals(TypeSymbolWithAnnotations other, TypeCompareKind comparison)
         {
-            if (ReferenceEquals(this, other))
+            if (this.IsSameAs(other))
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
-            if (other == null || !TypeSymbolEquals(other, comparison))
+            if (other.IsNull || !TypeSymbolEquals(other, comparison))
             {
                 return false;
             }
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override int GetHashCode(TypeSymbolWithAnnotations obj)
             {
-                if (obj == null)
+                if (obj.IsNull)
                 {
                     return 0;
                 }
@@ -446,9 +446,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override bool Equals(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
             {
-                if (x == null)
+                if (x.IsNull)
                 {
-                    return y == null;
+                    return y.IsNull;
                 }
                 return x.Equals(y, TypeCompareKind.CompareNullableModifiersForReferenceTypes);
             }
@@ -701,24 +701,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable;
         }
 
-        // Field-wise ReferenceEquals.
+#pragma warning disable CS0809
+        [Obsolete("Unsupported", error: true)]
         public static bool operator ==(TypeSymbolWithAnnotations? x, TypeSymbolWithAnnotations? y)
+#pragma warning restore CS0809
         {
-            return AreFieldsReferenceEquals(x.GetValueOrDefault(), y.GetValueOrDefault());
+            throw ExceptionUtilities.Unreachable;
+        }
+
+#pragma warning disable CS0809
+        [Obsolete("Unsupported", error: true)]
+        public static bool operator !=(TypeSymbolWithAnnotations? x, TypeSymbolWithAnnotations? y)
+#pragma warning restore CS0809
+        {
+            throw ExceptionUtilities.Unreachable;
         }
 
         // Field-wise ReferenceEquals.
-        public static bool operator !=(TypeSymbolWithAnnotations? x, TypeSymbolWithAnnotations? y)
+        internal bool IsSameAs(TypeSymbolWithAnnotations other)
         {
-            return !(x == y);
-        }
-
-        private static bool AreFieldsReferenceEquals(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
-        {
-            return ReferenceEquals(x._defaultType, y._defaultType) &&
-                ReferenceEquals(x.NonNullTypesContext, y.NonNullTypesContext) &&
-                x.IsAnnotated == y.IsAnnotated &&
-                ReferenceEquals(x._extensions, y._extensions);
+            return ReferenceEquals(_defaultType, other._defaultType) &&
+                ReferenceEquals(NonNullTypesContext, other.NonNullTypesContext) &&
+                IsAnnotated == other.IsAnnotated &&
+                ReferenceEquals(_extensions, other._extensions);
         }
 
         /// <summary>
@@ -1001,7 +1006,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var newUnderlying = _underlying.SubstituteTypeCore(typeMap, withTupleUnification);
-                if (newUnderlying != this._underlying)
+                if (!newUnderlying.IsSameAs(this._underlying))
                 {
                     if ((newUnderlying.TypeSymbol.Equals(this._underlying.TypeSymbol, TypeCompareKind.AllAspects) ||
                             newUnderlying.TypeSymbol is IndexedTypeParameterSymbolForOverriding) &&

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -41,6 +41,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             /// <summary>
             /// Set the fields of the builder.
             /// </summary>
+            /// <remarks>
+            /// This method guarantees: fields will be set once; exactly one caller is
+            /// returned true; and IsNull will return true until all fields are initialized.
+            /// This method does not guarantee that all fields will be set by the same
+            /// caller. Instead, the expectation is that all callers will attempt to initialize
+            /// the builder with equivalent TypeSymbolWithAnnotations instances where
+            /// different fields of the builder may be assigned from different instances.
+            /// </remarks>
             internal bool InterlockedInitialize(TypeSymbolWithAnnotations type)
             {
                 if ((object)_defaultType != null)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             RefKind refKind,
             string name = "")
         {
-            Debug.Assert(type != null);
+            Debug.Assert(!type.IsNull);
             Debug.Assert(name != null);
             Debug.Assert(ordinal >= 0);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             RefKind refKind,
             string name = "")
         {
-            Debug.Assert((object)type != null);
+            Debug.Assert(type != null);
             Debug.Assert(name != null);
             Debug.Assert(ordinal >= 0);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public TypeSubstitutedLocalSymbol(LocalSymbol originalVariable, TypeSymbolWithAnnotations type, Symbol containingSymbol)
         {
             Debug.Assert(originalVariable != null);
-            Debug.Assert((object)type != null);
+            Debug.Assert(type != null);
             Debug.Assert(containingSymbol != null);
 
             _originalVariable = originalVariable;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public TypeSubstitutedLocalSymbol(LocalSymbol originalVariable, TypeSymbolWithAnnotations type, Symbol containingSymbol)
         {
             Debug.Assert(originalVariable != null);
-            Debug.Assert(type != null);
+            Debug.Assert(!type.IsNull);
             Debug.Assert(containingSymbol != null);
 
             _originalVariable = originalVariable;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal TupleTypeSymbol WithElementTypes(ImmutableArray<TypeSymbolWithAnnotations> newElementTypes)
         {
             Debug.Assert(_elementTypes.Length == newElementTypes.Length);
-            Debug.Assert(newElementTypes.All(t => t != null));
+            Debug.Assert(newElementTypes.All(t => !t.IsNull));
 
             NamedTypeSymbol firstTupleType;
             NamedTypeSymbol chainedTupleType;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal TupleTypeSymbol WithElementTypes(ImmutableArray<TypeSymbolWithAnnotations> newElementTypes)
         {
             Debug.Assert(_elementTypes.Length == newElementTypes.Length);
-            Debug.Assert(newElementTypes.All(t => (object)t != null));
+            Debug.Assert(newElementTypes.All(t => t != null));
 
             NamedTypeSymbol firstTupleType;
             NamedTypeSymbol chainedTupleType;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -624,12 +624,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal bool ContainsNullableReferenceTypes()
         {
-            return TypeSymbolWithAnnotations.ContainsNullableReferenceTypes(typeWithAnnotationsOpt: null, typeOpt: this);
+            return TypeSymbolWithAnnotations.ContainsNullableReferenceTypes(typeWithAnnotationsOpt: default, typeOpt: this);
         }
 
         internal bool ContainsAnnotatedUnconstrainedTypeParameter()
         {
-            return TypeSymbolWithAnnotations.ContainsAnnotatedUnconstrainedTypeParameter(typeWithAnnotationsOpt: null, typeOpt: this);
+            return TypeSymbolWithAnnotations.ContainsAnnotatedUnconstrainedTypeParameter(typeWithAnnotationsOpt: default, typeOpt: this);
         }
 
         internal abstract void AddNullableTransforms(ArrayBuilder<bool> transforms);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -572,7 +572,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             T arg,
             bool canDigThroughNullable = false)
         {
-            Debug.Assert((typeWithAnnotationsOpt == null) != (typeOpt is null));
+            Debug.Assert(typeWithAnnotationsOpt.IsNull != (typeOpt is null));
 
             // In order to handle extremely "deep" types like "int[][][][][][][][][]...[]"
             // or int*****************...* we implement manual tail recursion rather than 
@@ -610,7 +610,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
                 }
 
-                if (typeWithAnnotationsOpt != null && typeWithAnnotationsPredicateOpt != null)
+                if (!typeWithAnnotationsOpt.IsNull && typeWithAnnotationsPredicateOpt != null)
                 {
                     if (typeWithAnnotationsPredicateOpt(typeWithAnnotationsOpt, arg, isNestedNamedType))
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -545,7 +545,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool canDigThroughNullable = false)
         {
             return VisitType(
-                typeWithAnnotationsOpt: null,
+                typeWithAnnotationsOpt: default,
                 typeOpt: type,
                 typeWithAnnotationsPredicateOpt: null,
                 typePredicateOpt: predicate,
@@ -572,7 +572,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             T arg,
             bool canDigThroughNullable = false)
         {
-            Debug.Assert((typeWithAnnotationsOpt is null) != (typeOpt is null));
+            Debug.Assert((typeWithAnnotationsOpt == null) != (typeOpt is null));
 
             // In order to handle extremely "deep" types like "int[][][][][][][][][]...[]"
             // or int*****************...* we implement manual tail recursion rather than 
@@ -580,7 +580,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             while (true)
             {
-                TypeSymbol current = typeOpt ?? typeWithAnnotationsOpt?.TypeSymbol;
+                TypeSymbol current = typeOpt ?? typeWithAnnotationsOpt.TypeSymbol;
                 bool isNestedNamedType = false;
 
                 // Visit containing types from outer-most to inner-most.
@@ -596,7 +596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             if ((object)containingType != null)
                             {
                                 isNestedNamedType = true;
-                                var result = VisitType(null, containingType, typeWithAnnotationsPredicateOpt, typePredicateOpt, arg, canDigThroughNullable);
+                                var result = VisitType(default, containingType, typeWithAnnotationsPredicateOpt, typePredicateOpt, arg, canDigThroughNullable);
                                 if ((object)result != null)
                                 {
                                     return result;
@@ -610,7 +610,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
                 }
 
-                if ((object)typeWithAnnotationsOpt != null && typeWithAnnotationsPredicateOpt != null)
+                if (typeWithAnnotationsOpt != null && typeWithAnnotationsPredicateOpt != null)
                 {
                     if (typeWithAnnotationsPredicateOpt(typeWithAnnotationsOpt, arg, isNestedNamedType))
                     {
@@ -650,7 +650,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             // Let's try to avoid early resolution of nullable types
                             var result = VisitType(
-                                typeWithAnnotationsOpt: canDigThroughNullable ? null : typeArg,
+                                typeWithAnnotationsOpt: canDigThroughNullable ? default : typeArg,
                                 typeOpt: canDigThroughNullable ? typeArg.NullableUnderlyingTypeOrSelf : null,
                                 typeWithAnnotationsPredicateOpt,
                                 typePredicateOpt,
@@ -676,7 +676,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 // Let's try to avoid early resolution of nullable types
-                typeWithAnnotationsOpt = canDigThroughNullable ? null : next;
+                typeWithAnnotationsOpt = canDigThroughNullable ? default : next;
                 typeOpt = canDigThroughNullable ? next.NullableUnderlyingTypeOrSelf : null;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             MutableTypeMap substitution = null;
-            bool result = CanUnifyHelper((object)t1 == null ? null : TypeSymbolWithAnnotations.Create(t1),
-                                         (object)t2 == null ? null : TypeSymbolWithAnnotations.Create(t2), 
+            bool result = CanUnifyHelper(TypeSymbolWithAnnotations.Create(t1),
+                                         TypeSymbolWithAnnotations.Create(t2), 
                                          ref substitution);
 #if DEBUG
             if (result && ((object)t1 != null && (object)t2 != null))
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     previous = type;
                     type = type.SubstituteType(substitution);
-                } while ((object)type != previous);
+                } while (type != previous);
             }
 
             return type;
@@ -73,9 +73,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         private static bool CanUnifyHelper(TypeSymbolWithAnnotations t1, TypeSymbolWithAnnotations t2, ref MutableTypeMap substitution)
         {
-            if ((object)t1 == null || (object)t2 == null)
+            if (t1 == null || t2 == null)
             {
-                return (object)t1 == t2;
+                return t1 == t2;
             }
 
             if (t1.TypeSymbol == t2.TypeSymbol && t1.CustomModifiers.SequenceEqual(t2.CustomModifiers))

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     previous = type;
                     type = type.SubstituteType(substitution);
-                } while (type != previous);
+                } while (!type.IsSameAs(previous));
             }
 
             return type;
@@ -73,9 +73,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         private static bool CanUnifyHelper(TypeSymbolWithAnnotations t1, TypeSymbolWithAnnotations t2, ref MutableTypeMap substitution)
         {
-            if (t1 == null || t2 == null)
+            if (t1.IsNull || t2.IsNull)
             {
-                return t1 == t2;
+                return t1.IsSameAs(t2);
             }
 
             if (t1.TypeSymbol == t2.TypeSymbol && t1.CustomModifiers.SequenceEqual(t2.CustomModifiers))

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -23011,7 +23011,7 @@ class C
             var model = comp.GetSemanticModel(tree);
             var x = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ElementAt(1);
             Assert.Equal("x", x.Identifier.ToString());
-            var xSymbol = (model.GetDeclaredSymbol(x) as LocalSymbol)?.Type;
+            var xSymbol = ((LocalSymbol)model.GetDeclaredSymbol(x)).Type;
             Assert.Equal("(System.Int32 a, System.Int32 b)", xSymbol.ToTestDisplayString());
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -159,7 +159,7 @@ namespace System
             Assert.Equal("System.IAsyncResult", beginInvoke.ReturnType.TypeSymbol.ToTestDisplayString());
             for (int i = 0; i < invoke.Parameters.Length; i++)
             {
-                Assert.Equal(invoke.Parameters[i].Type, beginInvoke.Parameters[i].Type);
+                Assert.Equal(invoke.Parameters[i].Type.TypeSymbol, beginInvoke.Parameters[i].Type.TypeSymbol);
                 Assert.Equal(invoke.Parameters[i].RefKind, beginInvoke.Parameters[i].RefKind);
             }
             var lastParameterType = beginInvoke.Parameters[invoke.Parameters.Length].Type.TypeSymbol;
@@ -168,13 +168,13 @@ namespace System
             Assert.Equal("System.Object", beginInvoke.Parameters[invoke.Parameters.Length + 1].Type.TypeSymbol.ToTestDisplayString());
 
             var endInvoke = myDel.GetMembers("EndInvoke").Single() as MethodSymbol;
-            Assert.Equal(invoke.ReturnType, endInvoke.ReturnType);
+            Assert.Equal(invoke.ReturnType.TypeSymbol, endInvoke.ReturnType.TypeSymbol);
             int k = 0;
             for (int i = 0; i < invoke.Parameters.Length; i++)
             {
                 if (invoke.Parameters[i].RefKind != RefKind.None)
                 {
-                    Assert.Equal(invoke.Parameters[i].Type, endInvoke.Parameters[k].Type);
+                    Assert.Equal(invoke.Parameters[i].Type.TypeSymbol, endInvoke.Parameters[k].Type.TypeSymbol);
                     Assert.Equal(invoke.Parameters[i].RefKind, endInvoke.Parameters[k++].RefKind);
                 }
             }

--- a/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 
         private bool UsesIsNullable(TypeSymbolWithAnnotations type)
         {
-            if (type == null)
+            if (type.IsNull)
             {
                 return false;
             }

--- a/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/UsesIsNullableVisitor.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 
         private bool UsesIsNullable(TypeSymbolWithAnnotations type)
         {
-            if (type is null)
+            if (type == null)
             {
                 return false;
             }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1305,7 +1305,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 var name = local.Name;
                 if ((name != null) && (GeneratedNames.GetKind(name) == GeneratedNameKind.DisplayClassLocalOrField))
                 {
-                    if (displayClassTypes.Add(local.Type?.TypeSymbol))
+                    var localType = local.Type.TypeSymbol;
+                    if ((object)localType != null && displayClassTypes.Add(localType))
                     {
                         var instance = new DisplayClassInstanceFromLocal((EELocalSymbol)local);
                         displayClassInstances.Add(new DisplayClassInstanceAndFields(instance));


### PR DESCRIPTION
The `struct TypeSymbolWithAnnotations` includes an allocation for less common cases only: for nullable type parameters; and when the type has associated custom modifiers.
