### PR TITLE
add check for symbol.IsOverride when renaming a symbol

### DIFF
--- a/src/EditorFeatures/Test2/Rename/CSharp/OverrideTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/OverrideTests.vb
@@ -1,0 +1,78 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
+    <[UseExportProvider]>
+    Public Class OverrideTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Public Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameOverrideMemberFromDerivedClass()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
+                            <Document>
+namespace ClassLibrary1
+{
+    public class Class1
+    {
+        public virtual void [|M|]() { }
+    }
+}
+                        </Document>
+                        </Project>
+                        <Project Language="C#" AssemblyName="ClassLibrary2" CommonReferences="true">
+                            <ProjectReference>ClassLibrary1</ProjectReference>
+                            <Document>
+namespace ClassLibrary2
+{
+    public class Class2 : ClassLibrary1.Class1
+    {
+        public override void [|$$M|]() { }
+    }
+}
+                        </Document>
+                        </Project>
+                    </Workspace>, renameTo:="A")
+
+            End Using
+        End Sub
+
+        <WorkItem(25682, "https://github.com/dotnet/roslyn/issues/25682")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameOverrideMemberFromDerivedClassWhenMemberIsPrivate()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
+                            <Document>
+namespace ClassLibrary1
+{
+    public class Class1
+    {
+        public virtual void [|M|]() { }
+    }
+}
+                        </Document>
+                        </Project>
+                        <Project Language="C#" AssemblyName="ClassLibrary2" CommonReferences="true">
+                            <ProjectReference>ClassLibrary1</ProjectReference>
+                            <Document>
+namespace ClassLibrary2
+{
+    public class Class2 : ClassLibrary1.Class1
+    {
+        override void [|$$M|]() { }
+    }
+}
+                        </Document>
+                        </Project>
+                    </Workspace>, renameTo:="A")
+
+            End Using
+        End Sub
+
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/Rename/CSharp/OverrideTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/OverrideTests.vb
@@ -74,5 +74,68 @@ namespace ClassLibrary2
             End Using
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameOverrideMemberFromDerivedClass_abstract_virtual()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
+                            <Document>
+namespace ClassLibrary1
+{
+    public abstract class Class1
+    {
+        public abstract void M();
+    }
+}
+                        </Document>
+                        </Project>
+                        <Project Language="C#" AssemblyName="ClassLibrary2" CommonReferences="true">
+                            <ProjectReference>ClassLibrary1</ProjectReference>
+                            <Document>
+namespace ClassLibrary2
+{
+    public class Class2 : ClassLibrary1.Class1
+    {
+        virtual void [|$$M|]() { }
+    }
+}
+                        </Document>
+                        </Project>
+                    </Workspace>, renameTo:="A")
+
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameOverrideMemberFromDerivedClass_abstract_override()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
+                            <Document>
+namespace ClassLibrary1
+{
+    public abstract class Class1
+    {
+        public virtual void [|M|]();
+    }
+}
+                        </Document>
+                        </Project>
+                        <Project Language="C#" AssemblyName="ClassLibrary2" CommonReferences="true">
+                            <ProjectReference>ClassLibrary1</ProjectReference>
+                            <Document>
+namespace ClassLibrary2
+{
+    public class Class2 : ClassLibrary1.Class1
+    {
+        override void [|$$M|]() { }
+    }
+}
+                        </Document>
+                        </Project>
+                    </Workspace>, renameTo:="A")
+
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Rename
                 }
                 else
                 {
-                    // We are trying to figure out the projects that directly depend on the project that contains the declaration for 
+                    // We are trying to figure out the projects that directly depend on the project that contains the declaration for
                     // the rename symbol.  Other projects should not be affected by the rename.
                     var relevantProjects = projectIdsOfRenameSymbolDeclaration.Concat(projectIdsOfRenameSymbolDeclaration.SelectMany(p =>
                        solution.GetProjectDependencyGraph().GetProjectsThatDirectlyDependOnThisProject(p))).Distinct();
@@ -109,7 +109,8 @@ namespace Microsoft.CodeAnalysis.Rename
         private static bool ShouldRenameOnlyAffectDeclaringProject(ISymbol symbol)
         {
             // Explicit interface implementations can cascade to other projects
-            return symbol.DeclaredAccessibility == Accessibility.Private && !symbol.ExplicitInterfaceImplementations().Any();
+            // check if the symbol is override. https://github.com/dotnet/roslyn/issues/25682
+            return symbol.DeclaredAccessibility == Accessibility.Private && !symbol.ExplicitInterfaceImplementations().Any() && !symbol.IsOverride;
         }
 
         internal static TokenRenameInfo GetTokenRenameInfo(


### PR DESCRIPTION
Fixed https://github.com/dotnet/roslyn/issues/25682
