### PR TITLE
Perf improvement: remove unnecessary calls for CreateServicesOnUIThread() from …

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -95,9 +95,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 Workspace.AdviseSolutionEvents(solution);
             }
 
-            // Ensure services that must be created on the UI thread have been.
-            HACK_AbstractCreateServicesOnUiThread.CreateServicesOnUIThread(ComponentModel, RoslynLanguageName);
-
             LoadComponentsInUIContextOnceSolutionFullyLoaded(cancellationToken);
         }
 


### PR DESCRIPTION
AbstractPackage.InitializeAsync(). It is already called in AbstractPackage.LoadComponentsInUIContextOnceSolutionFullyLoaded()

Fixing https://github.com/dotnet/roslyn/issues/28978