### PR TITLE
Fix IntroduceVariable when the textSpan is whitespace

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -5720,5 +5720,30 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [WorkItem(27949, "https://github.com/dotnet/roslyn/issues/27949")]
+        public async Task TestWhitespaceSpanInAssignment()
+        {
+            await TestMissingAsync(@"
+class C
+{
+    int x = [| |] 0;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [WorkItem(28665, "https://github.com/dotnet/roslyn/issues/28665")]
+        public async Task TestWhitespaceSpanInAttribute()
+        {
+            await TestMissingAsync(@"
+class C
+{
+    [Example( [| |] )]
+    public void Foo()
+    {
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -3116,5 +3116,27 @@ end class",
     end sub
 end class")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <WorkItem(27949, "https://github.com/dotnet/roslyn/issues/27949")>
+        Public Async Function TestWhitespaceSpanInAssignment() As Task
+            Await TestMissingAsync("
+Class C
+    Dim x As Integer = [| |] 0
+End Class
+")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <WorkItem(28665, "https://github.com/dotnet/roslyn/issues/28665")>
+        Public Async Function TestWhitespaceSpanInAttribute() As Task
+            Await TestMissingAsync("
+Class C
+    <Example( [| |] )>
+    Public Function Foo()
+    End Function
+End Class
+")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -200,6 +200,13 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                     // We are pointing in the trailing whitespace trivia of a token, we shouldn't include that token
                     startToken = startToken.GetNextToken();
                     var newStart = startToken.Span.Start;
+
+                    if (textSpan.End < newStart)
+                    {
+                        // Additional trivia exists between 'textSpan' and the start of the next token, so the two are not considered adjacent
+                        return null;
+                    }
+
                     textSpan = TextSpan.FromBounds(newStart, textSpan.End);
                 }
 


### PR DESCRIPTION
If the textSpan is a span of whitespace that is itself surrounded by
whitespace, trying to recover by getting the next token and creating a
new textSpan will result in a gold bar. This change prevents the gold bar by
checking the proposed newStart position and returning if it is past
the end position.

This fixes #27949 and fixes #28665.