### PR TITLE
CheckTupleElementNames throws error for missing tuple element.

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -973,7 +973,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (elementNames[i] == "")
                     {
-                        throw new ArgumentException(CodeAnalysisResources.TupleElementNameEmpty, $"{nameof(elementNames)}[{i}]");
+                        //throw new ArgumentException(CodeAnalysisResources.TupleElementNameEmpty, $"{nameof(elementNames)}[{i}]");
                     }
                 }
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -973,7 +973,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (elementNames[i] == "")
                     {
-                        //throw new ArgumentException(CodeAnalysisResources.TupleElementNameEmpty, $"{nameof(elementNames)}[{i}]");
+                        throw new ArgumentException(CodeAnalysisResources.TupleElementNameEmpty, $"{nameof(elementNames)}[{i}]");
                     }
                 }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/TupleConstructionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/TupleConstructionSignatureHelpProviderTests.cs
@@ -38,6 +38,25 @@ class C
             await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
         }
 
+        [WorkItem(655607, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/655607")]
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TestMissingTupleElement()
+        {
+            var markup = @"
+class C
+{
+    void M()
+    {
+        (a, ) = [|($$
+|]  }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(object a, object)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public async Task InvocationAfterOpenParen2()
         {

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -9,10 +9,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis.LanguageServices;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -2092,7 +2092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else if (expr.IsKind(SyntaxKind.IdentifierName))
                         {
-                            elementNamesBuilder.Add(((IdentifierNameSyntax)expr).Identifier.ValueText == "" ? null : ((IdentifierNameSyntax)expr).Identifier.ValueText);
+                            elementNamesBuilder.Add(IsNullOrWhitespace(((IdentifierNameSyntax)expr).Identifier.ValueText) ? null : ((IdentifierNameSyntax)expr).Identifier.ValueText);
                             elementTypesBuilder.Add(GetTypes(expr).FirstOrDefault().InferredType ?? this.Compilation.ObjectType);
                         }
                         else
@@ -2115,6 +2115,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                     elementTypesBuilder.Free();
                     elementNamesBuilder.Free();
                 }
+            }
+
+            private bool IsNullOrWhitespace(string text)
+            {
+
+                if (text == null)
+                {
+                    return true;
+                }
+
+                for (var i = 0; i < text.Length; i++)
+                {
+                    if (!SyntaxFacts.IsWhitespace(text[i]) || !SyntaxFacts.IsNewLine(text[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
 
             private void AddTypeAndName(

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -2092,7 +2092,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else if (expr.IsKind(SyntaxKind.IdentifierName))
                         {
-                            elementNamesBuilder.Add(IsNullOrWhitespace(((IdentifierNameSyntax)expr).Identifier.ValueText) ? null : ((IdentifierNameSyntax)expr).Identifier.ValueText);
+                            elementNamesBuilder.Add(IsNullOrWhitespace(((IdentifierNameSyntax)expr).Identifier.ValueText) ? 
+                                null : 
+                                ((IdentifierNameSyntax)expr).Identifier.ValueText);
                             elementTypesBuilder.Add(GetTypes(expr).FirstOrDefault().InferredType ?? this.Compilation.ObjectType);
                         }
                         else

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -2092,7 +2092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else if (expr.IsKind(SyntaxKind.IdentifierName))
                         {
-                            elementNamesBuilder.Add(((TypeSyntax)expr).IsVar ? "" : ((IdentifierNameSyntax)expr).Identifier.ValueText);
+                            elementNamesBuilder.Add(((IdentifierNameSyntax)expr).Identifier.ValueText == "" ? null : ((IdentifierNameSyntax)expr).Identifier.ValueText);
                             elementTypesBuilder.Add(GetTypes(expr).FirstOrDefault().InferredType ?? this.Compilation.ObjectType);
                         }
                         else

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -2092,7 +2092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else if (expr.IsKind(SyntaxKind.IdentifierName))
                         {
-                            elementNamesBuilder.Add(IsNullOrWhitespace(((IdentifierNameSyntax)expr).Identifier.ValueText) ? 
+                            elementNamesBuilder.Add(string.IsNullOrWhiteSpace(((IdentifierNameSyntax)expr).Identifier.ValueText) ? 
                                 null : 
                                 ((IdentifierNameSyntax)expr).Identifier.ValueText);
                             elementTypesBuilder.Add(GetTypes(expr).FirstOrDefault().InferredType ?? this.Compilation.ObjectType);
@@ -2117,25 +2117,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     elementTypesBuilder.Free();
                     elementNamesBuilder.Free();
                 }
-            }
-
-            private bool IsNullOrWhitespace(string text)
-            {
-
-                if (text == null)
-                {
-                    return true;
-                }
-
-                for (var i = 0; i < text.Length; i++)
-                {
-                    if (!SyntaxFacts.IsWhitespace(text[i]) || !SyntaxFacts.IsNewLine(text[i]))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
             }
 
             private void AddTypeAndName(

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -2092,7 +2092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else if (expr.IsKind(SyntaxKind.IdentifierName))
                         {
-                            elementNamesBuilder.Add(((IdentifierNameSyntax)expr).Identifier.ValueText);
+                            elementNamesBuilder.Add(((TypeSyntax)expr).IsVar ? "" : ((IdentifierNameSyntax)expr).Identifier.ValueText);
                             elementTypesBuilder.Add(GetTypes(expr).FirstOrDefault().InferredType ?? this.Compilation.ObjectType);
                         }
                         else

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -2090,11 +2090,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             AddTypeAndName((TupleExpressionSyntax)expr, elementTypesBuilder, elementNamesBuilder);
                         }
-                        else if (expr.IsKind(SyntaxKind.IdentifierName))
+                        else if (expr is IdentifierNameSyntax name)
                         {
-                            elementNamesBuilder.Add(string.IsNullOrWhiteSpace(((IdentifierNameSyntax)expr).Identifier.ValueText) ? 
-                                null : 
-                                ((IdentifierNameSyntax)expr).Identifier.ValueText);
+                            elementNamesBuilder.Add(name.Identifier.ValueText == "" ? null : 
+                                name.Identifier.ValueText);
                             elementTypesBuilder.Add(GetTypes(expr).FirstOrDefault().InferredType ?? this.Compilation.ObjectType);
                         }
                         else


### PR DESCRIPTION

### Customer scenario
Type the following in editor window 
```csharp
class C
{
    void M()
    {
        (a, ) = (
    }
}
```
Put caret at the opening parenthesis on the right side of the assignment statement and invoke Signature Helper (Ctrl+Shift+space)

Actual:
CheckTupleElementNames throws error CodeAnalysisResource.TupleElementNameEmpty

Expected:
No error thrown

### Bugs this fixes
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/655607

### Workarounds, if any
none

### Risk
None

### Performance impact
None

### Is this a regression from a previous update?
No

### Root cause analysis
Original code did not account for missing tuple element

### How was the bug found?
Watson

### Test documentation updated?
New unit test added