### PR TITLE
Fixing false unresolvedConflict when renaming overloaded VB properties

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -3114,6 +3114,64 @@ End Class
 
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
+            <WorkItem(16576, "https://github.com/dotnet/roslyn/issues/16576")>
+            Public Sub RenameParameterizedPropertyResolvedConflict()
+                Using result = RenameEngineResult.Create(_outputHelper,
+                        <Workspace>
+                            <Project Language="Visual Basic" CommonReferences="true">
+                                <Document><![CDATA[
+Public Class C
+    Public ReadOnly Property P(a As Object) As Int32
+        Get
+            Return 2
+        End Get
+    End Property
+    Public ReadOnly Property [|$$P2|](a As String) As Int32
+        Get
+            Return {|Conflict0:P|}("")
+        End Get
+    End Property
+End Class
+]]>
+                                </Document>
+                            </Project>
+                        </Workspace>, renameTo:="P")
+
+                    result.AssertLabeledSpansAre("Conflict0", type:=RelatedLocationType.ResolvedNonReferenceConflict)
+                End Using
+            End Sub
+
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
+            <WorkItem(16576, "https://github.com/dotnet/roslyn/issues/16576")>
+            Public Sub RenameParameterizedPropertyUnresolvedConflict()
+                Using result = RenameEngineResult.Create(_outputHelper,
+                        <Workspace>
+                            <Project Language="Visual Basic" CommonReferences="true">
+                                <Document><![CDATA[
+Public Class C
+    Public ReadOnly Property {|Conflict:P|}(a As String) As Int32
+        Get
+            Return 2
+        End Get
+    End Property
+    Public ReadOnly Property [|$$P2|](a As String) As Int32
+        Get
+            Return 3
+        End Get
+    End Property
+End Class
+]]>
+                                </Document>
+                            </Project>
+                        </Workspace>, renameTo:="P")
+
+                    result.AssertLabeledSpansAre("Conflict", type:=RelatedLocationType.UnresolvedConflict)
+                End Using
+            End Sub
+
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(10469, "https://github.com/dotnet/roslyn/issues/10469")>
             Public Sub RenameTypeToCurrent()
                 Using result = RenameEngineResult.Create(_outputHelper,

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -3137,7 +3137,7 @@ End Class
                             </Project>
                         </Workspace>, renameTo:="P")
 
-                    result.AssertLabeledSpansAre("Conflict0", type:=RelatedLocationType.ResolvedNonReferenceConflict)
+                    result.AssertLabeledSpansAre("Conflict0", replacement:="Return P(CObj(""""))", type:=RelatedLocationType.ResolvedNonReferenceConflict)
                 End Using
             End Sub
 

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/DeclarationConflictHelpers.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/DeclarationConflictHelpers.cs
@@ -122,13 +122,13 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             return resultBuilder.ToImmutableAndFree();
         }
 
-        private static ImmutableArray<ImmutableArray<ITypeSymbol>> GetAllSignatures(IPropertySymbol method, bool trimOptionalParameters)
+        private static ImmutableArray<ImmutableArray<ITypeSymbol>> GetAllSignatures(IPropertySymbol property, bool trimOptionalParameters)
         {
             var resultBuilder = ArrayBuilder<ImmutableArray<ITypeSymbol>>.GetInstance();
 
             var signatureBuilder = ArrayBuilder<ITypeSymbol>.GetInstance();
 
-            foreach (var parameter in method.Parameters)
+            foreach (var parameter in property.Parameters)
             {
                 // In VB, a method effectively creates multiple signatures which are produced by
                 // chopping off each of the optional parameters on the end, last to first, per 4.1.1 of

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -731,6 +731,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                         .Select(Function(loc) reverseMappedLocations(loc)))
 
             ElseIf renamedSymbol.Kind = SymbolKind.Property Then
+                conflicts.AddRange(
+                    DeclarationConflictHelpers.GetMembersWithConflictingSignatures(DirectCast(renamedSymbol, IPropertySymbol), trimOptionalParameters:=True) _
+                        .Select(Function(loc) reverseMappedLocations(loc)))
                 ConflictResolver.AddConflictingParametersOfProperties(
                     referencedSymbols.Select(Function(s) s.Symbol).Concat(renameSymbol).Where(Function(sym) sym.Kind = SymbolKind.Property),
                     renamedSymbol.Name,


### PR DESCRIPTION
fixing https://github.com/dotnet/roslyn/issues/16576