### PR TITLE
Avoid IsValueType in ApplyNullableTransforms

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -467,7 +467,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var type = TypeSymbolWithAnnotations.Create(@interface, isNullableIfReferenceType: null);
                 yield return type.GetTypeRefWithAttributes(
                     moduleBeingBuilt,
-                    this,
+                    declaringSymbol: this,
                     typeRef);
             }
         }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -467,7 +467,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var type = TypeSymbolWithAnnotations.Create(@interface, isNullableIfReferenceType: null);
                 yield return type.GetTypeRefWithAttributes(
                     moduleBeingBuilt,
-                    this.DeclaringCompilation,
+                    this,
                     typeRef);
             }
         }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 yield return type.GetTypeRefWithAttributes(
                                                             moduleBeingBuilt,
-                                                            this.DeclaringCompilation,
+                                                            this,
                                                             typeRef);
             }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 yield return type.GetTypeRefWithAttributes(
                                                             moduleBeingBuilt,
-                                                            this,
+                                                            declaringSymbol: this,
                                                             typeRef);
             }
 

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                 var type = TypeSymbolWithAnnotations.Create(@interface, isNullableIfReferenceType: null);
                 yield return type.GetTypeRefWithAttributes(
                     moduleBeingBuilt,
-                    UnderlyingNamedType,
+                    declaringSymbol: UnderlyingNamedType,
                     typeRef);
             }
         }

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                 var type = TypeSymbolWithAnnotations.Create(@interface, isNullableIfReferenceType: null);
                 yield return type.GetTypeRefWithAttributes(
                     moduleBeingBuilt,
-                    UnderlyingNamedType.DeclaringCompilation,
+                    UnderlyingNamedType,
                     typeRef);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -254,6 +254,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return CreateLazyNullableType(compilation, this);
         }
 
+        // PROTOTYPE(NullableReferenceTypes): Consider replacing AsNullableReferenceType()
+        // and AsNotNullableReferenceType() with a single WithIsAnnotated(bool).
+
         /// <summary>
         /// Adjust types in signatures coming from metadata.
         /// </summary>
@@ -709,11 +712,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override int GetHashCode()
 #pragma warning restore CS0809
         {
-            if (_defaultType is null)
+            if (IsNull)
             {
                 return 0;
             }
-            return Hash.Combine(_defaultType.GetHashCode(), IsAnnotated.GetHashCode());
+            return Hash.Combine(TypeSymbol.GetHashCode(), IsAnnotated.GetHashCode());
         }
 
 #pragma warning disable CS0809

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -654,17 +654,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 result = result.WithTypeAndModifiers(newTypeSymbol, result.CustomModifiers);
             }
 
-            if (!result.IsValueType)
-            {
-                if (isAnnotated)
-                {
-                    result = result.AsNullableReferenceType();
-                }
-                else
-                {
-                    result = result.AsNotNullableReferenceType();
-                }
-            }
+            result = isAnnotated ?
+                result.AsNullableReferenceType() :
+                result.AsNotNullableReferenceType();
 
             result = result.WithNonNullTypesContext(nonNullTypesContext);
             return true;

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -709,7 +709,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override int GetHashCode()
 #pragma warning restore CS0809
         {
-            throw ExceptionUtilities.Unreachable;
+            if (_defaultType is null)
+            {
+                return 0;
+            }
+            return Hash.Combine(_defaultType.GetHashCode(), IsAnnotated.GetHashCode());
         }
 
 #pragma warning disable CS0809

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1600,13 +1600,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal static Cci.TypeReferenceWithAttributes GetTypeRefWithAttributes(
             this TypeSymbolWithAnnotations type,
             Microsoft.CodeAnalysis.CSharp.Emit.PEModuleBuilder moduleBuilder,
-            CSharpCompilation declaringCompilation,
+            Symbol declaringSymbol,
             Cci.ITypeReference typeRef)
         {
             var builder = ArrayBuilder<Cci.ICustomAttribute>.GetInstance();
             if (type.TypeSymbol.ContainsTupleNames())
             {
-                SynthesizedAttributeData attr = declaringCompilation.SynthesizeTupleNamesAttribute(type.TypeSymbol);
+                SynthesizedAttributeData attr = declaringSymbol.DeclaringCompilation.SynthesizeTupleNamesAttribute(type.TypeSymbol);
                 if (attr != null)
                 {
                     builder.Add(attr);
@@ -1615,7 +1615,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // PROTOTYPE(NullableReferenceTypes): type.ReportAnnotatedUnconstrainedTypeParameterIfAny()
             if (type.ContainsNullableReferenceTypes())
             {
-                SynthesizedAttributeData attr = moduleBuilder.SynthesizeNullableAttribute(type.TypeSymbol, type);
+                SynthesizedAttributeData attr = moduleBuilder.SynthesizeNullableAttribute(declaringSymbol, type);
                 if (attr != null)
                 {
                     builder.Add(attr);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -37718,5 +37718,29 @@ class B : A
                 //             n = base.F.Length;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "base.F").WithLocation(21, 17));
         }
+
+        [WorkItem(29041, "https://github.com/dotnet/roslyn/issues/29041")]
+        [Fact]
+        public void ConstraintCycleFromMetadata()
+        {
+            var source0 =
+@"using System;
+public class A<T> where T : IEquatable<T>
+{
+}";
+            var comp0 = CreateCompilation(source0, parseOptions: TestOptions.Regular8);
+            var ref0 = comp0.EmitToImageReference();
+
+            var source =
+@"class B
+{
+    static void Main()
+    {
+        new A<string>();
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
+            comp.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -38105,27 +38105,25 @@ class B : A
 
         [WorkItem(29049, "https://github.com/dotnet/roslyn/issues/29049")]
         [Fact]
-        public void ConstraintFromMetadata()
+        public void TypeSymbolWithAnnotations_GetHashCode()
         {
-            var source0 =
-@"using System;
-public class A<T> where T : IEquatable<string> { }";
             var source =
-@"class B
+@"interface I<T> { }
+class A : I<A> { }
+class B<T> where T : I<A?> { }
+class Program
 {
     static void Main()
     {
-        object o = new A<string?>(); // warning
+        new B<A>();
     }
 }";
-            var comp0 = CreateCompilation(source0, parseOptions: TestOptions.Regular8);
-            var ref0 = comp0.EmitToImageReference();
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             var diagnostics = comp.GetDiagnostics();
             diagnostics.Verify(
-                // (5,26): warning CS8631: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'A<T>'. Nullability of type argument 'string?' doesn't match constraint type 'System.IEquatable<string>'.
-                //         object o = new A<string?>(); // warning
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "string?").WithArguments("A<T>", "System.IEquatable<string>", "T", "string?").WithLocation(5, 26));
+                // (8,15): warning CS8631: The type 'A' cannot be used as type parameter 'T' in the generic type or method 'B<T>'. Nullability of type argument 'A' doesn't match constraint type 'I<A?>'.
+                //         new B<A>();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "A").WithArguments("B<T>", "I<A?>", "T", "A").WithLocation(8, 15));
             // Diagnostics must support GetHashCode() and Equals(), to allow removing
             // duplicates (see CommonCompiler.ReportErrors.)
             foreach (var diagnostic in diagnostics)
@@ -38154,7 +38152,7 @@ public class A6<T> where T : IEquatable<int?> { }";
 {
     static void Main()
     {
-        new A0<string?>();
+        new A0<string?>(); // warning
         new A0<string>();
         new A2<string?>();
         new A2<string>(); // warning
@@ -38166,7 +38164,7 @@ public class A6<T> where T : IEquatable<int?> { }";
             var comp0 = CreateCompilation(source0, parseOptions: TestOptions.Regular8);
             var ref0 = comp0.EmitToImageReference();
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
-            // PROTOTYPE(NullableReferenceTypes): Should report a warning for A2<string>().
+            // PROTOTYPE(NullableReferenceTypes): Should report a warning for A0<string?>() and A2<string>().
             comp.VerifyDiagnostics(
                 // (9,16): warning CS8631: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'A5<T>'. Nullability of type argument 'string?' doesn't match constraint type 'System.IEquatable<string?>'.
                 //         new A5<string?>();
@@ -38197,7 +38195,7 @@ public class A6<T> where T : IEquatable<int?> { }";
             comp0 = CreateCompilation(new[] { source0, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             ref0 = comp0.EmitToImageReference();
             comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, references: new[] { ref0 });
-            // PROTOTYPE(NullableReferenceTypes): Should report a warning for A2<string>().
+            // PROTOTYPE(NullableReferenceTypes): Should report a warning for A0<string?>() and A2<string>().
             comp.VerifyDiagnostics(
                 // (9,16): warning CS8631: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'A5<T>'. Nullability of type argument 'string?' doesn't match constraint type 'System.IEquatable<string?>'.
                 //         new A5<string?>();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -38125,7 +38125,7 @@ class Program
                 //         new B<A>();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "A").WithArguments("B<T>", "I<A?>", "T", "A").WithLocation(8, 15));
             // Diagnostics must support GetHashCode() and Equals(), to allow removing
-            // duplicates (see CommonCompiler.ReportErrors.)
+            // duplicates (see CommonCompiler.ReportErrors).
             foreach (var diagnostic in diagnostics)
             {
                 diagnostic.GetHashCode();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
@@ -492,6 +493,7 @@ class C
             comp.VerifyDiagnostics();
         }
 
+        [WorkItem(29041, "https://github.com/dotnet/roslyn/issues/29041")]
         [Fact]
         public void GenericType_NonNullTypes()
         {
@@ -528,6 +530,7 @@ class C<T> where T : struct
             // [NonNullTypes(false)]
             comp = CreateCompilation(new[] { source, NonNullTypesFalse, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             // PROTOTYPE(NullableReferenceTypes): Should not report any warnings.
+            // See https://github.com/dotnet/roslyn/issues/29065.
             comp.VerifyDiagnostics(
                 // (5,5): warning CS8618: Non-nullable field 'F1' is uninitialized.
                 //     A() { }
@@ -536,6 +539,7 @@ class C<T> where T : struct
             // [NonNullTypes] missing
             comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
             // PROTOTYPE(NullableReferenceTypes): Should not report any warnings.
+            // See https://github.com/dotnet/roslyn/issues/29065.
             comp.VerifyDiagnostics(
                 // (5,5): warning CS8618: Non-nullable field 'F1' is uninitialized.
                 //     A() { }


### PR DESCRIPTION
Avoid calling `IsValueType` in `ApplyNullableTransforms` since `ApplyNullableTransforms` may be called while the `TypeSymbol` is being constructed. (In the case of #29041, when constructing a `PETypeParameterSymbol` where the constraints reference the type parameter.)

Calling `IsValueType` in `ApplyNullableTransforms` is not necessary since the `IsAnnotated` bit is only set in the `[Nullable(new bool[])]` attribute for nullable reference types.