### PR TITLE
Add parameter CodeFixProvider: Add support for `this` and `base` constructor initializers invocations.

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
@@ -2412,6 +2412,7 @@ public class C {
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
         public async Task TestThis_DontOfferToFixTheConstructorWithTheDiagnosticOnIt()
         {
+            // error CS1729: 'C' does not contain a constructor that takes 1 arguments
             var code =
 @"
 public class C {
@@ -2453,7 +2454,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
         public async Task TestBase_Fix_IfACandidateIsAvailable()
         {
-            // error CS1729: 'C' does not contain a constructor that takes 2 arguments
+            // error CS1729: 'B' does not contain a constructor that takes 1 arguments
             var code =
 @"
 public class B

--- a/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
@@ -2407,5 +2407,73 @@ public class C {
 }";
             await TestMissingAsync(code);
         }
+
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestThis_DontOfferToFixTheConstructorWithTheDiagnosticOnIt()
+        {
+            var code =
+@"
+public class C {
+    
+    public C(): [|this|](1)
+    { }
+}";
+            await TestMissingAsync(code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestThis_Fix_IfACandidateIsAvailable()
+        {
+            // error CS1729: 'C' does not contain a constructor that takes 2 arguments
+            var code =
+@"
+class C 
+{
+    public C(int i) { }
+    
+    public C(): [|this|](1, 1)
+    { }
+}";
+            var fix0 =
+@"
+class C 
+{
+    public C(int i, int v) { }
+    
+    public C(): this(1, 1)
+    { }
+}";
+            await TestInRegularAndScriptAsync(code, fix0, index: 0);
+            await TestActionCountAsync(code, 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestBase_Fix_IfACandidateIsAvailable()
+        {
+            // error CS1729: 'C' does not contain a constructor that takes 2 arguments
+            var code =
+@"
+public class B
+{
+    B() { }
+}
+public class C : B
+{
+    public C(int i) : [|base|](i) { }
+}";
+            var fix0 =
+@"
+public class B
+{
+    B(int i) { }
+}
+public class C : B
+{
+    public C(int i) : base(i) { }
+}";
+            await TestInRegularAndScriptAsync(code, fix0, index: 0);
+            await TestActionCountAsync(code, 1);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
@@ -2408,7 +2408,7 @@ public class C {
             await TestMissingAsync(code);
         }
 
-
+        [WorkItem(29061, "https://github.com/dotnet/roslyn/issues/29061")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
         public async Task TestThis_DontOfferToFixTheConstructorWithTheDiagnosticOnIt()
         {
@@ -2422,6 +2422,7 @@ public class C {
             await TestMissingAsync(code);
         }
 
+        [WorkItem(29061, "https://github.com/dotnet/roslyn/issues/29061")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
         public async Task TestThis_Fix_IfACandidateIsAvailable()
         {
@@ -2448,6 +2449,7 @@ class C
             await TestActionCountAsync(code, 1);
         }
 
+        [WorkItem(29061, "https://github.com/dotnet/roslyn/issues/29061")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
         public async Task TestBase_Fix_IfACandidateIsAvailable()
         {

--- a/src/EditorFeatures/VisualBasicTest/AddParameter/AddParameterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddParameter/AddParameterTests.vb
@@ -1043,7 +1043,7 @@ End Class
 
         <WorkItem(29061, "https://github.com/dotnet/roslyn/issues/29061")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)>
-        Public Async Function TestConstructorInitializer_OfferFixForConstructorWithDiagnostic() As Task
+        Public Async Function TestConstructorInitializer_DontOfferFixForConstructorWithDiagnostic() As Task
             ' Error BC30057: Too many arguments to 'Public Sub New()'.
             Dim code =
 "
@@ -1053,18 +1053,7 @@ Public Class C
     End Sub
 End Class
 "
-            ' The fixed code has error BC30298: Constructor 'Public Sub New(v As Integer)' cannot call itself: 
-            ' Public Sub New(v As Integer)' calls 'Public Sub New(v As Integer)'.
-            ' The correct behavior would be to not offer a fix.
-            Dim fix =
-"
-Public Class C
-    Public Sub New(v As Integer)
-        Me.New(1)
-    End Sub
-End Class
-"
-            Await TestInRegularAndScriptAsync(code, fix)
+            Await TestMissingAsync(code)
         End Function
 
         <WorkItem(29061, "https://github.com/dotnet/roslyn/issues/29061")>
@@ -1093,21 +1082,8 @@ Public Class C
     End Sub
 End Class
 "
-            ' This fix is wrong for several reasons. The root cause is, that the fix is offered for the constructor
-            ' with the diagnostic on it causing "error BC30298: Constructor '..' cannot call itself" sooner or later.
-            Dim fix1 =
-"
-Public Class C
-    Public Sub New(i As Integer)
-    End Sub
-    
-    Public Sub New(v As Integer)
-        Me.New(1,1)
-    End Sub
-End Class
-"
             Await TestInRegularAndScriptAsync(code, fix0, index:=0)
-            Await TestInRegularAndScriptAsync(code, fix1, index:=1)
+            Await TestActionCountAsync(code, 1)
         End Function
 
         <WorkItem(29061, "https://github.com/dotnet/roslyn/issues/29061")>

--- a/src/EditorFeatures/VisualBasicTest/AddParameter/AddParameterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddParameter/AddParameterTests.vb
@@ -830,7 +830,7 @@ Public Class C
         M(new System.Exception(), 2)
     End Sub
 End Class"
-            Await TestInRegularAndScriptAsync(code, Fix)
+            Await TestInRegularAndScriptAsync(code, fix)
         End Function
 
         <WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")>
@@ -1039,6 +1039,110 @@ Public Class C
 End Class
 "
             Await TestMissingAsync(code)
+        End Function
+
+        <WorkItem(29061, "https://github.com/dotnet/roslyn/issues/29061")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)>
+        Public Async Function TestConstructorInitializer_OfferFixForConstructorWithDiagnostic() As Task
+            ' Error BC30057: Too many arguments to 'Public Sub New()'.
+            Dim code =
+"
+Public Class C
+    Public Sub New()
+        Me.New([|1|])
+    End Sub
+End Class
+"
+            ' The fixed code has error BC30298: Constructor 'Public Sub New(v As Integer)' cannot call itself: 
+            ' Public Sub New(v As Integer)' calls 'Public Sub New(v As Integer)'.
+            ' The correct behavior would be to not offer a fix.
+            Dim fix =
+"
+Public Class C
+    Public Sub New(v As Integer)
+        Me.New(1)
+    End Sub
+End Class
+"
+            Await TestInRegularAndScriptAsync(code, fix)
+        End Function
+
+        <WorkItem(29061, "https://github.com/dotnet/roslyn/issues/29061")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)>
+        Public Async Function TestConstructorInitializer_OfferFixForOtherConstructors() As Task
+            ' Error BC30516: Overload resolution failed because no accessible 'New' accepts this number of arguments.
+            Dim code =
+"
+Public Class C
+    Public Sub New(i As Integer)
+    End Sub
+    
+    Public Sub New()
+        Me.[|New|](1,1)
+    End Sub
+End Class
+"
+            Dim fix0 =
+"
+Public Class C
+    Public Sub New(i As Integer, v As Integer)
+    End Sub
+    
+    Public Sub New()
+        Me.New(1,1)
+    End Sub
+End Class
+"
+            ' This fix is wrong for several reasons. The root cause is, that the fix is offered for the constructor
+            ' with the diagnostic on it causing "error BC30298: Constructor '..' cannot call itself" sooner or later.
+            Dim fix1 =
+"
+Public Class C
+    Public Sub New(i As Integer)
+    End Sub
+    
+    Public Sub New(v As Integer)
+        Me.New(1,1)
+    End Sub
+End Class
+"
+            Await TestInRegularAndScriptAsync(code, fix0, index:=0)
+            Await TestInRegularAndScriptAsync(code, fix1, index:=1)
+        End Function
+
+        <WorkItem(29061, "https://github.com/dotnet/roslyn/issues/29061")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)>
+        Public Async Function TestConstructorInitializer_OfferFixForBaseConstrcutors() As Task
+            ' error BC30057: Too many arguments to 'Public Sub New()'.
+            Dim code =
+"
+Public Class B
+    Public Sub New()
+    End Sub
+End Class
+
+Public Class C
+    Inherits B
+    Public Sub New()
+        MyBase.New([|1|])
+    End Sub
+End Class
+"
+            Dim fix0 =
+"
+Public Class B
+    Public Sub New(v As Integer)
+    End Sub
+End Class
+
+Public Class C
+    Inherits B
+    Public Sub New()
+        MyBase.New(1)
+    End Sub
+End Class
+"
+            Await TestInRegularAndScriptAsync(code, fix0, index:=0)
         End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
@@ -48,8 +48,6 @@ namespace Microsoft.CodeAnalysis.CSharp.AddParameter
         {
             if (node is ConstructorInitializerSyntax constructorInitializer)
             {
-                var diagnostic = context.Diagnostics.First();
-                var argumentOpt = TryGetRelevantArgument(initialNode, node, diagnostic);
                 var document = context.Document;
                 var cancellationToken = context.CancellationToken;
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
@@ -75,6 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddParameter
                         }
 
                         var arguments = constructorInitializer.ArgumentList.Arguments;
+                        var argumentOpt = TryGetRelevantArgument(initialNode, node, context.Diagnostics.First());
 
                         var insertionData = GetArgumentInsertPositionForMethodCandidates(
                             argumentOpt, semanticModel, syntaxFacts, arguments, methodCandidates);

--- a/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
@@ -64,10 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddParameter
                     {
                         var methodCandidates = type.InstanceConstructors;
                         var arguments = constructorInitializer.ArgumentList.Arguments;
-                        return new RegisterFixData<ArgumentSyntax>(
-                            arguments,
-                            methodCandidates,
-                            true);
+                        return new RegisterFixData<ArgumentSyntax>(arguments, methodCandidates, isConstructorInitializer: true);
                     }
                 }
             }

--- a/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddParameter
         protected override ImmutableArray<string> CannotConvertDiagnosticIds
             => GenerateConstructorDiagnosticIds.CannotConvertDiagnosticIds;
 
-        protected override RegisterFixData<ArgumentSyntax> GetDataForFix_LanguageSpecificExpression(
+        protected override RegisterFixData<ArgumentSyntax> TryGetLanguageSpecificFixInfo(
             SemanticModel semanticModel,
             SyntaxNode node,
             CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
@@ -63,14 +63,11 @@ namespace Microsoft.CodeAnalysis.CSharp.AddParameter
                     if (type != null && type.IsFromSource())
                     {
                         var methodCandidates = type.InstanceConstructors;
-                        if (constructorInitializer.IsKind(SyntaxKind.ThisConstructorInitializer))
-                        {
-                            // Exclude the constructor with the diagnostic from the list of candidates
-                            methodCandidates = methodCandidates.Remove(constructorSymbol);
-                        }
-
                         var arguments = constructorInitializer.ArgumentList.Arguments;
-                        return new RegisterFixData<ArgumentSyntax>(arguments, methodCandidates);
+                        return new RegisterFixData<ArgumentSyntax>(
+                            arguments,
+                            methodCandidates,
+                            true);
                     }
                 }
             }

--- a/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
@@ -44,9 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddParameter
             => GenerateConstructorDiagnosticIds.CannotConvertDiagnosticIds;
 
         protected override RegisterFixData<ArgumentSyntax> GetDataForFix_LanguageSpecificExpression(
-            Document document,
             SemanticModel semanticModel,
-            ISyntaxFactsService syntaxFacts,
             SyntaxNode node,
             CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -126,19 +126,19 @@ namespace Microsoft.CodeAnalysis.AddParameter
                 var typeNode = syntaxFacts.GetObjectCreationType(objectCreation);
                 if (typeNode == null)
                 {
-                    return null;
+                    return new RegisterFixData<TArgumentSyntax>();
                 }
 
                 // If we can't figure out the type being created, or the type isn't in source,
                 // then there's nothing we can do.
                 if (!(semanticModel.GetSymbolInfo(typeNode, cancellationToken).GetAnySymbol() is INamedTypeSymbol type))
                 {
-                    return null;
+                    return new RegisterFixData<TArgumentSyntax>();
                 }
 
                 if (!type.IsNonImplicitAndFromSource())
                 {
-                    return null;
+                    return new RegisterFixData<TArgumentSyntax>();
                 }
 
                 var arguments = (SeparatedSyntaxList<TArgumentSyntax>)syntaxFacts.GetArgumentsOfObjectCreationExpression(objectCreation);

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -114,35 +114,6 @@ namespace Microsoft.CodeAnalysis.AddParameter
             return null;
         }
 
-        /// <summary>
-        /// In VB a constructor calls other constructor overloads via a Me.New(..) invocation. We need to exclude the constructor with
-        /// the diagnostic from the candidates because that would likely introduces a recursive call to itself, which in turn would be
-        /// compiler error BC30298: Constructor 'Public Sub New(...)' cannot call itself.
-        /// </summary>
-        private static ImmutableArray<IMethodSymbol> RemoveConstructorWithDiagnosticFromCandidates(
-            TInvocationExpressionSyntax invocationExpression,
-            ImmutableArray<IMethodSymbol> candidates,
-            CancellationToken cancellationToken)
-        {
-            foreach (var candidate in candidates)
-            {
-                if (candidate.MethodKind != MethodKind.Constructor)
-                {
-                    break;
-                }
-
-                if (candidate.DeclaringSyntaxReferences.Any(syntaxReference
-                    => syntaxReference.GetSyntax(cancellationToken)?.Parent?.Contains(invocationExpression) == true))
-                {
-                    candidates = candidates.Remove(candidate);
-                    break;
-                }
-
-            }
-
-            return candidates;
-        }
-
         private static RegisterFixData<TArgumentSyntax> TryGetObjectCreationFixInfo(
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFacts,
@@ -178,6 +149,35 @@ namespace Microsoft.CodeAnalysis.AddParameter
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// In VB a constructor calls other constructor overloads via a Me.New(..) invocation. We need to exclude the constructor with
+        /// the diagnostic from the candidates because that would likely introduces a recursive call to itself, which in turn would be
+        /// compiler error BC30298: Constructor 'Public Sub New(...)' cannot call itself.
+        /// </summary>
+        private static ImmutableArray<IMethodSymbol> RemoveConstructorWithDiagnosticFromCandidates(
+            TInvocationExpressionSyntax invocationExpression,
+            ImmutableArray<IMethodSymbol> candidates,
+            CancellationToken cancellationToken)
+        {
+            foreach (var candidate in candidates)
+            {
+                if (candidate.MethodKind != MethodKind.Constructor)
+                {
+                    break;
+                }
+
+                if (candidate.DeclaringSyntaxReferences.Any(syntaxReference
+                    => syntaxReference.GetSyntax(cancellationToken)?.Parent?.Contains(invocationExpression) == true))
+                {
+                    candidates = candidates.Remove(candidate);
+                    break;
+                }
+
+            }
+
+            return candidates;
         }
 
         private static ImmutableArray<ArgumentInsertPositionData<TArgumentSyntax>> GetArgumentInsertPositionForMethodCandidates(

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
                 var arguments = (SeparatedSyntaxList<TArgumentSyntax>)syntaxFacts.GetArgumentsOfObjectCreationExpression(objectCreation);
                 var methodCandidates = type.InstanceConstructors;
 
-                return new RegisterFixData<TArgumentSyntax>(arguments, methodCandidates, false);
+                return new RegisterFixData<TArgumentSyntax>(arguments, methodCandidates, isConstructorInitializer: false);
             }
 
             return null;

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -61,8 +61,8 @@ namespace Microsoft.CodeAnalysis.AddParameter
             for (var node = initialNode; node != null; node = node.Parent)
             {
                 var fixData =
-                    GetDataForFix_InvocationExpressionAsync(document, semanticModel, syntaxFacts, node, cancellationToken) ??
-                    GetDataForFix_ObjectCreationExpressionAsync(document, semanticModel, syntaxFacts, node, cancellationToken) ??
+                    GetDataForFix_InvocationExpression(document, semanticModel, syntaxFacts, node, cancellationToken) ??
+                    GetDataForFix_ObjectCreationExpression(document, semanticModel, syntaxFacts, node, cancellationToken) ??
                     GetDataForFix_LanguageSpecificExpression(document, semanticModel, syntaxFacts, node, cancellationToken);
 
                 if (fixData != null)
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
                               .LastOrDefault(a => a.AncestorsAndSelf().Contains(node));
         }
 
-        private static RegisterFixData<TArgumentSyntax> GetDataForFix_InvocationExpressionAsync(
+        private static RegisterFixData<TArgumentSyntax> GetDataForFix_InvocationExpression(
             Document document,
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFacts,
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
             return null;
         }
 
-        private static RegisterFixData<TArgumentSyntax> GetDataForFix_ObjectCreationExpressionAsync(
+        private static RegisterFixData<TArgumentSyntax> GetDataForFix_ObjectCreationExpression(
             Document document,
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFacts,

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
         protected abstract ImmutableArray<string> TooManyArgumentsDiagnosticIds { get; }
         protected abstract ImmutableArray<string> CannotConvertDiagnosticIds { get; }
 
-        protected virtual RegisterFixData<TArgumentSyntax> GetDataForFix_LanguageSpecificExpression(
+        protected virtual RegisterFixData<TArgumentSyntax> TryGetLanguageSpecificFixInfo(
             SemanticModel semanticModel,
             SyntaxNode node,
             CancellationToken cancellationToken)
@@ -59,9 +59,9 @@ namespace Microsoft.CodeAnalysis.AddParameter
             for (var node = initialNode; node != null; node = node.Parent)
             {
                 var fixData =
-                    GetDataForFix_InvocationExpression(semanticModel, syntaxFacts, node, cancellationToken) ??
-                    GetDataForFix_ObjectCreationExpression(semanticModel, syntaxFacts, node, cancellationToken) ??
-                    GetDataForFix_LanguageSpecificExpression(semanticModel, node, cancellationToken);
+                    TryGetInvocationExpressionFixInfo(semanticModel, syntaxFacts, node, cancellationToken) ??
+                    TryGetObjectCreationFixInfo(semanticModel, syntaxFacts, node, cancellationToken) ??
+                    TryGetLanguageSpecificFixInfo(semanticModel, node, cancellationToken);
 
                 if (fixData != null)
                 {
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
                               .LastOrDefault(a => a.AncestorsAndSelf().Contains(node));
         }
 
-        private static RegisterFixData<TArgumentSyntax> GetDataForFix_InvocationExpression(
+        private static RegisterFixData<TArgumentSyntax> TryGetInvocationExpressionFixInfo(
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFacts,
             SyntaxNode node,
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
             return null;
         }
 
-        private static RegisterFixData<TArgumentSyntax> GetDataForFix_ObjectCreationExpression(
+        private static RegisterFixData<TArgumentSyntax> TryGetObjectCreationFixInfo(
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFacts,
             SyntaxNode node,

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -39,9 +39,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
         protected abstract ImmutableArray<string> CannotConvertDiagnosticIds { get; }
 
         protected virtual RegisterFixData<TArgumentSyntax> GetDataForFix_LanguageSpecificExpression(
-            Document document,
             SemanticModel semanticModel,
-            ISyntaxFactsService syntaxFacts,
             SyntaxNode node,
             CancellationToken cancellationToken)
             => null;
@@ -61,9 +59,9 @@ namespace Microsoft.CodeAnalysis.AddParameter
             for (var node = initialNode; node != null; node = node.Parent)
             {
                 var fixData =
-                    GetDataForFix_InvocationExpression(document, semanticModel, syntaxFacts, node, cancellationToken) ??
-                    GetDataForFix_ObjectCreationExpression(document, semanticModel, syntaxFacts, node, cancellationToken) ??
-                    GetDataForFix_LanguageSpecificExpression(document, semanticModel, syntaxFacts, node, cancellationToken);
+                    GetDataForFix_InvocationExpression(semanticModel, syntaxFacts, node, cancellationToken) ??
+                    GetDataForFix_ObjectCreationExpression(semanticModel, syntaxFacts, node, cancellationToken) ??
+                    GetDataForFix_LanguageSpecificExpression(semanticModel, node, cancellationToken);
 
                 if (fixData != null)
                 {
@@ -99,7 +97,6 @@ namespace Microsoft.CodeAnalysis.AddParameter
         }
 
         private static RegisterFixData<TArgumentSyntax> GetDataForFix_InvocationExpression(
-            Document document,
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFacts,
             SyntaxNode node,
@@ -117,7 +114,6 @@ namespace Microsoft.CodeAnalysis.AddParameter
         }
 
         private static RegisterFixData<TArgumentSyntax> GetDataForFix_ObjectCreationExpression(
-            Document document,
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFacts,
             SyntaxNode node,

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
         /// There are some exceptions to this rule. Returning null indicates that the fixer needs
         /// to find the relevant argument by itself.
         /// </summary>
-        protected TArgumentSyntax TryGetRelevantArgument(
+        private TArgumentSyntax TryGetRelevantArgument(
             SyntaxNode initialNode, SyntaxNode node, Diagnostic diagnostic)
         {
             if (this.TooManyArgumentsDiagnosticIds.Contains(diagnostic.Id))
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
             return null;
         }
 
-        protected ImmutableArray<ArgumentInsertPositionData<TArgumentSyntax>> GetArgumentInsertPositionForMethodCandidates(
+        private static ImmutableArray<ArgumentInsertPositionData<TArgumentSyntax>> GetArgumentInsertPositionForMethodCandidates(
             TArgumentSyntax argumentOpt,
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFacts,
@@ -197,10 +197,10 @@ namespace Microsoft.CodeAnalysis.AddParameter
             return methodsAndArgumentToAdd.ToImmutableAndFree();
         }
 
-        private int NonParamsParameterCount(IMethodSymbol method)
+        private static int NonParamsParameterCount(IMethodSymbol method)
             => method.IsParams() ? method.Parameters.Length - 1 : method.Parameters.Length;
 
-        protected void RegisterFixForMethodOverloads(
+        private void RegisterFixForMethodOverloads(
             CodeFixContext context,
             SeparatedSyntaxList<TArgumentSyntax> arguments,
             ImmutableArray<ArgumentInsertPositionData<TArgumentSyntax>> methodsAndArgumentsToAdd)
@@ -687,7 +687,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
                         parameterOptions: SymbolDisplayParameterOptions.IncludeParamsRefOut | SymbolDisplayParameterOptions.IncludeType,
                         miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-        private TArgumentSyntax DetermineFirstArgumentToAdd(
+        private static TArgumentSyntax DetermineFirstArgumentToAdd(
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFacts,
             StringComparer comparer,
@@ -769,7 +769,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
             return null;
         }
 
-        private bool TypeInfoMatchesWithParamsExpansion(
+        private static bool TypeInfoMatchesWithParamsExpansion(
             TypeInfo argumentTypeInfo, IParameterSymbol parameter,
             bool isNullLiteral, bool isDefaultLiteral)
         {
@@ -784,7 +784,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
             return false;
         }
 
-        private bool TypeInfoMatchesType(
+        private static bool TypeInfoMatchesType(
             TypeInfo argumentTypeInfo, ITypeSymbol type,
             bool isNullLiteral, bool isDefaultLiteral)
         {

--- a/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
+++ b/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
@@ -8,17 +8,19 @@ namespace Microsoft.CodeAnalysis.AddParameter
     internal class RegisterFixData<TArgumentSyntax>
         where TArgumentSyntax : SyntaxNode
     {
-        public RegisterFixData() : this(new SeparatedSyntaxList<TArgumentSyntax>(), ImmutableArray<IMethodSymbol>.Empty)
+        public RegisterFixData() : this(new SeparatedSyntaxList<TArgumentSyntax>(), ImmutableArray<IMethodSymbol>.Empty, false)
         {
         }
 
-        public RegisterFixData(SeparatedSyntaxList<TArgumentSyntax> arguments, ImmutableArray<IMethodSymbol> methodCandidates)
+        public RegisterFixData(SeparatedSyntaxList<TArgumentSyntax> arguments, ImmutableArray<IMethodSymbol> methodCandidates, bool isConstructorInitializer)
         {
             Arguments = arguments;
             MethodCandidates = methodCandidates;
+            IsConstructorInitializer = isConstructorInitializer;
         }
 
         public SeparatedSyntaxList<TArgumentSyntax> Arguments { get; }
         public ImmutableArray<IMethodSymbol> MethodCandidates { get; }
+        public bool IsConstructorInitializer { get; }
     }
 }

--- a/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
+++ b/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.AddParameter
+{
+    internal class RegisterFixData<TArgumentSyntax> where
+        TArgumentSyntax : SyntaxNode
+    {
+        public RegisterFixData(SeparatedSyntaxList<TArgumentSyntax> arguments, ImmutableArray<IMethodSymbol> methodCandidates)
+        {
+            Arguments = arguments;
+            MethodCandidates = methodCandidates;
+        }
+
+        public SeparatedSyntaxList<TArgumentSyntax> Arguments { get; }
+        public ImmutableArray<IMethodSymbol> MethodCandidates { get; }
+    }
+}

--- a/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
+++ b/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
@@ -5,8 +5,8 @@ using System.Text;
 
 namespace Microsoft.CodeAnalysis.AddParameter
 {
-    internal class RegisterFixData<TArgumentSyntax> where
-        TArgumentSyntax : SyntaxNode
+    internal class RegisterFixData<TArgumentSyntax>
+        where TArgumentSyntax : SyntaxNode
     {
         public RegisterFixData(SeparatedSyntaxList<TArgumentSyntax> arguments, ImmutableArray<IMethodSymbol> methodCandidates)
         {

--- a/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
+++ b/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;

--- a/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
+++ b/src/Features/Core/Portable/AddParameter/RegisterFixData.cs
@@ -8,6 +8,10 @@ namespace Microsoft.CodeAnalysis.AddParameter
     internal class RegisterFixData<TArgumentSyntax>
         where TArgumentSyntax : SyntaxNode
     {
+        public RegisterFixData() : this(new SeparatedSyntaxList<TArgumentSyntax>(), ImmutableArray<IMethodSymbol>.Empty)
+        {
+        }
+
         public RegisterFixData(SeparatedSyntaxList<TArgumentSyntax> arguments, ImmutableArray<IMethodSymbol> methodCandidates)
         {
             Arguments = arguments;


### PR DESCRIPTION
This PR adds support for `this()` and `base()` invocations kinds to the *Add a parameter to existing constructor* CodeFixProvider.

Because `this` and `base` are C# specific I implemented the feature in the *CSharpAddParameterCodeFixProvider.cs* (This avoids the creation of several C#-only methods in `ISyntaxFactsService`).

/cc @CyrusNajmabadi and @jnm2 (who reported this on gitter).