### PR TITLE
IOperation and CFG support for null-coalescing assignment

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -435,7 +435,6 @@
   <Node Name="BoundNullCoalescingAssignmentOperator" Base="BoundExpression">
     <Field Name="LeftOperand" Type="BoundExpression" />
     <Field Name="RightOperand" Type="BoundExpression" />
-    <Field Name="IsChecked" Type="bool" />
   </Node>
 
   <Node Name="BoundConditionalOperator" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -1337,7 +1337,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundNullCoalescingAssignmentOperator : BoundExpression
     {
-        public BoundNullCoalescingAssignmentOperator(SyntaxNode syntax, BoundExpression leftOperand, BoundExpression rightOperand, bool isChecked, TypeSymbol type, bool hasErrors = false)
+        public BoundNullCoalescingAssignmentOperator(SyntaxNode syntax, BoundExpression leftOperand, BoundExpression rightOperand, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.NullCoalescingAssignmentOperator, syntax, type, hasErrors || leftOperand.HasErrors() || rightOperand.HasErrors())
         {
 
@@ -1346,7 +1346,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             this.LeftOperand = leftOperand;
             this.RightOperand = rightOperand;
-            this.IsChecked = isChecked;
         }
 
 
@@ -1354,18 +1353,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundExpression RightOperand { get; }
 
-        public bool IsChecked { get; }
-
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitNullCoalescingAssignmentOperator(this);
         }
 
-        public BoundNullCoalescingAssignmentOperator Update(BoundExpression leftOperand, BoundExpression rightOperand, bool isChecked, TypeSymbol type)
+        public BoundNullCoalescingAssignmentOperator Update(BoundExpression leftOperand, BoundExpression rightOperand, TypeSymbol type)
         {
-            if (leftOperand != this.LeftOperand || rightOperand != this.RightOperand || isChecked != this.IsChecked || type != this.Type)
+            if (leftOperand != this.LeftOperand || rightOperand != this.RightOperand || type != this.Type)
             {
-                var result = new BoundNullCoalescingAssignmentOperator(this.Syntax, leftOperand, rightOperand, isChecked, type, this.HasErrors);
+                var result = new BoundNullCoalescingAssignmentOperator(this.Syntax, leftOperand, rightOperand, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -8960,7 +8957,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression leftOperand = (BoundExpression)this.Visit(node.LeftOperand);
             BoundExpression rightOperand = (BoundExpression)this.Visit(node.RightOperand);
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(leftOperand, rightOperand, node.IsChecked, type);
+            return node.Update(leftOperand, rightOperand, type);
         }
         public override BoundNode VisitConditionalOperator(BoundConditionalOperator node)
         {
@@ -10024,7 +10021,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 new TreeDumperNode("leftOperand", null, new TreeDumperNode[] { Visit(node.LeftOperand, null) }),
                 new TreeDumperNode("rightOperand", null, new TreeDumperNode[] { Visit(node.RightOperand, null) }),
-                new TreeDumperNode("isChecked", node.IsChecked, null),
                 new TreeDumperNode("type", node.Type, null)
             }
             );

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingAssignmentOperator.cs
@@ -22,7 +22,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // lhsRead ?? (transformedLHS = loweredRight)
 
             // transformedLHS = rhs
-            BoundExpression assignment = MakeAssignmentOperator(syntax, transformedLHS, loweredRight, node.LeftOperand.Type, used: true, node.IsChecked, isCompoundAssignment: true);
+            // isCompoundAssignment is only used for dynamic scenarios, and we want those scenarios to treat this like a standard assignment.
+            // See CodeGenNullCoalescingAssignmentTests.CoalescingAssignment_DynamicRuntimeCastFailure, which will fail if
+            // isCompoundAssignment is set to true. It will fail to throw a runtime binder cast exception.
+            BoundExpression assignment = MakeAssignmentOperator(syntax, transformedLHS, loweredRight, node.LeftOperand.Type, used: true, isChecked: false, isCompoundAssignment: false);
 
             // lhsRead ?? (transformedLHS = loweredRight)
             BoundExpression conditionalExpression = MakeNullCoalescingOperator(syntax, lhsRead, assignment, Conversion.Identity, node.LeftOperand.Type);

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -253,6 +253,8 @@ namespace Microsoft.CodeAnalysis.Operations
                     return CreateMethodBodyOperation((BoundNonConstructorMethodBody)boundNode);
                 case BoundKind.DiscardExpression:
                     return CreateDiscardExpressionOperation((BoundDiscardExpression)boundNode);
+                case BoundKind.NullCoalescingAssignmentOperator:
+                    return CreateBoundNullCoalescingAssignmentOperatorOperation((BoundNullCoalescingAssignmentOperator)boundNode);
 
                 default:
                     Optional<object> constantValue = ConvertToOptional((boundNode as BoundExpression)?.ConstantValue);
@@ -1290,6 +1292,19 @@ namespace Microsoft.CodeAnalysis.Operations
             }
 
             return new LazyCoalesceExpression(expression, whenNull, valueConversion, _semanticModel, syntax, type, constantValue, isImplicit);
+        }
+
+        private IOperation CreateBoundNullCoalescingAssignmentOperatorOperation(BoundNullCoalescingAssignmentOperator boundNode)
+        {
+            Lazy<IOperation> target = new Lazy<IOperation>(() => Create(boundNode.LeftOperand));
+            Lazy<IOperation> whenNull = new Lazy<IOperation>(() => Create(boundNode.RightOperand));
+            bool isChecked = boundNode.IsChecked;
+            SyntaxNode syntax = boundNode.Syntax;
+            ITypeSymbol type = boundNode.Type;
+            Optional<object> constantValue = ConvertToOptional(boundNode.ConstantValue);
+            bool isImplicit = boundNode.WasCompilerGenerated;
+
+            return new LazyCoalesceAssignmentOperation(target, whenNull, isChecked, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
         private IAwaitOperation CreateBoundAwaitExpressionOperation(BoundAwaitExpression boundAwaitExpression)

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1297,14 +1297,13 @@ namespace Microsoft.CodeAnalysis.Operations
         private IOperation CreateBoundNullCoalescingAssignmentOperatorOperation(BoundNullCoalescingAssignmentOperator boundNode)
         {
             Lazy<IOperation> target = new Lazy<IOperation>(() => Create(boundNode.LeftOperand));
-            Lazy<IOperation> whenNull = new Lazy<IOperation>(() => Create(boundNode.RightOperand));
-            bool isChecked = boundNode.IsChecked;
+            Lazy<IOperation> value = new Lazy<IOperation>(() => Create(boundNode.RightOperand));
             SyntaxNode syntax = boundNode.Syntax;
             ITypeSymbol type = boundNode.Type;
             Optional<object> constantValue = ConvertToOptional(boundNode.ConstantValue);
             bool isImplicit = boundNode.WasCompilerGenerated;
 
-            return new LazyCoalesceAssignmentOperation(target, whenNull, isChecked, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new LazyCoalesceAssignmentOperation(target, value, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
         private IAwaitOperation CreateBoundAwaitExpressionOperation(BoundAwaitExpression boundAwaitExpression)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
@@ -1038,7 +1038,7 @@ In Indexer Setter
 
             verifier.VerifyIL("C.VerifyField()", expectedIL: @"
 {
-  // Code size      244 (0xf4)
+  // Code size      240 (0xf0)
   .maxstack  10
   .locals init (object V_0)
   IL_0000:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int?>> C.<>o__1.<>p__2""
@@ -1079,46 +1079,46 @@ In Indexer Setter
   IL_0085:  ldloc.0
   IL_0086:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
   IL_008b:  dup
-  IL_008c:  brtrue.s   IL_00ee
+  IL_008c:  brtrue.s   IL_00ea
   IL_008e:  pop
   IL_008f:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__1.<>p__1""
-  IL_0094:  brtrue.s   IL_00d3
-  IL_0096:  ldc.i4     0x81
-  IL_009b:  ldstr      ""F1""
-  IL_00a0:  ldtoken    ""C""
-  IL_00a5:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_00aa:  ldc.i4.2
-  IL_00ab:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-  IL_00b0:  dup
-  IL_00b1:  ldc.i4.0
-  IL_00b2:  ldc.i4.0
-  IL_00b3:  ldnull
-  IL_00b4:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_00b9:  stelem.ref
-  IL_00ba:  dup
-  IL_00bb:  ldc.i4.1
-  IL_00bc:  ldc.i4.0
-  IL_00bd:  ldnull
-  IL_00be:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_00c3:  stelem.ref
-  IL_00c4:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.SetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-  IL_00c9:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_00ce:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__1.<>p__1""
-  IL_00d3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__1.<>p__1""
-  IL_00d8:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>>.Target""
-  IL_00dd:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__1.<>p__1""
-  IL_00e2:  ldloc.0
-  IL_00e3:  ldc.i4.0
-  IL_00e4:  box        ""int""
-  IL_00e9:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, dynamic)""
-  IL_00ee:  callvirt   ""int? System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int?>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-  IL_00f3:  ret
+  IL_0094:  brtrue.s   IL_00cf
+  IL_0096:  ldc.i4.0
+  IL_0097:  ldstr      ""F1""
+  IL_009c:  ldtoken    ""C""
+  IL_00a1:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_00a6:  ldc.i4.2
+  IL_00a7:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+  IL_00ac:  dup
+  IL_00ad:  ldc.i4.0
+  IL_00ae:  ldc.i4.0
+  IL_00af:  ldnull
+  IL_00b0:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_00b5:  stelem.ref
+  IL_00b6:  dup
+  IL_00b7:  ldc.i4.1
+  IL_00b8:  ldc.i4.0
+  IL_00b9:  ldnull
+  IL_00ba:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_00bf:  stelem.ref
+  IL_00c0:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.SetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+  IL_00c5:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_00ca:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__1.<>p__1""
+  IL_00cf:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__1.<>p__1""
+  IL_00d4:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>>.Target""
+  IL_00d9:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__1.<>p__1""
+  IL_00de:  ldloc.0
+  IL_00df:  ldc.i4.0
+  IL_00e0:  box        ""int""
+  IL_00e5:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, dynamic)""
+  IL_00ea:  callvirt   ""int? System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int?>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_00ef:  ret
 }
 ");
 
             verifier.VerifyIL("C.VerifyProperty()", expectedIL: @"
 {
-  // Code size      244 (0xf4)
+  // Code size      240 (0xf0)
   .maxstack  10
   .locals init (object V_0)
   IL_0000:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int?>> C.<>o__2.<>p__2""
@@ -1159,46 +1159,46 @@ In Indexer Setter
   IL_0085:  ldloc.0
   IL_0086:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
   IL_008b:  dup
-  IL_008c:  brtrue.s   IL_00ee
+  IL_008c:  brtrue.s   IL_00ea
   IL_008e:  pop
   IL_008f:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__2.<>p__1""
-  IL_0094:  brtrue.s   IL_00d3
-  IL_0096:  ldc.i4     0x81
-  IL_009b:  ldstr      ""P1""
-  IL_00a0:  ldtoken    ""C""
-  IL_00a5:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_00aa:  ldc.i4.2
-  IL_00ab:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-  IL_00b0:  dup
-  IL_00b1:  ldc.i4.0
-  IL_00b2:  ldc.i4.0
-  IL_00b3:  ldnull
-  IL_00b4:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_00b9:  stelem.ref
-  IL_00ba:  dup
-  IL_00bb:  ldc.i4.1
-  IL_00bc:  ldc.i4.0
-  IL_00bd:  ldnull
-  IL_00be:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_00c3:  stelem.ref
-  IL_00c4:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.SetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-  IL_00c9:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_00ce:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__2.<>p__1""
-  IL_00d3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__2.<>p__1""
-  IL_00d8:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>>.Target""
-  IL_00dd:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__2.<>p__1""
-  IL_00e2:  ldloc.0
-  IL_00e3:  ldc.i4.1
-  IL_00e4:  box        ""int""
-  IL_00e9:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, dynamic)""
-  IL_00ee:  callvirt   ""int? System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int?>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-  IL_00f3:  ret
+  IL_0094:  brtrue.s   IL_00cf
+  IL_0096:  ldc.i4.0
+  IL_0097:  ldstr      ""P1""
+  IL_009c:  ldtoken    ""C""
+  IL_00a1:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_00a6:  ldc.i4.2
+  IL_00a7:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+  IL_00ac:  dup
+  IL_00ad:  ldc.i4.0
+  IL_00ae:  ldc.i4.0
+  IL_00af:  ldnull
+  IL_00b0:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_00b5:  stelem.ref
+  IL_00b6:  dup
+  IL_00b7:  ldc.i4.1
+  IL_00b8:  ldc.i4.0
+  IL_00b9:  ldnull
+  IL_00ba:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_00bf:  stelem.ref
+  IL_00c0:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.SetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+  IL_00c5:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_00ca:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__2.<>p__1""
+  IL_00cf:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__2.<>p__1""
+  IL_00d4:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>>.Target""
+  IL_00d9:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>> C.<>o__2.<>p__1""
+  IL_00de:  ldloc.0
+  IL_00df:  ldc.i4.1
+  IL_00e0:  box        ""int""
+  IL_00e5:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, dynamic)""
+  IL_00ea:  callvirt   ""int? System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int?>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_00ef:  ret
 }
 ");
 
             verifier.VerifyIL("C.VerifyIndexer()", expectedIL: @"
 {
-  // Code size      256 (0x100)
+  // Code size      252 (0xfc)
   .maxstack  9
   .locals init (object V_0)
   IL_0000:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int?>> C.<>o__3.<>p__2""
@@ -1245,46 +1245,46 @@ In Indexer Setter
   IL_008b:  ldc.i4.0
   IL_008c:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, int)""
   IL_0091:  dup
-  IL_0092:  brtrue.s   IL_00fa
+  IL_0092:  brtrue.s   IL_00f6
   IL_0094:  pop
   IL_0095:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>> C.<>o__3.<>p__1""
-  IL_009a:  brtrue.s   IL_00de
-  IL_009c:  ldc.i4     0x81
-  IL_00a1:  ldtoken    ""C""
-  IL_00a6:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_00ab:  ldc.i4.3
-  IL_00ac:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-  IL_00b1:  dup
-  IL_00b2:  ldc.i4.0
-  IL_00b3:  ldc.i4.0
-  IL_00b4:  ldnull
-  IL_00b5:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_00ba:  stelem.ref
-  IL_00bb:  dup
-  IL_00bc:  ldc.i4.1
-  IL_00bd:  ldc.i4.3
-  IL_00be:  ldnull
-  IL_00bf:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_00c4:  stelem.ref
-  IL_00c5:  dup
-  IL_00c6:  ldc.i4.2
-  IL_00c7:  ldc.i4.0
-  IL_00c8:  ldnull
-  IL_00c9:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_00ce:  stelem.ref
-  IL_00cf:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.SetIndex(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-  IL_00d4:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_00d9:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>> C.<>o__3.<>p__1""
-  IL_00de:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>> C.<>o__3.<>p__1""
-  IL_00e3:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>>.Target""
-  IL_00e8:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>> C.<>o__3.<>p__1""
-  IL_00ed:  ldloc.0
-  IL_00ee:  ldc.i4.0
-  IL_00ef:  ldc.i4.2
-  IL_00f0:  box        ""int""
-  IL_00f5:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic)""
-  IL_00fa:  callvirt   ""int? System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int?>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-  IL_00ff:  ret
+  IL_009a:  brtrue.s   IL_00da
+  IL_009c:  ldc.i4.0
+  IL_009d:  ldtoken    ""C""
+  IL_00a2:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_00a7:  ldc.i4.3
+  IL_00a8:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+  IL_00ad:  dup
+  IL_00ae:  ldc.i4.0
+  IL_00af:  ldc.i4.0
+  IL_00b0:  ldnull
+  IL_00b1:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_00b6:  stelem.ref
+  IL_00b7:  dup
+  IL_00b8:  ldc.i4.1
+  IL_00b9:  ldc.i4.3
+  IL_00ba:  ldnull
+  IL_00bb:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_00c0:  stelem.ref
+  IL_00c1:  dup
+  IL_00c2:  ldc.i4.2
+  IL_00c3:  ldc.i4.0
+  IL_00c4:  ldnull
+  IL_00c5:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_00ca:  stelem.ref
+  IL_00cb:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.SetIndex(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+  IL_00d0:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_00d5:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>> C.<>o__3.<>p__1""
+  IL_00da:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>> C.<>o__3.<>p__1""
+  IL_00df:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>>.Target""
+  IL_00e4:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>> C.<>o__3.<>p__1""
+  IL_00e9:  ldloc.0
+  IL_00ea:  ldc.i4.0
+  IL_00eb:  ldc.i4.2
+  IL_00ec:  box        ""int""
+  IL_00f1:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, int, dynamic)""
+  IL_00f6:  callvirt   ""int? System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int?>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_00fb:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
@@ -211,5 +211,685 @@ ICoalesceAssignmentOperation(IsChecked: True) (OperationKind.CoalesceAssignment,
 
             VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
         }
+
+        [Fact]
+        public void CoalesceAssignmentFlow_SimpleAssignment()
+        {
+            string source = @"
+class C
+{
+    static void M(object o1, object o2)
+    /*<bind>*/{
+        o1 ??= o2;
+    }/*</bind>*/
+}
+";
+            string expectedFlowGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1} {R2}
+
+.locals {R1}
+{
+    CaptureIds: [1]
+    .locals {R2}
+    {
+        CaptureIds: [0]
+        Block[B1] - Block
+            Predecessors: [B0]
+            Statements (1)
+                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+            Next (Regular) Block[B2]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+            Next (Regular) Block[B4]
+                Leaving: {R2}
+        Block[B3] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1 ??= o2')
+                  Value: 
+                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= o2')
+                      Left: 
+                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                      Right: 
+                        IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
+
+            Next (Regular) Block[B4]
+                Leaving: {R2}
+    }
+
+    Block[B4] - Block
+        Predecessors: [B2] [B3]
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'o1 ??= o2;')
+              Expression: 
+                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= o2')
+
+        Next (Regular) Block[B5]
+            Leaving: {R1}
+}
+
+Block[B5] - Exit
+    Predecessors: [B4]
+    Statements (0)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignmentFlow_NullableValueTypeTarget()
+        {
+            string source = @"
+class C
+{
+    static void M(int? i1, int i2)
+    /*<bind>*/{
+        i1 ??= i2;
+    }/*</bind>*/
+}
+";
+            string expectedFlowGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1} {R2}
+
+.locals {R1}
+{
+    CaptureIds: [1]
+    .locals {R2}
+    {
+        CaptureIds: [0]
+        Block[B1] - Block
+            Predecessors: [B0]
+            Statements (1)
+                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'i1')
+                  Value: 
+                    IParameterReferenceOperation: i1 (OperationKind.ParameterReference, Type: System.Int32?) (Syntax: 'i1')
+
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'i1')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
+
+            Next (Regular) Block[B2]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'i1')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
+
+            Next (Regular) Block[B4]
+                Leaving: {R2}
+        Block[B3] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'i1 ??= i2')
+                  Value: 
+                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32?, IsImplicit) (Syntax: 'i1 ??= i2')
+                      Left: 
+                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
+                      Right: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32?, IsImplicit) (Syntax: 'i2')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitNullable)
+                          Operand: 
+                            IParameterReferenceOperation: i2 (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'i2')
+
+            Next (Regular) Block[B4]
+                Leaving: {R2}
+    }
+
+    Block[B4] - Block
+        Predecessors: [B2] [B3]
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'i1 ??= i2;')
+              Expression: 
+                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1 ??= i2')
+
+        Next (Regular) Block[B5]
+            Leaving: {R1}
+}
+
+Block[B5] - Exit
+    Predecessors: [B4]
+    Statements (0)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignmentFlow_WhenNullConversion()
+        {
+            string source = @"
+class C
+{
+    static void M(object o1, string s1)
+    /*<bind>*/{
+        o1 ??= s1;
+    }/*</bind>*/
+}
+";
+            string expectedFlowGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1} {R2}
+
+.locals {R1}
+{
+    CaptureIds: [1]
+    .locals {R2}
+    {
+        CaptureIds: [0]
+        Block[B1] - Block
+            Predecessors: [B0]
+            Statements (1)
+                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+            Next (Regular) Block[B2]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+            Next (Regular) Block[B4]
+                Leaving: {R2}
+        Block[B3] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1 ??= s1')
+                  Value: 
+                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1')
+                      Left: 
+                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                      Right: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 's1')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
+
+            Next (Regular) Block[B4]
+                Leaving: {R2}
+    }
+
+    Block[B4] - Block
+        Predecessors: [B2] [B3]
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'o1 ??= s1;')
+              Expression: 
+                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1')
+
+        Next (Regular) Block[B5]
+            Leaving: {R1}
+}
+
+Block[B5] - Exit
+    Predecessors: [B4]
+    Statements (0)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignmentFlow_WhenNullHasFlow()
+        {
+            string source = @"
+class C
+{
+    static void M(object o1, string s1, string s2)
+    /*<bind>*/{
+        o1 ??= s1 ?? s2;
+    }/*</bind>*/
+}
+";
+            string expectedFlowGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1} {R2}
+
+.locals {R1}
+{
+    CaptureIds: [1]
+    .locals {R2}
+    {
+        CaptureIds: [0]
+        Block[B1] - Block
+            Predecessors: [B0]
+            Statements (1)
+                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                Entering: {R3} {R4}
+
+            Next (Regular) Block[B2]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+            Next (Regular) Block[B7]
+                Leaving: {R2}
+
+        .locals {R3}
+        {
+            CaptureIds: [3]
+            .locals {R4}
+            {
+                CaptureIds: [2]
+                Block[B3] - Block
+                    Predecessors: [B1]
+                    Statements (1)
+                        IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
+                          Value: 
+                            IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
+
+                    Jump if True (Regular) to Block[B5]
+                        IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 's1')
+                          Operand: 
+                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+                        Leaving: {R4}
+
+                    Next (Regular) Block[B4]
+                Block[B4] - Block
+                    Predecessors: [B3]
+                    Statements (1)
+                        IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
+                          Value: 
+                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+
+                    Next (Regular) Block[B6]
+                        Leaving: {R4}
+            }
+
+            Block[B5] - Block
+                Predecessors: [B3]
+                Statements (1)
+                    IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
+                      Value: 
+                        IParameterReferenceOperation: s2 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's2')
+
+                Next (Regular) Block[B6]
+            Block[B6] - Block
+                Predecessors: [B4] [B5]
+                Statements (1)
+                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1 ??= s1 ?? s2')
+                      Value: 
+                        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1 ?? s2')
+                          Left: 
+                            IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                          Right: 
+                            IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 's1 ?? s2')
+                              Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                                (ImplicitReference)
+                              Operand: 
+                                IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
+
+                Next (Regular) Block[B7]
+                    Leaving: {R3} {R2}
+        }
+    }
+
+    Block[B7] - Block
+        Predecessors: [B2] [B6]
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'o1 ??= s1 ?? s2;')
+              Expression: 
+                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1 ?? s2')
+
+        Next (Regular) Block[B8]
+            Leaving: {R1}
+}
+
+Block[B8] - Exit
+    Predecessors: [B7]
+    Statements (0)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignmentFlow_BothSidesHaveFlow()
+        {
+            string source = @"
+class C
+{
+    static void M(object o1, object o2, string s1, string s2)
+    /*<bind>*/{
+        (o1 ?? o2) ??= (s1 ?? s2);
+    }/*</bind>*/
+}
+";
+            string expectedFlowGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1} {R2} {R3} {R4}
+
+.locals {R1}
+{
+    CaptureIds: [3]
+    .locals {R2}
+    {
+        CaptureIds: [2]
+        .locals {R3}
+        {
+            CaptureIds: [1]
+            .locals {R4}
+            {
+                CaptureIds: [0]
+                Block[B1] - Block
+                    Predecessors: [B0]
+                    Statements (1)
+                        IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1')
+                          Value: 
+                            IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object, IsInvalid) (Syntax: 'o1')
+
+                    Jump if True (Regular) to Block[B3]
+                        IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'o1')
+                          Operand: 
+                            IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1')
+                        Leaving: {R4}
+
+                    Next (Regular) Block[B2]
+                Block[B2] - Block
+                    Predecessors: [B1]
+                    Statements (1)
+                        IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1')
+                          Value: 
+                            IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1')
+
+                    Next (Regular) Block[B4]
+                        Leaving: {R4}
+            }
+
+            Block[B3] - Block
+                Predecessors: [B1]
+                Statements (1)
+                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o2')
+                      Value: 
+                        IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object, IsInvalid) (Syntax: 'o2')
+
+                Next (Regular) Block[B4]
+            Block[B4] - Block
+                Predecessors: [B2] [B3]
+                Statements (1)
+                    IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                      Value: 
+                        IInvalidOperation (OperationKind.Invalid, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                          Children(1):
+                              IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+
+                Next (Regular) Block[B5]
+                    Leaving: {R3}
+        }
+
+        Block[B5] - Block
+            Predecessors: [B4]
+            Statements (0)
+            Jump if True (Regular) to Block[B7]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                Entering: {R5} {R6}
+
+            Next (Regular) Block[B6]
+        Block[B6] - Block
+            Predecessors: [B5]
+            Statements (1)
+                IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+
+            Next (Regular) Block[B11]
+                Leaving: {R2}
+
+        .locals {R5}
+        {
+            CaptureIds: [5]
+            .locals {R6}
+            {
+                CaptureIds: [4]
+                Block[B7] - Block
+                    Predecessors: [B5]
+                    Statements (1)
+                        IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
+                          Value: 
+                            IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
+
+                    Jump if True (Regular) to Block[B9]
+                        IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 's1')
+                          Operand: 
+                            IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+                        Leaving: {R6}
+
+                    Next (Regular) Block[B8]
+                Block[B8] - Block
+                    Predecessors: [B7]
+                    Statements (1)
+                        IFlowCaptureOperation: 5 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
+                          Value: 
+                            IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+
+                    Next (Regular) Block[B10]
+                        Leaving: {R6}
+            }
+
+            Block[B9] - Block
+                Predecessors: [B7]
+                Statements (1)
+                    IFlowCaptureOperation: 5 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
+                      Value: 
+                        IParameterReferenceOperation: s2 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's2')
+
+                Next (Regular) Block[B10]
+            Block[B10] - Block
+                Predecessors: [B8] [B9]
+                Statements (1)
+                    IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: '(o1 ?? o2)  ...  (s1 ?? s2)')
+                      Value: 
+                        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: ?, IsInvalid, IsImplicit) (Syntax: '(o1 ?? o2)  ...  (s1 ?? s2)')
+                          Left: 
+                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                          Right: 
+                            IFlowCaptureReferenceOperation: 5 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
+
+                Next (Regular) Block[B11]
+                    Leaving: {R5} {R2}
+        }
+    }
+
+    Block[B11] - Block
+        Predecessors: [B6] [B10]
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: '(o1 ?? o2)  ... (s1 ?? s2);')
+              Expression: 
+                IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: ?, IsInvalid, IsImplicit) (Syntax: '(o1 ?? o2)  ...  (s1 ?? s2)')
+
+        Next (Regular) Block[B12]
+            Leaving: {R1}
+}
+
+Block[B12] - Exit
+    Predecessors: [B11]
+    Statements (0)
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // file.cs(6,10): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         (o1 ?? o2) ??= (s1 ?? s2);
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "o1 ?? o2").WithLocation(6, 10)
+            };
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignmentFlow_NestedUse()
+        {
+            string source = @"
+class C
+{
+    static void M(object o1, object o2, object o3)
+    /*<bind>*/{
+        o1 ??= (o2 ??= o3);
+    }/*</bind>*/
+}
+";
+            string expectedFlowGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1} {R2}
+
+.locals {R1}
+{
+    CaptureIds: [1]
+    .locals {R2}
+    {
+        CaptureIds: [0]
+        Block[B1] - Block
+            Predecessors: [B0]
+            Statements (1)
+                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                Entering: {R3} {R4}
+
+            Next (Regular) Block[B2]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+            Next (Regular) Block[B7]
+                Leaving: {R2}
+
+        .locals {R3}
+        {
+            CaptureIds: [3]
+            .locals {R4}
+            {
+                CaptureIds: [2]
+                Block[B3] - Block
+                    Predecessors: [B1]
+                    Statements (1)
+                        IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2')
+                          Value: 
+                            IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
+
+                    Jump if True (Regular) to Block[B5]
+                        IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o2')
+                          Operand: 
+                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+
+                    Next (Regular) Block[B4]
+                Block[B4] - Block
+                    Predecessors: [B3]
+                    Statements (1)
+                        IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2')
+                          Value: 
+                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+
+                    Next (Regular) Block[B6]
+                        Leaving: {R4}
+                Block[B5] - Block
+                    Predecessors: [B3]
+                    Statements (1)
+                        IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2 ??= o3')
+                          Value: 
+                            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o2 ??= o3')
+                              Left: 
+                                IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+                              Right: 
+                                IParameterReferenceOperation: o3 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o3')
+
+                    Next (Regular) Block[B6]
+                        Leaving: {R4}
+            }
+
+            Block[B6] - Block
+                Predecessors: [B4] [B5]
+                Statements (1)
+                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1 ??= (o2 ??= o3)')
+                      Value: 
+                        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= (o2 ??= o3)')
+                          Left: 
+                            IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                          Right: 
+                            IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2 ??= o3')
+
+                Next (Regular) Block[B7]
+                    Leaving: {R3} {R2}
+        }
+    }
+
+    Block[B7] - Block
+        Predecessors: [B2] [B6]
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'o1 ??= (o2 ??= o3);')
+              Expression: 
+                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= (o2 ??= o3)')
+
+        Next (Regular) Block[B8]
+            Leaving: {R1}
+}
+
+Block[B8] - Exit
+    Predecessors: [B7]
+    Statements (0)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
@@ -273,15 +273,31 @@ Block[B0] - Entry
               Value: 
                 IParameterReferenceOperation: i1 (OperationKind.ParameterReference, Type: System.Int32?) (Syntax: 'i1')
 
-        Jump if True (Regular) to Block[B2]
-            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'i1')
-              Operand: 
-                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
+        Next (Regular) Block[B2]
+            Entering: {R2}
 
-        Next (Regular) Block[B3]
-            Leaving: {R1}
-    Block[B2] - Block
-        Predecessors: [B1]
+    .locals {R2}
+    {
+        CaptureIds: [1]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'i1')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
+
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'i1')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
+                Leaving: {R2}
+
+            Next (Regular) Block[B4]
+                Leaving: {R2} {R1}
+    }
+
+    Block[B3] - Block
+        Predecessors: [B2]
         Statements (1)
             ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32?, IsImplicit) (Syntax: 'i1 ??= i2')
               Left: 
@@ -293,12 +309,12 @@ Block[B0] - Entry
                   Operand: 
                     IParameterReferenceOperation: i2 (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'i2')
 
-        Next (Regular) Block[B3]
+        Next (Regular) Block[B4]
             Leaving: {R1}
 }
 
-Block[B3] - Exit
-    Predecessors: [B1] [B2]
+Block[B4] - Exit
+    Predecessors: [B2] [B3]
     Statements (0)
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
@@ -334,15 +350,31 @@ Block[B0] - Entry
               Value: 
                 IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
 
-        Jump if True (Regular) to Block[B2]
-            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
-              Operand: 
-                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+        Next (Regular) Block[B2]
+            Entering: {R2}
 
-        Next (Regular) Block[B3]
-            Leaving: {R1}
-    Block[B2] - Block
-        Predecessors: [B1]
+    .locals {R2}
+    {
+        CaptureIds: [1]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                Leaving: {R2}
+
+            Next (Regular) Block[B4]
+                Leaving: {R2} {R1}
+    }
+
+    Block[B3] - Block
+        Predecessors: [B2]
         Statements (1)
             ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1')
               Left: 
@@ -354,12 +386,12 @@ Block[B0] - Entry
                   Operand: 
                     IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
 
-        Next (Regular) Block[B3]
+        Next (Regular) Block[B4]
             Leaving: {R1}
 }
 
-Block[B3] - Exit
-    Predecessors: [B1] [B2]
+Block[B4] - Exit
+    Predecessors: [B2] [B3]
     Statements (0)
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
@@ -395,56 +427,70 @@ Block[B0] - Entry
               Value: 
                 IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
 
-        Jump if True (Regular) to Block[B2]
-            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
-              Operand: 
-                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-            Entering: {R2} {R3}
-
-        Next (Regular) Block[B6]
-            Leaving: {R1}
+        Next (Regular) Block[B2]
+            Entering: {R2}
 
     .locals {R2}
     {
-        CaptureIds: [2]
-        .locals {R3}
+        CaptureIds: [1]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                Leaving: {R2}
+                Entering: {R3} {R4}
+
+            Next (Regular) Block[B7]
+                Leaving: {R2} {R1}
+    }
+    .locals {R3}
+    {
+        CaptureIds: [3]
+        .locals {R4}
         {
-            CaptureIds: [1]
-            Block[B2] - Block
-                Predecessors: [B1]
-                Statements (1)
-                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
-                      Value: 
-                        IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
-
-                Jump if True (Regular) to Block[B4]
-                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 's1')
-                      Operand: 
-                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
-                    Leaving: {R3}
-
-                Next (Regular) Block[B3]
+            CaptureIds: [2]
             Block[B3] - Block
                 Predecessors: [B2]
                 Statements (1)
                     IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
                       Value: 
-                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+                        IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
 
-                Next (Regular) Block[B5]
-                    Leaving: {R3}
+                Jump if True (Regular) to Block[B5]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 's1')
+                      Operand: 
+                        IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+                    Leaving: {R4}
+
+                Next (Regular) Block[B4]
+            Block[B4] - Block
+                Predecessors: [B3]
+                Statements (1)
+                    IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
+                      Value: 
+                        IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+
+                Next (Regular) Block[B6]
+                    Leaving: {R4}
         }
 
-        Block[B4] - Block
-            Predecessors: [B2]
+        Block[B5] - Block
+            Predecessors: [B3]
             Statements (1)
-                IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
+                IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
                   Value: 
                     IParameterReferenceOperation: s2 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's2')
 
-            Next (Regular) Block[B5]
-        Block[B5] - Block
-            Predecessors: [B3] [B4]
+            Next (Regular) Block[B6]
+        Block[B6] - Block
+            Predecessors: [B4] [B5]
             Statements (1)
                 ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1 ?? s2')
                   Left: 
@@ -454,15 +500,15 @@ Block[B0] - Entry
                       Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
                         (ImplicitReference)
                       Operand: 
-                        IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
+                        IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
 
-            Next (Regular) Block[B6]
-                Leaving: {R2} {R1}
+            Next (Regular) Block[B7]
+                Leaving: {R3} {R1}
     }
 }
 
-Block[B6] - Exit
-    Predecessors: [B1] [B5]
+Block[B7] - Exit
+    Predecessors: [B2] [B6]
     Statements (0)
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
@@ -541,55 +587,63 @@ Block[B0] - Entry
 
             Next (Regular) Block[B5]
                 Leaving: {R2}
+                Entering: {R4}
     }
-
-    Block[B5] - Block
-        Predecessors: [B4]
-        Statements (0)
-        Jump if True (Regular) to Block[B6]
-            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
-              Operand: 
-                IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
-            Entering: {R4} {R5}
-
-        Next (Regular) Block[B10]
-            Leaving: {R1}
-
     .locals {R4}
     {
-        CaptureIds: [4]
-        .locals {R5}
+        CaptureIds: [3]
+        Block[B5] - Block
+            Predecessors: [B4]
+            Statements (1)
+                IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+
+            Jump if True (Regular) to Block[B6]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                Leaving: {R4}
+                Entering: {R5} {R6}
+
+            Next (Regular) Block[B10]
+                Leaving: {R4} {R1}
+    }
+    .locals {R5}
+    {
+        CaptureIds: [5]
+        .locals {R6}
         {
-            CaptureIds: [3]
+            CaptureIds: [4]
             Block[B6] - Block
                 Predecessors: [B5]
                 Statements (1)
-                    IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
+                    IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
                       Value: 
                         IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
 
                 Jump if True (Regular) to Block[B8]
                     IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 's1')
                       Operand: 
-                        IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
-                    Leaving: {R5}
+                        IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+                    Leaving: {R6}
 
                 Next (Regular) Block[B7]
             Block[B7] - Block
                 Predecessors: [B6]
                 Statements (1)
-                    IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
+                    IFlowCaptureOperation: 5 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
                       Value: 
-                        IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+                        IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
 
                 Next (Regular) Block[B9]
-                    Leaving: {R5}
+                    Leaving: {R6}
         }
 
         Block[B8] - Block
             Predecessors: [B6]
             Statements (1)
-                IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
+                IFlowCaptureOperation: 5 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
                   Value: 
                     IParameterReferenceOperation: s2 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's2')
 
@@ -601,10 +655,10 @@ Block[B0] - Entry
                   Left: 
                     IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
                   Right: 
-                    IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
+                    IFlowCaptureReferenceOperation: 5 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
 
             Next (Regular) Block[B10]
-                Leaving: {R4} {R1}
+                Leaving: {R5} {R1}
     }
 }
 
@@ -649,74 +703,104 @@ Block[B0] - Entry
               Value: 
                 IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
 
-        Jump if True (Regular) to Block[B2]
-            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
-              Operand: 
-                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-            Entering: {R2} {R3}
-
-        Next (Regular) Block[B6]
-            Leaving: {R1}
+        Next (Regular) Block[B2]
+            Entering: {R2}
 
     .locals {R2}
     {
-        CaptureIds: [2]
-        .locals {R3}
+        CaptureIds: [1]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                Leaving: {R2}
+                Entering: {R3} {R4}
+
+            Next (Regular) Block[B8]
+                Leaving: {R2} {R1}
+    }
+    .locals {R3}
+    {
+        CaptureIds: [4]
+        .locals {R4}
         {
-            CaptureIds: [1]
-            Block[B2] - Block
-                Predecessors: [B1]
-                Statements (1)
-                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2')
-                      Value: 
-                        IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
-
-                Jump if True (Regular) to Block[B4]
-                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o2')
-                      Operand: 
-                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
-
-                Next (Regular) Block[B3]
+            CaptureIds: [2]
             Block[B3] - Block
                 Predecessors: [B2]
                 Statements (1)
-                    IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2 ??= o3')
+                    IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2')
                       Value: 
-                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+                        IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
 
-                Next (Regular) Block[B5]
-                    Leaving: {R3}
-            Block[B4] - Block
-                Predecessors: [B2]
+                Next (Regular) Block[B4]
+                    Entering: {R5}
+
+            .locals {R5}
+            {
+                CaptureIds: [3]
+                Block[B4] - Block
+                    Predecessors: [B3]
+                    Statements (1)
+                        IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2')
+                          Value: 
+                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+
+                    Jump if True (Regular) to Block[B6]
+                        IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o2')
+                          Operand: 
+                            IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+                        Leaving: {R5}
+
+                    Next (Regular) Block[B5]
+                Block[B5] - Block
+                    Predecessors: [B4]
+                    Statements (1)
+                        IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2 ??= o3')
+                          Value: 
+                            IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+
+                    Next (Regular) Block[B7]
+                        Leaving: {R5} {R4}
+            }
+
+            Block[B6] - Block
+                Predecessors: [B4]
                 Statements (1)
-                    IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2 ??= o3')
+                    IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2 ??= o3')
                       Value: 
                         ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o2 ??= o3')
                           Left: 
-                            IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
                           Right: 
                             IParameterReferenceOperation: o3 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o3')
 
-                Next (Regular) Block[B5]
-                    Leaving: {R3}
+                Next (Regular) Block[B7]
+                    Leaving: {R4}
         }
 
-        Block[B5] - Block
-            Predecessors: [B3] [B4]
+        Block[B7] - Block
+            Predecessors: [B5] [B6]
             Statements (1)
                 ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= (o2 ??= o3)')
                   Left: 
                     IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
                   Right: 
-                    IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2 ??= o3')
+                    IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2 ??= o3')
 
-            Next (Regular) Block[B6]
-                Leaving: {R2} {R1}
+            Next (Regular) Block[B8]
+                Leaving: {R3} {R1}
     }
 }
 
-Block[B6] - Exit
-    Predecessors: [B1] [B5]
+Block[B8] - Exit
+    Predecessors: [B2] [B7]
     Statements (0)
 ";
             var expectedDiagnostics = DiagnosticDescription.None;

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
@@ -26,7 +26,7 @@ class C
 ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: System.Object) (Syntax: 'o1 ??= o2')
   Target: 
     IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
-  WhenNull: 
+  Value: 
     IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
@@ -50,7 +50,7 @@ class C
 ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: System.Object) (Syntax: 'o1 ??= s1')
   Target: 
     IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
-  WhenNull: 
+  Value: 
     IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 's1')
       Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
       Operand: 
@@ -77,7 +77,7 @@ class C
 ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: ?, IsInvalid) (Syntax: 'c1 ??= s1')
   Target: 
     IParameterReferenceOperation: c1 (OperationKind.ParameterReference, Type: C, IsInvalid) (Syntax: 'c1')
-  WhenNull: 
+  Value: 
     IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String, IsInvalid) (Syntax: 's1')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
@@ -105,7 +105,7 @@ class C
 ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: ?, IsInvalid) (Syntax: 'i1 ??= s1')
   Target: 
     IParameterReferenceOperation: i1 (OperationKind.ParameterReference, Type: System.Int32, IsInvalid) (Syntax: 'i1')
-  WhenNull: 
+  Value: 
     IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String, IsInvalid) (Syntax: 's1')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
@@ -135,7 +135,7 @@ ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: ?, IsInval
   Target: 
     IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'o1')
       Children(0)
-  WhenNull: 
+  Value: 
     IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'o2')
       Children(0)
 ";
@@ -174,7 +174,7 @@ IInvocationOperation (void C.M2(System.Object o)) (OperationKind.Invocation, Typ
         ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: System.Object) (Syntax: 'o1 ??= o2')
           Target: 
             IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
-          WhenNull: 
+          Value: 
             IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
         InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
         OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
@@ -201,10 +201,10 @@ class C
 }
 ";
             string expectedOperationTree = @"
-ICoalesceAssignmentOperation(IsChecked: True) (OperationKind.CoalesceAssignment, Type: dynamic) (Syntax: 'd1 ??= d2')
+ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: dynamic) (Syntax: 'd1 ??= d2')
   Target: 
     IParameterReferenceOperation: d1 (OperationKind.ParameterReference, Type: dynamic) (Syntax: 'd1')
-  WhenNull: 
+  Value: 
     IParameterReferenceOperation: d2 (OperationKind.ParameterReference, Type: dynamic) (Syntax: 'd2')
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
@@ -213,87 +213,39 @@ ICoalesceAssignmentOperation(IsChecked: True) (OperationKind.CoalesceAssignment,
         }
 
         [Fact]
-        public void CoalesceAssignmentFlow_SimpleAssignment()
+        public void CoalesceAssignment_NullValueAndTarget()
         {
             string source = @"
 class C
 {
-    static void M(object o1, object o2)
-    /*<bind>*/{
-        o1 ??= o2;
-    }/*</bind>*/
-}
-";
-            string expectedFlowGraph = @"
-Block[B0] - Entry
-    Statements (0)
-    Next (Regular) Block[B1]
-        Entering: {R1} {R2}
-
-.locals {R1}
-{
-    CaptureIds: [1]
-    .locals {R2}
+    static void M()
     {
-        CaptureIds: [0]
-        Block[B1] - Block
-            Predecessors: [B0]
-            Statements (1)
-                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
-                  Value: 
-                    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
-
-            Jump if True (Regular) to Block[B3]
-                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
-                  Operand: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-
-            Next (Regular) Block[B2]
-        Block[B2] - Block
-            Predecessors: [B1]
-            Statements (1)
-                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
-                  Value: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-
-            Next (Regular) Block[B4]
-                Leaving: {R2}
-        Block[B3] - Block
-            Predecessors: [B1]
-            Statements (1)
-                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1 ??= o2')
-                  Value: 
-                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= o2')
-                      Left: 
-                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-                      Right: 
-                        IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
-
-            Next (Regular) Block[B4]
-                Leaving: {R2}
+        /*<bind>*/??=/*</bind>*/;
     }
-
-    Block[B4] - Block
-        Predecessors: [B2] [B3]
-        Statements (1)
-            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'o1 ??= o2;')
-              Expression: 
-                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= o2')
-
-        Next (Regular) Block[B5]
-            Leaving: {R1}
 }
-
-Block[B5] - Exit
-    Predecessors: [B4]
-    Statements (0)
 ";
-            var expectedDiagnostics = DiagnosticDescription.None;
+            string expectedOperationTree = @"
+ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: ?, IsInvalid) (Syntax: '/*<bind>*/? ... /*</bind>*/')
+  Target: 
+    IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
+      Children(0)
+  Value: 
+    IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: '')
+      Children(0)
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // file.cs(5,6): error CS1525: Invalid expression term '??='
+                //     {
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("??=").WithLocation(5, 6),
+                // file.cs(6,33): error CS1525: Invalid expression term ';'
+                //         /*<bind>*/??=/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ";").WithArguments(";").WithLocation(6, 33)
+            };
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
         }
 
-        [Fact]
+        [Fact, CompilerTrait(CompilerFeature.Dataflow)]
         public void CoalesceAssignmentFlow_NullableValueTypeTarget()
         {
             string source = @"
@@ -309,68 +261,44 @@ class C
 Block[B0] - Entry
     Statements (0)
     Next (Regular) Block[B1]
-        Entering: {R1} {R2}
+        Entering: {R1}
 
 .locals {R1}
 {
-    CaptureIds: [1]
-    .locals {R2}
-    {
-        CaptureIds: [0]
-        Block[B1] - Block
-            Predecessors: [B0]
-            Statements (1)
-                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'i1')
-                  Value: 
-                    IParameterReferenceOperation: i1 (OperationKind.ParameterReference, Type: System.Int32?) (Syntax: 'i1')
-
-            Jump if True (Regular) to Block[B3]
-                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'i1')
-                  Operand: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
-
-            Next (Regular) Block[B2]
-        Block[B2] - Block
-            Predecessors: [B1]
-            Statements (1)
-                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'i1')
-                  Value: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
-
-            Next (Regular) Block[B4]
-                Leaving: {R2}
-        Block[B3] - Block
-            Predecessors: [B1]
-            Statements (1)
-                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'i1 ??= i2')
-                  Value: 
-                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32?, IsImplicit) (Syntax: 'i1 ??= i2')
-                      Left: 
-                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
-                      Right: 
-                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32?, IsImplicit) (Syntax: 'i2')
-                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                            (ImplicitNullable)
-                          Operand: 
-                            IParameterReferenceOperation: i2 (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'i2')
-
-            Next (Regular) Block[B4]
-                Leaving: {R2}
-    }
-
-    Block[B4] - Block
-        Predecessors: [B2] [B3]
+    CaptureIds: [0]
+    Block[B1] - Block
+        Predecessors: [B0]
         Statements (1)
-            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'i1 ??= i2;')
-              Expression: 
-                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1 ??= i2')
+            IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'i1')
+              Value: 
+                IParameterReferenceOperation: i1 (OperationKind.ParameterReference, Type: System.Int32?) (Syntax: 'i1')
 
-        Next (Regular) Block[B5]
+        Jump if True (Regular) to Block[B2]
+            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'i1')
+              Operand: 
+                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
+
+        Next (Regular) Block[B3]
+            Leaving: {R1}
+    Block[B2] - Block
+        Predecessors: [B1]
+        Statements (1)
+            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32?, IsImplicit) (Syntax: 'i1 ??= i2')
+              Left: 
+                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'i1')
+              Right: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32?, IsImplicit) (Syntax: 'i2')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    (ImplicitNullable)
+                  Operand: 
+                    IParameterReferenceOperation: i2 (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'i2')
+
+        Next (Regular) Block[B3]
             Leaving: {R1}
 }
 
-Block[B5] - Exit
-    Predecessors: [B4]
+Block[B3] - Exit
+    Predecessors: [B1] [B2]
     Statements (0)
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
@@ -378,7 +306,7 @@ Block[B5] - Exit
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
         }
 
-        [Fact]
+        [Fact, CompilerTrait(CompilerFeature.Dataflow)]
         public void CoalesceAssignmentFlow_WhenNullConversion()
         {
             string source = @"
@@ -394,68 +322,44 @@ class C
 Block[B0] - Entry
     Statements (0)
     Next (Regular) Block[B1]
-        Entering: {R1} {R2}
+        Entering: {R1}
 
 .locals {R1}
 {
-    CaptureIds: [1]
-    .locals {R2}
-    {
-        CaptureIds: [0]
-        Block[B1] - Block
-            Predecessors: [B0]
-            Statements (1)
-                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
-                  Value: 
-                    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
-
-            Jump if True (Regular) to Block[B3]
-                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
-                  Operand: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-
-            Next (Regular) Block[B2]
-        Block[B2] - Block
-            Predecessors: [B1]
-            Statements (1)
-                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
-                  Value: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-
-            Next (Regular) Block[B4]
-                Leaving: {R2}
-        Block[B3] - Block
-            Predecessors: [B1]
-            Statements (1)
-                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1 ??= s1')
-                  Value: 
-                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1')
-                      Left: 
-                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-                      Right: 
-                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 's1')
-                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
-                            (ImplicitReference)
-                          Operand: 
-                            IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
-
-            Next (Regular) Block[B4]
-                Leaving: {R2}
-    }
-
-    Block[B4] - Block
-        Predecessors: [B2] [B3]
+    CaptureIds: [0]
+    Block[B1] - Block
+        Predecessors: [B0]
         Statements (1)
-            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'o1 ??= s1;')
-              Expression: 
-                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1')
+            IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+              Value: 
+                IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
 
-        Next (Regular) Block[B5]
+        Jump if True (Regular) to Block[B2]
+            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+              Operand: 
+                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+
+        Next (Regular) Block[B3]
+            Leaving: {R1}
+    Block[B2] - Block
+        Predecessors: [B1]
+        Statements (1)
+            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1')
+              Left: 
+                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+              Right: 
+                IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 's1')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                    (ImplicitReference)
+                  Operand: 
+                    IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
+
+        Next (Regular) Block[B3]
             Leaving: {R1}
 }
 
-Block[B5] - Exit
-    Predecessors: [B4]
+Block[B3] - Exit
+    Predecessors: [B1] [B2]
     Statements (0)
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
@@ -463,7 +367,7 @@ Block[B5] - Exit
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
         }
 
-        [Fact]
+        [Fact, CompilerTrait(CompilerFeature.Dataflow)]
         public void CoalesceAssignmentFlow_WhenNullHasFlow()
         {
             string source = @"
@@ -479,110 +383,86 @@ class C
 Block[B0] - Entry
     Statements (0)
     Next (Regular) Block[B1]
-        Entering: {R1} {R2}
+        Entering: {R1}
 
 .locals {R1}
 {
-    CaptureIds: [1]
+    CaptureIds: [0]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (1)
+            IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+              Value: 
+                IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+
+        Jump if True (Regular) to Block[B2]
+            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+              Operand: 
+                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+            Entering: {R2} {R3}
+
+        Next (Regular) Block[B6]
+            Leaving: {R1}
+
     .locals {R2}
     {
-        CaptureIds: [0]
-        Block[B1] - Block
-            Predecessors: [B0]
-            Statements (1)
-                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
-                  Value: 
-                    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
-
-            Jump if True (Regular) to Block[B3]
-                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
-                  Operand: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-                Entering: {R3} {R4}
-
-            Next (Regular) Block[B2]
-        Block[B2] - Block
-            Predecessors: [B1]
-            Statements (1)
-                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
-                  Value: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-
-            Next (Regular) Block[B7]
-                Leaving: {R2}
-
+        CaptureIds: [2]
         .locals {R3}
         {
-            CaptureIds: [3]
-            .locals {R4}
-            {
-                CaptureIds: [2]
-                Block[B3] - Block
-                    Predecessors: [B1]
-                    Statements (1)
-                        IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
-                          Value: 
-                            IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
-
-                    Jump if True (Regular) to Block[B5]
-                        IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 's1')
-                          Operand: 
-                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
-                        Leaving: {R4}
-
-                    Next (Regular) Block[B4]
-                Block[B4] - Block
-                    Predecessors: [B3]
-                    Statements (1)
-                        IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
-                          Value: 
-                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
-
-                    Next (Regular) Block[B6]
-                        Leaving: {R4}
-            }
-
-            Block[B5] - Block
-                Predecessors: [B3]
+            CaptureIds: [1]
+            Block[B2] - Block
+                Predecessors: [B1]
                 Statements (1)
-                    IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
+                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
                       Value: 
-                        IParameterReferenceOperation: s2 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's2')
+                        IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
 
-                Next (Regular) Block[B6]
-            Block[B6] - Block
-                Predecessors: [B4] [B5]
+                Jump if True (Regular) to Block[B4]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 's1')
+                      Operand: 
+                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+                    Leaving: {R3}
+
+                Next (Regular) Block[B3]
+            Block[B3] - Block
+                Predecessors: [B2]
                 Statements (1)
-                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1 ??= s1 ?? s2')
+                    IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
                       Value: 
-                        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1 ?? s2')
-                          Left: 
-                            IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-                          Right: 
-                            IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 's1 ?? s2')
-                              Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
-                                (ImplicitReference)
-                              Operand: 
-                                IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
+                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
 
-                Next (Regular) Block[B7]
-                    Leaving: {R3} {R2}
+                Next (Regular) Block[B5]
+                    Leaving: {R3}
         }
+
+        Block[B4] - Block
+            Predecessors: [B2]
+            Statements (1)
+                IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
+                  Value: 
+                    IParameterReferenceOperation: s2 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's2')
+
+            Next (Regular) Block[B5]
+        Block[B5] - Block
+            Predecessors: [B3] [B4]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1 ?? s2')
+                  Left: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                  Right: 
+                    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 's1 ?? s2')
+                      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                        (ImplicitReference)
+                      Operand: 
+                        IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
+
+            Next (Regular) Block[B6]
+                Leaving: {R2} {R1}
     }
-
-    Block[B7] - Block
-        Predecessors: [B2] [B6]
-        Statements (1)
-            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'o1 ??= s1 ?? s2;')
-              Expression: 
-                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= s1 ?? s2')
-
-        Next (Regular) Block[B8]
-            Leaving: {R1}
 }
 
-Block[B8] - Exit
-    Predecessors: [B7]
+Block[B6] - Exit
+    Predecessors: [B1] [B5]
     Statements (0)
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
@@ -590,7 +470,7 @@ Block[B8] - Exit
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
         }
 
-        [Fact]
+        [Fact, CompilerTrait(CompilerFeature.Dataflow)]
         public void CoalesceAssignmentFlow_BothSidesHaveFlow()
         {
             string source = @"
@@ -606,154 +486,130 @@ class C
 Block[B0] - Entry
     Statements (0)
     Next (Regular) Block[B1]
-        Entering: {R1} {R2} {R3} {R4}
+        Entering: {R1} {R2} {R3}
 
 .locals {R1}
 {
-    CaptureIds: [3]
+    CaptureIds: [2]
     .locals {R2}
     {
-        CaptureIds: [2]
+        CaptureIds: [1]
         .locals {R3}
         {
-            CaptureIds: [1]
-            .locals {R4}
-            {
-                CaptureIds: [0]
-                Block[B1] - Block
-                    Predecessors: [B0]
-                    Statements (1)
-                        IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1')
-                          Value: 
-                            IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object, IsInvalid) (Syntax: 'o1')
+            CaptureIds: [0]
+            Block[B1] - Block
+                Predecessors: [B0]
+                Statements (1)
+                    IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1')
+                      Value: 
+                        IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object, IsInvalid) (Syntax: 'o1')
 
-                    Jump if True (Regular) to Block[B3]
-                        IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'o1')
-                          Operand: 
-                            IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1')
-                        Leaving: {R4}
+                Jump if True (Regular) to Block[B3]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'o1')
+                      Operand: 
+                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1')
+                    Leaving: {R3}
 
-                    Next (Regular) Block[B2]
-                Block[B2] - Block
-                    Predecessors: [B1]
-                    Statements (1)
-                        IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1')
-                          Value: 
-                            IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1')
-
-                    Next (Regular) Block[B4]
-                        Leaving: {R4}
-            }
-
-            Block[B3] - Block
+                Next (Regular) Block[B2]
+            Block[B2] - Block
                 Predecessors: [B1]
                 Statements (1)
-                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o2')
+                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1')
                       Value: 
-                        IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object, IsInvalid) (Syntax: 'o2')
+                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1')
 
                 Next (Regular) Block[B4]
-            Block[B4] - Block
-                Predecessors: [B2] [B3]
-                Statements (1)
-                    IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
-                      Value: 
-                        IInvalidOperation (OperationKind.Invalid, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
-                          Children(1):
-                              IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
-
-                Next (Regular) Block[B5]
                     Leaving: {R3}
         }
 
-        Block[B5] - Block
-            Predecessors: [B4]
-            Statements (0)
-            Jump if True (Regular) to Block[B7]
-                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
-                  Operand: 
-                    IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
-                Entering: {R5} {R6}
-
-            Next (Regular) Block[B6]
-        Block[B6] - Block
-            Predecessors: [B5]
+        Block[B3] - Block
+            Predecessors: [B1]
             Statements (1)
-                IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o2')
                   Value: 
-                    IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                    IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object, IsInvalid) (Syntax: 'o2')
 
-            Next (Regular) Block[B11]
+            Next (Regular) Block[B4]
+        Block[B4] - Block
+            Predecessors: [B2] [B3]
+            Statements (1)
+                IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                  Value: 
+                    IInvalidOperation (OperationKind.Invalid, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                      Children(1):
+                          IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+
+            Next (Regular) Block[B5]
                 Leaving: {R2}
-
-        .locals {R5}
-        {
-            CaptureIds: [5]
-            .locals {R6}
-            {
-                CaptureIds: [4]
-                Block[B7] - Block
-                    Predecessors: [B5]
-                    Statements (1)
-                        IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
-                          Value: 
-                            IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
-
-                    Jump if True (Regular) to Block[B9]
-                        IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 's1')
-                          Operand: 
-                            IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
-                        Leaving: {R6}
-
-                    Next (Regular) Block[B8]
-                Block[B8] - Block
-                    Predecessors: [B7]
-                    Statements (1)
-                        IFlowCaptureOperation: 5 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
-                          Value: 
-                            IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
-
-                    Next (Regular) Block[B10]
-                        Leaving: {R6}
-            }
-
-            Block[B9] - Block
-                Predecessors: [B7]
-                Statements (1)
-                    IFlowCaptureOperation: 5 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
-                      Value: 
-                        IParameterReferenceOperation: s2 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's2')
-
-                Next (Regular) Block[B10]
-            Block[B10] - Block
-                Predecessors: [B8] [B9]
-                Statements (1)
-                    IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: '(o1 ?? o2)  ...  (s1 ?? s2)')
-                      Value: 
-                        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: ?, IsInvalid, IsImplicit) (Syntax: '(o1 ?? o2)  ...  (s1 ?? s2)')
-                          Left: 
-                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
-                          Right: 
-                            IFlowCaptureReferenceOperation: 5 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
-
-                Next (Regular) Block[B11]
-                    Leaving: {R5} {R2}
-        }
     }
 
-    Block[B11] - Block
-        Predecessors: [B6] [B10]
-        Statements (1)
-            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid) (Syntax: '(o1 ?? o2)  ... (s1 ?? s2);')
-              Expression: 
-                IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: ?, IsInvalid, IsImplicit) (Syntax: '(o1 ?? o2)  ...  (s1 ?? s2)')
+    Block[B5] - Block
+        Predecessors: [B4]
+        Statements (0)
+        Jump if True (Regular) to Block[B6]
+            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+              Operand: 
+                IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+            Entering: {R4} {R5}
 
-        Next (Regular) Block[B12]
+        Next (Regular) Block[B10]
             Leaving: {R1}
+
+    .locals {R4}
+    {
+        CaptureIds: [4]
+        .locals {R5}
+        {
+            CaptureIds: [3]
+            Block[B6] - Block
+                Predecessors: [B5]
+                Statements (1)
+                    IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
+                      Value: 
+                        IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
+
+                Jump if True (Regular) to Block[B8]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 's1')
+                      Operand: 
+                        IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+                    Leaving: {R5}
+
+                Next (Regular) Block[B7]
+            Block[B7] - Block
+                Predecessors: [B6]
+                Statements (1)
+                    IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's1')
+                      Value: 
+                        IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1')
+
+                Next (Regular) Block[B9]
+                    Leaving: {R5}
+        }
+
+        Block[B8] - Block
+            Predecessors: [B6]
+            Statements (1)
+                IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 's2')
+                  Value: 
+                    IParameterReferenceOperation: s2 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's2')
+
+            Next (Regular) Block[B9]
+        Block[B9] - Block
+            Predecessors: [B7] [B8]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: ?, IsInvalid, IsImplicit) (Syntax: '(o1 ?? o2)  ...  (s1 ?? s2)')
+                  Left: 
+                    IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'o1 ?? o2')
+                  Right: 
+                    IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 's1 ?? s2')
+
+            Next (Regular) Block[B10]
+                Leaving: {R4} {R1}
+    }
 }
 
-Block[B12] - Exit
-    Predecessors: [B11]
+Block[B10] - Exit
+    Predecessors: [B5] [B9]
     Statements (0)
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
@@ -765,7 +621,7 @@ Block[B12] - Exit
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
         }
 
-        [Fact]
+        [Fact, CompilerTrait(CompilerFeature.Dataflow)]
         public void CoalesceAssignmentFlow_NestedUse()
         {
             string source = @"
@@ -781,110 +637,86 @@ class C
 Block[B0] - Entry
     Statements (0)
     Next (Regular) Block[B1]
-        Entering: {R1} {R2}
+        Entering: {R1}
 
 .locals {R1}
 {
-    CaptureIds: [1]
+    CaptureIds: [0]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (1)
+            IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
+              Value: 
+                IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+
+        Jump if True (Regular) to Block[B2]
+            IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
+              Operand: 
+                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+            Entering: {R2} {R3}
+
+        Next (Regular) Block[B6]
+            Leaving: {R1}
+
     .locals {R2}
     {
-        CaptureIds: [0]
-        Block[B1] - Block
-            Predecessors: [B0]
-            Statements (1)
-                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
-                  Value: 
-                    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
-
-            Jump if True (Regular) to Block[B3]
-                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o1')
-                  Operand: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-                Entering: {R3} {R4}
-
-            Next (Regular) Block[B2]
-        Block[B2] - Block
-            Predecessors: [B1]
-            Statements (1)
-                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1')
-                  Value: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
-
-            Next (Regular) Block[B7]
-                Leaving: {R2}
-
+        CaptureIds: [2]
         .locals {R3}
         {
-            CaptureIds: [3]
-            .locals {R4}
-            {
-                CaptureIds: [2]
-                Block[B3] - Block
-                    Predecessors: [B1]
-                    Statements (1)
-                        IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2')
-                          Value: 
-                            IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
-
-                    Jump if True (Regular) to Block[B5]
-                        IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o2')
-                          Operand: 
-                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
-
-                    Next (Regular) Block[B4]
-                Block[B4] - Block
-                    Predecessors: [B3]
-                    Statements (1)
-                        IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2')
-                          Value: 
-                            IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
-
-                    Next (Regular) Block[B6]
-                        Leaving: {R4}
-                Block[B5] - Block
-                    Predecessors: [B3]
-                    Statements (1)
-                        IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2 ??= o3')
-                          Value: 
-                            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o2 ??= o3')
-                              Left: 
-                                IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
-                              Right: 
-                                IParameterReferenceOperation: o3 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o3')
-
-                    Next (Regular) Block[B6]
-                        Leaving: {R4}
-            }
-
-            Block[B6] - Block
-                Predecessors: [B4] [B5]
+            CaptureIds: [1]
+            Block[B2] - Block
+                Predecessors: [B1]
                 Statements (1)
-                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o1 ??= (o2 ??= o3)')
+                    IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2')
                       Value: 
-                        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= (o2 ??= o3)')
+                        IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
+
+                Jump if True (Regular) to Block[B4]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'o2')
+                      Operand: 
+                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+
+                Next (Regular) Block[B3]
+            Block[B3] - Block
+                Predecessors: [B2]
+                Statements (1)
+                    IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2 ??= o3')
+                      Value: 
+                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
+
+                Next (Regular) Block[B5]
+                    Leaving: {R3}
+            Block[B4] - Block
+                Predecessors: [B2]
+                Statements (1)
+                    IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'o2 ??= o3')
+                      Value: 
+                        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o2 ??= o3')
                           Left: 
-                            IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                            IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2')
                           Right: 
-                            IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2 ??= o3')
+                            IParameterReferenceOperation: o3 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o3')
 
-                Next (Regular) Block[B7]
-                    Leaving: {R3} {R2}
+                Next (Regular) Block[B5]
+                    Leaving: {R3}
         }
+
+        Block[B5] - Block
+            Predecessors: [B3] [B4]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= (o2 ??= o3)')
+                  Left: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+                  Right: 
+                    IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o2 ??= o3')
+
+            Next (Regular) Block[B6]
+                Leaving: {R2} {R1}
     }
-
-    Block[B7] - Block
-        Predecessors: [B2] [B6]
-        Statements (1)
-            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'o1 ??= (o2 ??= o3);')
-              Expression: 
-                IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Object, IsImplicit) (Syntax: 'o1 ??= (o2 ??= o3)')
-
-        Next (Regular) Block[B8]
-            Leaving: {R1}
 }
 
-Block[B8] - Exit
-    Predecessors: [B7]
+Block[B6] - Exit
+    Predecessors: [B1] [B5]
     Statements (0)
 ";
             var expectedDiagnostics = DiagnosticDescription.None;

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    [CompilerTrait(CompilerFeature.IOperation)]
+    public partial class IOperationTests : SemanticModelTestBase
+    {
+        [Fact]
+        public void CoalesceAssignment_SimpleCase()
+        {
+
+            string source = @"
+class C
+{
+    static void M(object o1, object o2)
+    {
+        /*<bind>*/o1 ??= o2/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: System.Object) (Syntax: 'o1 ??= o2')
+  Target: 
+    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+  WhenNull: 
+    IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignment_WithConversion()
+        {
+            string source = @"
+class C
+{
+    static void M(object o1, string s1)
+    {
+        /*<bind>*/o1 ??= s1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: System.Object) (Syntax: 'o1 ??= s1')
+  Target: 
+    IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+  WhenNull: 
+    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 's1')
+      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+      Operand: 
+        IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String) (Syntax: 's1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignment_NoConversion()
+        {
+            string source = @"
+class C
+{
+    static void M(C c1, string s1)
+    {
+        /*<bind>*/c1 ??= s1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: ?, IsInvalid) (Syntax: 'c1 ??= s1')
+  Target: 
+    IParameterReferenceOperation: c1 (OperationKind.ParameterReference, Type: C, IsInvalid) (Syntax: 'c1')
+  WhenNull: 
+    IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String, IsInvalid) (Syntax: 's1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // file.cs(6,19): error CS0019: Operator '??=' cannot be applied to operands of type 'C' and 'string'
+                //         /*<bind>*/c1 ??= s1/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "c1 ??= s1").WithArguments("??=", "C", "string").WithLocation(6, 19)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignment_ValueTypeLeft()
+        {
+            string source = @"
+class C
+{
+    static void M(int i1, string s1)
+    {
+        /*<bind>*/i1 ??= s1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: ?, IsInvalid) (Syntax: 'i1 ??= s1')
+  Target: 
+    IParameterReferenceOperation: i1 (OperationKind.ParameterReference, Type: System.Int32, IsInvalid) (Syntax: 'i1')
+  WhenNull: 
+    IParameterReferenceOperation: s1 (OperationKind.ParameterReference, Type: System.String, IsInvalid) (Syntax: 's1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // file.cs(6,19): error CS0019: Operator '??=' cannot be applied to operands of type 'int' and 'string'
+                //         /*<bind>*/i1 ??= s1/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "i1 ??= s1").WithArguments("??=", "int", "string").WithLocation(6, 19)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignment_MissingLeftAndRight()
+        {
+
+            string source = @"
+class C
+{
+    static void M()
+    {
+        /*<bind>*/o1 ??= o2/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: ?, IsInvalid) (Syntax: 'o1 ??= o2')
+  Target: 
+    IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'o1')
+      Children(0)
+  WhenNull: 
+    IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'o2')
+      Children(0)
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // file.cs(6,19): error CS0103: The name 'o1' does not exist in the current context
+                //         /*<bind>*/o1 ??= o2/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "o1").WithArguments("o1").WithLocation(6, 19),
+                // file.cs(6,26): error CS0103: The name 'o2' does not exist in the current context
+                //         /*<bind>*/o1 ??= o2/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "o2").WithArguments("o2").WithLocation(6, 26)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignment_AsExpression()
+        {
+
+            string source = @"
+class C
+{
+    static void M(object o1, object o2)
+    {
+        /*<bind>*/M2(o1 ??= o2)/*</bind>*/;
+    }
+    static void M2(object o) {}
+}
+";
+            string expectedOperationTree = @"
+IInvocationOperation (void C.M2(System.Object o)) (OperationKind.Invocation, Type: System.Void) (Syntax: 'M2(o1 ??= o2)')
+  Instance Receiver: 
+    null
+  Arguments(1):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: o) (OperationKind.Argument, Type: null) (Syntax: 'o1 ??= o2')
+        ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: System.Object) (Syntax: 'o1 ??= o2')
+          Target: 
+            IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+          WhenNull: 
+            IParameterReferenceOperation: o2 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o2')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void CoalesceAssignment_CheckedDynamic()
+        {
+
+            string source = @"
+class C
+{
+    static void M(dynamic d1, dynamic d2)
+    {
+        checked
+        {
+            /*<bind>*/d1 ??= d2/*</bind>*/;
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+ICoalesceAssignmentOperation(IsChecked: True) (OperationKind.CoalesceAssignment, Type: dynamic) (Syntax: 'd1 ??= d2')
+  Target: 
+    IParameterReferenceOperation: d1 (OperationKind.ParameterReference, Type: dynamic) (Syntax: 'd1')
+  WhenNull: 
+    IParameterReferenceOperation: d2 (OperationKind.ParameterReference, Type: dynamic) (Syntax: 'd2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullCoalsceAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullCoalsceAssignmentTests.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    [CompilerTrait(CompilerFeature.NullCoalescingAssignment)]
+    public partial class NullCoalesceAssignmentTests : SemanticModelTestBase
+    {
+        [Fact]
+        public void CoalescingAssignment_NoConversion()
+        {
+            var source = @"
+class C
+{
+    void M(C c1, C c2)
+    {
+        c1 ??= c2;
+    }
+}";
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+            var cType = comp.GetTypeByMetadataName("C");
+
+            var syntaxTree = comp.SyntaxTrees.Single();
+            var syntaxRoot = syntaxTree.GetRoot();
+            var semanticModel = comp.GetSemanticModel(syntaxTree);
+            var coalesceAssignment = syntaxRoot.DescendantNodes().OfType<AssignmentExpressionSyntax>().Single();
+
+            assertTypeInfo(coalesceAssignment);
+            assertTypeInfo(coalesceAssignment.Left);
+            assertTypeInfo(coalesceAssignment.Right);
+
+            void assertTypeInfo(SyntaxNode syntax)
+            {
+                var typeInfo = semanticModel.GetTypeInfo(syntax);
+                Assert.NotNull(typeInfo);
+                Assert.Equal(cType, typeInfo.Type);
+                Assert.Equal(cType, typeInfo.ConvertedType);
+
+            }
+        }
+
+        [Fact]
+        public void CoalescingAssignment_ValueConversion()
+        {
+            var source = @"
+class C
+{
+    void M(C c1, D d1)
+    {
+        c1 ??= d1;
+    }
+}
+class D : C {}";
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+            var cType = comp.GetTypeByMetadataName("C");
+            var dType = comp.GetTypeByMetadataName("D");
+
+            var syntaxTree = comp.SyntaxTrees.Single();
+            var syntaxRoot = syntaxTree.GetRoot();
+            var semanticModel = comp.GetSemanticModel(syntaxTree);
+            var coalesceAssignment = syntaxRoot.DescendantNodes().OfType<AssignmentExpressionSyntax>().Single();
+
+            assertTypeInfo(coalesceAssignment);
+            assertTypeInfo(coalesceAssignment.Left);
+
+            var whenNullTypeInfo = semanticModel.GetTypeInfo(coalesceAssignment.Right);
+            Assert.NotNull(whenNullTypeInfo);
+            Assert.Equal(dType, whenNullTypeInfo.Type);
+            Assert.Equal(cType, whenNullTypeInfo.ConvertedType);
+
+            void assertTypeInfo(SyntaxNode syntax)
+            {
+                var typeInfo = semanticModel.GetTypeInfo(syntax);
+                Assert.NotNull(typeInfo);
+                Assert.Equal(cType, typeInfo.Type);
+                Assert.Equal(cType, typeInfo.ConvertedType);
+
+            }
+        }
+
+        [Fact]
+        public void CoalescingAssignment_AsConvertedExpression()
+        {
+            var source = @"
+class C
+{
+    void M(D d1, D d2)
+    {
+        M2(d1 ??= d1);
+    }
+    void M2(C c) {}
+}
+class D : C {}";
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+            var cType = comp.GetTypeByMetadataName("C");
+            var dType = comp.GetTypeByMetadataName("D");
+
+            var syntaxTree = comp.SyntaxTrees.Single();
+            var syntaxRoot = syntaxTree.GetRoot();
+            var semanticModel = comp.GetSemanticModel(syntaxTree);
+            var coalesceAssignment = syntaxRoot.DescendantNodes().OfType<AssignmentExpressionSyntax>().Single();
+
+            var whenNullTypeInfo = semanticModel.GetTypeInfo(coalesceAssignment);
+            Assert.NotNull(whenNullTypeInfo);
+            Assert.Equal(dType, whenNullTypeInfo.Type);
+            Assert.Equal(cType, whenNullTypeInfo.ConvertedType);
+
+            assertTypeInfo(coalesceAssignment.Right);
+            assertTypeInfo(coalesceAssignment.Left);
+
+            void assertTypeInfo(SyntaxNode syntax)
+            {
+                var typeInfo = semanticModel.GetTypeInfo(syntax);
+                Assert.NotNull(typeInfo);
+                Assert.Equal(dType, typeInfo.Type);
+                Assert.Equal(dType, typeInfo.ConvertedType);
+
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullCoalsceAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullCoalsceAssignmentTests.cs
@@ -40,6 +40,7 @@ class C
             {
                 var typeInfo = semanticModel.GetTypeInfo(syntax);
                 Assert.NotNull(typeInfo);
+                Assert.NotNull(typeInfo.Type);
                 Assert.Equal(cType, typeInfo.Type);
                 Assert.Equal(cType, typeInfo.ConvertedType);
 
@@ -81,6 +82,7 @@ class D : C {}";
             {
                 var typeInfo = semanticModel.GetTypeInfo(syntax);
                 Assert.NotNull(typeInfo);
+                Assert.NotNull(typeInfo.Type);
                 Assert.Equal(cType, typeInfo.Type);
                 Assert.Equal(cType, typeInfo.ConvertedType);
 
@@ -123,6 +125,7 @@ class D : C {}";
             {
                 var typeInfo = semanticModel.GetTypeInfo(syntax);
                 Assert.NotNull(typeInfo);
+                Assert.NotNull(typeInfo.Type);
                 Assert.Equal(dType, typeInfo.Type);
                 Assert.Equal(dType, typeInfo.ConvertedType);
 

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -3790,18 +3790,15 @@ namespace Microsoft.CodeAnalysis.Operations
         public override IOperation WhenNull => SetParentOperation(_lazyWhenNull.Value, this);
     }
 
-    internal abstract partial class BaseCoaleseAssignmentOperation : Operation, ICoalesceAssignmentOperation
+    internal abstract partial class BaseCoalesceAssignmentOperation : Operation, ICoalesceAssignmentOperation
     {
-        protected BaseCoaleseAssignmentOperation(bool isChecked, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+        protected BaseCoalesceAssignmentOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(OperationKind.CoalesceAssignment, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            IsChecked = isChecked;
         }
 
         public abstract IOperation Target { get; }
-        public abstract IOperation WhenNull { get; }
-        public bool IsChecked { get; }
-
+        public abstract IOperation Value { get; }
         public override IEnumerable<IOperation> Children
         {
             get
@@ -3810,9 +3807,9 @@ namespace Microsoft.CodeAnalysis.Operations
                 {
                     yield return Target;
                 }
-                if (WhenNull != null)
+                if (Value != null)
                 {
-                    yield return WhenNull;
+                    yield return Value;
                 }
             }
         }
@@ -3828,31 +3825,32 @@ namespace Microsoft.CodeAnalysis.Operations
         }
     }
 
-    internal sealed class CoalesceAssignmentOperation : BaseCoaleseAssignmentOperation
+    internal sealed class CoalesceAssignmentOperation : BaseCoalesceAssignmentOperation
     {
-        public CoalesceAssignmentOperation(IOperation target, IOperation whenNull, bool isChecked, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-            base(isChecked, semanticModel, syntax, type, constantValue, isImplicit)
+        public CoalesceAssignmentOperation(IOperation target, IOperation value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             Target = SetParentOperation(target, this);
-            WhenNull = SetParentOperation(whenNull, this);
+            Value = SetParentOperation(value, this);
         }
 
         public override IOperation Target { get; }
-        public override IOperation WhenNull { get; }
+        public override IOperation Value { get; }
     }
 
-    internal sealed class LazyCoalesceAssignmentOperation : BaseCoaleseAssignmentOperation
+    internal sealed class LazyCoalesceAssignmentOperation : BaseCoalesceAssignmentOperation
     {
         private readonly Lazy<IOperation> _lazyTarget;
         private readonly Lazy<IOperation> _lazyWhenNull;
-        public LazyCoalesceAssignmentOperation(Lazy<IOperation> lazyTarget, Lazy<IOperation> lazyWhenNull, bool isChecked, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(isChecked, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyCoalesceAssignmentOperation(Lazy<IOperation> lazyTarget, Lazy<IOperation> lazyValue, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyTarget = lazyTarget;
-            _lazyWhenNull = lazyWhenNull;
+            _lazyWhenNull = lazyValue;
         }
 
         public override IOperation Target => SetParentOperation(_lazyTarget.Value, this);
-        public override IOperation WhenNull => SetParentOperation(_lazyWhenNull.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyWhenNull.Value, this);
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -2839,7 +2839,7 @@ oneMoreTime:
         {
             SpillEvalStack();
 
-            // If we're in a statement context, we elide the useless capture of the result of the assignment, as it will
+            // If we're in a statement context, we elide the capture of the result of the assignment, as it will
             // just be wrapped in an expression statement that isn't used anywhere and isn't observed by anything.
             bool isStatement = operation.Parent.Kind == OperationKind.ExpressionStatement;
             Debug.Assert(captureIdForResult == null || !isStatement);

--- a/src/Compilers/Core/Portable/Operations/ICoalesceAssignmentOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/ICoalesceAssignmentOperation.cs
@@ -4,31 +4,19 @@ namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>
     /// Represents a coalesce assignment operation with a target and a conditionally-evaluated value:
-    ///  (1) <see cref="Target"/> is evaluated for null. If it is null, <see cref="WhenNull"/> is evaluated and assigned to target.
-    ///  (2) <see cref="WhenNull"/> is conditionally evaluated if <see cref="Target"/> is null, and the result is assigned into <see cref="Target"/>.
-    /// The result of the entire expression is <see cref="Target"/>, which is only evaluated once.
+    ///  (1) <see cref="IAssignmentOperation.Target"/> is evaluated for null. If it is null, <see cref="IAssignmentOperation.Value"/> is evaluated and assigned to target.
+    ///  (2) <see cref="IAssignmentOperation.Value"/> is conditionally evaluated if <see cref="IAssignmentOperation.Target"/> is null, and the result is assigned into <see cref="IAssignmentOperation.Target"/>.
+    /// The result of the entire expression is <see cref="IAssignmentOperation.Target"/>, which is only evaluated once.
     /// <para>
     /// Current Usage:
-    ///  (1) C# null-coalescing assignment operation <code>Target ??= WhenNull</code>.
+    ///  (1) C# null-coalescing assignment operation <code>Target ??= Value</code>.
     /// </para>
     /// </summary>
     /// <remarks>
     /// This interface is reserved for implementation by its associated APIs. We reserve the right to
     /// change it in the future.
     /// </remarks>
-    public interface ICoalesceAssignmentOperation : IOperation
+    public interface ICoalesceAssignmentOperation : IAssignmentOperation
     {
-        /// <summary>
-        /// Operation to be unconditionally evaluated and assigned if null.
-        /// </summary>
-        IOperation Target { get; }
-        /// <summary>
-        /// Operation to be conditionally evaluated and assigned to <see cref="Target"/> if <see cref="Target"/> is null.
-        /// </summary>
-        IOperation WhenNull { get; }
-        /// <summary>
-        /// Whether the assignment is evaluated as a checked operation. This only has meaning in dynamic contexts.
-        /// </summary>
-        bool IsChecked { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Operations/ICoalesceAssignmentOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/ICoalesceAssignmentOperation.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Operations
+{
+    /// <summary>
+    /// Represents a coalesce assignment operation with a target and a conditionally-evaluated value:
+    ///  (1) <see cref="Target"/> is evaluated for null. If it is null, <see cref="WhenNull"/> is evaluated and assigned to target.
+    ///  (2) <see cref="WhenNull"/> is conditionally evaluated if <see cref="Target"/> is null, and the result is assigned into <see cref="Target"/>.
+    /// The result of the entire expression is <see cref="Target"/>, which is only evaluated once.
+    /// <para>
+    /// Current Usage:
+    ///  (1) C# null-coalescing assignment operation <code>Target ??= WhenNull</code>.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    public interface ICoalesceAssignmentOperation : IOperation
+    {
+        /// <summary>
+        /// Operation to be unconditionally evaluated and assigned if null.
+        /// </summary>
+        IOperation Target { get; }
+        /// <summary>
+        /// Operation to be conditionally evaluated and assigned to <see cref="Target"/> if <see cref="Target"/> is null.
+        /// </summary>
+        IOperation WhenNull { get; }
+        /// <summary>
+        /// Whether the assignment is evaluated as a checked operation. This only has meaning in dynamic contexts.
+        /// </summary>
+        bool IsChecked { get; }
+    }
+}

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -315,6 +315,11 @@ namespace Microsoft.CodeAnalysis.Operations
                                           operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
         }
 
+        public override IOperation VisitCoalesceAssignment(ICoalesceAssignmentOperation operation, object argument)
+        {
+            return new CoalesceAssignmentOperation(Visit(operation.Target), Visit(operation.WhenNull), operation.IsChecked, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
+        }
+
         public override IOperation VisitIsType(IIsTypeOperation operation, object argument)
         {
             return new IsTypeExpression(Visit(operation.ValueOperand), operation.TypeOperand, operation.IsNegated, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         public override IOperation VisitCoalesceAssignment(ICoalesceAssignmentOperation operation, object argument)
         {
-            return new CoalesceAssignmentOperation(Visit(operation.Target), Visit(operation.WhenNull), operation.IsChecked, ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
+            return new CoalesceAssignmentOperation(Visit(operation.Target), Visit(operation.Value), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
         }
 
         public override IOperation VisitIsType(IIsTypeOperation operation, object argument)

--- a/src/Compilers/Core/Portable/Operations/OperationKind.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationKind.cs
@@ -206,6 +206,9 @@ namespace Microsoft.CodeAnalysis
         /// <summary>Indicates an <see cref="IFlowAnonymousFunctionOperation"/>.</summary>
         FlowAnonymousFunction = 0x60,
 
+        /// <summary>Indicates an <see cref="ICoalesceAssignmentOperation"/>.</summary>
+        CoalesceAssignment = 0x61,
+
         // /// <summary>Indicates an <see cref="IFixedOperation"/>.</summary>
         // https://github.com/dotnet/roslyn/issues/21281
         //Fixed = <TBD>,

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -284,6 +284,11 @@ namespace Microsoft.CodeAnalysis.Operations
             DefaultVisit(operation);
         }
 
+        public virtual void VisitCoalesceAssignment(ICoalesceAssignmentOperation operation)
+        {
+            DefaultVisit(operation);
+        }
+
         public virtual void VisitIsType(IIsTypeOperation operation)
         {
             DefaultVisit(operation);
@@ -843,6 +848,11 @@ namespace Microsoft.CodeAnalysis.Operations
         }
 
         public virtual TResult VisitCoalesce(ICoalesceOperation operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        public virtual TResult VisitCoalesceAssignment(ICoalesceAssignmentOperation operation, TArgument argument)
         {
             return DefaultVisit(operation, argument);
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -19,9 +19,6 @@ Microsoft.CodeAnalysis.IOperation.SemanticModel.get -> Microsoft.CodeAnalysis.Se
 Microsoft.CodeAnalysis.OperationKind.CoalesceAssignment = 97 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.Operations.CommonConversion.IsImplicit.get -> bool
 Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation
-Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation.IsChecked.get -> bool
-Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation.Target.get -> Microsoft.CodeAnalysis.IOperation
-Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation.WhenNull.get -> Microsoft.CodeAnalysis.IOperation
 abstract Microsoft.CodeAnalysis.Compilation.ClassifyCommonConversion(Microsoft.CodeAnalysis.ITypeSymbol source, Microsoft.CodeAnalysis.ITypeSymbol destination) -> Microsoft.CodeAnalysis.Operations.CommonConversion
 abstract Microsoft.CodeAnalysis.Compilation.ContainsSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> bool
 abstract Microsoft.CodeAnalysis.Compilation.GetSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -16,7 +16,12 @@ Microsoft.CodeAnalysis.FlowAnalysis.IIsNullOperation.Operand.get -> Microsoft.Co
 Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation
 Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation.Local.get -> Microsoft.CodeAnalysis.ILocalSymbol
 Microsoft.CodeAnalysis.IOperation.SemanticModel.get -> Microsoft.CodeAnalysis.SemanticModel
+Microsoft.CodeAnalysis.OperationKind.CoalesceAssignment = 97 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.Operations.CommonConversion.IsImplicit.get -> bool
+Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation
+Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation.IsChecked.get -> bool
+Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation.Target.get -> Microsoft.CodeAnalysis.IOperation
+Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation.WhenNull.get -> Microsoft.CodeAnalysis.IOperation
 abstract Microsoft.CodeAnalysis.Compilation.ClassifyCommonConversion(Microsoft.CodeAnalysis.ITypeSymbol source, Microsoft.CodeAnalysis.ITypeSymbol destination) -> Microsoft.CodeAnalysis.Operations.CommonConversion
 abstract Microsoft.CodeAnalysis.Compilation.ContainsSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> bool
 abstract Microsoft.CodeAnalysis.Compilation.GetSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>
@@ -121,11 +126,13 @@ static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph.Create(Microsoft.Cod
 static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph.Create(Microsoft.CodeAnalysis.Operations.IPropertyInitializerOperation initializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph
 static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph.Create(Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.SemanticModel semanticModel, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitCaughtException(Microsoft.CodeAnalysis.FlowAnalysis.ICaughtExceptionOperation operation) -> void
+virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitCoalesceAssignment(Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitFlowCapture(Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitFlowCaptureReference(Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureReferenceOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitIsNull(Microsoft.CodeAnalysis.FlowAnalysis.IIsNullOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitStaticLocalInitializationSemaphore(Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitCaughtException(Microsoft.CodeAnalysis.FlowAnalysis.ICaughtExceptionOperation operation, TArgument argument) -> TResult
+virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitCoalesceAssignment(Microsoft.CodeAnalysis.Operations.ICoalesceAssignmentOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitFlowCapture(Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitFlowCaptureReference(Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureReferenceOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitIsNull(Microsoft.CodeAnalysis.FlowAnalysis.IIsNullOperation operation, TArgument argument) -> TResult

--- a/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
@@ -784,8 +784,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                         $"Operation [{operationIndex}] in [{getBlockId(block)}] uses not initialized capture [{id.Value}].");
 
                     // Except for a few specific scenarios, any references to captures should either be long-lived capture references,
-                    // or they should come from the enclosing region. Otherwise, it signifies that the region packing algorithm failed
-                    // to correctly recognize regions that could have been merged.
+                    // or they should come from the enclosing region.
                     Assert.True(block.EnclosingRegion.CaptureIds.Contains(id) || longLivedIds.Contains(id) ||
                                 ((isFirstOperandOfDynamicOrUserDefinedLogicalOperator(reference) ||
                                      isIncrementedNullableForToLoopControlVariable(reference) ||
@@ -831,11 +830,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             bool isCoalesceAssignmentTarget(IFlowCaptureReferenceOperation reference)
             {
-                SyntaxNode referenceSyntax = reference.Syntax;
-                if (referenceSyntax.Parent.IsKind(CSharp.SyntaxKind.ParenthesizedExpression))
+                if (reference.Language != LanguageNames.CSharp)
                 {
-                    referenceSyntax = referenceSyntax.Parent;
+                    return false;
                 }
+
+                CSharpSyntaxNode referenceSyntax = applyParenthesizedIfAnyCS((CSharpSyntaxNode)reference.Syntax);
                 return referenceSyntax.Parent is AssignmentExpressionSyntax conditionalAccess &&
                        conditionalAccess.IsKind(CSharp.SyntaxKind.CoalesceAssignmentExpression) &&
                        conditionalAccess.Left == referenceSyntax;

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1142,15 +1142,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public override void VisitCoalesceAssignment(ICoalesceAssignmentOperation operation)
         {
             LogString(nameof(ICoalesceAssignmentOperation));
-            if (operation.IsChecked)
-            {
-                LogString($"(IsChecked: {operation.IsChecked})");
-            }
-
             LogCommonPropertiesAndNewLine(operation);
 
             Visit(operation.Target, nameof(operation.Target));
-            Visit(operation.WhenNull, nameof(operation.WhenNull));
+            Visit(operation.Value, nameof(operation.Value));
         }
 
         public override void VisitIsType(IIsTypeOperation operation)

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1139,6 +1139,20 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Visit(operation.WhenNull, "WhenNull");
         }
 
+        public override void VisitCoalesceAssignment(ICoalesceAssignmentOperation operation)
+        {
+            LogString(nameof(ICoalesceAssignmentOperation));
+            if (operation.IsChecked)
+            {
+                LogString($"(IsChecked: {operation.IsChecked})");
+            }
+
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Target, nameof(operation.Target));
+            Visit(operation.WhenNull, nameof(operation.WhenNull));
+        }
+
         public override void VisitIsType(IIsTypeOperation operation)
         {
             LogString(nameof(IIsTypeOperation));

--- a/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
@@ -705,8 +705,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public override void VisitCoalesceAssignment(ICoalesceAssignmentOperation operation)
         {
             Assert.Equal(OperationKind.CoalesceAssignment, operation.Kind);
-            AssertEx.Equal(new[] { operation.Target, operation.WhenNull }, operation.Children);
-            var isChecked = operation.IsChecked;
+            Assert.NotNull(operation.Target);
+            Assert.NotNull(operation.Value);
+            AssertEx.Equal(new[] { operation.Target, operation.Value }, operation.Children);
         }
 
         public override void VisitIsType(IIsTypeOperation operation)

--- a/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
@@ -702,6 +702,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var valueConversion = operation.ValueConversion;
         }
 
+        public override void VisitCoalesceAssignment(ICoalesceAssignmentOperation operation)
+        {
+            Assert.Equal(OperationKind.CoalesceAssignment, operation.Kind);
+            AssertEx.Equal(new[] { operation.Target, operation.WhenNull }, operation.Children);
+            var isChecked = operation.IsChecked;
+        }
+
         public override void VisitIsType(IIsTypeOperation operation)
         {
             Assert.Equal(OperationKind.IsType, operation.Kind);

--- a/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
@@ -705,8 +705,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public override void VisitCoalesceAssignment(ICoalesceAssignmentOperation operation)
         {
             Assert.Equal(OperationKind.CoalesceAssignment, operation.Kind);
-            Assert.NotNull(operation.Target);
-            Assert.NotNull(operation.Value);
             AssertEx.Equal(new[] { operation.Target, operation.Value }, operation.Children);
         }
 


### PR DESCRIPTION
Added IOperation and CFG support and tests for null-coalescing assignments. Also added tests for semantic model APIs. @dotnet/roslyn-compiler @cston @dotnet/analyzer-ioperation for review.