### PR TITLE
don't crash on extension manager disposed on shutdown.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
@@ -4,14 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
-using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 {
@@ -76,61 +73,74 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
         // internal for testing purpose
         internal static ImmutableArray<HostDiagnosticAnalyzerPackage> GetHostAnalyzerPackagesWithName(object extensionManager, Type parameterType)
         {
-            // dynamic is wierd. it can't see internal type with public interface even if callee is
-            // implementation of the public interface in internal type. so we can't use dynamic here
-
-            var builder = ImmutableArray.CreateBuilder<HostDiagnosticAnalyzerPackage>();
-
-            // var enabledExtensions = extensionManager.GetEnabledExtensions(AnalyzerContentTypeName);
-            var extensionManagerType = extensionManager.GetType();
-            var extensionManager_GetEnabledExtensionsMethod = extensionManagerType.GetRuntimeMethod("GetEnabledExtensions", new Type[] { typeof(string) });
-            var enabledExtensions = extensionManager_GetEnabledExtensionsMethod.Invoke(extensionManager, new object[] { AnalyzerContentTypeName }) as IEnumerable<object>;
-
-            foreach (var extension in enabledExtensions)
+            try
             {
-                // var name = extension.Header.LocalizedName;
-                var extensionType = extension.GetType();
-                var extensionType_HeaderProperty = extensionType.GetRuntimeProperty("Header");
-                var extension_Header = extensionType_HeaderProperty.GetValue(extension);
-                var extension_HeaderType = extension_Header.GetType();
-                var extension_HeaderType_LocalizedNameProperty = extension_HeaderType.GetRuntimeProperty("LocalizedName");
-                var name = extension_HeaderType_LocalizedNameProperty.GetValue(extension_Header) as string;
+                // dynamic is wierd. it can't see internal type with public interface even if callee is
+                // implementation of the public interface in internal type. so we can't use dynamic here
 
-                var assemblies = ImmutableArray.CreateBuilder<string>();
+                var builder = ImmutableArray.CreateBuilder<HostDiagnosticAnalyzerPackage>();
 
-                // var extension_Content = extension.Content;
-                var extensionType_ContentProperty = extensionType.GetRuntimeProperty("Content");
-                var extension_Content = extensionType_ContentProperty.GetValue(extension) as IEnumerable<object>;
+                // var enabledExtensions = extensionManager.GetEnabledExtensions(AnalyzerContentTypeName);
+                var extensionManagerType = extensionManager.GetType();
+                var extensionManager_GetEnabledExtensionsMethod = extensionManagerType.GetRuntimeMethod("GetEnabledExtensions", new Type[] { typeof(string) });
+                var enabledExtensions = extensionManager_GetEnabledExtensionsMethod.Invoke(extensionManager, new object[] { AnalyzerContentTypeName }) as IEnumerable<object>;
 
-                foreach (var content in extension_Content)
+                foreach (var extension in enabledExtensions)
                 {
-                    if (!ShouldInclude(content))
+                    // var name = extension.Header.LocalizedName;
+                    var extensionType = extension.GetType();
+                    var extensionType_HeaderProperty = extensionType.GetRuntimeProperty("Header");
+                    var extension_Header = extensionType_HeaderProperty.GetValue(extension);
+                    var extension_HeaderType = extension_Header.GetType();
+                    var extension_HeaderType_LocalizedNameProperty = extension_HeaderType.GetRuntimeProperty("LocalizedName");
+                    var name = extension_HeaderType_LocalizedNameProperty.GetValue(extension_Header) as string;
+
+                    var assemblies = ImmutableArray.CreateBuilder<string>();
+
+                    // var extension_Content = extension.Content;
+                    var extensionType_ContentProperty = extensionType.GetRuntimeProperty("Content");
+                    var extension_Content = extensionType_ContentProperty.GetValue(extension) as IEnumerable<object>;
+
+                    foreach (var content in extension_Content)
                     {
-                        continue;
+                        if (!ShouldInclude(content))
+                        {
+                            continue;
+                        }
+
+                        var extensionType_GetContentMethod = extensionType.GetRuntimeMethod("GetContentLocation", new Type[] { parameterType });
+                        var assembly = extensionType_GetContentMethod?.Invoke(extension, new object[] { content }) as string;
+                        if (assembly == null)
+                        {
+                            continue;
+                        }
+
+                        assemblies.Add(assembly);
                     }
 
-                    var extensionType_GetContentMethod = extensionType.GetRuntimeMethod("GetContentLocation", new Type[] { parameterType });
-                    var assembly = extensionType_GetContentMethod?.Invoke(extension, new object[] { content }) as string;
-                    if (assembly == null)
-                    {
-                        continue;
-                    }
-
-                    assemblies.Add(assembly);
+                    builder.Add(new HostDiagnosticAnalyzerPackage(name, assemblies.ToImmutable()));
                 }
 
-                builder.Add(new HostDiagnosticAnalyzerPackage(name, assemblies.ToImmutable()));
+                var packages = builder.ToImmutable();
+
+                EnsureMandatoryAnalyzers(packages);
+
+                // make sure enabled extensions are alive in memory
+                // so that we can debug it through if mandatory analyzers are missing
+                GC.KeepAlive(enabledExtensions);
+
+                return packages;
             }
-
-            var packages = builder.ToImmutable();
-
-            EnsureMandatoryAnalyzers(packages);
-
-            // make sure enabled extensions are alive in memory
-            // so that we can debug it through if mandatory analyzers are missing
-            GC.KeepAlive(enabledExtensions);
-
-            return packages;
+            catch (InvalidOperationException)
+            {
+                // this can be called from any thread, and extension manager could be disposed in the middle of us using it since
+                // now all these are free-threaded and there is no central coordinator, or API or state is immutable that prevent states from
+                // changing in the middle of others using it.
+                //
+                // fortunately, this only happens on disposing at shutdown, so we just catch the exception and silently swallow it. 
+                // we are about to shutdown anyway.
+                return ImmutableArray<HostDiagnosticAnalyzerPackage>.Empty;
+            }
         }
 
         private static void EnsureMandatoryAnalyzers(ImmutableArray<HostDiagnosticAnalyzerPackage> packages)


### PR DESCRIPTION
### Customer scenario

close VS and sometimes VS crash while shutting down.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/657750?src=WorkItemMention&amp%3Bsrc-action=artifact_link

### Workarounds, if any

wait VS is idle before shutdown VS.

### Risk

Low. it removes existing crash.

### Performance impact

Low. all we do is catching a known exception on VS shutdown and ignore it.

### Is this a regression from a previous update?

Yes. these used to happen on UI thread during package load, now we moved it out from UI thread and made lazy. in some case, it looks like the code above get called while VS is already in shutdown.

### Root cause analysis

I believe this is a common issue in async, lazy world when some states are not immutable. especially disposable. since in that world, guaranteeing the mutation ordering is not as simple as the synchronous world.

### How was the bug found?

watson.