### PR TITLE
[WIP] Introduce IPeekDefinitionService

### DIFF
--- a/src/EditorFeatures/Core/GoToDefinition/IPeekDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/IPeekDefinitionService.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.VisualStudio.Language.Intellisense;
+
+namespace Microsoft.CodeAnalysis.Editor
+{
+    internal interface IPeekDefinitionService : ILanguageService
+    {
+        /// <summary>
+        /// Gets <see cref="IPeekableItem"/>s for the definitions for the symbol at the specific position in the document.
+        /// </summary>
+        /// <remarks>
+        /// A more direct version of <see cref="IGoToDefinitionService.FindDefinitionsAsync"/> that returns <see cref="IPeekableItem"/>s.
+        /// Called from the UI thread.
+        /// </remarks>
+        IEnumerable<IPeekableItem> GetDefinitionPeekItems(Document document, int position, CancellationToken cancellationToken);
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/Peek/PeekableItemSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Peek/PeekableItemSource.cs
@@ -65,13 +65,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
 
                 if (!document.SupportsSemanticModel)
                 {
-                    // For documents without semantic models, just try to use the goto-def service
-                    // as a reasonable place to peek at.
-                    var goToDefinitionService = document.GetLanguageService<IGoToDefinitionService>();
-                    var navigableItems = goToDefinitionService.FindDefinitionsAsync(document, triggerPoint.Value.Position, cancellationToken)
-                                                              .WaitAndGetResult(cancellationToken);
+                    var peekDefinitionService = document.GetLanguageService<IPeekDefinitionService>();
+                    if (peekDefinitionService != null)
+                    {
+                        results = peekDefinitionService.GetDefinitionPeekItems(document, triggerPoint.Value.Position, cancellationToken);
+                    }
+                    else
+                    {
+                        // For documents without semantic models, just try to use the goto-def service
+                        // as a reasonable place to peek at.
+                        var goToDefinitionService = document.GetLanguageService<IGoToDefinitionService>();
+                        var navigableItems = goToDefinitionService.FindDefinitionsAsync(document, triggerPoint.Value.Position, cancellationToken)
+                                                                  .WaitAndGetResult(cancellationToken);
 
-                    results = GetPeekableItemsForNavigableItems(navigableItems, document.Project, _peekResultFactory, cancellationToken);
+                        results = GetPeekableItemsForNavigableItems(navigableItems, document.Project, _peekResultFactory, cancellationToken);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
TS wants to be able to peek at files that don't have corresponding documents (which INavigableItem requires).

It would have been part of IGoToDefinitionService, but that would have caused breaking changes for TS and F#.

I believe this is the final shape, but I don't want to submit before I've actually tried implementing it in TS.  However, I've confirmed that Peek Definition still works in TS without an implementation of IPeekDefinitionService, so I'm confident the fallback works.
