### PR TITLE
Add tests and tweak binding of suppression operator

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2052,7 +2052,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // PROTOTYPE(NullableReferenceTypes): Should be a warning, not an error.
                     Error(diagnostics, ErrorCode.ERR_NotNullableOperatorNotReferenceType, node);
                 }
-                type = type.SetUnknownNullabilityForReferenceTypes();
             }
             return new BoundSuppressNullableWarningExpression(node, expr, type);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -78,6 +78,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(sourceExpression != null);
             Debug.Assert((object)destination != null);
 
+            if (sourceExpression.Kind == BoundKind.ExpressionWithNullability)
+            {
+                sourceExpression = ((BoundExpressionWithNullability)sourceExpression).Expression;
+            }
+
             var sourceType = sourceExpression.Type;
 
             //PERF: identity conversion is by far the most common implicit conversion, check for that first

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -78,11 +78,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(sourceExpression != null);
             Debug.Assert((object)destination != null);
 
-            if (sourceExpression.Kind == BoundKind.ExpressionWithNullability)
-            {
-                sourceExpression = ((BoundExpressionWithNullability)sourceExpression).Expression;
-            }
-
             var sourceType = sourceExpression.Type;
 
             //PERF: identity conversion is by far the most common implicit conversion, check for that first

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -275,8 +275,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.Literal:
                 case BoundKind.UnboundLambda:
                     break;
-                case BoundKind.ValuePlaceholder:
-                    return ((BoundValuePlaceholder)expr).IsNullable;
+                case BoundKind.ExpressionWithNullability:
+                    return ((BoundExpressionWithNullability)expr).IsNullable;
                 default:
                     // PROTOTYPE(NullableReferenceTypes): Handle all expression kinds.
                     //Debug.Assert(false, "Unhandled expression: " + expr.Kind);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1733,9 +1733,10 @@
     <Field Name="Initializer" Type="BoundExpressionStatement" Null="allow"/>
   </Node>
 
-  <!-- Special node, used only during nullability flow analysis -->
-  <!-- PROTOTYPE(NullableReferenceTypes): Derive from BoundValuePlaceholderBase and give specific name. -->
-  <Node Name="BoundValuePlaceholder" Base="BoundExpression">
+  <!-- Node only used during nullability flow analysis to represent an expression with an updated nullability -->
+  <!-- PROTOTYPE(NullableReferenceTypes): Derive from BoundValuePlaceholderBase. -->
+  <Node Name="BoundExpressionWithNullability" Base="BoundExpression">
+    <Field Name="Expression" Type="BoundExpression" Null="disallow"/>
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="allow"/> <!-- We use null Type for placeholders representing out vars -->
     <Field Name="IsNullable" Type="bool?" Null="allow"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1819,7 +1819,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return type.IsNull ?
                     expr :
-                    new BoundValuePlaceholder(expr.Syntax, type.IsNullable, type.TypeSymbol);
+                    new BoundExpressionWithNullability(expr.Syntax, expr, type.IsNullable, type.TypeSymbol);
             }
 
             (BoundExpression, TypeSymbolWithAnnotations) visitConditionalOperand(LocalState state, BoundExpression operand)
@@ -2533,9 +2533,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (argument is BoundLocal local && local.DeclarationKind == BoundLocalDeclarationKind.WithInferredType)
                 {
                     // 'out var' doesn't contribute to inference
-                    return new BoundValuePlaceholder(argument.Syntax, isNullable: null, type: null);
+                    return new BoundExpressionWithNullability(argument.Syntax, argument, isNullable: null, type: null);
                 }
-                return new BoundValuePlaceholder(argument.Syntax, argumentType.IsNullable, argumentType.TypeSymbol);
+                return new BoundExpressionWithNullability(argument.Syntax, argument, argumentType.IsNullable, argumentType.TypeSymbol);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -225,7 +225,56 @@ public class C
     }
 }
 ", parseOptions: TestOptions.Regular8);
+            // PROTOTYPE(NullableReferenceTypes): should not warn 
+            c.VerifyDiagnostics(
+                // (7,18): warning CS8626: No best nullability for operands of conditional expression 'uint' and 'int'.
+                //         uint x = true ? a : 1;
+                Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "true ? a : 1").WithArguments("uint", "int").WithLocation(7, 18),
+                // (8,18): warning CS8626: No best nullability for operands of conditional expression 'int' and 'uint'.
+                //         uint y = true ? 1 : a;
+                Diagnostic(ErrorCode.WRN_NoBestNullabilityConditionalExpression, "true ? 1 : a").WithArguments("int", "uint").WithLocation(8, 18)
+                );
+        }
 
+        [Fact, WorkItem(26746, "https://github.com/dotnet/roslyn/issues/26746")]
+        public void TernaryWithImplicitUsedDefinedConversion()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+public class C
+{
+    public void M()
+    {
+        C c = new C();
+        C x = true ? c : 1;
+        C y = true ? 1 : c;
+    }
+    public static implicit operator C?(int i) => throw null;
+}
+", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+            // PROTOTYPE(NullableReferenceTypes): should be warning
+            c.VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(26746, "https://github.com/dotnet/roslyn/issues/26746")]
+        public void TernaryWithImplicitUsedDefinedConversion2()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+public class C
+{
+    public void M()
+    {
+        C c = null!;
+        int x = true ? c : 1;
+        int y = true ? 1 : c;
+
+        C? c2 = null;
+        int x2 = true ? c2 : 1;
+        int y2 = true ? 1 : c2;
+    }
+    public static implicit operator int(C i) => throw null;
+}
+", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+            // PROTOTYPE(NullableReferenceTypes): should be warning
             c.VerifyDiagnostics();
         }
 


### PR DESCRIPTION
It turns out that doing conversion from expression with flow-analyzed nullability is more complicated than I thought. After discussion with Chuck, I removed that portion of the PR. I'm keeping the tests and the tweak to binding of the suppression operator.

~~When inferring the best type (considering nullability) in a ternary, we wrap each expression with an updated nullability. We were using `BoundValuePlaceholder` for that (which this PR renames to `BoundExpressionWithNullability`).~~
~~The problem is that best type inference considers conversions from expressions, which this wrapper was breaking. The fix is to unwrap such expressions when computing conversions from expressions (which do not need top-level nullability anyways).~~

~~This affected a test (`SuppressNullableWarning_Conditional`) which identified an issue with the type in a `BoundSuppressNullableWarningExpression`. This issue was previously masked by the wrapper. The issue is that we removed all nullability information during binding, when making such bound nodes. But, according to the current feature spec, only the top-level nullability should be changed.~~

Relates to https://github.com/dotnet/roslyn/issues/26746 (but doesn't fix it after all)
Closes https://github.com/dotnet/roslyn/issues/26812 (double assignment)