### PR TITLE
Don't warn when returning suppressed null

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4133,6 +4133,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return false;
             }
+            var unwrappedValue = SkipReferenceConversions(value);
+            if (unwrappedValue.Kind == BoundKind.SuppressNullableWarningExpression)
+            {
+                return false;
+            }
             ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_NullAsNonNullable, value.Syntax);
             return true;
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -232,6 +232,22 @@ class C
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "G").WithLocation(13, 32));
         }
 
+        [Fact, WorkItem(26739, "https://github.com/dotnet/roslyn/issues/26618")]
+        public void SuppressionOnNullConvertedToConstrainedTypeParameterType()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+public class C
+{
+    public T M<T>() where T : C
+    {
+        return null!;
+    }
+}
+", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+
+            c.VerifyDiagnostics();
+        }
+
         [Fact]
         public void MissingInt()
         {


### PR DESCRIPTION
The `!` should suppress warning in `return null!;`.
Fixes https://github.com/dotnet/roslyn/issues/26618