### PR TITLE
Display _ for unannotated TypeSymbolWithAnnotations in debugger

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -97,9 +97,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
+            bool isNullableType = typeOpt.IsNullableType();
+            bool isAnnotated = typeOpt.IsAnnotated;
+
             if (format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier) &&
-                !typeOpt.IsNullableType() &&
-                typeOpt.IsAnnotated)
+                !isNullableType &&
+                isAnnotated)
             {
                 AddPunctuation(SyntaxKind.QuestionToken);
             }
@@ -108,6 +111,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 typeOpt.IsNullable == false)
             {
                 AddPunctuation(SyntaxKind.ExclamationToken);
+            }
+            else if (format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeUnannotatedTypeModifier) &&
+                !isNullableType &&
+                !isAnnotated)
+            {
+                AddPunctuation(SyntaxKind.UnderscoreToken);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -119,8 +119,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal static readonly SymbolDisplayFormat DebuggerDisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
-            /*compilerInternalOptions: SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier*/);
+            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier,
+            // Can't use IncludeNonNullableTypeModifier as it pulls on NonNullTypes, which causes cycles while debugging
+            compilerInternalOptions: SymbolDisplayCompilerInternalOptions.IncludeUnannotatedTypeModifier);
 
         internal static readonly SymbolDisplayFormat TestDisplayFormat = new SymbolDisplayFormat(
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
@@ -385,6 +386,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var str = TypeSymbol.ToDisplayString(format);
             if (format != null && !IsValueType)
             {
+                if ((format.CompilerInternalOptions & SymbolDisplayCompilerInternalOptions.IncludeUnannotatedTypeModifier) != 0 &&
+                    !IsAnnotated)
+                {
+                    return str + "_";
+                }
+
                 switch (IsNullable)
                 {
                     case true:

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
@@ -58,6 +58,11 @@ namespace Microsoft.CodeAnalysis
         IncludeNonNullableTypeModifier = 1 << 6,
 
         /// <summary>
+        /// Append '_' to non-nullable reference types.
+        /// </summary>
+        IncludeUnannotatedTypeModifier = 1 << 7,
+
+        /// <summary>
         /// Display `System.ValueTuple` instead of tuple syntax `(...)`.
         /// </summary>
         UseValueTuple = 1 << 7,


### PR DESCRIPTION
Since we can't pull on `NonNullTypes` during binding, the debugger display method does not distinguish between `!` and `~` (printed as nothing). Instead it just prints nothing for both cases.
I found that confusing. This PR makes both unannotated cases print as `_` (underscore) while debugging.