### PR TITLE
remove the hard dependency between AbstractSnippetCommandHandler and ISyntaxFactsService

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
@@ -51,6 +51,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             return false;
         }
 
+        protected virtual Func<char, bool> GetIsIdentifierPartCharacterFunction(Document document)
+        {
+            var syntaxFactsService = document.GetLanguageService<ISyntaxFactsService>();
+            return syntaxFactsService.IsIdentifierPartCharacter;
+        }
+
         public bool ExecuteCommand(TabKeyCommandArgs args, CommandExecutionContext context)
         {
             AssertIsForeground();
@@ -246,7 +252,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             }
 
             var currentText = subjectBuffer.AsTextContainer().CurrentText;
-            var syntaxFactsService = document.GetLanguageService<ISyntaxFactsService>();
+            var isIdentifierPartCharacter = GetIsIdentifierPartCharacterFunction(document);
 
             var endPositionInSubjectBuffer = textView.GetCaretPoint(subjectBuffer);
             if (endPositionInSubjectBuffer == null)
@@ -261,7 +267,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             while (startPosition > 0)
             {
                 char c = currentText[startPosition - 1];
-                if (!syntaxFactsService.IsIdentifierPartCharacter(c) && c != '#' && c != '~')
+                if (!isIdentifierPartCharacter(c) && c != '#' && c != '~')
                 {
                     break;
                 }


### PR DESCRIPTION
I'm working on enabling snippet support for F# by re-using `AbstractSnippetCommandHandler.cs`, but it has a hard requirement on `ISyntaxFactsService`.  That service is internal to [Microsoft.CodeAnalysis.Workspaces](https://github.com/dotnet/roslyn/blob/f2c441274de1620496975ee223ec255c13bcafaa/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs) and F# doesn't have internal visibility into that.

There are 2 possibilities for allowing F# to use this abstract base class:
1.  Allow F# to directly implement `ISyntaxFactsService`.  This would either require that interface to be made public (bad because it adds a huge public API surface), or allowing more IVTs for F# (bad because we're trying to reduce our dependency on internals.)  This is also bad because F# doesn't participate in the Roslyn syntax trees so implementing this interface just so we can implement a single method is a very forceful insertion of a square peg into a round hole.
2.  Make the part that depends on `ISyntaxFactsService` virtual to allow F# to override it.  From here there are some sub-options:
- Let each language specify how it implements the `IsIdentifierPartCharacter()` method.  **This is the method I've chosen for this PR.**  C# and VB retain their existing behavior, but F# is allowed to override this.  The down-side to this is a virtual method that returns a type of `Func<char, bool>` which feels a bit artificial in the C#/VB world.  (Note, there is still the open question of the call site: should the comparisons to `'#'` and `'~'` be included in the virtual method or not?)
- Simply mark the entire `TryHandleTypedSnippet()` method as virtual, e.g.,
``` diff
- protected bool TryHandleTypedSnippet(ITextView textView, ITextBuffer subjectBuffer)
+ protected virtual bool TryHandleTypedSnippet(ITextView textView, ITextBuffer subjectBuffer)
```
The downside to this is that F# has to re-implement the internals of this method, and if there's ever a change then F# won't get to consume it.