### PR TITLE
Upgrade to the Shell 15.8.27828 NuGet packages

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -12,7 +12,7 @@
 
     <BasicUndoVersion>0.9.3</BasicUndoVersion>
     <CommandLineParserVersion>2.0.273-beta</CommandLineParserVersion>
-    <EnvDTEVersion>8.0.1</EnvDTEVersion>
+    <EnvDTEVersion>8.0.2</EnvDTEVersion>
     <EnvDTE80Version>8.0.0</EnvDTE80Version>
     <dotnetxunitVersion>2.3.1</dotnetxunitVersion>
     <FakeSignVersion>0.9.2</FakeSignVersion>
@@ -238,11 +238,11 @@
     <SQLitePCLRawbundle_greenVersion>1.1.2</SQLitePCLRawbundle_greenVersion>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.8.68-develop-g109a00ff</MicrosoftVSSDKBuildToolsVersion>
-    <VSLangProjVersion>7.0.3300</VSLangProjVersion>
-    <VSLangProj140Version>14.3.25407-alpha</VSLangProj140Version>
-    <VSLangProj2Version>7.0.5000</VSLangProj2Version>
-    <VSLangProj80Version>8.0.0.0-alpha</VSLangProj80Version>
-    <VsWebsiteInteropVersion>8.0.0.0-alpha</VsWebsiteInteropVersion>
+    <VSLangProjVersion>7.0.3301</VSLangProjVersion>
+    <VSLangProj140Version>14.0.25030</VSLangProj140Version>
+    <VSLangProj2Version>7.0.5001</VSLangProj2Version>
+    <VSLangProj80Version>8.0.50728</VSLangProj80Version>
+    <VsWebsiteInteropVersion>8.0.50727</VsWebsiteInteropVersion>
     <vswhereVersion>2.4.1</vswhereVersion>
     <XliffTasksVersion>0.2.0-beta-63004-01</XliffTasksVersion>
     <xunitVersion>2.3.1</xunitVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -93,7 +93,6 @@
     <MicrosoftVisualStudioSDKEmbedInteropTypesVersion>15.0.17</MicrosoftVisualStudioSDKEmbedInteropTypesVersion>
     <MicrosoftVisualStudioEditorVersion>15.8.414-preview</MicrosoftVisualStudioEditorVersion>
     <MicrosoftVisualStudioGraphModelVersion>15.8.27812-alpha</MicrosoftVisualStudioGraphModelVersion>
-    <MicrosoftVisualStudioImagingVersion>15.7.27703</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>14.3.26930</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
     <MicrosoftVisualStudioInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioInteractiveWindowVersion>
     <MicrosoftVisualStudioLanguageVersion>15.8.414-preview</MicrosoftVisualStudioLanguageVersion>
@@ -114,8 +113,8 @@
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.15.103</MicrosoftVisualStudioSetupConfigurationInteropVersion>
     <MicrosoftVisualStudioSettings140Version>14.3.25407</MicrosoftVisualStudioSettings140Version>
     <MicrosoftVisualStudioShell140Version>14.3.25407</MicrosoftVisualStudioShell140Version>
-    <MicrosoftVisualStudioShell150Version>15.7.27703</MicrosoftVisualStudioShell150Version>
-    <MicrosoftVisualStudioShellFrameworkVersion>15.7.27703</MicrosoftVisualStudioShellFrameworkVersion>
+    <MicrosoftVisualStudioShell150Version>15.8.27828</MicrosoftVisualStudioShell150Version>
+    <MicrosoftVisualStudioShellFrameworkVersion>15.8.27828</MicrosoftVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioShellDesignVersion>15.7.27703</MicrosoftVisualStudioShellDesignVersion>
     <MicrosoftVisualStudioShellImmutable100Version>15.0.25415</MicrosoftVisualStudioShellImmutable100Version>
     <MicrosoftVisualStudioShellImmutable110Version>15.0.25415</MicrosoftVisualStudioShellImmutable110Version>
@@ -136,7 +135,6 @@
     <MicrosoftVisualStudioTextManagerInterop120Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop120Version>
     <MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>
     <MicrosoftVisualStudioThreadingVersion>15.8.99-rc</MicrosoftVisualStudioThreadingVersion>
-    <MicrosoftVisualStudioUtilitiesVersion> 15.7.27703</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>15.3.23</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioVsInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioVsInteractiveWindowVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>

--- a/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
+++ b/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
@@ -142,7 +142,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="$(MicrosoftVisualStudioShellInterop80Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop100Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />

--- a/src/EditorFeatures/Core.Wpf/Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj
+++ b/src/EditorFeatures/Core.Wpf/Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.NavigateTo.Interfaces" Version="$(MicrosoftVisualStudioLanguageNavigateToInterfacesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="$(MicrosoftVisualStudioRemoteControlVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="$(MicrosoftVisualStudioSDKEmbedInteropTypesVersion)" />

--- a/src/EditorFeatures/Test2/Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.vbproj
+++ b/src/EditorFeatures/Test2/Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.vbproj
@@ -65,7 +65,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.CallHierarchy" Version="$(MicrosoftVisualStudioLanguageCallHierarchyVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />

--- a/src/EditorFeatures/TestUtilities2/Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.vbproj
+++ b/src/EditorFeatures/TestUtilities2/Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.vbproj
@@ -47,7 +47,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.CallHierarchy" Version="$(MicrosoftVisualStudioLanguageCallHierarchyVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <!-- Microsoft.VisualStudio.Platform.VSEditor references Microsoft.VisualStudio.Text.Internal since it's needed at runtime; we want to insure we are using
          it _only_ for runtime dependencies and not anything compile time -->

--- a/src/EditorFeatures/Text/Microsoft.CodeAnalysis.EditorFeatures.Text.csproj
+++ b/src/EditorFeatures/Text/Microsoft.CodeAnalysis.EditorFeatures.Text.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(MicrosoftVisualStudioTextLogicVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
   </ItemGroup>
   <ItemGroup>
     <!-- InternalsVisibleTo go here -->

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
@@ -21,13 +21,12 @@
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />
-      <!--This package depends on the following 4 packages, however we can not enforce them in there.
+      <!--This package depends on the following 3 packages, however we can not enforce them in there.
       Roslyn depends on Editor packages which are not released yet, enforcing these dependenceis will delay the release of roslyn package,
       while roslyn and editor packages are supposed to release together with Visual Studio.-->
       <!--<dependency id="Microsoft.VisualStudio.CoreUtility" version="$MicrosoftVisualStudioCoreUtilityVersion$" />
       <dependency id="Microsoft.VisualStudio.Text.Data" version="$MicrosoftVisualStudioTextDataVersion$" />
-      <dependency id="Microsoft.VisualStudio.Text.Logic" version="$MicrosoftVisualStudioTextLogicVersion$" />
-      <dependency id="Microsoft.VisualStudio.Utilities" version="$MicrosoftVisualStudioUtilitiesVersion$" />-->
+      <dependency id="Microsoft.VisualStudio.Text.Logic" version="$MicrosoftVisualStudioTextLogicVersion$" />-->
     </dependencies>
 
     <language>en-US</language>

--- a/src/Tools/GenerateSdkPackages/files.txt
+++ b/src/Tools/GenerateSdkPackages/files.txt
@@ -7,16 +7,3 @@ StaticAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.UI.dll
 VMP\Microsoft.VisualStudio.GraphModel.dll
 VMP\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll
 VSTelemetryPackage\Microsoft.VisualStudio.Telemetry.dll
-Microsoft.VisualStudio.XmlEditor.dll
-Microsoft.XmlEditor.dll
-Microsoft.XmlEditorUI.dll
-Microsoft.XmlEditorNeutralUI.dll
-Microsoft.XslDebugger.dll
-Microsoft.VisualStudio.XsdDesigner.dll
-Microsoft.VisualStudio.XsdDesigner.Controls.Graph.dll
-Microsoft.VisualStudio.XsdDesignerPackage.dll
-Microsoft.VisualStudio.DataDesign.Common.dll
-Microsoft.VSDesigner.dll
-Microsoft.VisualStudio.XmlEditor.dll
-Microsoft.VisualStudio.VSHelp.dll
-Microsoft.VisualStudio.DataTools.Interop.dll

--- a/src/Tools/GenerateSdkPackages/files.txt
+++ b/src/Tools/GenerateSdkPackages/files.txt
@@ -1,6 +1,3 @@
-Microsoft.VisualStudio.Debugger.Engine.dll
-Microsoft.VisualStudio.Debugger.Metadata.dll
-Microsoft.VisualStudio.Debugger.UI.Interfaces.dll
 Microsoft.VisualStudio.CallHierarchy.Package.Definitions.dll
 Microsoft.Internal.Performance.CodeMarkers.DesignTime.dll
 Progression\Microsoft.VisualStudio.Progression.CodeSchema.dll

--- a/src/VisualStudio/Core/Test.Next/Roslyn.VisualStudio.Next.UnitTests.csproj
+++ b/src/VisualStudio/Core/Test.Next/Roslyn.VisualStudio.Next.UnitTests.csproj
@@ -62,8 +62,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language" Version="$(MicrosoftVisualStudioLanguageVersion)" />

--- a/src/VisualStudio/TestUtilities2/Microsoft.VisualStudio.LanguageServices.Test.Utilities2.vbproj
+++ b/src/VisualStudio/TestUtilities2/Microsoft.VisualStudio.LanguageServices.Test.Utilities2.vbproj
@@ -82,7 +82,6 @@
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="$(MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.CallHierarchy" Version="$(MicrosoftVisualStudioLanguageCallHierarchyVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(MicrosoftVisualStudioTextLogicVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />


### PR DESCRIPTION
This upgrades us to 15.8.27828 for the core Visual Studio Shell NuGet packages.

I am removing our explicit references to Microsoft.VisualStudio.Imaging and Microsoft.VisualStudio.Utilities; both of these are carried along in references to Shell.15.0, and trying to state them explicitly just results in package downgrade warnings. I also fix up some other interop packages we had created ourselves now that official ones exist too.