### PR TITLE
fixing hintspan size when Sub has attributes

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Structure/MethodDeclarationStructureTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Structure/MethodDeclarationStructureTests.vb
@@ -16,13 +16,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
         Public Async Function TestSub() As Task
             Const code = "
 Class C
-    {|span:Sub $$Goo()
-    End Sub|} ' Goo
+    {|span:{|hintspan:Sub $$Goo()
+    End Sub|}|} ' Goo
 End Class
 "
 
             Await VerifyBlockSpansAsync(code,
-                Region("span", "Sub Goo() ...", autoCollapse:=True))
+                Region("span", "hintspan", "Sub Goo() ...", autoCollapse:=True))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Outlining)>
@@ -156,6 +156,24 @@ End Class
             Await VerifyBlockSpansAsync(code,
                 Region("span1", "' My ...", autoCollapse:=True),
                 Region("span2", "Sub Goo() Implements Bar.Baz ...", autoCollapse:=True))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Outlining)>
+        <WorkItem(27462, "https://github.com/dotnet/roslyn/issues/27462")>
+        Public Async Function TestSubWithAttribute() As Task
+            Const code = "
+Imports System.Runtime.CompilerServices
+
+Public Module SomeModule
+  {|span:<Extension>
+  {|hintspan:Public Sub $$WillNotShowPreviewWhenFolded(ArgFoo As Object)
+    'this will NOT be visible in the preview tooltip.
+  End Sub|}|}
+End Module
+"
+
+            Await VerifyBlockSpansAsync(code,
+                Region("span", "hintspan", "<Extension> Public Sub WillNotShowPreviewWhenFolded(ArgFoo As Object) ...", autoCollapse:=True))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Outlining)>

--- a/src/Features/VisualBasic/Portable/Structure/VisualBasicStructureHelpers.vb
+++ b/src/Features/VisualBasic/Portable/Structure/VisualBasicStructureHelpers.vb
@@ -132,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 Dim attributeOwner = firstToken.Parent.Parent
                 For Each child In attributeOwner.ChildNodesAndTokens
                     If child.Kind() <> SyntaxKind.AttributeList Then
-                        Return TextSpan.FromBounds(child.SpanStart, child.Span.End)
+                        Return TextSpan.FromBounds(child.SpanStart, blockNode.Span.End)
                     End If
                 Next
             End If


### PR DESCRIPTION
fixing https://github.com/dotnet/roslyn/issues/27462