### PR TITLE
Check misused ? annotation outside executable code

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             if (InExecutableBinder)
                             {
-                                // Inside a method body or other executable code, we can afford to pull on NonNullTypes symbol or question IsValueType without causing cycles.
+                                // Inside a method body or other executable code, we can pull on NonNullTypes symbol or question IsValueType without causing cycles.
                                 // Types created outside executable context should be checked by the responsible symbol (the method symbol checks its return type, for instance).
 
                                 if (!typeArgument.IsValueType && NonNullTypesContext.NonNullTypes != true)

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -484,11 +484,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (returnType.ContainsNullableReferenceTypes())
                 {
                     binder.Compilation.EnsureNullableAttributeExists(diagnostics, lambdaSymbol.DiagnosticLocation, modifyCompilation: false);
+                    // Note: we don't need to warn on annotations used without NonNullTypes context for lambdas, as this is handled in binding already
                 }
             }
 
             ParameterHelpers.ReportAnnotatedUnconstrainedTypeParameters(lambdaParameters, diagnostics);
             ParameterHelpers.EnsureNullableAttributeExists(lambdaParameters, diagnostics, modifyCompilation: false);
+            // Note: we don't need to warn on annotations used without NonNullTypes context for lambdas, as this is handled in binding already
 
             block = BindLambdaBody(lambdaSymbol, lambdaBodyBinder, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -169,6 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(parameters, diagnostics, modifyCompilation: false);
             ParameterHelpers.ReportAnnotatedUnconstrainedTypeParameters(parameters, diagnostics);
             ParameterHelpers.EnsureNullableAttributeExists(parameters, diagnostics, modifyCompilation: false);
+            // Note: we don't need to warn on annotations used without NonNullTypes context for local functions, as this is handled in binding already
 
             var isVararg = arglistToken.Kind() == SyntaxKind.ArgListKeyword;
             if (isVararg)
@@ -235,6 +236,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (returnType.ContainsNullableReferenceTypes())
             {
                 DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: false);
+                // Note: we don't need to warn on annotations used without NonNullTypes context for local functions, as this is handled in binding already
             }
 
             Debug.Assert(_refKind == RefKind.None

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -144,6 +144,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal static void ReportMissingNonNullTypesContextForAnnotation(ImmutableArray<ParameterSymbol> parameters, DiagnosticBag diagnostics)
+        {
+            foreach (var parameter in parameters)
+            {
+                if (parameter.Type.ContainsNullableReferenceTypes())
+                {
+                    parameter.ReportMissingNonNullTypesContextForAnnotation(diagnostics, parameter.GetNonNullSyntaxNode().Location);
+                }
+            }
+        }
+
         internal static void ReportAnnotatedUnconstrainedTypeParameters(ImmutableArray<ParameterSymbol> parameters, DiagnosticBag diagnostics)
         {
             foreach (var parameter in parameters)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -116,6 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(Parameters, diagnostics, modifyCompilation: true);
             ParameterHelpers.ReportAnnotatedUnconstrainedTypeParameters(Parameters, diagnostics);
             ParameterHelpers.EnsureNullableAttributeExists(Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.ReportMissingNonNullTypesContextForAnnotation(Parameters, diagnostics);
         }
 
         internal ConstructorDeclarationSyntax GetSyntax()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -321,10 +321,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (ReturnType.ContainsNullableReferenceTypes())
                 {
                     this.DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);
+                    ReportMissingNonNullTypesContextForAnnotation(diagnostics, location);
                 }
 
                 ParameterHelpers.ReportAnnotatedUnconstrainedTypeParameters(Parameters, diagnostics);
                 ParameterHelpers.EnsureNullableAttributeExists(Parameters, diagnostics, modifyCompilation: true);
+                ParameterHelpers.ReportMissingNonNullTypesContextForAnnotation(Parameters, diagnostics);
             }
 
             public override ImmutableArray<CustomModifier> RefCustomModifiers => _refCustomModifiers;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -693,6 +693,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (this.Type.ContainsNullableReferenceTypes())
             {
                 this.DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);
+                ReportMissingNonNullTypesContextForAnnotation(diagnostics, location);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -132,6 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (this.Type.ContainsNullableReferenceTypes())
             {
                 DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);
+                ReportMissingNonNullTypesContextForAnnotation(diagnostics, location);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1432,6 +1432,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 interfaces.Any(t => t.ContainsNullableReferenceTypes()))
             {
                 this.DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);
+                ReportMissingNonNullTypesContextForAnnotation(diagnostics, location);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -1054,10 +1054,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (ReturnType.ContainsNullableReferenceTypes())
             {
                 this.DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);
+                ReportMissingNonNullTypesContextForAnnotation(diagnostics, location);
             }
 
             ParameterHelpers.ReportAnnotatedUnconstrainedTypeParameters(Parameters, diagnostics);
             ParameterHelpers.EnsureNullableAttributeExists(Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.ReportMissingNonNullTypesContextForAnnotation(Parameters, diagnostics);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -773,10 +773,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (this.Type.ContainsNullableReferenceTypes())
             {
                 DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);
+                ReportMissingNonNullTypesContextForAnnotation(diagnostics, location);
             }
 
             ParameterHelpers.ReportAnnotatedUnconstrainedTypeParameters(this.Parameters, diagnostics);
             ParameterHelpers.EnsureNullableAttributeExists(this.Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.ReportMissingNonNullTypesContextForAnnotation(this.Parameters, diagnostics);
         }
 
         private void CheckAccessibility(Location location, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -654,9 +654,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (ReturnType.ContainsNullableReferenceTypes())
             {
                 this.DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);
+                ReportMissingNonNullTypesContextForAnnotation(diagnostics, location);
             }
             ParameterHelpers.ReportAnnotatedUnconstrainedTypeParameters(Parameters, diagnostics);
             ParameterHelpers.EnsureNullableAttributeExists(Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.ReportMissingNonNullTypesContextForAnnotation(Parameters, diagnostics);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -856,6 +856,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal void ReportMissingNonNullTypesContextForAnnotation(DiagnosticBag diagnostics, Location location)
+        {
+            if (this.NonNullTypes != true)
+            {
+                diagnostics.Add(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, location);
+            }
+        }
+
         internal DiagnosticInfo GetUseSiteDiagnosticForSymbolOrContainingType()
         {
             var info = this.GetUseSiteDiagnostic();

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -61,7 +61,7 @@ class C
 {
     static void F(object? x, object?[] y) { }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyEmitDiagnostics();
         }
 
@@ -85,7 +85,7 @@ class C
 {
     static void F(object? x, object?[] y) { }
 }";
-            var comp = CreateCompilation(source, references: new[] { ref0 }, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, references: new[] { ref0 }, parseOptions: TestOptions.Regular8);
             comp.VerifyEmitDiagnostics();
         }
 
@@ -104,7 +104,7 @@ class C
 {
     static void F(object? x, object?[] y) { }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             comp.VerifyEmitDiagnostics(
                 // (10,19): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NullableAttribute..ctor'
                 //     static void F(object? x, object?[] y) { }
@@ -166,6 +166,9 @@ class C
                 references: new[] { ref0 },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyEmitDiagnostics(
+                // (3,5): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     object? F() => null;
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "object?").WithLocation(3, 5),
                 // error CS0518: Predefined type 'System.Boolean' is not defined or imported
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Boolean").WithLocation(1, 1));
         }
@@ -194,6 +197,9 @@ class C
                 references: new[] { ref0 },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyEmitDiagnostics(
+                // (3,5): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     object? F() => null;
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "object?").WithLocation(3, 5),
                 // error CS0518: Predefined type 'System.Attribute' is not defined or imported
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
                 // error CS0518: Predefined type 'System.Attribute' is not defined or imported
@@ -229,6 +235,9 @@ class C
                 references: new[] { ref0 },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyEmitDiagnostics(
+                // (3,5): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     object? F() => null;
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "object?").WithLocation(3, 5),
                 // error CS1729: 'Attribute' does not contain a constructor that takes 0 arguments
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount).WithArguments("System.Attribute", "0").WithLocation(1, 1),
                 // error CS1729: 'Attribute' does not contain a constructor that takes 0 arguments
@@ -306,7 +315,7 @@ class C
 {
     public object? F = new object();
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (3,20): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //     public object? F = new object();
@@ -1098,7 +1107,7 @@ class C
 class B : A<object?>
 {
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (4,7): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 // class B : A<object?>
@@ -1115,7 +1124,7 @@ class B : A<object?>
 class C : I<(object X, object? Y)>
 {
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (4,7): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 // class C : I<(object X, object? Y)>
@@ -1130,7 +1139,7 @@ class C : I<(object X, object? Y)>
 {
     object? F() => null;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (3,5): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //     object? F() => null;
@@ -1145,7 +1154,7 @@ class C : I<(object X, object? Y)>
 {
     void F(object?[] c) { }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (3,12): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //     void F(object?[] c) { }
@@ -1160,7 +1169,7 @@ class C : I<(object X, object? Y)>
 {
     C(object?[] c) { }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (3,7): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //     C(object?[] c) { }
@@ -1175,7 +1184,7 @@ class C : I<(object X, object? Y)>
 {
     object? P => null;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (3,5): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //     object? P => null;
@@ -1190,7 +1199,7 @@ class C : I<(object X, object? Y)>
 {
     object this[object x, object? y] => throw new System.NotImplementedException();
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (3,27): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //     object this[object x, object? y] => throw new System.NotImplementedException();
@@ -1205,7 +1214,7 @@ class C : I<(object X, object? Y)>
 {
     public static object? operator+(C a, C b) => null;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (3,19): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //     public static object? operator+(C a, C b) => null;
@@ -1220,7 +1229,7 @@ class C : I<(object X, object? Y)>
 {
     public static object operator+(C a, object?[] b) => a;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (3,41): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 //     public static object operator+(C a, object?[] b) => a;
@@ -1232,7 +1241,7 @@ class C : I<(object X, object? Y)>
         {
             var source =
 @"delegate object? D();";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (1,10): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 // delegate object? D();
@@ -1244,7 +1253,7 @@ class C : I<(object X, object? Y)>
         {
             var source =
 @"delegate void D(object?[] o);";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseModule);
             comp.VerifyEmitDiagnostics(
                 // (1,17): error CS0518: Predefined type 'System.Runtime.CompilerServices.NullableAttribute' is not defined or imported
                 // delegate void D(object?[] o);
@@ -1455,7 +1464,7 @@ public class B<T> :
         (dynamic? _1, (object _2, dynamic? _3), object _4, dynamic? _5, object _6, dynamic? _7, object _8, dynamic? _9) arg) => arg;
     public (dynamic? _1, (object _2, dynamic? _3), object _4, dynamic? _5, object _6, dynamic? _7, object _8, dynamic? _9) Property { get; set; }
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             CompileAndVerify(comp, validator: assembly =>
             {
                 var reader = assembly.GetMetadataReader();
@@ -1526,7 +1535,7 @@ public class B<T> :
         b.Property._9.ToString(); // 3
     }
 }";
-            var comp2 = CreateCompilation(source2, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
+            var comp2 = CreateCompilation(new[] { source2, NonNullTypesTrue }, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
                 // (6,9): warning CS8602: Possible dereference of a null reference.
                 //         b.Field._9.ToString(); // 1

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
@@ -2145,21 +2145,24 @@ IInvocationOperation (void P.M2([System.Boolean[missing]? x = true])) (Operation
 ";
 
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class P
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (9,20): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     static void M2(bool? x = true)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 20),
-                // (9,20): error CS0518: Predefined type 'System.Boolean' is not defined or imported
-                //     static void M2(bool? x = true)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool").WithArguments("System.Boolean").WithLocation(9, 20),
-                // (9,12): error CS0518: Predefined type 'System.Void' is not defined or imported
-                //     static void M2(bool? x = true)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void").WithLocation(9, 12),
                 // (4,12): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //     static void M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void").WithLocation(4, 12),
+                // (9,20): error CS0518: Predefined type 'System.Boolean' is not defined or imported
+                //     static void M2(bool? x = true)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool").WithArguments("System.Boolean").WithLocation(9, 20),
+                // (9,20): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     static void M2(bool? x = true)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 20),
+                // (9,12): error CS0518: Predefined type 'System.Void' is not defined or imported
+                //     static void M2(bool? x = true)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void").WithLocation(9, 12),
+                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // class P
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
+                // (9,20): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     static void M2(bool? x = true)
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "bool? x = true").WithLocation(9, 20),
                 // (9,30): error CS0518: Predefined type 'System.Boolean' is not defined or imported
                 //     static void M2(bool? x = true)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "true").WithArguments("System.Boolean").WithLocation(9, 30),
@@ -2207,9 +2210,6 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = tru
 
             // PROTOTYPE(NullableReferenceTypes): Why are two errors reported for missing System.Nullable`1.
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class P
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
                 // (4,12): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     static P M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(4, 12),
@@ -2227,6 +2227,12 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = tru
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"P(bool? x = true)
     {
     }").WithArguments("System.Void").WithLocation(9, 5),
+                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // class P
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
+                // (9,7): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     P(bool? x = true)
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "bool? x = true").WithLocation(9, 7),
                 // (9,17): error CS0518: Predefined type 'System.Boolean' is not defined or imported
                 //     P(bool? x = true)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "true").WithArguments("System.Boolean").WithLocation(9, 17),
@@ -2281,33 +2287,36 @@ IPropertyReferenceOperation: System.Int32[missing] P.this[System.Int32[missing] 
 ";
 
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // (3,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class P
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(3, 7),
-                // (6,21): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     public int this[int x, int? y = 5]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(6, 21),
-                // (6,28): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     public int this[int x, int? y = 5]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int?").WithArguments("System.Nullable`1").WithLocation(6, 28),
-                // (6,28): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     public int this[int x, int? y = 5]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(6, 28),
+                // (5,13): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     private int _number = 0;
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 13),
                 // (6,12): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     public int this[int x, int? y = 5]
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(6, 12),
+                // (6,21): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     public int this[int x, int? y = 5]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(6, 21),
+                // (6,28): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     public int this[int x, int? y = 5]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(6, 28),
+                // (6,28): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     public int this[int x, int? y = 5]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int?").WithArguments("System.Nullable`1").WithLocation(6, 28),
                 // (9,9): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //         set { _number = value; }
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "set { _number = value; }").WithArguments("System.Void").WithLocation(9, 9),
                 // (12,5): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //     void M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void").WithLocation(12, 5),
+                // (3,7): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // class P
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(3, 7),
+                // (6,28): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     public int this[int x, int? y = 5]
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "int? y = 5").WithLocation(6, 28),
                 // (6,37): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     public int this[int x, int? y = 5]
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "5").WithArguments("System.Int32").WithLocation(6, 37),
-                // (5,13): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     private int _number = 0;
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 13),
                 // (5,27): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     private int _number = 0;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(5, 27),
@@ -2355,21 +2364,24 @@ IInvocationOperation (void P.M2([System.Boolean[missing]? x = null])) (Operation
 ";
 
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class P
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (9,20): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     static void M2(bool? x = null)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 20),
-                // (9,20): error CS0518: Predefined type 'System.Boolean' is not defined or imported
-                //     static void M2(bool? x = null)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool").WithArguments("System.Boolean").WithLocation(9, 20),
-                // (9,12): error CS0518: Predefined type 'System.Void' is not defined or imported
-                //     static void M2(bool? x = null)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void").WithLocation(9, 12),
                 // (4,12): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //     static void M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void").WithLocation(4, 12),
+                // (9,20): error CS0518: Predefined type 'System.Boolean' is not defined or imported
+                //     static void M2(bool? x = null)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool").WithArguments("System.Boolean").WithLocation(9, 20),
+                // (9,20): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     static void M2(bool? x = null)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 20),
+                // (9,12): error CS0518: Predefined type 'System.Void' is not defined or imported
+                //     static void M2(bool? x = null)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void").WithLocation(9, 12),
+                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // class P
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
+                // (9,20): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     static void M2(bool? x = null)
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "bool? x = null").WithLocation(9, 20),
                 // (6,19): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //         /*<bind>*/M2()/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "M2").WithArguments("System.Object").WithLocation(6, 19),
@@ -2412,9 +2424,6 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = nul
 
             // PROTOTYPE(NullableReferenceTypes): Why are two errors reported for missing System.Nullable`1.
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class P
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
                 // (4,12): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     static P M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(4, 12),
@@ -2432,6 +2441,12 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = nul
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"P(bool? x = null)
     {
     }").WithArguments("System.Void").WithLocation(9, 5),
+                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // class P
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
+                // (9,7): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     P(bool? x = null)
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "bool? x = null").WithLocation(9, 7),
                 // (6,30): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //         return /*<bind>*/new P()/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(6, 30),
@@ -2484,30 +2499,33 @@ IPropertyReferenceOperation: System.Int32[missing] P.this[System.Int32[missing] 
                 // (16,1): error CS1022: Type or namespace definition, or end-of-file expected
                 // }
                 Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(16, 1),
-                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class P
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (5,21): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     public int this[int x, int? y = null]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 21),
-                // (5,28): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     public int this[int x, int? y = null]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int?").WithArguments("System.Nullable`1").WithLocation(5, 28),
-                // (5,28): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     public int this[int x, int? y = null]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 28),
+                // (4,13): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     private int _number = 0;
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(4, 13),
                 // (5,12): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     public int this[int x, int? y = null]
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 12),
+                // (5,21): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     public int this[int x, int? y = null]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 21),
+                // (5,28): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     public int this[int x, int? y = null]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 28),
+                // (5,28): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     public int this[int x, int? y = null]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int?").WithArguments("System.Nullable`1").WithLocation(5, 28),
                 // (8,9): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //         set { _number = value; }
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "set { _number = value; }").WithArguments("System.Void").WithLocation(8, 9),
                 // (11,5): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //     void M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void").WithLocation(11, 5),
-                // (4,13): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     private int _number = 0;
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(4, 13),
+                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // class P
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
+                // (5,28): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     public int this[int x, int? y = null]
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "int? y = null").WithLocation(5, 28),
                 // (4,27): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     private int _number = 0;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(4, 27),
@@ -3487,47 +3505,50 @@ IInvalidOperation (OperationKind.Invalid, Type: P, IsInvalid) (Syntax: 'new P() 
 ";
 
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class P
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (5,21): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     public int this[int x, int? y = 0]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 21),
-                // (5,28): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     public int this[int x, int? y = 0]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int?").WithArguments("System.Nullable`1").WithLocation(5, 28),
-                // (5,28): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     public int this[int x, int? y = 0]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 28),
+                // (4,13): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     private int _number = 0;
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(4, 13),
                 // (5,12): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     public int this[int x, int? y = 0]
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 12),
+                // (5,21): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     public int this[int x, int? y = 0]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 21),
+                // (5,28): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     public int this[int x, int? y = 0]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 28),
+                // (5,28): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     public int this[int x, int? y = 0]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int?").WithArguments("System.Nullable`1").WithLocation(5, 28),
                 // (8,9): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //         set { _number = value; }
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "set { _number = value; }").WithArguments("System.Void").WithLocation(8, 9),
                 // (11,5): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     P M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(11, 5),
+                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // class P
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
+                // (5,28): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     public int this[int x, int? y = 0]
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "int? y = 0").WithLocation(5, 28),
                 // (5,37): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     public int this[int x, int? y = 0]
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(5, 37),
-                // (4,13): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     private int _number = 0;
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(4, 13),
                 // (4,27): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     private int _number = 0;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(4, 27),
                 // (13,30): error CS0518: Predefined type 'System.Object' is not defined or imported
-                //         return /*<bind>*/new P() { [0] = 1 };/*</bind>*/;
+                //         return /*<bind>*/new P() { [0] = 1 }/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(13, 30),
                 // (13,37): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //         return /*<bind>*/new P() { [0] = 1 };/*</bind>*/;
+                //         return /*<bind>*/new P() { [0] = 1 }/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(13, 37),
                 // (13,42): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //         return /*<bind>*/new P() { [0] = 1 };/*</bind>*/;
+                //         return /*<bind>*/new P() { [0] = 1 }/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "1").WithArguments("System.Int32").WithLocation(13, 42),
                 // (13,30): error CS0518: Predefined type 'System.Void' is not defined or imported
-                //         return /*<bind>*/new P() { [0] = 1 };/*</bind>*/;
+                //         return /*<bind>*/new P() { [0] = 1 }/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Void").WithLocation(13, 30),
                 // (2,7): error CS1729: 'object' does not contain a constructor that takes 0 arguments
                 // class P
@@ -3582,44 +3603,47 @@ IInvalidOperation (OperationKind.Invalid, Type: P, IsInvalid) (Syntax: 'new P() 
 ";
 
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class P
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (5,21): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     public int this[int x, int? y = null]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 21),
-                // (5,28): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     public int this[int x, int? y = null]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int?").WithArguments("System.Nullable`1").WithLocation(5, 28),
-                // (5,28): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     public int this[int x, int? y = null]
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 28),
+                // (4,13): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     private int _number = 0;
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(4, 13),
                 // (5,12): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     public int this[int x, int? y = null]
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 12),
+                // (5,21): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     public int this[int x, int? y = null]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 21),
+                // (5,28): error CS0518: Predefined type 'System.Int32' is not defined or imported
+                //     public int this[int x, int? y = null]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(5, 28),
+                // (5,28): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     public int this[int x, int? y = null]
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int?").WithArguments("System.Nullable`1").WithLocation(5, 28),
                 // (8,9): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //         set { _number = value; }
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "set { _number = value; }").WithArguments("System.Void").WithLocation(8, 9),
                 // (11,5): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     P M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(11, 5),
-                // (4,13): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //     private int _number = 0;
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int").WithArguments("System.Int32").WithLocation(4, 13),
+                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // class P
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
+                // (5,28): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     public int this[int x, int? y = null]
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "int? y = null").WithLocation(5, 28),
                 // (4,27): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     private int _number = 0;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(4, 27),
                 // (13,30): error CS0518: Predefined type 'System.Object' is not defined or imported
-                //         return /*<bind>*/new P() { [0] = 1 };/*</bind>*/;
+                //         return /*<bind>*/new P() { [0] = 1 }/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(13, 30),
                 // (13,37): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //         return /*<bind>*/new P() { [0] = 1 };/*</bind>*/;
+                //         return /*<bind>*/new P() { [0] = 1 }/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(13, 37),
                 // (13,42): error CS0518: Predefined type 'System.Int32' is not defined or imported
-                //         return /*<bind>*/new P() { [0] = 1 };/*</bind>*/;
+                //         return /*<bind>*/new P() { [0] = 1 }/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "1").WithArguments("System.Int32").WithLocation(13, 42),
                 // (13,30): error CS0518: Predefined type 'System.Void' is not defined or imported
-                //         return /*<bind>*/new P() { [0] = 1 };/*</bind>*/;
+                //         return /*<bind>*/new P() { [0] = 1 }/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Void").WithLocation(13, 30),
                 // (2,7): error CS1729: 'object' does not contain a constructor that takes 0 arguments
                 // class P

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -191,7 +191,7 @@ class C
         [Fact, WorkItem(26812, "https://github.com/dotnet/roslyn/issues/26812")]
         public void DoubleAssignment()
         {
-            CSharpCompilation c = CreateCompilation(@"
+            CSharpCompilation c = CreateCompilation(new[] { @"
 using static System.Console;
 class C
 {
@@ -206,7 +206,7 @@ class C
         WriteLine(y.Length);
     }
 }
-", parseOptions: TestOptions.Regular8);
+", NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics();
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -529,11 +529,17 @@ class C<T> where T : struct
 
             // [NonNullTypes(false)]
             comp = CreateCompilation(new[] { source, NonNullTypesFalse, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (10,8): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     T? F3;
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "F3").WithLocation(10, 8));
 
             // [NonNullTypes] missing
             comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (10,8): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
+                //     T? F3;
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "F3").WithLocation(10, 8));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Test `where T : unmanaged`.


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/roslyn/pull/28842 (which warned on misused ? annotation in executable code).

Reporting such diagnostics on precise locations isn't straightforward, but I'm not sure if it's essential. It does cause a mismatch between warnings inside and outside executable code...
Let me know what you think.