### PR TITLE
Do not override assembly version in non-official builds

### DIFF
--- a/build/Targets/RepoToolset/Version.props
+++ b/build/Targets/RepoToolset/Version.props
@@ -45,7 +45,7 @@
     
         <VersionSuffixDateStamp>$([MSBuild]::Subtract($([System.Convert]::ToInt32($(_BuildNumberFiveDigitDateStamp))), $([MSBuild]::Multiply($(_BuildNumberFiveDigitDateStampYearsToOffset), 8800))))</VersionSuffixDateStamp>
         <VersionSuffixBuildOfTheDay>$(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))))</VersionSuffixBuildOfTheDay>
-        <VersionSuffixBuildOfTheDayPadded>$(_BuildNumberBuildOfTheDay.PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</VersionSuffixBuildOfTheDayPadded>
+        <VersionSuffixBuildOfTheDayPadded>$(VersionSuffixBuildOfTheDay.PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</VersionSuffixBuildOfTheDayPadded>
 
         <_BuildNumberSuffix Condition="'$(SemanticVersioningV1)' != 'true'">.$(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay)</_BuildNumberSuffix>
         <_BuildNumberSuffix Condition="'$(SemanticVersioningV1)' == 'true'">-$(VersionSuffixDateStamp)-$(VersionSuffixBuildOfTheDayPadded)</_BuildNumberSuffix>

--- a/build/Targets/RepoToolset/Version.props
+++ b/build/Targets/RepoToolset/Version.props
@@ -18,6 +18,11 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- TODO: Remove. OfficialBuildId should be set directly by the build definition  -->
+    <OfficialBuildId Condition="'$(OfficialBuild)' == 'true'">$(BUILD_BUILDNUMBER)</OfficialBuildId>
+  </PropertyGroup>
+
   <Choose>
     <When Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">
       <PropertyGroup>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -19,9 +19,10 @@
 
     <!-- 
       By default the assembly version in official builds is "$(VersionPrefix).0".
-      When building servicing set AssemblyVersion to fixed value to avoid updating binding redirects.
+      When building servicing set AssemblyVersion property to a fixed value to avoid updating binding redirects in VS.
+      Keep the setting conditional. The toolset sets the assembly version to 42.42.42.42 if not set explicitly.
     -->
-    <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">$(VersionPrefix).0</AssemblyVersion>
   </PropertyGroup>
 
   <Import Project="RepoToolset\ProjectLayout.props" />

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -210,7 +210,7 @@ function Restore-Packages() {
 function Make-BootstrapBuild() {
     $dir = Join-Path $binariesDir "Bootstrap"
     Write-Host "Building Bootstrap compiler"
-    $bootstrapArgs = "/p:UseShippingAssemblyVersion=true /p:InitialDefineConstants=BOOTSTRAP"
+    $bootstrapArgs = "/p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP"
     Remove-Item -re $dir -ErrorAction SilentlyContinue
     Create-Directory $dir
     if ($buildCoreClr) {


### PR DESCRIPTION
The toolset sets the assembly version to 42.42.42.42 if not set explicitly.