### PR TITLE
Improved User Experience with "Navigate to decompiled sources"

### DIFF
--- a/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using ICSharpCode.Decompiler.Metadata;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
+{
+    internal class AssemblyResolver : IAssemblyResolver
+    {
+        private readonly Compilation parentCompilation;
+        private static readonly Version zeroVersion = new Version(0, 0, 0, 0);
+
+        public AssemblyResolver(Compilation parentCompilation)
+        {
+            this.parentCompilation = parentCompilation;
+        }
+
+        public PEFile Resolve(IAssemblyReference name)
+        {
+            foreach (var assembly in parentCompilation.GetReferencedAssemblySymbols())
+            {
+                // First, find the correct IAssemblySymbol by name and PublicKeyToken.
+                if (assembly.Identity.Name != name.Name
+                    || !assembly.Identity.PublicKeyToken.SequenceEqual(name.PublicKeyToken ?? Array.Empty<byte>()))
+                {
+                    continue;
+                }
+
+                // Normally we skip versions that do not match, except if the reference is "mscorlib" (see comments below)
+                // or if the name.Version is '0.0.0.0'. This is because we require the metadata of all transitive references
+                // and modules, to achieve best decompilation results.
+                // In the case of .NET Standard projects for example, the 'netstandard' reference contains no references
+                // with actual versions. All versions are '0.0.0.0', therefore we have to ignore those version numbers,
+                // and can just use the references provided by Roslyn instead.
+                if (assembly.Identity.Version != name.Version && name.Version != zeroVersion
+                    && !string.Equals("mscorlib", assembly.Identity.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    // MSBuild treats mscorlib special for the purpose of assembly resolution/unification, where all
+                    // versions of the assembly are considered equal. The same policy is adopted here.
+                    continue;
+                }
+
+                // reference assemblies should be fine here, we only need the metadata of references.
+                var reference = parentCompilation.GetMetadataReference(assembly);
+                return new PEFile(reference.Display, PEStreamOptions.PrefetchMetadata);
+            }
+
+            // not found
+            return null;
+        }
+
+        public PEFile ResolveModule(PEFile mainModule, string moduleName)
+        {
+            // Primitive implementation to support multi-module assemblies
+            // where all modules are located next to the main module.
+            string baseDirectory = Path.GetDirectoryName(mainModule.FileName);
+            string moduleFileName = Path.Combine(baseDirectory, moduleName);
+            if (!File.Exists(moduleFileName))
+                return null;
+            return new PEFile(moduleFileName, PEStreamOptions.PrefetchMetadata);
+        }
+    }
+
+}

--- a/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
@@ -60,7 +60,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             string baseDirectory = Path.GetDirectoryName(mainModule.FileName);
             string moduleFileName = Path.Combine(baseDirectory, moduleName);
             if (!File.Exists(moduleFileName))
+            {
                 return null;
+            }
+
             return new PEFile(moduleFileName, PEStreamOptions.PrefetchMetadata);
         }
     }

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -15,6 +15,7 @@ using ICSharpCode.Decompiler.CSharp;
 using ICSharpCode.Decompiler.CSharp.Transforms;
 using ICSharpCode.Decompiler.Metadata;
 using ICSharpCode.Decompiler.TypeSystem;
+using Microsoft.CodeAnalysis.CSharp.DocumentationComments;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Formatting;

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.CSharp.Transforms;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
+
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
+{
+    internal class CSharpDecompiledSourceService : IDecompiledSourceService
+    {
+        private HostLanguageServices provider;
+
+        public CSharpDecompiledSourceService(HostLanguageServices provider)
+        {
+            this.provider = provider;
+        }
+
+        public async Task<Document> AddSourceToAsync(Document document, ISymbol symbol, CancellationToken cancellationToken = default)
+        {
+            // Get the name of the type the symbol is in
+            var containingOrThis = symbol.GetContainingTypeOrThis();
+            var fullName = GetFullReflectionName(containingOrThis);
+
+            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+
+            string assemblyLocation = null;
+            var isReferenceAssembly = symbol.ContainingAssembly.GetAttributes().Any(attribute => attribute.AttributeClass.Name == nameof(ReferenceAssemblyAttribute)
+                && attribute.AttributeClass.ToNameDisplayString() == typeof(ReferenceAssemblyAttribute).FullName);
+            if (isReferenceAssembly)
+            {
+                try
+                {
+                    var fullAssemblyName = symbol.ContainingAssembly.Identity.GetDisplayName();
+                    GlobalAssemblyCache.Instance.ResolvePartialName(fullAssemblyName, out assemblyLocation, preferredCulture: CultureInfo.CurrentCulture);
+                }
+                catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+                {
+                }
+            }
+
+            if (assemblyLocation == null)
+            {
+                var reference = compilation.GetMetadataReference(symbol.ContainingAssembly);
+                assemblyLocation = (reference as PortableExecutableReference)?.FilePath;
+                if (assemblyLocation == null)
+                {
+                    throw new NotSupportedException(EditorFeaturesResources.Cannot_navigate_to_the_symbol_under_the_caret);
+                }
+            }
+
+            document = PerformDecompilation(document, fullName, compilation, assemblyLocation);
+
+            return document;
+        }
+
+        static Document PerformDecompilation(Document document, string fullName, Compilation compilation, string assemblyLocation)
+        {
+            // Load the assembly.
+            var pefile = new PEFile(assemblyLocation, PEStreamOptions.PrefetchEntireImage);
+
+            // Initialize a decompiler with default settings.
+            var settings = new DecompilerSettings(LanguageVersion.Latest);
+            var decompiler = new CSharpDecompiler(pefile, new RoslynAssemblyResolver(compilation), settings);
+            // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
+            // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
+            decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers());
+
+            var fullTypeName = new FullTypeName(fullName);
+
+            var decompilerVersion = FileVersionInfo.GetVersionInfo(typeof(CSharpDecompiler).Assembly.Location);
+
+            // Add header to match output of metadata-only view.
+            // (This also makes debugging easier, because you can see which assembly was decompiled inside VS.)
+            var header = $"#region {FeaturesResources.Assembly} {pefile.FullName}" + Environment.NewLine
+                + $"// {assemblyLocation}" + Environment.NewLine
+                + $"// Decompiled with ICSharpCode.Decompiler {decompilerVersion.FileVersion}" + Environment.NewLine
+                + "#endregion" + Environment.NewLine;
+
+            // Try to decompile; if an exception is thrown the caller will handle it
+            var text = decompiler.DecompileTypeAsString(fullTypeName);
+            return document.WithText(SourceText.From(header + text));
+        }
+
+        private class RoslynAssemblyResolver : IAssemblyResolver
+        {
+            private readonly Compilation parentCompilation;
+            private static readonly Version zeroVersion = new Version(0, 0, 0, 0);
+
+            public RoslynAssemblyResolver(Compilation parentCompilation)
+            {
+                this.parentCompilation = parentCompilation;
+            }
+
+            public PEFile Resolve(IAssemblyReference name)
+            {
+                foreach (var assembly in parentCompilation.GetReferencedAssemblySymbols())
+                {
+                    // First, find the correct IAssemblySymbol by name and PublicKeyToken.
+                    if (assembly.Identity.Name != name.Name
+                        || !assembly.Identity.PublicKeyToken.SequenceEqual(name.PublicKeyToken ?? Array.Empty<byte>()))
+                    {
+                        continue;
+                    }
+
+                    // Normally we skip versions that do not match, except if the reference is "mscorlib" (see comments below)
+                    // or if the name.Version is '0.0.0.0'. This is because we require the metadata of all transitive references
+                    // and modules, to achieve best decompilation results.
+                    // In the case of .NET Standard projects for example, the 'netstandard' reference contains no references
+                    // with actual versions. All versions are '0.0.0.0', therefore we have to ignore those version numbers,
+                    // and can just use the references provided by Roslyn instead.
+                    if (assembly.Identity.Version != name.Version && name.Version != zeroVersion
+                        && !string.Equals("mscorlib", assembly.Identity.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // MSBuild treats mscorlib special for the purpose of assembly resolution/unification, where all
+                        // versions of the assembly are considered equal. The same policy is adopted here.
+                        continue;
+                    }
+
+                    // reference assemblies should be fine here, we only need the metadata of references.
+                    var reference = parentCompilation.GetMetadataReference(assembly);
+                    return new PEFile(reference.Display, PEStreamOptions.PrefetchMetadata);
+                }
+
+                // not found
+                return null;
+            }
+
+            public PEFile ResolveModule(PEFile mainModule, string moduleName)
+            {
+                // Primitive implementation to support multi-module assemblies
+                // where all modules are located next to the main module.
+                string baseDirectory = Path.GetDirectoryName(mainModule.FileName);
+                string moduleFileName = Path.Combine(baseDirectory, moduleName);
+                if (!File.Exists(moduleFileName))
+                    return null;
+                return new PEFile(moduleFileName, PEStreamOptions.PrefetchMetadata);
+            }
+        }
+
+        private string GetFullReflectionName(INamedTypeSymbol containingType)
+        {
+            var stack = new Stack<string>();
+            stack.Push(containingType.MetadataName);
+            var ns = containingType.ContainingNamespace;
+            do
+            {
+                stack.Push(ns.Name);
+                ns = ns.ContainingNamespace;
+            }
+            while (ns != null && !ns.IsGlobalNamespace);
+
+            return string.Join(".", stack);
+        }
+
+    }
+}

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceServiceFactory.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceServiceFactory.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
+{
+    [ExportLanguageServiceFactory(typeof(IDecompiledSourceService), LanguageNames.CSharp), Shared]
+    internal partial class CSharpDecompiledSourceServiceFactory : ILanguageServiceFactory
+    {
+        public ILanguageService CreateLanguageService(HostLanguageServices provider)
+        {
+            return new CSharpDecompiledSourceService(provider);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharp/DecompiledSource/DocCommentConverter.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/DocCommentConverter.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.DocumentationComments;
+using Microsoft.CodeAnalysis.MetadataAsSource;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
+{
+    // This is a copy of CSharpMetadataAsSourceService.DocCommentConverter
+    internal class DocCommentConverter : CSharpSyntaxRewriter
+    {
+        private readonly IDocumentationCommentFormattingService _formattingService;
+        private readonly CancellationToken _cancellationToken;
+
+        public static SyntaxNode ConvertToRegularComments(SyntaxNode node, IDocumentationCommentFormattingService formattingService, CancellationToken cancellationToken)
+        {
+            var converter = new DocCommentConverter(formattingService, cancellationToken);
+
+            return converter.Visit(node);
+        }
+
+        private DocCommentConverter(IDocumentationCommentFormattingService formattingService, CancellationToken cancellationToken)
+            : base(visitIntoStructuredTrivia: false)
+        {
+            _formattingService = formattingService;
+            _cancellationToken = cancellationToken;
+        }
+
+        public override SyntaxNode Visit(SyntaxNode node)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            if (node == null)
+            {
+                return node;
+            }
+
+            // Process children first
+            node = base.Visit(node);
+
+            // Check the leading trivia for doc comments.
+            if (node.GetLeadingTrivia().Any(SyntaxKind.SingleLineDocumentationCommentTrivia))
+            {
+                var newLeadingTrivia = new List<SyntaxTrivia>();
+
+                foreach (var trivia in node.GetLeadingTrivia())
+                {
+                    if (trivia.Kind() == SyntaxKind.SingleLineDocumentationCommentTrivia)
+                    {
+                        newLeadingTrivia.Add(SyntaxFactory.Comment("//"));
+                        newLeadingTrivia.Add(SyntaxFactory.ElasticCarriageReturnLineFeed);
+
+                        var structuredTrivia = (DocumentationCommentTriviaSyntax)trivia.GetStructure();
+                        newLeadingTrivia.AddRange(ConvertDocCommentToRegularComment(structuredTrivia));
+                    }
+                    else
+                    {
+                        newLeadingTrivia.Add(trivia);
+                    }
+                }
+
+                node = node.WithLeadingTrivia(newLeadingTrivia);
+            }
+
+            return node;
+        }
+
+        private IEnumerable<SyntaxTrivia> ConvertDocCommentToRegularComment(DocumentationCommentTriviaSyntax structuredTrivia)
+        {
+            var xmlFragment = DocumentationCommentUtilities.ExtractXMLFragment(structuredTrivia.ToFullString(), "///");
+
+            var docComment = DocumentationComment.FromXmlFragment(xmlFragment);
+
+            var commentLines = AbstractMetadataAsSourceService.DocCommentFormatter.Format(_formattingService, docComment);
+
+            foreach (var line in commentLines)
+            {
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    yield return SyntaxFactory.Comment("// " + line);
+                }
+                else
+                {
+                    yield return SyntaxFactory.Comment("//");
+                }
+
+                yield return SyntaxFactory.ElasticCarriageReturnLineFeed;
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/CSharp/Microsoft.CodeAnalysis.CSharp.EditorFeatures.csproj
+++ b/src/EditorFeatures/CSharp/Microsoft.CodeAnalysis.CSharp.EditorFeatures.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="$(ICSharpCodeDecompilerVersion)" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="CSharpEditorResources.resx">

--- a/src/EditorFeatures/Core/IDecompiledSourceService.cs
+++ b/src/EditorFeatures/Core/IDecompiledSourceService.cs
@@ -17,6 +17,6 @@ namespace Microsoft.CodeAnalysis.Editor
         /// <param name="symbol">The symbol to generate source for</param>
         /// <param name="cancellationToken">To cancel document operations</param>
         /// <returns>The updated document</returns>
-        Task<Document> AddSourceToAsync(Document document, ISymbol symbol, CancellationToken cancellationToken = default);
+        Task<Document> AddSourceToAsync(Document document, ISymbol symbol, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Core/IDecompiledSourceService.cs
+++ b/src/EditorFeatures/Core/IDecompiledSourceService.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Editor
+{
+    internal interface IDecompiledSourceService : ILanguageService
+    {
+        /// <summary>
+        /// Generates formatted source code containing general information about the symbol's
+        /// containing assembly and the decompiled source code which the given ISymbol is or is a part of
+        /// into the given document
+        /// </summary>
+        /// <param name="document">The document to generate source into</param>
+        /// <param name="symbol">The symbol to generate source for</param>
+        /// <param name="cancellationToken">To cancel document operations</param>
+        /// <returns>The updated document</returns>
+        Task<Document> AddSourceToAsync(Document document, ISymbol symbol, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
                     {
                         try
                         {
-                            var decompiledSourceService = temporaryDocument.Project.LanguageServices.GetService<IDecompiledSourceService>();
+                            var decompiledSourceService = temporaryDocument.GetLanguageService<IDecompiledSourceService>();
                             if (decompiledSourceService != null)
                             {
                                 temporaryDocument = await decompiledSourceService.AddSourceToAsync(temporaryDocument, symbol, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -3,19 +3,11 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using ICSharpCode.Decompiler;
-using ICSharpCode.Decompiler.CSharp;
-using ICSharpCode.Decompiler.CSharp.Transforms;
-using ICSharpCode.Decompiler.Metadata;
-using ICSharpCode.Decompiler.TypeSystem;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -128,7 +120,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
                     {
                         try
                         {
-                            temporaryDocument = await DecompileSymbolAsync(temporaryDocument, symbol, cancellationToken).ConfigureAwait(false);
+                            var decompiledSourceService = temporaryDocument.Project.LanguageServices.GetService<IDecompiledSourceService>();
+                            if (decompiledSourceService != null)
+                            {
+                                temporaryDocument = await decompiledSourceService.AddSourceToAsync(temporaryDocument, symbol, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                useDecompiler = false;
+                            }
                         }
                         catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
                         {
@@ -189,136 +189,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
             var documentTooltip = topLevelNamedType.ToDisplayString(new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces));
 
             return new MetadataAsSourceFile(fileInfo.TemporaryFilePath, navigateLocation, documentName, documentTooltip);
-        }
-
-        private async Task<Document> DecompileSymbolAsync(Document temporaryDocument, ISymbol symbol, CancellationToken cancellationToken)
-        {
-            // Get the name of the type the symbol is in
-            var containingOrThis = symbol.GetContainingTypeOrThis();
-            var fullName = GetFullReflectionName(containingOrThis);
-
-            var compilation = await temporaryDocument.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-
-            string assemblyLocation = null;
-            var isReferenceAssembly = symbol.ContainingAssembly.GetAttributes().Any(attribute => attribute.AttributeClass.Name == nameof(ReferenceAssemblyAttribute)
-                && attribute.AttributeClass.ToNameDisplayString() == typeof(ReferenceAssemblyAttribute).FullName);
-            if (isReferenceAssembly)
-            {
-                try
-                {
-                    var fullAssemblyName = symbol.ContainingAssembly.Identity.GetDisplayName();
-                    GlobalAssemblyCache.Instance.ResolvePartialName(fullAssemblyName, out assemblyLocation, preferredCulture: CultureInfo.CurrentCulture);
-                }
-                catch (Exception e) when (FatalError.ReportWithoutCrash(e))
-                {
-                }
-            }
-
-            if (assemblyLocation == null)
-            {
-                var reference = compilation.GetMetadataReference(symbol.ContainingAssembly);
-                assemblyLocation = (reference as PortableExecutableReference)?.FilePath;
-                if (assemblyLocation == null)
-                {
-                    throw new NotSupportedException(EditorFeaturesResources.Cannot_navigate_to_the_symbol_under_the_caret);
-                }
-            }
-
-            // Load the assembly.
-            var pefile = new PEFile(assemblyLocation, PEStreamOptions.PrefetchEntireImage);
-
-            // Initialize a decompiler with default settings.
-            var settings = new DecompilerSettings(LanguageVersion.Latest);
-            var decompiler = new CSharpDecompiler(pefile, new RoslynAssemblyResolver(compilation), settings);
-            // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
-            // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
-            decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers());
-
-            var fullTypeName = new FullTypeName(fullName);
-
-            var decompilerVersion = FileVersionInfo.GetVersionInfo(typeof(CSharpDecompiler).Assembly.Location);
-
-            // Add header to match output of metadata-only view.
-            // (This also makes debugging easier, because you can see which assembly was decompiled inside VS.)
-            var header = $"#region {FeaturesResources.Assembly} {pefile.FullName}" + Environment.NewLine
-                + $"// {assemblyLocation}" + Environment.NewLine
-                + $"// Decompiled with ICSharpCode.Decompiler {decompilerVersion.FileVersion}" + Environment.NewLine
-                + "#endregion" + Environment.NewLine;
-
-            // Try to decompile; if an exception is thrown the caller will handle it
-            var text = decompiler.DecompileTypeAsString(fullTypeName);
-            return temporaryDocument.WithText(SourceText.From(header + text));
-        }
-
-        private class RoslynAssemblyResolver : IAssemblyResolver
-        {
-            private readonly Compilation parentCompilation;
-            private static readonly Version zeroVersion = new Version(0, 0, 0, 0);
-
-            public RoslynAssemblyResolver(Compilation parentCompilation)
-            {
-                this.parentCompilation = parentCompilation;
-            }
-
-            public PEFile Resolve(IAssemblyReference name)
-            {
-                foreach (var assembly in parentCompilation.GetReferencedAssemblySymbols())
-                {
-                    // First, find the correct IAssemblySymbol by name and PublicKeyToken.
-                    if (assembly.Identity.Name != name.Name
-                        || !assembly.Identity.PublicKeyToken.SequenceEqual(name.PublicKeyToken ?? Array.Empty<byte>()))
-                    {
-                        continue;
-                    }
-
-                    // Normally we skip versions that do not match, except if the reference is "mscorlib" (see comments below)
-                    // or if the name.Version is '0.0.0.0'. This is because we require the metadata of all transitive references
-                    // and modules, to achieve best decompilation results.
-                    // In the case of .NET Standard projects for example, the 'netstandard' reference contains no references
-                    // with actual versions. All versions are '0.0.0.0', therefore we have to ignore those version numbers,
-                    // and can just use the references provided by Roslyn instead.
-                    if (assembly.Identity.Version != name.Version && name.Version != zeroVersion
-                        && !string.Equals("mscorlib", assembly.Identity.Name, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // MSBuild treats mscorlib special for the purpose of assembly resolution/unification, where all
-                        // versions of the assembly are considered equal. The same policy is adopted here.
-                        continue;
-                    }
-
-                    // reference assemblies should be fine here, we only need the metadata of references.
-                    var reference = parentCompilation.GetMetadataReference(assembly);
-                    return new PEFile(reference.Display, PEStreamOptions.PrefetchMetadata);
-                }
-
-                // not found
-                return null;
-            }
-
-            public PEFile ResolveModule(PEFile mainModule, string moduleName)
-            {
-                // Primitive implementation to support multi-module assemblies
-                // where all modules are located next to the main module.
-                string baseDirectory = Path.GetDirectoryName(mainModule.FileName);
-                string moduleFileName = Path.Combine(baseDirectory, moduleName);
-                if (!File.Exists(moduleFileName))
-                    return null;
-                return new PEFile(moduleFileName, PEStreamOptions.PrefetchMetadata);
-            }
-        }
-
-        private string GetFullReflectionName(INamedTypeSymbol containingType)
-        {
-            var stack = new Stack<string>();
-            stack.Push(containingType.MetadataName);
-            var ns = containingType.ContainingNamespace;
-            do
-            {
-                stack.Push(ns.Name);
-                ns = ns.ContainingNamespace;
-            }
-            while (ns != null && !ns.IsGlobalNamespace);
-
-            return string.Join(".", stack);
         }
 
         private async Task<Location> RelocateSymbol_NoLock(MetadataAsSourceGeneratedFileInfo fileInfo, SymbolKey symbolId, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Version="$(MicrosoftCodeAnalysisElfieVersion)" />
-    <PackageReference Include="ICSharpCode.Decompiler" Version="$(ICSharpCodeDecompilerVersion)" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="InteractiveHost" />

--- a/src/Features/CSharp/Portable/DocumentationComments/DocCommentConverter.cs
+++ b/src/Features/CSharp/Portable/DocumentationComments/DocCommentConverter.cs
@@ -2,15 +2,13 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
+namespace Microsoft.CodeAnalysis.CSharp.DocumentationComments
 {
-    // This is a copy of CSharpMetadataAsSourceService.DocCommentConverter
     internal class DocCommentConverter : CSharpSyntaxRewriter
     {
         private readonly IDocumentationCommentFormattingService _formattingService;

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.DocumentationComments;
 using Microsoft.CodeAnalysis.CSharp.Simplification;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
@@ -125,88 +126,6 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
             protected override bool IsNewLine(char c)
             {
                 return SyntaxFacts.IsNewLine(c);
-            }
-        }
-
-        private class DocCommentConverter : CSharpSyntaxRewriter
-        {
-            private readonly IDocumentationCommentFormattingService _formattingService;
-            private readonly CancellationToken _cancellationToken;
-
-            public static SyntaxNode ConvertToRegularComments(SyntaxNode node, IDocumentationCommentFormattingService formattingService, CancellationToken cancellationToken)
-            {
-                var converter = new DocCommentConverter(formattingService, cancellationToken);
-
-                return converter.Visit(node);
-            }
-
-            private DocCommentConverter(IDocumentationCommentFormattingService formattingService, CancellationToken cancellationToken)
-                : base(visitIntoStructuredTrivia: false)
-            {
-                _formattingService = formattingService;
-                _cancellationToken = cancellationToken;
-            }
-
-            public override SyntaxNode Visit(SyntaxNode node)
-            {
-                _cancellationToken.ThrowIfCancellationRequested();
-
-                if (node == null)
-                {
-                    return node;
-                }
-
-                // Process children first
-                node = base.Visit(node);
-
-                // Check the leading trivia for doc comments.
-                if (node.GetLeadingTrivia().Any(SyntaxKind.SingleLineDocumentationCommentTrivia))
-                {
-                    var newLeadingTrivia = new List<SyntaxTrivia>();
-
-                    foreach (var trivia in node.GetLeadingTrivia())
-                    {
-                        if (trivia.Kind() == SyntaxKind.SingleLineDocumentationCommentTrivia)
-                        {
-                            newLeadingTrivia.Add(SyntaxFactory.Comment("//"));
-                            newLeadingTrivia.Add(SyntaxFactory.ElasticCarriageReturnLineFeed);
-
-                            var structuredTrivia = (DocumentationCommentTriviaSyntax)trivia.GetStructure();
-                            newLeadingTrivia.AddRange(ConvertDocCommentToRegularComment(structuredTrivia));
-                        }
-                        else
-                        {
-                            newLeadingTrivia.Add(trivia);
-                        }
-                    }
-
-                    node = node.WithLeadingTrivia(newLeadingTrivia);
-                }
-
-                return node;
-            }
-
-            private IEnumerable<SyntaxTrivia> ConvertDocCommentToRegularComment(DocumentationCommentTriviaSyntax structuredTrivia)
-            {
-                var xmlFragment = DocumentationCommentUtilities.ExtractXMLFragment(structuredTrivia.ToFullString(), "///");
-
-                var docComment = DocumentationComment.FromXmlFragment(xmlFragment);
-
-                var commentLines = AbstractMetadataAsSourceService.DocCommentFormatter.Format(_formattingService, docComment);
-
-                foreach (var line in commentLines)
-                {
-                    if (!string.IsNullOrWhiteSpace(line))
-                    {
-                        yield return SyntaxFactory.Comment("// " + line);
-                    }
-                    else
-                    {
-                        yield return SyntaxFactory.Comment("//");
-                    }
-
-                    yield return SyntaxFactory.ElasticCarriageReturnLineFeed;
-                }
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -113,14 +113,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             // Generate new source or retrieve existing source for the symbol in question
-            var allowDecompilation = project.Solution.Workspace.Options.GetOption(FeatureOnOffOptions.NavigateToDecompiledSources) && !symbol.IsFromSource();
-            if (allowDecompilation && !project.Solution.Workspace.Options.GetOption(FeatureOnOffOptions.AcceptedDecompilerDisclaimer))
+            bool allowDecompilation = false;
+
+            // Check whether decompilation is supported for the project. We currently only support this for C# projects.
+            if (project.LanguageServices.GetService<IDecompiledSourceService>() != null)
             {
-                var notificationService = project.Solution.Workspace.Services.GetService<INotificationService>();
-                allowDecompilation = notificationService.ConfirmMessageBox(ServicesVSResources.Decompiler_Legal_Notice_Message, ServicesVSResources.Decompiler_Legal_Notice_Title, NotificationSeverity.Warning);
-                if (allowDecompilation)
+                allowDecompilation = project.Solution.Workspace.Options.GetOption(FeatureOnOffOptions.NavigateToDecompiledSources) && !symbol.IsFromSource();
+                if (allowDecompilation && !project.Solution.Workspace.Options.GetOption(FeatureOnOffOptions.AcceptedDecompilerDisclaimer))
                 {
-                    project.Solution.Workspace.Options = project.Solution.Workspace.Options.WithChangedOption(FeatureOnOffOptions.AcceptedDecompilerDisclaimer, true);
+                    var notificationService = project.Solution.Workspace.Services.GetService<INotificationService>();
+                    allowDecompilation = notificationService.ConfirmMessageBox(ServicesVSResources.Decompiler_Legal_Notice_Message, ServicesVSResources.Decompiler_Legal_Notice_Title, NotificationSeverity.Warning);
+                    if (allowDecompilation)
+                    {
+                        project.Solution.Workspace.Options = project.Solution.Workspace.Options.WithChangedOption(FeatureOnOffOptions.AcceptedDecompilerDisclaimer, true);
+                    }
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             // Generate new source or retrieve existing source for the symbol in question
-            bool allowDecompilation = false;
+            var allowDecompilation = false;
 
             // Check whether decompilation is supported for the project. We currently only support this for C# projects.
             if (project.LanguageServices.GetService<IDecompiledSourceService>() != null)


### PR DESCRIPTION
This pull request is intended as suggestion and should serve as basis for further discussion of the "Navigate to decompiled sources" feature.

This pull request implements the following changes:
* Move ICSharpCode.Decompiler reference to Microsoft.CodeAnalysis.CSharp.EditorFeatures
* Add Microsoft.CodeAnalysis.Editor.IDecompiledSourceService
* Add basic implementation of the IDecompiledSourceService for C#: CSharpDecompiledSourceService
* Move decompilation feature from MetadataAsSourceFileService to CSharpDecompiledSourceService
* Do not show legal notice if decompilation is not available
* Use "metadata-as-source" style for documentation comments
* Format the decompiled code using the Roslyn formatter

## Why
* Currently ICSharpCode.Decompiler only supports C# and the "Navigation to decompiled sources" feature is only listed on the C#-specific options page.
* I think that offering decompiled C# source code to VB users with VB syntax highlighting and broken navigation is even worse than the problems outlined in https://github.com/dotnet/roslyn/issues/26436.
* Creating a separate language service for decompilation enables us to further develop the feature with full access to C# language infrastructure. (this also addresses https://github.com/dotnet/roslyn/pull/23430#issuecomment-348351417 and https://github.com/dotnet/roslyn/pull/23430#pullrequestreview-80383618)
* Being able to use the Roslyn C# formatter is the best fix for https://github.com/dotnet/roslyn/issues/25007 and https://github.com/dotnet/roslyn/issues/28276 because it will take a long time for us to be able to reimplement all the formatting options in our codebase. And that time is better spent with implementing support for other language features and/or improving decompilation quality.

## Points for further discussion
* How should we improve the folding experience for the decompiled member bodies? I have been experimenting with `AbstractSyntaxNodeStructureProvider` to further improve the experience by completely hiding the source code when the source file is first opened. However I am not sure how to implement this, because there can only be one fold per line.
* I want to mention https://github.com/dotnet/roslyn/issues/26989 here again: For navigation in decompiled sources to work perfectly, the "MetadataAsSource" workspace would have to be extended to include internal/private symbols as well. Maybe we should think about creating a separate workspace for DecompiledSource?
* Implementation of VB support:
    - Currently we have no resources for this, because we would have to reimplement the semantic analysis for VB on our end from scratch. We did this for C#, because we had most of it already done before Roslyn was a thing. This takes time that is better spent with improving the existing decompiler.
    - The only way I can ever see this going forward is to able to use Roslyn, however that would **require the decompiler to get InternalsVisibleTo access to Roslyn internals**. For details see our analysis in https://github.com/icsharpcode/ILSpy/issues/896 especially https://github.com/icsharpcode/ILSpy/issues/896#issuecomment-388616670.