### PR TITLE
Fix problem to rename Attribute

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             /// </summary>
             private readonly bool _shortenedTriggerSpan;
             private readonly bool _isRenamingAttributePrefix;
-            private readonly bool _isCaseSensitiveAttribute;
+            private readonly bool _isLanguageCaseSensitive;
 
             public bool CanRename { get; }
             public string LocalizedErrorMessage { get; }
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 TextSpan triggerSpan,
                 SymbolAndProjectId renameSymbolAndProjectId,
                 bool forceRenameOverloads,
-                bool isCaseSensitiveAttribute,
+                bool isLanguageCaseSensitive,
                 CancellationToken cancellationToken)
             {
                 this.CanRename = true;
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 this.TriggerSpan = GetReferenceEditSpan(new InlineRenameLocation(document, triggerSpan), cancellationToken);
 
                 _shortenedTriggerSpan = this.TriggerSpan != triggerSpan;
-                _isCaseSensitiveAttribute = isCaseSensitiveAttribute;
+                _isLanguageCaseSensitive = isLanguageCaseSensitive;
             }
 
             private bool CanRenameAttributePrefix(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // Ok, the symbol is good.  Now, make sure that the trigger text starts with the prefix
                 // of the attribute.  If it does, then we can rename just the attribute prefix (otherwise
                 // we need to rename the entire attribute).
-                var nameWithoutAttribute = this.RenameSymbol.Name.GetWithoutAttributeSuffix(isCaseSensitive: _isCaseSensitiveAttribute);
+                var nameWithoutAttribute = this.RenameSymbol.Name.GetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive);
                 var triggerText = GetSpanText(document, triggerSpan, cancellationToken);
 
                 return triggerText.StartsWith(triggerText); // TODO: Always true? What was it supposed to do?
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 return new TextSpan(location.TextSpan.Start + position, replacementText.Length);
             }
 
-            private string GetWithoutAttributeSuffix(string value) => value.GetWithoutAttributeSuffix(isCaseSensitive: _isCaseSensitiveAttribute);
+            private string GetWithoutAttributeSuffix(string value) => value.GetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive);
 
             private static string GetSpanText(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // Ok, the symbol is good.  Now, make sure that the trigger text starts with the prefix
                 // of the attribute.  If it does, then we can rename just the attribute prefix (otherwise
                 // we need to rename the entire attribute).
-                var nameWithoutAttribute = this.RenameSymbol.Name.GetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive);
+                var nameWithoutAttribute = GetWithoutAttributeSuffix(this.RenameSymbol.Name);
                 var triggerText = GetSpanText(document, triggerSpan, cancellationToken);
 
                 return triggerText.StartsWith(triggerText); // TODO: Always true? What was it supposed to do?

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
 
             private string GetWithoutAttributeSuffix(string value) => value.GetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive);
-            private bool TryGetWithoutAttributeSuffix(string value, out string result) => value.TryGetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive, result: out result);
+            private bool HasAttributeSuffix(string value) => value.TryGetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive, result: out var _);
 
             private static string GetSpanText(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
             {
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 if (this.RenameSymbol.IsAttribute() || (this.RenameSymbol.Kind == SymbolKind.Alias && ((IAliasSymbol)this.RenameSymbol).Target.IsAttribute()))
                 {
-                    if (TryGetWithoutAttributeSuffix(this.RenameSymbol.Name, out var _))
+                    if (HasAttributeSuffix(this.RenameSymbol.Name))
                     {
                         return true;
                     }
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             public string GetFinalSymbolName(string replacementText)
             {
-                if (_isRenamingAttributePrefix && !TryGetWithoutAttributeSuffix(replacementText, out var _))
+                if (_isRenamingAttributePrefix && !HasAttributeSuffix(replacementText))
                 {
                     return replacementText + AttributeSuffix;
                 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -54,7 +55,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 TextSpan triggerSpan,
                 SymbolAndProjectId renameSymbolAndProjectId,
                 bool forceRenameOverloads,
-                bool isLanguageCaseSensitive,
                 CancellationToken cancellationToken)
             {
                 this.CanRename = true;
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 this.TriggerSpan = GetReferenceEditSpan(new InlineRenameLocation(document, triggerSpan), cancellationToken);
 
                 _shortenedTriggerSpan = this.TriggerSpan != triggerSpan;
-                _isLanguageCaseSensitive = isLanguageCaseSensitive;
+                _isLanguageCaseSensitive = document.GetLanguageService<ISyntaxFactsService>().IsCaseSensitive;
             }
 
             private bool CanRenameAttributePrefix(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -150,6 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
 
             private string GetWithoutAttributeSuffix(string value) => value.GetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive);
+            private bool TryGetWithoutAttributeSuffix(string value, out string result) => value.TryGetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive, result: out result);
 
             private static string GetSpanText(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
             {
@@ -162,8 +163,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 if (this.RenameSymbol.IsAttribute() || (this.RenameSymbol.Kind == SymbolKind.Alias && ((IAliasSymbol)this.RenameSymbol).Target.IsAttribute()))
                 {
-                    var name = GetWithoutAttributeSuffix(this.RenameSymbol.Name);
-                    if (name != null)
+                    if (TryGetWithoutAttributeSuffix(this.RenameSymbol.Name, out var _))
                     {
                         return true;
                     }
@@ -198,13 +198,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             public string GetFinalSymbolName(string replacementText)
             {
-                if (_isRenamingAttributePrefix)
+                if (_isRenamingAttributePrefix && !TryGetWithoutAttributeSuffix(replacementText, out var _))
                 {
-                    var isTextWithAttribute = GetWithoutAttributeSuffix(replacementText) != null;
-                    if (!isTextWithAttribute)
-                    {
-                        return replacementText + AttributeSuffix;
-                    }
+                    return replacementText + AttributeSuffix;
                 }
 
                 return replacementText;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             /// </summary>
             private readonly bool _shortenedTriggerSpan;
             private readonly bool _isRenamingAttributePrefix;
-            private readonly bool _isLanguageCaseSensitive;
 
             public bool CanRename { get; }
             public string LocalizedErrorMessage { get; }
@@ -70,7 +69,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 this.TriggerSpan = GetReferenceEditSpan(new InlineRenameLocation(document, triggerSpan), cancellationToken);
 
                 _shortenedTriggerSpan = this.TriggerSpan != triggerSpan;
-                _isLanguageCaseSensitive = document.GetLanguageService<ISyntaxFactsService>().IsCaseSensitive;
             }
 
             private bool CanRenameAttributePrefix(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
@@ -149,8 +147,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 return new TextSpan(location.TextSpan.Start + position, replacementText.Length);
             }
 
-            private string GetWithoutAttributeSuffix(string value) => value.GetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive);
-            private bool HasAttributeSuffix(string value) => value.TryGetWithoutAttributeSuffix(isCaseSensitive: _isLanguageCaseSensitive, result: out var _);
+            private string GetWithoutAttributeSuffix(string value) 
+                => value.GetWithoutAttributeSuffix(isCaseSensitive: _document.GetLanguageService<ISyntaxFactsService>().IsCaseSensitive);
+
+            private bool HasAttributeSuffix(string value) 
+                => value.TryGetWithoutAttributeSuffix(isCaseSensitive: _document.GetLanguageService<ISyntaxFactsService>().IsCaseSensitive, result: out var _);
 
             private static string GetSpanText(Document document, TextSpan triggerSpan, CancellationToken cancellationToken)
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             public string GetFinalSymbolName(string replacementText)
             {
-                if (_isRenamingAttributePrefix)
+                if (_isRenamingAttributePrefix && !replacementText.EndsWith(AttributeSuffix))
                 {
                     return replacementText + AttributeSuffix;
                 }
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             public bool TryOnBeforeGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText)
             {
                 return _refactorNotifyServices.TryOnBeforeGlobalSymbolRenamed(workspace, changedDocumentIDs, RenameSymbol,
-                    this.GetFinalSymbolName(replacementText), throwOnFailure: false);
+                     this.GetFinalSymbolName(replacementText), throwOnFailure: false);
             }
 
             public bool TryOnAfterGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, string replacementText)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
@@ -217,8 +217,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
 
             return new SymbolInlineRenameInfo(
-                refactorNotifyServices, document, triggerToken.Span, 
-                symbolAndProjectId, forceRenameOverloads, cancellationToken);
+                refactorNotifyServices, document, triggerToken.Span,
+                symbolAndProjectId, forceRenameOverloads, syntaxFactsService.IsCaseSensitive, cancellationToken);
         }
 
         private SyntaxToken GetTriggerToken(Document document, int position, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/AbstractEditorInlineRenameService.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             return new SymbolInlineRenameInfo(
                 refactorNotifyServices, document, triggerToken.Span,
-                symbolAndProjectId, forceRenameOverloads, syntaxFactsService.IsCaseSensitive, cancellationToken);
+                symbolAndProjectId, forceRenameOverloads, cancellationToken);
         }
 
         private SyntaxToken GetTriggerToken(Document document, int position, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -487,7 +487,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                             if (_referenceSpanToLinkedRenameSpanMap.ContainsKey(replacement.OriginalSpan) && kind != RenameSpanKind.Complexified)
                             {
                                 var linkedRenameSpan = _session._renameInfo.GetConflictEditSpan(
-                                    new InlineRenameLocation(newDocument, replacement.NewSpan), _session.ReplacementText, cancellationToken);
+                                    new InlineRenameLocation(newDocument, replacement.NewSpan), GetWithoutAttributeSuffix(_session.ReplacementText, document), cancellationToken);
                                 if (linkedRenameSpan.HasValue)
                                 {
                                     if (!mergeConflictComments.Any(s => replacement.NewSpan.IntersectsWith(s)))
@@ -536,6 +536,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     this.ApplyReplacementText(updateSelection: false);
                     RaiseSpansChanged();
                 }
+            }
+
+            private string GetWithoutAttributeSuffix(string text, Document document)
+            {
+                bool isCaseSensitive = document.GetLanguageService<LanguageServices.ISyntaxFactsService>().IsCaseSensitive;
+
+                if (!_session.ReplacementText.TryGetWithoutAttributeSuffix(isCaseSensitive, out string replaceText))
+                {
+                    replaceText = _session.ReplacementText;
+                }
+
+                return replaceText;
             }
 
             private static async Task<IEnumerable<TextChange>> GetTextChangesFromTextDifferencingServiceAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken = default)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -486,8 +486,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                             if (_referenceSpanToLinkedRenameSpanMap.ContainsKey(replacement.OriginalSpan) && kind != RenameSpanKind.Complexified)
                             {
+                                var syntax =  document.GetLanguageService<LanguageServices.ISyntaxFactsService>();
                                 var linkedRenameSpan = _session._renameInfo.GetConflictEditSpan(
-                                    new InlineRenameLocation(newDocument, replacement.NewSpan), GetWithoutAttributeSuffix(_session.ReplacementText, document), cancellationToken);
+                                    new InlineRenameLocation(newDocument, replacement.NewSpan), GetWithoutAttributeSuffix(_session.ReplacementText, syntax.IsCaseSensitive), cancellationToken);
                                 if (linkedRenameSpan.HasValue)
                                 {
                                     if (!mergeConflictComments.Any(s => replacement.NewSpan.IntersectsWith(s)))
@@ -538,13 +539,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
-            private string GetWithoutAttributeSuffix(string text, Document document)
+            private static string GetWithoutAttributeSuffix(string text, bool isCaseSensitive)
             {
-                bool isCaseSensitive = document.GetLanguageService<LanguageServices.ISyntaxFactsService>().IsCaseSensitive;
-
-                if (!_session.ReplacementText.TryGetWithoutAttributeSuffix(isCaseSensitive, out string replaceText))
+                if (!text.TryGetWithoutAttributeSuffix(isCaseSensitive, out string replaceText))
                 {
-                    replaceText = _session.ReplacementText;
+                    replaceText = text;
                 }
 
                 return replaceText;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -486,9 +486,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                             if (_referenceSpanToLinkedRenameSpanMap.ContainsKey(replacement.OriginalSpan) && kind != RenameSpanKind.Complexified)
                             {
-                                var syntax =  document.GetLanguageService<LanguageServices.ISyntaxFactsService>();
                                 var linkedRenameSpan = _session._renameInfo.GetConflictEditSpan(
-                                    new InlineRenameLocation(newDocument, replacement.NewSpan), GetWithoutAttributeSuffix(_session.ReplacementText, syntax.IsCaseSensitive), cancellationToken);
+                                    new InlineRenameLocation(newDocument, replacement.NewSpan), GetWithoutAttributeSuffix(_session.ReplacementText, document.GetLanguageService<LanguageServices.ISyntaxFactsService>().IsCaseSensitive), cancellationToken);
                                 if (linkedRenameSpan.HasValue)
                                 {
                                     if (!mergeConflictComments.Any(s => replacement.NewSpan.IntersectsWith(s)))

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -663,29 +663,112 @@ namespace NS
             }
         }
 
-
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
         [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
-        public async Task RenameTrackingOnReference_Attribute()
+        public async Task RenameTrackingOnReference_Attribute_CSharp()
         {
             var code = @"
 using System;
 
-class [|Custom|]$$Attribute : Attribute
+class [|$$ustom|]Attribute : Attribute
 {
 }
 ";
             using (var state = RenameTrackingTestState.Create(code, LanguageNames.CSharp))
             {
-                state.EditorOperations.InsertText("s");
-                await state.AssertTag("CustomAttribute", "CustomsAttribute", invokeAction: true);
+                state.EditorOperations.InsertText("C");
+                await state.AssertTag("ustomAttribute", "CustomAttribute", invokeAction: true);
                 var expectedCode = @"
 using System;
 
-class CustomsAttribute : Attribute
+class CustomAttribute : Attribute
 {
 }
+";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public async Task RenameTrackingOnReference_Attribute_VB()
+        {
+            var code = @"
+Import System;
+
+Public Class [|$$ustom|]Attribute 
+        Inherits Attribute
+End Class
+";
+            using (var state = RenameTrackingTestState.Create(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.InsertText("C");
+                await state.AssertTag("ustomAttribute", "CustomAttribute", invokeAction: true);
+                var expectedCode = @"
+Import System;
+
+Public Class CustomAttribute 
+        Inherits Attribute
+End Class
+";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public async Task RenameTrackingOnReference_Capitalized_Attribute_VB()
+        {
+            var code = @"
+Import System;
+
+Public Class [|$$ustom|]ATTRIBUTE 
+        Inherits Attribute
+End Class
+";
+            using (var state = RenameTrackingTestState.Create(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.InsertText("C");
+                await state.AssertTag("ustomATTRIBUTE", "CustomATTRIBUTE", invokeAction: true);
+                var expectedCode = @"
+Import System;
+
+Public Class CustomATTRIBUTE 
+        Inherits Attribute
+End Class
+";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public async Task RenameTrackingOnReference_Not_Capitalized_Attribute_VB()
+        {
+            var code = @"
+Import System;
+
+Public Class [|$$ustom|]attribute 
+        Inherits Attribute
+End Class
+";
+            using (var state = RenameTrackingTestState.Create(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.InsertText("C");
+                await state.AssertTag("ustomattribute", "Customattribute", invokeAction: true);
+                var expectedCode = @"
+Import System;
+
+Public Class Customattribute 
+        Inherits Attribute
+End Class
 ";
                 Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
 

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -670,6 +670,8 @@ namespace NS
         public async Task RenameTrackingOnReference_Attribute()
         {
             var code = @"
+using System;
+
 class [|Custom|]$$Attribute : Attribute
 {
 }
@@ -679,6 +681,8 @@ class [|Custom|]$$Attribute : Attribute
                 state.EditorOperations.InsertText("s");
                 await state.AssertTag("CustomAttribute", "CustomsAttribute", invokeAction: true);
                 var expectedCode = @"
+using System;
+
 class CustomsAttribute : Attribute
 {
 }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -666,19 +666,20 @@ namespace NS
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
         public async Task RenameTrackingOnReference_Attribute()
         {
             var code = @"
-class My$$Attribute : Attribute
+class [|Custom|]$$Attribute : Attribute
 {
 }
 ";
             using (var state = RenameTrackingTestState.Create(code, LanguageNames.CSharp))
             {
                 state.EditorOperations.InsertText("s");
-                await state.AssertTag("MyAttribute", "MysAttribute", invokeAction: true);
+                await state.AssertTag("CustomAttribute", "CustomsAttribute", invokeAction: true);
                 var expectedCode = @"
-class MysAttribute : Attribute
+class CustomsAttribute : Attribute
 {
 }
 ";

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -663,6 +663,30 @@ namespace NS
             }
         }
 
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameTrackingOnReference_Attribute()
+        {
+            var code = @"
+class My$$Attribute : Attribute
+{
+}
+";
+            using (var state = RenameTrackingTestState.Create(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("s");
+                await state.AssertTag("MyAttribute", "MysAttribute", invokeAction: true);
+                var expectedCode = @"
+class MysAttribute : Attribute
+{
+}
+";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+
+            }
+        }
+
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
         public async Task RenameTrackingNotifiesThirdPartiesOfRenameOperation()

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -178,6 +178,7 @@ class Deconstructable
             If isRenameAttribute Then
                 checkReplacementText = checkReplacementText + "Attribute"
             End If
+
             Await VerifyTagsAreCorrect(workspace, checkReplacementText)
         End Function
 
@@ -227,6 +228,69 @@ using System;
 class [|$$ustom|]Attribute : Attribute 
 {
 }
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustom", "C", isRenameAttribute:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")>
+        Public Async Function RenameAttributeVb() As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document>
+Import System;
+
+Public Class [|$$ustom|]Attribute 
+        Inherits Attribute
+End Class
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustom", "C", isRenameAttribute:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")>
+        Public Async Function RenameAttributeCapitalizedVb() As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document>
+Import System;
+
+Public Class [|$$ustom|]ATTRIBUTE 
+        Inherits Attribute
+End Class
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustom", "C", isRenameAttribute:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")>
+        Public Async Function RenameAttributeNotCapitalizedVb() As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document>
+Import System;
+
+Public Class [|$$ustom|]attribute 
+        Inherits Attribute 
+End Class
                             </Document>
                         </Project>
                     </Workspace>)

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -153,8 +153,7 @@ class Deconstructable
                                                            renameTextPrefix As String,
                                                            Optional renameOverloads As Boolean = False,
                                                            Optional renameInStrings As Boolean = False,
-                                                           Optional renameInComments As Boolean = False,
-                                                           Optional isRenameAttribute As Boolean = False) As Task
+                                                           Optional renameInComments As Boolean = False) As Task
             Dim optionSet = workspace.Options
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameOverloads, renameOverloads)
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameInStrings, renameInStrings)
@@ -174,12 +173,7 @@ class Deconstructable
 
             session.Commit()
 
-            Dim checkReplacementText As String = replacementText
-            If isRenameAttribute Then
-                checkReplacementText = checkReplacementText + "Attribute"
-            End If
-
-            Await VerifyTagsAreCorrect(workspace, checkReplacementText)
+            Await VerifyTagsAreCorrect(workspace, replacementText)
         End Function
 
         <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/13186")>
@@ -212,90 +206,6 @@ class Program
                     </Workspace>)
 
                 Await VerifyRenameOptionChangedSessionCommit(workspace, "goo", "bar", renameOverloads:=True)
-            End Using
-        End Function
-
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.Rename)>
-        <WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")>
-        Public Async Function RenameAttributeCSharp() As Task
-            Using workspace = CreateWorkspaceWithWaiter(
-                    <Workspace>
-                        <Project Language="C#" CommonReferences="true">
-                            <Document>
-using System;
-
-class [|$$ustom|]Attribute : Attribute 
-{
-}
-                            </Document>
-                        </Project>
-                    </Workspace>)
-
-                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustom", "C", isRenameAttribute:=True)
-            End Using
-        End Function
-
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.Rename)>
-        <WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")>
-        Public Async Function RenameAttributeVb() As Task
-            Using workspace = CreateWorkspaceWithWaiter(
-                    <Workspace>
-                        <Project Language="Visual Basic" CommonReferences="true">
-                            <Document>
-Import System;
-
-Public Class [|$$ustom|]Attribute 
-        Inherits Attribute
-End Class
-                            </Document>
-                        </Project>
-                    </Workspace>)
-
-                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustom", "C", isRenameAttribute:=True)
-            End Using
-        End Function
-
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.Rename)>
-        <WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")>
-        Public Async Function RenameAttributeCapitalizedVb() As Task
-            Using workspace = CreateWorkspaceWithWaiter(
-                    <Workspace>
-                        <Project Language="Visual Basic" CommonReferences="true">
-                            <Document>
-Import System;
-
-Public Class [|$$ustom|]ATTRIBUTE 
-        Inherits Attribute
-End Class
-                            </Document>
-                        </Project>
-                    </Workspace>)
-
-                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustom", "C", isRenameAttribute:=True)
-            End Using
-        End Function
-
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.Rename)>
-        <WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")>
-        Public Async Function RenameAttributeNotCapitalizedVb() As Task
-            Using workspace = CreateWorkspaceWithWaiter(
-                    <Workspace>
-                        <Project Language="Visual Basic" CommonReferences="true">
-                            <Document>
-Import System;
-
-Public Class [|$$ustom|]attribute 
-        Inherits Attribute 
-End Class
-                            </Document>
-                        </Project>
-                    </Workspace>)
-
-                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustom", "C", isRenameAttribute:=True)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -153,7 +153,8 @@ class Deconstructable
                                                            renameTextPrefix As String,
                                                            Optional renameOverloads As Boolean = False,
                                                            Optional renameInStrings As Boolean = False,
-                                                           Optional renameInComments As Boolean = False) As Task
+                                                           Optional renameInComments As Boolean = False,
+                                                           Optional isRenameAttribute As Boolean = False) As Task
             Dim optionSet = workspace.Options
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameOverloads, renameOverloads)
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameInStrings, renameInStrings)
@@ -173,7 +174,11 @@ class Deconstructable
 
             session.Commit()
 
-            Await VerifyTagsAreCorrect(workspace, replacementText)
+            Dim checkReplacementText As String = replacementText
+            If isRenameAttribute Then
+                checkReplacementText = checkReplacementText + "Attribute"
+            End If
+            Await VerifyTagsAreCorrect(workspace, checkReplacementText)
         End Function
 
         <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/13186")>
@@ -211,12 +216,14 @@ class Program
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
-        <WorkItem(21657,"https://github.com/dotnet/roslyn/issues/21657")>
+        <WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")>
         Public Async Function RenameAttributeCSharp() As Task
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
+using System;
+
 class [|$$ustom|]Attribute : Attribute 
 {
 }
@@ -224,7 +231,7 @@ class [|$$ustom|]Attribute : Attribute
                         </Project>
                     </Workspace>)
 
-                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustomAttribute", "C")
+                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustom", "C", isRenameAttribute:=True)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -211,6 +211,25 @@ class Program
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(21657,"https://github.com/dotnet/roslyn/issues/21657")>
+        Public Async Function RenameAttributeCSharp() As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class [|$$ustom|]Attribute : Attribute 
+{
+}
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Await VerifyRenameOptionChangedSessionCommit(workspace, "ustomAttribute", "C")
+            End Using
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(700921, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/700921")>
         Public Async Function RenameOverloadsVisualBasic() As Task
             Using workspace = CreateWorkspaceWithWaiter(

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
@@ -157,7 +157,6 @@ class stomAttribute : Attribute
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
             var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
-            //AssertEx.SetEqual(renameSpans, tags);
 
             VisualStudio.Editor.SendKeys("Custom");
             VisualStudio.Editor.Verify.TextContains(@"
@@ -169,6 +168,43 @@ class Bar
 }
 
 class CustomAttribute : Attribute
+{
+}
+", true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public void VerifyAttributeRenameWhileRenameAttributeClass()
+        {
+            var markup = @"
+using System;
+
+[stom]
+class Bar 
+{
+}
+
+class [|$$stom|]Attribute : Attribute
+{
+}
+";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+
+            VisualStudio.Editor.SendKeys("Custom");
+            VisualStudio.Editor.Verify.TextContains(@"
+using System;
+
+[Custom]
+class Bar 
+{
+}
+
+class Custom$$Attribute : Attribute
 {
 }
 ", true);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
@@ -88,7 +88,7 @@ class Program
             var markup = @"
 using System;
 
-class [|Custom|]$$Attribute : Attribute
+class [|$$ustom|]Attribute : Attribute
 {
 }
 ";
@@ -99,11 +99,11 @@ class [|Custom|]$$Attribute : Attribute
             var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            VisualStudio.Editor.SendKeys("Customs", VirtualKey.Enter);
+            VisualStudio.Editor.SendKeys("Custom", VirtualKey.Enter);
             VisualStudio.Editor.Verify.TextContains(@"
 using System;
 
-class CustomsAttribute : Attribute
+class CustomAttribute : Attribute
 {
 }");
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
@@ -109,6 +109,72 @@ class CustomAttribute : Attribute
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public void VerifyAttributeRenameWhileRenameClasss()
+        {
+            var markup = @"
+using System;
+
+class [|$$stom|]Attribute : Attribute
+{
+}
+";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            VisualStudio.Editor.SendKeys("Custom");
+            VisualStudio.Editor.Verify.TextContains(@"
+using System;
+
+class Custom$$Attribute : Attribute
+{
+}
+",true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public void VerifyAttributeRenameWhileRenameAttribute()
+        {
+            var markup = @"
+using System;
+
+[[|$$stom|]]
+class Bar 
+{
+}
+
+class stomAttribute : Attribute
+{
+}
+";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            //AssertEx.SetEqual(renameSpans, tags);
+
+            VisualStudio.Editor.SendKeys("Custom");
+            VisualStudio.Editor.Verify.TextContains(@"
+using System;
+
+[Custom$$]
+class Bar 
+{
+}
+
+class CustomAttribute : Attribute
+{
+}
+", true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
         public void VerifyLocalVariableRenameWithCommentsUpdated()
         {
             // "variable" is intentionally misspelled as "varixable" and "this" is misspelled as

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
@@ -82,52 +82,30 @@ class Program
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
         public void VerifyAttributeRename()
         {
             var markup = @"
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
-[|My|]
-class Program
+class [|Custom|]$$Attribute : Attribute
 {
-    static void Main(string[] args)
-    {
-         Console.WriteLine(""Hello World!"");
-    }
-    private class |My|Attribute : Attribute
-    {
-    }
-}";
-            using (var telemetry = VisualStudio.EnableTestTelemetryChannel())
-            {
-                SetUpEditor(markup);
-                InlineRenameDialog.Invoke();
+}
+";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
 
-                MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
-                var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
-                AssertEx.SetEqual(renameSpans, tags);
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
 
-                VisualStudio.Editor.SendKeys(VirtualKey.T, VirtualKey.E, VirtualKey.S, VirtualKey.T, VirtualKey.Enter);
-                VisualStudio.Editor.Verify.TextContains(@"
+            VisualStudio.Editor.SendKeys("Customs", VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
-[TEST]
-class Program
+class CustomsAttribute : Attribute
 {
-    static void Main(string[] args)
-    {
-         Console.WriteLine(""Hello World!"");
-    }
-    private class TESTAttribute : Attribute
-    {
-    }
 }");
-                telemetry.VerifyFired("vs/ide/vbcs/rename/inlinesession/session", "vs/ide/vbcs/rename/commitcore");
-            }
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
@@ -220,6 +220,67 @@ End Class");
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
         [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public void VerifyAttributeRenameWhileRenameClasss()
+        {
+            var markup = @"
+Import System;
+
+Public Class [|$$ustom|]Attribute 
+        Inherits Attribute
+End Class";
+
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            VisualStudio.Editor.SendKeys("Custom");
+            VisualStudio.Editor.Verify.TextContains(@"
+Import System;
+
+Public Class Custom$$Attribute 
+        Inherits Attribute
+End Class", true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public void VerifyAttributeRenameWhileRenameAttribute()
+        {
+            var markup = @"
+Import System;
+
+<[|$$ustom|]>
+Class Bar
+End Class
+
+Public Class ustomAttribute 
+        Inherits Attribute
+End Class";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            //AssertEx.SetEqual(renameSpans, tags);
+
+            VisualStudio.Editor.SendKeys("Custom");
+            VisualStudio.Editor.Verify.TextContains(@"
+Import System;
+
+<Custom$$>
+Class Bar
+End Class
+
+Public Class CustomAttribute 
+        Inherits Attribute
+End Class", true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
         public void VerifyAttributeCapitalizedRename()
         {
             var markup = @"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
@@ -239,7 +239,7 @@ End Class";
             VisualStudio.Editor.Verify.TextContains(@"
 Import System;
 
-Public Class CustomATTRIBUTE
+Public Class CustomAttribute
         Inherits Attribute
 End Class");
         }
@@ -265,7 +265,7 @@ End Class";
             VisualStudio.Editor.Verify.TextContains(@"
 Import System;
 
-Public Class Customattribute
+Public Class CustomAttribute
         Inherits Attribute
 End Class");
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
@@ -264,7 +264,6 @@ End Class";
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
             var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
-            //AssertEx.SetEqual(renameSpans, tags);
 
             VisualStudio.Editor.SendKeys("Custom");
             VisualStudio.Editor.Verify.TextContains(@"
@@ -275,6 +274,39 @@ Class Bar
 End Class
 
 Public Class CustomAttribute 
+        Inherits Attribute
+End Class", true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public void VerifyAttributeRenameWhileRenameAttributeClass()
+        {
+            var markup = @"
+Import System;
+
+<ustom>
+Class Bar
+End Class
+
+Public Class [|$$ustom|]Attribute 
+        Inherits Attribute
+End Class";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+
+            VisualStudio.Editor.SendKeys("Custom");
+            VisualStudio.Editor.Verify.TextContains(@"
+Import System;
+
+<Custom>
+Class Bar
+End Class
+
+Public Class Custom$$Attribute 
         Inherits Attribute
 End Class", true);
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
@@ -191,5 +191,83 @@ Public MustInherit Class A
     Public MustOverride Sub y(y As String) Implements I.y
 End Class");
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public void VerifyAttributeRename()
+        {
+            var markup = @"
+Import System;
+
+Public Class [|$$ustom|]Attribute 
+        Inherits Attribute
+End Class";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            VisualStudio.Editor.SendKeys("Custom", VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
+Import System;
+
+Public Class CustomAttribute 
+        Inherits Attribute
+    End Class");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public void VerifyAttributeCapitalizedRename()
+        {
+            var markup = @"
+Import System;
+
+Public Class [|$$ustom|]ATTRIBUTE
+        Inherits Attribute
+End Class";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            VisualStudio.Editor.SendKeys("Custom", VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
+Import System;
+
+Public Class CustomATTRIBUTE
+        Inherits Attribute
+End Class");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(21657, "https://github.com/dotnet/roslyn/issues/21657")]
+        public void VerifyAttributeNotCapitalizedRename()
+        {
+            var markup = @"
+Import System;
+
+Public Class [|$$ustom|]attribute
+        Inherits Attribute
+End Class";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            VisualStudio.Editor.SendKeys("Custom", VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
+Import System;
+
+Public Class Customattribute
+        Inherits Attribute
+End Class");
+        }
     }
 }


### PR DESCRIPTION
~I'm with a problem to find this bug.~

~When I run~ `VerifyAttributeRename`  ~the bug happens, but when I run~ `RenameTrackingOnReference_Attribute`  ~it doesn't~

~Is my test correct?~

Issue: https://github.com/dotnet/roslyn/issues/21657

Fixed problem to Rename Attribute
