### PR TITLE
Fork completion tests

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpCompletionCommandHandlerTests.vb
@@ -20,7 +20,7 @@ Imports Microsoft.VisualStudio.Text.Projection
 Imports Microsoft.VisualStudio.Utilities
 Imports Roslyn.Utilities
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.NewCompletion
     <[UseExportProvider]>
     Public Class CSharpCompletionCommandHandlerTests
         <WorkItem(541201, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541201")>

--- a/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -2,22 +2,21 @@
 
 Imports System.Threading.Tasks
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.NewCompletion
 
     <[UseExportProvider]>
-    Public Class VisualBasicCompletionCommandHandlerTests_InternalsVisibleTo
+    Public Class CSharpCompletionCommandHandlerTests_InternalsVisibleTo
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function CodeCompletionContainsOtherAssembliesOfSolution() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -31,11 +30,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionContainsOtherAssemblyIfAttributeSuffixIsPresent() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("$$
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -49,11 +47,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsTriggeredWhenDoubleQuoteIsEntered() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo($$
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo($$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -68,11 +65,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsEmptyUntilDoubleQuotesAreEntered() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo$$
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -81,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 Await state.WaitForAsynchronousOperationsAsync()
                 Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
                 state.SendTypeChars("("c)
-                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertNoCompletionSession()
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
                 Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
@@ -95,11 +91,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsTriggeredWhenCharacterIsEnteredAfterOpeningDoubleQuote() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
                         </Document>
                     </Project>
                 </Workspace>)
@@ -114,11 +109,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsNotTriggeredWhenCharacterIsEnteredThatIsNotRightBesideTheOpeniningDoubleQuote() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("a$$")>
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("a$$")]
                         </Document>
                     </Project>
                 </Workspace>)
@@ -132,9 +126,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsNotTriggeredWhenDoubleQuoteIsEnteredAtStartOfFile() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb">$$
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -149,17 +143,20 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsNotTriggeredByArrayElementAccess() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-Namespace A
-	Public Class C
-		Public Sub M()
-			Dim d = New System.Collections.Generic.Dictionary(Of String, String)()
-			Dim v = d$$
-		End Sub
-	End Class
-End Namespace
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs"><![CDATA[
+namespace A
+{
+    public class C
+    {
+        public void M()
+        {
+            var d = new System.Collections.Generic.Dictionary<string, string>();
+            var v = d$$;
+        }
+    }
+}
 ]]>
                         </Document>
                     </Project>
@@ -174,9 +171,8 @@ End Namespace
                             Not state.CompletionItemsContainsAny({"ClassLibrary1"}))
                     End Function
                 Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
-                state.SendTypeChars("("c)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                state.SendTypeChars("["c)
+                Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
                 state.SendTypeChars(""""c)
                 Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
             End Using
@@ -185,11 +181,11 @@ End Namespace
         Private Async Function AssertCompletionListHasItems(code As String, hasItems As Boolean) As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb">
-Imports System.Runtime.CompilerServices
-Imports System.Reflection
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
 <%= code %>
                         </Document>
                     </Project>
@@ -200,98 +196,99 @@ Imports System.Reflection
                     Await state.AssertCompletionSession()
                     Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
                 Else
-                    If Not state.CurrentCompletionPresenterSession Is Nothing Then
-                        Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
-                    End If
+                    Await state.AssertNoCompletionSession
                 End If
             End Using
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_AfterSingleDoubleQuoteAndClosing() As Task
-            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""$$)>", True)
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""$$)]", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_AfterText() As Task
-            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""Test$$)>", True)
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""Test$$)]", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfCursorIsInSecondParameter() As Task
-            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""Test"", ""$$", True)
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""Test"", ""$$", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasNoItems_IfCursorIsClosingDoubleQuote1() As Task
-            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""Test""$$", False)
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""Test""$$", False)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasNoItems_IfCursorIsClosingDoubleQuote2() As Task
-            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""""$$", False)
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""""$$", False)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfNamedParameterIsPresent() As Task
-            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""$$, AllInternalsVisible:=True)>", True)
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""$$, AllInternalsVisible = true)]", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfNamedParameterAndNamedPositionalParametersArePresent() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(assemblyName: ""$$, AllInternalsVisible = true)]", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasNoItems_IfNumberIsEntered() As Task
-            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(1$$2)>", False)
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(1$$2)]", False)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasNoItems_IfNotInternalsVisibleToAttribute() As Task
-            Await AssertCompletionListHasItems("<Assembly: AssemblyVersion(""$$"")>", False)
+            Await AssertCompletionListHasItems("[assembly: AssemblyVersion(""$$"")]", False)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfOtherAttributeIsPresent1() As Task
-            Await AssertCompletionListHasItems("<Assembly: AssemblyVersion(""1.0.0.0""), InternalsVisibleTo(""$$", True)
+            Await AssertCompletionListHasItems("[assembly: AssemblyVersion(""1.0.0.0""), InternalsVisibleTo(""$$", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfOtherAttributeIsPresent2() As Task
-            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""$$""), AssemblyVersion(""1.0.0.0"")>", True)
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""$$""), AssemblyVersion(""1.0.0.0"")]", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfOtherAttributesAreAhead() As Task
             Await AssertCompletionListHasItems("
-                <Assembly: AssemblyVersion(""1.0.0.0"")>
-                <Assembly: InternalsVisibleTo(""$$", True)
+                [assembly: AssemblyVersion(""1.0.0.0"")]
+                [assembly: InternalsVisibleTo(""$$", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfOtherAttributesAreFollowing() As Task
             Await AssertCompletionListHasItems("
-            <Assembly: InternalsVisibleTo(""$$
-            <Assembly: AssemblyVersion(""1.0.0.0"")>
-            <Assembly: AssemblyCompany(""Test"")>", True)
+            [assembly: InternalsVisibleTo(""$$
+            [assembly: AssemblyVersion(""1.0.0.0"")]
+            [assembly: AssemblyCompany(""Test"")]", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfNamespaceIsFollowing() As Task
             Await AssertCompletionListHasItems("
-            <Assembly: InternalsVisibleTo(""$$
-            Namespace A             
-                Public Class A
-                End Class
-            End Namespace", True)
+            [assembly: InternalsVisibleTo(""$$
+            namespace A {            
+                public class A { }
+            }", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function CodeCompletionHasItemsIfInteralVisibleToIsReferencedByTypeAlias() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
-<Assembly: IVT("$$
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
+[assembly: IVT("$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -305,11 +302,10 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
         Public Async Function CodeCompletionDoesNotContainCurrentAssembly() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
                         </Document>
                     </Project>
                 </Workspace>)
@@ -323,12 +319,11 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
         Public Async Function CodeCompletionInsertsAssemblyNameOnCommit() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
                     </Project>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document>
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
                         </Document>
                     </Project>
                 </Workspace>)
@@ -336,7 +331,7 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
                 Await state.AssertSelectedCompletionItem("ClassLibrary1")
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync()
-                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1"")>")
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1"")]")
             End Using
         End Function
 
@@ -344,15 +339,14 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
         Public Async Function CodeCompletionInsertsPublicKeyOnCommit() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
                         <CompilationOptions
                             CryptoKeyFile=<%= SigningTestHelpers.PublicKeyFile %>
                             StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
                     </Project>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document>
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
                         </Document>
                     </Project>
                 </Workspace>)
@@ -360,7 +354,7 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
                 Await state.AssertSelectedCompletionItem("ClassLibrary1")
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync()
-                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>")
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]")
             End Using
         End Function
 
@@ -368,17 +362,16 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
         Public Async Function CodeCompletionContainsPublicKeyIfKeyIsSpecifiedByAttribute() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
                         <CompilationOptions
                             StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
                         <Document>
-                            &lt;Assembly: System.Reflection.AssemblyKeyFile("<%= SigningTestHelpers.PublicKeyFile %>")&gt;
+                            [assembly: System.Reflection.AssemblyKeyFile("<%= SigningTestHelpers.PublicKeyFile.Replace("\", "\\") %>")]
                         </Document>
                     </Project>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document>
+    [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
                         </Document>
                     </Project>
                 </Workspace>)
@@ -386,7 +379,7 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
                 Await state.AssertSelectedCompletionItem("ClassLibrary1")
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync()
-                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>")
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]")
             End Using
         End Function
 
@@ -394,17 +387,15 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
         Public Async Function CodeCompletionContainsPublicKeyIfDelayedSigningIsEnabled() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
                         <CompilationOptions
                             CryptoKeyFile=<%= SigningTestHelpers.PublicKeyFile %>
-                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
-                            DelaySign="True"
-                        />
+                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>
+                            DelaySign="True"/>
                     </Project>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document>
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
                         </Document>
                     </Project>
                 </Workspace>)
@@ -412,7 +403,7 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
                 Await state.AssertSelectedCompletionItem("ClassLibrary1")
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync()
-                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>")
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]")
             End Using
         End Function
 
@@ -420,20 +411,21 @@ Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
         Public Async Function CodeCompletionListIsEmptyIfAttributeIsNotTheBCLAttribute() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: Test.InternalsVisibleTo("$$")>
-Namespace Test
-	<System.AttributeUsage(System.AttributeTargets.Assembly)> _
-	Public NotInheritable Class InternalsVisibleToAttribute
-		Inherits System.Attribute
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: Test.InternalsVisibleTo("$$")]
+namespace Test
+{
+    [System.AttributeUsage(System.AttributeTargets.Assembly)]
+    public sealed class InternalsVisibleToAttribute: System.Attribute
+    {
+        public InternalsVisibleToAttribute(string ignore)
+        {
 
-		Public Sub New(ignore As String)
-		End Sub
-	End Class
-End Namespace
-]]>
+        }
+    }
+}
                         </Document>
                     </Project>
                 </Workspace>)
@@ -446,15 +438,14 @@ End Namespace
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVT() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary1")>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary1")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -465,30 +456,29 @@ End Namespace
             End Using
         End Function
 
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTIfAssemblyNameIsAConstant() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <MetadataReferenceFromSource Language="Visual Basic" CommonReferences="true">
-                            <Document FilePath="ReferencedDocument.vb">
-Namespace A
-	Public NotInheritable Class Constants
-		Private Sub New()
-		End Sub
-		Public Const AssemblyName1 As String = "ClassLibrary1"
-	End Class
-End Namespace                            
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <MetadataReferenceFromSource Language="C#" CommonReferences="true">
+                            <Document FilePath="ReferencedDocument.cs">
+namespace A {
+    public static class Constants
+    {
+        public const string AssemblyName1 = "ClassLibrary1";
+    }
+}
                             </Document>
                         </MetadataReferenceFromSource>
-                        <Document FilePath="A.vb"><![CDATA[
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(A.Constants.AssemblyName1)>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
-]]>
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(A.Constants.AssemblyName1)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -503,41 +493,42 @@ End Namespace
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTForDifferentSyntax() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary4"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary5"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary6"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary7"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary8"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-' Code comment
-Imports System.Runtime.CompilerServices
-Imports System.Reflection
-Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
-' Code comment
-<Assembly: InternalsVisibleTo("ClassLibrary1", AllInternalsVisible:=True)>
-<Assembly: AssemblyVersion("1.0.0.0"), Assembly: InternalsVisibleTo("ClassLibrary2")>
-<Assembly: InternalsVisibleTo("ClassLibrary3"), Assembly: AssemblyCopyright("Copyright")>
-<Assembly: AssemblyDescription("Description")>
-<Assembly: InternalsVisibleTo("ClassLibrary4")>
-<Assembly: InternalsVisibleTo("ClassLibrary5, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb")>
-<Assembly: InternalsVisibleTo("ClassLibrary" + "6")>
-<Assembly: IVT("ClassLibrary7")>
-<Assembly: InternalsVisibleTo("$$
-Namespace A
-    Public Class A
-End Class
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary4"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary5"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary6"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary7"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary8"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary9"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+// Code comment
+using System.Runtime.CompilerServices;
+using System.Reflection;
+using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
+// Code comment
+[assembly: InternalsVisibleTo("ClassLibrary1", AllInternalsVisible = true)]
+[assembly: InternalsVisibleTo(assemblyName: "ClassLibrary2", AllInternalsVisible = true)]
+[assembly: AssemblyVersion("1.0.0.0"), InternalsVisibleTo("ClassLibrary3")]
+[assembly: InternalsVisibleTo("ClassLibrary4"), AssemblyCopyright("Copyright")]
+[assembly: AssemblyDescription("Description")]
+[assembly: InternalsVisibleTo("ClassLibrary5")]
+[assembly: InternalsVisibleTo("ClassLibrary6, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb")]
+[assembly: InternalsVisibleTo("ClassLibrary" + "7")]
+[assembly: IVT("ClassLibrary8")]
+[assembly: InternalsVisibleTo("$$
+namespace A {
+    public class A { }
+}
                         </Document>
                     </Project>
                 </Workspace>)
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionSession()
-                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2", "ClassLibrary3", "ClassLibrary4", "ClassLibrary5", "ClassLibrary6", "ClassLibrary7"}))
-                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary8"}))
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2", "ClassLibrary3", "ClassLibrary4", "ClassLibrary5", "ClassLibrary6", "ClassLibrary7", "ClassLibrary8"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary9"}))
             End Using
         End Function
 
@@ -545,15 +536,14 @@ End Class
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTWithSyntaxError() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="A.vb"><![CDATA[
-Imports System.Runtime.CompilerServices
-Imports System.Reflection
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
 
-<Assembly: InternalsVisibleTo("ClassLibrary" + 1.ToString())> ' Not a constant
-<Assembly: InternalsVisibleTo("$$
-]]>
+[assembly: InternalsVisibleTo("ClassLibrary" + 1)] // Not a constant
+[assembly: InternalsVisibleTo("$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -568,21 +558,19 @@ Imports System.Reflection
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTWithMoreThanOneDocument() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="OtherDocument.vb"><![CDATA[
-Imports System.Runtime.CompilerServices
-Imports System.Reflection
-<Assembly: InternalsVisibleTo("ClassLibrary1")>
-<Assembly: AssemblyDescription("Description")>
-]]>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="OtherDocument.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
+[assembly: InternalsVisibleTo("ClassLibrary1")]
+[assembly: AssemblyDescription("Description")]
                         </Document>
-                        <Document FilePath="A.vb"><![CDATA[
-Imports System.Runtime.CompilerServices
-Imports System.Reflection
-<Assembly: InternalsVisibleTo("$$
-]]>
+                        <Document FilePath="C.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
+[assembly: InternalsVisibleTo("$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -590,6 +578,24 @@ Imports System.Reflection
                 Await state.AssertCompletionSession()
                 Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
                 Assert.True(state.CompletionItemsContainsAll({"ClassLibrary2"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIgnoresUnsupportedProjectTypes() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="NoCompilation" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
+[assembly: InternalsVisibleTo("$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertNoCompletionSession()
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpCompletionCommandHandlerTests_Projections.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpCompletionCommandHandlerTests_Projections.vb
@@ -3,7 +3,7 @@
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.VisualStudio.Text.Projection
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.NewCompletion
     <[UseExportProvider]>
     Public Class CSharpCompletionCommandHandlerTests_Projections
 

--- a/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpCompletionCommandHandlerTests_XmlDoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpCompletionCommandHandlerTests_XmlDoc.vb
@@ -2,7 +2,7 @@
 
 Imports System.Threading.Tasks
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.NewCompletion
     <[UseExportProvider]>
     Public Class CSharpCompletionCommandHandlerTests_XmlDoc
 

--- a/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpIntelliSenseCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/NewCompletion/CSharpIntelliSenseCommandHandlerTests.vb
@@ -2,7 +2,7 @@
 
 Imports System.Threading.Tasks
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.NewCompletion
     <[UseExportProvider]>
     Public Class CSharpIntelliSenseCommandHandlerTests
         <WpfFact>

--- a/src/EditorFeatures/Test2/IntelliSense/NewCompletion/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/NewCompletion/VisualBasicCompletionCommandHandlerTests.vb
@@ -13,7 +13,7 @@ Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Text.Projection
 Imports Roslyn.Utilities
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.NewCompletion
     <[UseExportProvider]>
     Public Class VisualBasicCompletionCommandHandlerTests
         <WorkItem(546208, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546208")>

--- a/src/EditorFeatures/Test2/IntelliSense/NewCompletion/VisualBasicCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/NewCompletion/VisualBasicCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -2,21 +2,22 @@
 
 Imports System.Threading.Tasks
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.NewCompletion
 
     <[UseExportProvider]>
-    Public Class CSharpCompletionCommandHandlerTests_InternalsVisibleTo
+    Public Class VisualBasicCompletionCommandHandlerTests_InternalsVisibleTo
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function CodeCompletionContainsOtherAssembliesOfSolution() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -30,10 +31,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionContainsOtherAssemblyIfAttributeSuffixIsPresent() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("$$
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("$$
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -47,10 +49,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsTriggeredWhenDoubleQuoteIsEntered() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo($$
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo($$
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -65,10 +68,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsEmptyUntilDoubleQuotesAreEntered() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo$$
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo$$
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -77,7 +81,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 Await state.WaitForAsynchronousOperationsAsync()
                 Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
                 state.SendTypeChars("("c)
-                Await state.AssertNoCompletionSession()
+                Await state.WaitForAsynchronousOperationsAsync()
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
                 Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
@@ -91,10 +95,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsTriggeredWhenCharacterIsEnteredAfterOpeningDoubleQuote() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -109,10 +114,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsNotTriggeredWhenCharacterIsEnteredThatIsNotRightBesideTheOpeniningDoubleQuote() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("a$$")]
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("a$$")>
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -126,9 +132,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsNotTriggeredWhenDoubleQuoteIsEnteredAtStartOfFile() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">$$
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb">$$
                         </Document>
                     </Project>
                 </Workspace>)
@@ -143,20 +149,17 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Async Function CodeCompletionIsNotTriggeredByArrayElementAccess() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs"><![CDATA[
-namespace A
-{
-    public class C
-    {
-        public void M()
-        {
-            var d = new System.Collections.Generic.Dictionary<string, string>();
-            var v = d$$;
-        }
-    }
-}
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+Namespace A
+	Public Class C
+		Public Sub M()
+			Dim d = New System.Collections.Generic.Dictionary(Of String, String)()
+			Dim v = d$$
+		End Sub
+	End Class
+End Namespace
 ]]>
                         </Document>
                     </Project>
@@ -171,8 +174,9 @@ namespace A
                             Not state.CompletionItemsContainsAny({"ClassLibrary1"}))
                     End Function
                 Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
-                state.SendTypeChars("["c)
-                Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
+                state.SendTypeChars("("c)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
                 state.SendTypeChars(""""c)
                 Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
             End Using
@@ -181,11 +185,11 @@ namespace A
         Private Async Function AssertCompletionListHasItems(code As String, hasItems As Boolean) As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-using System.Runtime.CompilerServices;
-using System.Reflection;
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb">
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
 <%= code %>
                         </Document>
                     </Project>
@@ -196,99 +200,98 @@ using System.Reflection;
                     Await state.AssertCompletionSession()
                     Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
                 Else
-                    Await state.AssertNoCompletionSession
+                    If Not state.CurrentCompletionPresenterSession Is Nothing Then
+                        Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                    End If
                 End If
             End Using
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_AfterSingleDoubleQuoteAndClosing() As Task
-            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""$$)]", True)
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""$$)>", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_AfterText() As Task
-            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""Test$$)]", True)
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""Test$$)>", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfCursorIsInSecondParameter() As Task
-            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""Test"", ""$$", True)
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""Test"", ""$$", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasNoItems_IfCursorIsClosingDoubleQuote1() As Task
-            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""Test""$$", False)
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""Test""$$", False)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasNoItems_IfCursorIsClosingDoubleQuote2() As Task
-            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""""$$", False)
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""""$$", False)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfNamedParameterIsPresent() As Task
-            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""$$, AllInternalsVisible = true)]", True)
-        End Function
-
-        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function AssertCompletionListHasItems_IfNamedParameterAndNamedPositionalParametersArePresent() As Task
-            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(assemblyName: ""$$, AllInternalsVisible = true)]", True)
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""$$, AllInternalsVisible:=True)>", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasNoItems_IfNumberIsEntered() As Task
-            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(1$$2)]", False)
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(1$$2)>", False)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasNoItems_IfNotInternalsVisibleToAttribute() As Task
-            Await AssertCompletionListHasItems("[assembly: AssemblyVersion(""$$"")]", False)
+            Await AssertCompletionListHasItems("<Assembly: AssemblyVersion(""$$"")>", False)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfOtherAttributeIsPresent1() As Task
-            Await AssertCompletionListHasItems("[assembly: AssemblyVersion(""1.0.0.0""), InternalsVisibleTo(""$$", True)
+            Await AssertCompletionListHasItems("<Assembly: AssemblyVersion(""1.0.0.0""), InternalsVisibleTo(""$$", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfOtherAttributeIsPresent2() As Task
-            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""$$""), AssemblyVersion(""1.0.0.0"")]", True)
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""$$""), AssemblyVersion(""1.0.0.0"")>", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfOtherAttributesAreAhead() As Task
             Await AssertCompletionListHasItems("
-                [assembly: AssemblyVersion(""1.0.0.0"")]
-                [assembly: InternalsVisibleTo(""$$", True)
+                <Assembly: AssemblyVersion(""1.0.0.0"")>
+                <Assembly: InternalsVisibleTo(""$$", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfOtherAttributesAreFollowing() As Task
             Await AssertCompletionListHasItems("
-            [assembly: InternalsVisibleTo(""$$
-            [assembly: AssemblyVersion(""1.0.0.0"")]
-            [assembly: AssemblyCompany(""Test"")]", True)
+            <Assembly: InternalsVisibleTo(""$$
+            <Assembly: AssemblyVersion(""1.0.0.0"")>
+            <Assembly: AssemblyCompany(""Test"")>", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function AssertCompletionListHasItems_IfNamespaceIsFollowing() As Task
             Await AssertCompletionListHasItems("
-            [assembly: InternalsVisibleTo(""$$
-            namespace A {            
-                public class A { }
-            }", True)
+            <Assembly: InternalsVisibleTo(""$$
+            Namespace A             
+                Public Class A
+                End Class
+            End Namespace", True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function CodeCompletionHasItemsIfInteralVisibleToIsReferencedByTypeAlias() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
-[assembly: IVT("$$
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
+<Assembly: IVT("$$
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -302,10 +305,11 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
         Public Async Function CodeCompletionDoesNotContainCurrentAssembly() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -319,11 +323,12 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
         Public Async Function CodeCompletionInsertsAssemblyNameOnCommit() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
                     </Project>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document>
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -331,7 +336,7 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
                 Await state.AssertSelectedCompletionItem("ClassLibrary1")
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync()
-                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1"")]")
+                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1"")>")
             End Using
         End Function
 
@@ -339,14 +344,15 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
         Public Async Function CodeCompletionInsertsPublicKeyOnCommit() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
                         <CompilationOptions
                             CryptoKeyFile=<%= SigningTestHelpers.PublicKeyFile %>
                             StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
                     </Project>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document>
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -354,7 +360,7 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
                 Await state.AssertSelectedCompletionItem("ClassLibrary1")
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync()
-                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]")
+                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>")
             End Using
         End Function
 
@@ -362,16 +368,17 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
         Public Async Function CodeCompletionContainsPublicKeyIfKeyIsSpecifiedByAttribute() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
                         <CompilationOptions
                             StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
                         <Document>
-                            [assembly: System.Reflection.AssemblyKeyFile("<%= SigningTestHelpers.PublicKeyFile.Replace("\", "\\") %>")]
+                            &lt;Assembly: System.Reflection.AssemblyKeyFile("<%= SigningTestHelpers.PublicKeyFile %>")&gt;
                         </Document>
                     </Project>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document>
-    [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -379,7 +386,7 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
                 Await state.AssertSelectedCompletionItem("ClassLibrary1")
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync()
-                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]")
+                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>")
             End Using
         End Function
 
@@ -387,15 +394,17 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
         Public Async Function CodeCompletionContainsPublicKeyIfDelayedSigningIsEnabled() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
                         <CompilationOptions
                             CryptoKeyFile=<%= SigningTestHelpers.PublicKeyFile %>
-                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>
-                            DelaySign="True"/>
+                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
+                            DelaySign="True"
+                        />
                     </Project>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document>
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -403,7 +412,7 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
                 Await state.AssertSelectedCompletionItem("ClassLibrary1")
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync()
-                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]")
+                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>")
             End Using
         End Function
 
@@ -411,21 +420,20 @@ using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
         Public Async Function CodeCompletionListIsEmptyIfAttributeIsNotTheBCLAttribute() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-[assembly: Test.InternalsVisibleTo("$$")]
-namespace Test
-{
-    [System.AttributeUsage(System.AttributeTargets.Assembly)]
-    public sealed class InternalsVisibleToAttribute: System.Attribute
-    {
-        public InternalsVisibleToAttribute(string ignore)
-        {
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: Test.InternalsVisibleTo("$$")>
+Namespace Test
+	<System.AttributeUsage(System.AttributeTargets.Assembly)> _
+	Public NotInheritable Class InternalsVisibleToAttribute
+		Inherits System.Attribute
 
-        }
-    }
-}
+		Public Sub New(ignore As String)
+		End Sub
+	End Class
+End Namespace
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -438,14 +446,15 @@ namespace Test
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVT() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary1")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary1")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -456,29 +465,30 @@ namespace Test
             End Using
         End Function
 
-
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTIfAssemblyNameIsAConstant() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <MetadataReferenceFromSource Language="C#" CommonReferences="true">
-                            <Document FilePath="ReferencedDocument.cs">
-namespace A {
-    public static class Constants
-    {
-        public const string AssemblyName1 = "ClassLibrary1";
-    }
-}
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <MetadataReferenceFromSource Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="ReferencedDocument.vb">
+Namespace A
+	Public NotInheritable Class Constants
+		Private Sub New()
+		End Sub
+		Public Const AssemblyName1 As String = "ClassLibrary1"
+	End Class
+End Namespace                            
                             </Document>
                         </MetadataReferenceFromSource>
-                        <Document FilePath="C.cs">
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(A.Constants.AssemblyName1)]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(A.Constants.AssemblyName1)>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -493,42 +503,41 @@ namespace A {
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTForDifferentSyntax() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary4"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary5"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary6"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary7"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary8"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary9"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-// Code comment
-using System.Runtime.CompilerServices;
-using System.Reflection;
-using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
-// Code comment
-[assembly: InternalsVisibleTo("ClassLibrary1", AllInternalsVisible = true)]
-[assembly: InternalsVisibleTo(assemblyName: "ClassLibrary2", AllInternalsVisible = true)]
-[assembly: AssemblyVersion("1.0.0.0"), InternalsVisibleTo("ClassLibrary3")]
-[assembly: InternalsVisibleTo("ClassLibrary4"), AssemblyCopyright("Copyright")]
-[assembly: AssemblyDescription("Description")]
-[assembly: InternalsVisibleTo("ClassLibrary5")]
-[assembly: InternalsVisibleTo("ClassLibrary6, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb")]
-[assembly: InternalsVisibleTo("ClassLibrary" + "7")]
-[assembly: IVT("ClassLibrary8")]
-[assembly: InternalsVisibleTo("$$
-namespace A {
-    public class A { }
-}
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary4"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary5"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary6"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary7"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary8"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+' Code comment
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
+Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
+' Code comment
+<Assembly: InternalsVisibleTo("ClassLibrary1", AllInternalsVisible:=True)>
+<Assembly: AssemblyVersion("1.0.0.0"), Assembly: InternalsVisibleTo("ClassLibrary2")>
+<Assembly: InternalsVisibleTo("ClassLibrary3"), Assembly: AssemblyCopyright("Copyright")>
+<Assembly: AssemblyDescription("Description")>
+<Assembly: InternalsVisibleTo("ClassLibrary4")>
+<Assembly: InternalsVisibleTo("ClassLibrary5, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb")>
+<Assembly: InternalsVisibleTo("ClassLibrary" + "6")>
+<Assembly: IVT("ClassLibrary7")>
+<Assembly: InternalsVisibleTo("$$
+Namespace A
+    Public Class A
+End Class
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionSession()
-                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2", "ClassLibrary3", "ClassLibrary4", "ClassLibrary5", "ClassLibrary6", "ClassLibrary7", "ClassLibrary8"}))
-                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary9"}))
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2", "ClassLibrary3", "ClassLibrary4", "ClassLibrary5", "ClassLibrary6", "ClassLibrary7"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary8"}))
             End Using
         End Function
 
@@ -536,14 +545,15 @@ namespace A {
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTWithSyntaxError() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-using System.Runtime.CompilerServices;
-using System.Reflection;
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
 
-[assembly: InternalsVisibleTo("ClassLibrary" + 1)] // Not a constant
-[assembly: InternalsVisibleTo("$$
+<Assembly: InternalsVisibleTo("ClassLibrary" + 1.ToString())> ' Not a constant
+<Assembly: InternalsVisibleTo("$$
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -558,19 +568,21 @@ using System.Reflection;
         Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTWithMoreThanOneDocument() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="OtherDocument.cs">
-using System.Runtime.CompilerServices;
-using System.Reflection;
-[assembly: InternalsVisibleTo("ClassLibrary1")]
-[assembly: AssemblyDescription("Description")]
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="OtherDocument.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
+<Assembly: InternalsVisibleTo("ClassLibrary1")>
+<Assembly: AssemblyDescription("Description")>
+]]>
                         </Document>
-                        <Document FilePath="C.cs">
-using System.Runtime.CompilerServices;
-using System.Reflection;
-[assembly: InternalsVisibleTo("$$
+                        <Document FilePath="A.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
+<Assembly: InternalsVisibleTo("$$
+]]>
                         </Document>
                     </Project>
                 </Workspace>)
@@ -578,24 +590,6 @@ using System.Reflection;
                 Await state.AssertCompletionSession()
                 Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
                 Assert.True(state.CompletionItemsContainsAll({"ClassLibrary2"}))
-            End Using
-        End Function
-
-        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function CodeCompletionIgnoresUnsupportedProjectTypes() As Task
-            Using state = TestState.CreateTestStateFromWorkspace(
-                <Workspace>
-                    <Project Language="NoCompilation" AssemblyName="ClassLibrary1"/>
-                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
-                        <Document FilePath="C.cs">
-using System.Runtime.CompilerServices;
-using System.Reflection;
-[assembly: InternalsVisibleTo("$$
-                        </Document>
-                    </Project>
-                </Workspace>)
-                state.SendInvokeCompletionList()
-                Await state.AssertNoCompletionSession()
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/NewCompletion/VisualBasicCompletionCommandHandlerTests_Projections.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/NewCompletion/VisualBasicCompletionCommandHandlerTests_Projections.vb
@@ -4,7 +4,7 @@ Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.VisualStudio.Text.Projection
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.NewCompletion
     <[UseExportProvider]>
     Public Class VisualBasicCompletionCommandHandlerTests_Projections
 

--- a/src/EditorFeatures/Test2/IntelliSense/NewCompletion/VisualBasicCompletionCommandHandlerTests_XmlDoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/NewCompletion/VisualBasicCompletionCommandHandlerTests_XmlDoc.vb
@@ -2,7 +2,7 @@
 
 Imports System.Threading.Tasks
 
-Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.NewCompletion
     <[UseExportProvider]>
     Public Class VisualBasicCompletionCommandHandlerTests_XmlDoc
 

--- a/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpCompletionCommandHandlerTests.vb
@@ -1,0 +1,3914 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports System.Globalization
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.CSharp
+Imports Microsoft.CodeAnalysis.Editor.CSharp.Formatting
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Tags
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
+Imports Microsoft.VisualStudio.Text.Operations
+Imports Microsoft.VisualStudio.Text.Projection
+Imports Microsoft.VisualStudio.Utilities
+Imports Roslyn.Utilities
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.OldCompletion
+    ''' <summary>
+    ''' This is a test file corresponding to the old Completion service which we are going to turn off after migration to the new one.
+    ''' We should keep this file up-to-date and on par with the new file until then.
+    ''' </summary>
+    <[UseExportProvider]>
+    Public Class CSharpCompletionCommandHandlerTests
+        <WorkItem(541201, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541201")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TabCommitsWithoutAUniqueMatch() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+                                  $$
+                              </Document>)
+
+                state.SendTypeChars("using System.Ne")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Net", isHardSelected:=True)
+                state.SendTypeChars("x")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Net", isSoftSelected:=True)
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("using System.Net", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestAtEndOfFile() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>$$</Document>)
+
+                state.SendTypeChars("us")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("using", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNotAtStartOfExistingWord() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>$$using</Document>)
+
+                state.SendTypeChars("u")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("using", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMSCorLibTypes() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+using System;
+
+class c : $$
+                              </Document>)
+
+                state.SendTypeChars("A")
+                Await state.AssertCompletionSession()
+
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"Attribute", "Exception", "IDisposable"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestFiltering1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+using System;
+      
+class c { $$
+                              </Document>)
+
+                state.SendTypeChars("Sy")
+                Await state.AssertCompletionSession()
+
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"OperatingSystem", "System", "SystemException"}))
+                Assert.False(state.CompletionItemsContainsAny(displayText:={"Exception", "Activator"}))
+            End Using
+        End Function
+
+        ' NOTE(cyrusn): This should just be a unit test for SymbolCompletionProvider.  However, I'm
+        ' just porting the integration tests to here for now.
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMultipleTypes() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C { $$ } struct S { } enum E { } interface I { } delegate void D();
+                              </Document>)
+
+                state.SendTypeChars("C")
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"C", "S", "E", "I", "D"}))
+            End Using
+        End Function
+
+        ' NOTE(cyrusn): This should just be a unit test for KeywordCompletionProvider.  However, I'm
+        ' just porting the integration tests to here for now.
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestInEmptyFile() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+$$
+                              </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"abstract", "class", "namespace"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNotAfterTypingDotAfterIntegerLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class c { void M() { 3$$ } }
+                              </Document>)
+
+                state.SendTypeChars(".")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestAfterExplicitInvokeAfterDotAfterIntegerLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class c { void M() { 3.$$ } }
+                              </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ToString"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestEnterIsConsumed() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document>
+class Class1
+{
+    void Main(string[] args)
+    {
+        $$
+    }
+}</Document>)
+
+                state.SendTypeChars("System.TimeSpan.FromMin")
+                state.SendReturn()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(<text>
+class Class1
+{
+    void Main(string[] args)
+    {
+        System.TimeSpan.FromMinutes
+    }
+}</text>.NormalizedValue, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDescription1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System;
+
+/// <summary>
+/// TestDocComment
+/// </summary>
+class TestException : Exception { }
+
+class MyException : $$]]></Document>)
+
+                state.SendTypeChars("Test")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(description:="class TestException" & vbCrLf & "TestDocComment")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestObjectCreationPreselection1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System.Collections.Generic;
+
+class C
+{
+    public void Goo()
+    {
+        List<int> list = new$$
+    }
+}]]></Document>)
+
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True)
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"LinkedList<>", "List<>", "System"}))
+                state.SendTypeChars("Li")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True)
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"LinkedList<>", "List<>"}))
+                Assert.False(state.CompletionItemsContainsAny(displayText:={"System"}))
+                state.SendTypeChars("n")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="LinkedList<>", isHardSelected:=True)
+                state.SendBackspace()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True)
+                state.SendTab()
+                Assert.Contains("new List<int>", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDeconstructionDeclaration() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Goo()
+    {
+       var ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("i")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDeconstructionDeclaration2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Goo()
+    {
+       var (a, $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("i")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDeconstructionDeclaration3() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Goo()
+    {
+       var ($$) = (1, 2);
+    }
+}]]></Document>)
+
+                state.SendTypeChars("i")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedDeconstructionDeclarationWithVar() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Goo()
+    {
+       (var a$$) = (1, 2);
+    }
+}]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=False)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedDeconstructionDeclarationWithVarAfterComma() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Goo()
+    {
+       (var a, var a$$) = (1, 2);
+    }
+}]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=False)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedVarDeconstructionDeclarationWithVar() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Goo()
+    {
+       (var a, var ($$)) = (1, 2);
+    }
+}]]></Document>)
+
+
+                state.SendTypeChars("a")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars(", a")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("(var a, var (a, a)) = ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestVarDeconstructionDeclarationWithVar() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Goo()
+    {
+        $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+
+                state.SendTypeChars(" (a")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars(", a")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("var (a, a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedDeconstructionDeclarationWithSymbol() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Goo()
+    {
+       ($$) = (1, 2);
+    }
+}]]></Document>)
+
+                state.SendTypeChars("vari")
+                Await state.AssertSelectedCompletionItem(displayText:="Variable", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(Variable ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("x, vari")
+                Await state.AssertSelectedCompletionItem(displayText:="Variable", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(Variable x, Variable ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertSelectedCompletionItem(displayText:="Variable", isHardSelected:=False)
+                Assert.True(state.CompletionItemsContainsAll({"variable"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedDeconstructionDeclarationWithInt() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Integer
+{
+    public void Goo()
+    {
+       ($$) = (1, 2);
+    }
+}]]></Document>)
+
+                state.SendTypeChars("int")
+                Await state.AssertSelectedCompletionItem(displayText:="int", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(int ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("x, int")
+                Await state.AssertSelectedCompletionItem(displayText:="int", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(int x, int ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestIncompleteParenthesizedDeconstructionDeclaration() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Goo()
+    {
+       ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+
+                state.SendTypeChars(", va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+                state.SendTypeChars(")")
+                Assert.Contains("(var a, var a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestIncompleteParenthesizedDeconstructionDeclaration2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Goo()
+    {
+       ($$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+
+                state.SendTypeChars(", va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+                state.SendReturn()
+                Assert.Contains("(var a, var a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBackspaceInIncompleteParenthesizedDeconstructionDeclaration() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Goo()
+    {
+       (var as$$
+    }
+}]]></Document>)
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                state.SendBackspace()
+                ' This completion is hard-selected because the suggestion mode never triggers on backspace
+                ' See issue https://github.com/dotnet/roslyn/issues/15302
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+
+                state.SendTypeChars(", var as")
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+
+                state.SendTypeChars(")")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("(var as, var a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBackspaceInParenthesizedDeconstructionDeclaration() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Goo()
+    {
+       (var as$$)
+    }
+}]]></Document>)
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                state.SendBackspace()
+                ' This completion is hard-selected because the suggestion mode never triggers on backspace
+                ' See issue https://github.com/dotnet/roslyn/issues/15302
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+
+                state.SendTypeChars(", var as")
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("(var as, var a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(17256, "https://github.com/dotnet/roslyn/issues/17256")>
+        Public Async Function TestThrowExpression() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System;
+class C
+{
+    public object Goo()
+    {
+        return null ?? throw new$$
+    }
+}]]></Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertSelectedCompletionItem(displayText:="Exception", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(17256, "https://github.com/dotnet/roslyn/issues/17256")>
+        Public Async Function TestThrowStatement() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System;
+class C
+{
+    public object Goo()
+    {
+        throw new$$
+    }
+}]]></Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertSelectedCompletionItem(displayText:="Exception", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function TestNonTrailingNamedArgumentInCSharp7_1() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                 <Workspace>
+                     <Project Language="C#" LanguageVersion="CSharp7_1" CommonReferences="true" AssemblyName="CSProj">
+                         <Document FilePath="C.cs">
+class C
+{
+    public void M()
+    {
+        int better = 2;
+        M(a: 1, $$)
+    }
+    public void M(int a, int bar, int c) { }
+}
+                         </Document>
+                     </Project>
+                 </Workspace>)
+
+                state.SendTypeChars("b")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:", isHardSelected:=True)
+                state.SendTypeChars("e")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:", isSoftSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function TestNonTrailingNamedArgumentInCSharp7_2() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                 <Workspace>
+                     <Project Language="C#" LanguageVersion="CSharp7_2" CommonReferences="true" AssemblyName="CSProj">
+                         <Document FilePath="C.cs">
+class C
+{
+    public void M()
+    {
+        int better = 2;
+        M(a: 1, $$)
+    }
+    public void M(int a, int bar, int c) { }
+}
+                         </Document>
+                     </Project>
+                 </Workspace>)
+
+                state.SendTypeChars("b")
+                Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:", isHardSelected:=True)
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
+                state.SendTypeChars(", ")
+                Assert.Contains("M(a: 1, better,", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestDefaultSwitchLabel() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+        switch (o)
+        {
+            default:
+                goto $$
+        }
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="default", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto default;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestGotoOrdinaryLabel() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+label1:
+        goto $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("l")
+                Await state.AssertSelectedCompletionItem(displayText:="label1", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto label1;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestEscapedDefaultLabel() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+@default:
+        goto $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="@default", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto @default;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestEscapedDefaultLabel2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+        switch (o)
+        {
+            default:
+@default:
+                goto $$
+        }
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="default", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto default;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestEscapedDefaultLabelWithoutSwitch() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+@default:
+        goto $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="@default", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto @default;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(24432, "https://github.com/dotnet/roslyn/issues/24432")>
+        Public Async Function TestArrayInitialization() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    public void M()
+    {
+        Class[] x = $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("new ")
+                Await state.AssertSelectedCompletionItem(displayText:="Class", isSoftSelected:=True)
+                state.SendTypeChars("C")
+                Await state.AssertSelectedCompletionItem(displayText:="Class", isHardSelected:=True)
+                state.SendTypeChars("[")
+                Assert.Contains("Class[] x = new Class[", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars("] {")
+                Assert.Contains("Class[] x = new Class[] {", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(24432, "https://github.com/dotnet/roslyn/issues/24432")>
+        Public Async Function TestImplicitArrayInitialization() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    public void M()
+    {
+        Class[] x = $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("n")
+                Await state.AssertSelectedCompletionItem(displayText:="nameof", isHardSelected:=True)
+                state.SendTypeChars("e")
+                Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertSelectedCompletionItem(displayText:="Class", isSoftSelected:=True)
+                state.SendTypeChars("[")
+                Assert.Contains("Class[] x = new [", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars("] {")
+                Assert.Contains("Class[] x = new [] {", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(24432, "https://github.com/dotnet/roslyn/issues/24432")>
+        Public Async Function TestImplicitArrayInitialization2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    public void M()
+    {
+        Class[] x = $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("ne")
+                Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
+                state.SendTypeChars("[")
+                Assert.Contains("Class[] x = new[", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(24432, "https://github.com/dotnet/roslyn/issues/24432")>
+        Public Async Function TestImplicitArrayInitialization3() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    public void M()
+    {
+        Class[] x = $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("ne")
+                Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertSelectedCompletionItem(displayText:="Class", isSoftSelected:=True)
+                Assert.Contains("Class[] x = new ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars("[")
+                Assert.Contains("Class[] x = new [", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(24432, "https://github.com/dotnet/roslyn/issues/24432")>
+        Public Async Function TestImplicitArrayInitialization4() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    public void M()
+    {
+        Class[] x =$$
+    }
+}]]></Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("{")
+                Assert.Contains("Class[] x = {", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(24432, "https://github.com/dotnet/roslyn/issues/24432")>
+        Public Async Function TestImplicitArrayInitialization_WithTab() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    public void M()
+    {
+        Class[] x = $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("ne")
+                Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertSelectedCompletionItem(displayText:="Class", isSoftSelected:=True)
+                Assert.Contains("Class[] x = new ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTab()
+                Assert.Contains("Class[] x = new Class", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(24432, "https://github.com/dotnet/roslyn/issues/24432")>
+        Public Async Function TestTypelessImplicitArrayInitialization() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    public void M()
+    {
+        var x = $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("ne")
+                Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("[")
+                Assert.Contains("var x = new [", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars("] {")
+                Assert.Contains("var x = new [] {", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(24432, "https://github.com/dotnet/roslyn/issues/24432")>
+        Public Async Function TestTypelessImplicitArrayInitialization2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    public void M()
+    {
+        var x = $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("ne")
+                Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
+                state.SendTypeChars("[")
+                Assert.Contains("var x = new[", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(24432, "https://github.com/dotnet/roslyn/issues/24432")>
+        Public Async Function TestTypelessImplicitArrayInitialization3() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Class
+{
+    public void M()
+    {
+        var x = $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("ne")
+                Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("var x = new ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars("[")
+                Assert.Contains("var x = new [", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TestSymbolInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Fo()
+    {
+        ($$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("F")
+                Await state.AssertSelectedCompletionItem(displayText:="Fo", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(F:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TestSymbolInTupleLiteralAfterComma() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Fo()
+    {
+        (x, $$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("F")
+                Await state.AssertSelectedCompletionItem(displayText:="Fo", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(x, F:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
+        Public Async Function ColonInTupleNameInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("fi")
+                Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                Assert.Equal("first", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
+                state.SendTypeChars(":")
+                Assert.Contains("(first:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
+        Public Async Function ColonInExactTupleNameInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("first")
+                Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                Assert.Equal("first", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
+                state.SendTypeChars(":")
+                Assert.Contains("(first:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
+        Public Async Function ColonInTupleNameInTupleLiteralAfterComma() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = (0, $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("se")
+                Await state.AssertSelectedCompletionItem(displayText:="second:", isHardSelected:=True)
+                Assert.Equal("second", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
+                state.SendTypeChars(":")
+                Assert.Contains("(0, second:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
+        Public Async Function TabInTupleNameInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("fi")
+                Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                Assert.Equal("first", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
+                state.SendTab()
+                state.SendTypeChars(":")
+                state.SendTypeChars("0")
+                Assert.Contains("(first:0", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
+        Public Async Function TabInExactTupleNameInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("first")
+                Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                Assert.Equal("first", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
+                state.SendTab()
+                state.SendTypeChars(":")
+                state.SendTypeChars("0")
+                Assert.Contains("(first:0", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
+        Public Async Function TabInTupleNameInTupleLiteralAfterComma() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = (0, $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("se")
+                Await state.AssertSelectedCompletionItem(displayText:="second:", isHardSelected:=True)
+                Assert.Equal("second", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
+                state.SendTab()
+                state.SendTypeChars(":")
+                state.SendTypeChars("1")
+                Assert.Contains("(0, second:1", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TestKeywordInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Goo()
+    {
+        ($$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="decimal", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(d:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TestTupleType() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Goo()
+    {
+        ($$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="decimal", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(decimal ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TestDefaultKeyword() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Goo()
+    {
+        switch(true)
+        {
+            $$
+        }
+    }
+}]]></Document>)
+
+                state.SendTypeChars("def")
+                Await state.AssertSelectedCompletionItem(displayText:="default", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("default:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TestParenthesizedExpression() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Fo()
+    {
+        ($$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("F")
+                Await state.AssertSelectedCompletionItem(displayText:="Fo", isHardSelected:=True)
+                state.SendTypeChars(".")
+                Assert.Contains("(Fo.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TestInvocationExpression() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Goo(int Alice)
+    {
+        Goo($$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("A")
+                Await state.AssertSelectedCompletionItem(displayText:="Alice", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("Goo(Alice:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TestInvocationExpressionAfterComma() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Goo(int Alice, int Bob)
+    {
+        Goo(1, $$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("B")
+                Await state.AssertSelectedCompletionItem(displayText:="Bob", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("Goo(1, Bob:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TestCaseLabel() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Fo()
+    {
+        switch (1)
+        {
+            case $$
+        }
+    }
+}]]></Document>)
+
+                state.SendTypeChars("F")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Fo", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("case Fo:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(543268, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543268")>
+        Public Async Function TestTypePreselection1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+partial class C
+{
+}
+partial class C
+{
+    $$
+}]]></Document>)
+
+                state.SendTypeChars("C")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(543519, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543519")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNewPreselectionAfterVar() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    void M()
+    {
+        var c = $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("new ")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(543559, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543559")>
+        <WorkItem(543561, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543561")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestEscapedIdentifiers() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class @return
+{
+    void goo()
+    {
+        $$
+    }
+}
+]]></Document>)
+
+                state.SendTypeChars("@")
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("r")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="@return", isHardSelected:=True)
+                state.SendTab()
+                Assert.Contains("@return", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(543771, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543771")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCommitUniqueItem1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System;
+ 
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteL$$();
+    }
+}]]></Document>)
+
+                state.SendCommitUniqueCompletionListItem()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("WriteLine()", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(543771, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543771")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCommitUniqueItem2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System;
+ 
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteL$$ine();
+    }
+}]]></Document>)
+
+                state.SendCommitUniqueCompletionListItem()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitForUsingDirective1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+                                  $$
+                              </Document>)
+
+                state.SendTypeChars("using Sys")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                state.SendTypeChars("(")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("using Sys(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitForUsingDirective2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+                                  $$
+                              </Document>)
+
+                state.SendTypeChars("using Sys")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+                Assert.Contains("using System.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitForUsingDirective3() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+                                  $$
+                              </Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+
+                state.SendTypeChars("using Sys")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Await state.AssertNoCompletionSession()
+                state.AssertMatchesTextStartingAtLine(1, "using System;")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitForUsingDirective4() As Task
+            Using state = TestState.CreateCSharpTestState(
+                            <Document>
+                                $$
+                            </Document>)
+
+                state.SendTypeChars("using Sys")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("using Sys ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function KeywordsIncludedInObjectCreationCompletion() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void Goo()
+    {
+        string s = new$$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="string", isHardSelected:=True)
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(c) c.DisplayText = "int"))
+            End Using
+        End Function
+
+        <WorkItem(544293, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544293")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NoKeywordsOrSymbolsAfterNamedParameter() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class Goo
+{
+    void Test()
+    {
+        object m = null;
+        Method(obj:m, $$
+    }
+ 
+    void Method(object obj, int num = 23, string str = "")
+    {
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("a")
+                Await state.AssertCompletionSession()
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "num:"))
+                Assert.False(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "System"))
+                Assert.False(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(c) c.DisplayText = "int"))
+            End Using
+        End Function
+
+        <WorkItem(544017, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544017")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumCompletionTriggeredOnSpace() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+enum Numeros { Uno, Dos }
+class Goo
+{
+    void Bar(int a, Numeros n) { }
+    void Baz()
+    {
+        Bar(0$$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars(", ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True)
+                Assert.Equal(1, state.CurrentCompletionPresenterSession.CompletionItems.Where(Function(c) c.DisplayText = "Numeros").Count())
+            End Using
+        End Function
+
+        <WorkItem(479078, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/479078")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumCompletionTriggeredOnSpaceForNullables() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+enum Numeros { Uno, Dos }
+class Goo
+{
+    void Bar(int a, Numeros? n) { }
+    void Baz()
+    {
+        Bar(0$$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars(", ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True)
+                Assert.Equal(1, state.CurrentCompletionPresenterSession.CompletionItems.Where(Function(c) c.DisplayText = "Numeros").Count())
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumCompletionTriggeredOnDot() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document>
+enum Numeros { Uno, Dos }
+class Goo
+{
+    void Bar()
+    {
+        Numeros num = $$
+    }
+}
+                </Document>)
+
+                state.SendTypeChars("Nu.")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Contains("Numeros num = Numeros.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumCompletionNotTriggeredOnPlusCommitCharacter() As Task
+            Await EnumCompletionNotTriggeredOn("+"c)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumCompletionNotTriggeredOnLeftBraceCommitCharacter() As Task
+            Await EnumCompletionNotTriggeredOn("{"c)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumCompletionNotTriggeredOnSpaceCommitCharacter() As Task
+            Await EnumCompletionNotTriggeredOn(" "c)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumCompletionNotTriggeredOnSemicolonCommitCharacter() As Task
+            Await EnumCompletionNotTriggeredOn(";"c)
+        End Function
+
+        Private Async Function EnumCompletionNotTriggeredOn(c As Char) As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document>
+enum Numeros { Uno, Dos }
+class Goo
+{
+    void Bar()
+    {
+        Numeros num = $$
+    }
+}
+                </Document>)
+
+                state.SendTypeChars("Nu")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True)
+                state.SendTypeChars(c.ToString())
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.NotEqual("Numberos", state.CurrentCompletionPresenterSession?.SelectedItem?.DisplayText)
+                Assert.Contains(String.Format("Numeros num = Nu{0}", c), state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(544296, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544296")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestVerbatimNamedIdentifierFiltering() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class Program
+{
+    void Goo(int @int)
+    {
+        Goo($$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("i")
+                Await state.AssertCompletionSession()
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "@int:"))
+                state.SendTypeChars("n")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "@int:"))
+                state.SendTypeChars("t")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "@int:"))
+            End Using
+        End Function
+
+        <WorkItem(543687, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543687")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNoPreselectInInvalidObjectCreationLocation() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document><![CDATA[
+using System;
+
+class Program
+{
+    void Test()
+    {
+        $$
+    }
+}
+
+class Bar { }
+
+class Goo<T> : IGoo<T>
+{
+}
+
+interface IGoo<T>
+{
+}]]>
+                              </Document>)
+
+                state.SendTypeChars("IGoo<Bar> a = new ")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(544925, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544925")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestQualifiedEnumSelection() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+using System;
+ 
+class Program
+{
+    void Main()
+    {
+        Environment.GetFolderPath$$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("(")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Contains("Environment.SpecialFolder", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(545070, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545070")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestTextChangeSpanWithAtCharacter() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+public class @event
+{
+    $$@event()
+    {
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("public ")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("public @event", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDoNotInsertColonSoThatUserCanCompleteOutAVariableNameThatDoesNotCurrentlyExist_IE_TheCyrusCase() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+using System.Threading;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Goo($$)
+    }
+
+    void Goo(CancellationToken cancellationToken)
+    {
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("can")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("Goo(cancellationToken)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+#If False Then
+    <Scenario Name="Verify correct intellisense selection on ENTER">
+      <SetEditorText>
+        <![CDATA[class Class1
+{
+    void Main(string[] args)
+    {
+        //
+    }
+}]]>
+      </SetEditorText>
+      <PlaceCursor Marker="//" />
+      <SendKeys>var a = System.TimeSpan.FromMin{ENTER}{(}</SendKeys>
+      <VerifyEditorContainsText>
+        <![CDATA[class Class1
+{
+    void Main(string[] args)
+    {
+        var a = System.TimeSpan.FromMinutes(
+    }
+}]]>        
+      </VerifyEditorContainsText>
+    </Scenario>
+#End If
+
+        <WorkItem(544940, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544940")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AttributeNamedPropertyCompletionCommitWithTab() As Task
+            Using state = TestState.CreateCSharpTestState(
+                            <Document>
+class MyAttribute : System.Attribute
+{
+    public string Name { get; set; }
+}
+
+[MyAttribute($$
+public class Goo
+{
+}
+                            </Document>)
+                state.SendTypeChars("Nam")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Equal("[MyAttribute(Name =", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(544940, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544940")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AttributeNamedPropertyCompletionCommitWithEquals() As Task
+            Using state = TestState.CreateCSharpTestState(
+                            <Document>
+class MyAttribute : System.Attribute
+{
+    public string Name { get; set; }
+}
+
+[MyAttribute($$
+public class Goo
+{
+}
+                            </Document>)
+                state.SendTypeChars("Nam=")
+                Await state.AssertNoCompletionSession()
+                Assert.Equal("[MyAttribute(Name =", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(544940, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544940")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AttributeNamedPropertyCompletionCommitWithSpace() As Task
+            Using state = TestState.CreateCSharpTestState(
+                            <Document>
+class MyAttribute : System.Attribute
+{
+    public string Name { get; set; }
+}
+
+[MyAttribute($$
+public class Goo
+{
+}
+                            </Document>)
+                state.SendTypeChars("Nam ")
+                Await state.AssertNoCompletionSession()
+                Assert.Equal("[MyAttribute(Name ", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(545590, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545590")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestOverrideDefaultParameter() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    public virtual void Goo<S>(S x = default(S))
+    {
+    }
+}
+
+class D : C
+{
+    override $$
+}
+            ]]></Document>)
+                state.SendTypeChars(" Goo")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("public override void Goo<S>(S x = default(S))", state.SubjectBuffer.CurrentSnapshot.GetText(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(545664, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545664")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestArrayAfterOptionalParameter() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class A
+{
+    public virtual void Goo(int x = 0, int[] y = null) { }
+}
+
+class B : A
+{
+public override void Goo(int x = 0, params int[] y) { }
+}
+
+class C : B
+{
+    override$$
+}
+            ]]></Document>)
+                state.SendTypeChars(" Goo")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("    public override void Goo(int x = 0, int[] y = null)", state.SubjectBuffer.CurrentSnapshot.GetText(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(545967, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545967")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestVirtualSpaces() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    public string P { get; set; }
+    void M()
+    {
+        var v = new C
+        {$$
+        };
+    }
+}
+            ]]></Document>)
+                state.SendReturn()
+                Assert.True(state.TextView.Caret.InVirtualSpace)
+                Assert.Equal(12, state.TextView.Caret.Position.VirtualSpaces)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("P", isSoftSelected:=True)
+                state.SendDownKey()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("P", isHardSelected:=True)
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal("            P", state.GetLineFromCurrentCaretPosition().GetText())
+
+                Dim bufferPosition = state.TextView.Caret.Position.BufferPosition
+                Assert.Equal(13, bufferPosition.Position - bufferPosition.GetContainingLine().Start.Position)
+                Assert.False(state.TextView.Caret.InVirtualSpace)
+            End Using
+        End Function
+
+        <WorkItem(546561, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546561")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNamedParameterAgainstMRU() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class Program
+{
+    void Goo(string s) { }
+
+    static void Main()
+    {
+        $$
+    }
+}
+            ]]></Document>)
+                ' prime the MRU
+                state.SendTypeChars("string")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' Delete what we just wrote.
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendEscape()
+                Await state.AssertNoCompletionSession()
+
+                ' ensure we still select the named param even though 'string' is in the MRU.
+                state.SendTypeChars("Goo(s")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("s:")
+            End Using
+        End Function
+
+        <WorkItem(546403, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546403")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMissingOnObjectCreationAfterVar1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class A
+{
+    void Goo()
+    {
+        var v = new$$
+    }
+}
+            ]]></Document>)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(546403, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546403")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMissingOnObjectCreationAfterVar2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class A
+{
+    void Goo()
+    {
+        var v = new $$
+    }
+}
+            ]]></Document>)
+                state.SendTypeChars("X")
+                Await state.AssertCompletionSession()
+                Assert.False(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "X"))
+            End Using
+        End Function
+
+        <WorkItem(546917, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546917")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestEnumInSwitch() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+enum Numeros
+{
+}
+class C
+{
+    void M()
+    {
+        Numeros n;
+        switch (n)
+        {
+            case$$
+        }
+    }
+}
+            ]]></Document>)
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros")
+            End Using
+        End Function
+
+        <WorkItem(547016, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547016")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestAmbiguityInLocalDeclaration() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    public int W;
+    public C()
+    {
+        $$
+        W = 0;
+    }
+}
+
+            ]]></Document>)
+                state.SendTypeChars("w")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="W")
+            End Using
+        End Function
+
+        <WorkItem(530835, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530835")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCompletionFilterSpanCaretBoundary() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    public void Method()
+    {
+        $$
+    }
+}
+            ]]></Document>)
+                state.SendTypeChars("Met")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Method")
+                state.SendLeftKey()
+                state.SendLeftKey()
+                state.SendLeftKey()
+                state.SendTypeChars("new")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Method", isSoftSelected:=True)
+            End Using
+        End Function
+
+        <WorkItem(5487, "https://github.com/dotnet/roslyn/issues/5487")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCommitCharTypedAtTheBeginingOfTheFilterSpan() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public bool Method()
+    {
+        if ($$
+    }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("Met")
+                Await state.AssertCompletionSession()
+                state.SendLeftKey()
+                state.SendLeftKey()
+                state.SendLeftKey()
+                Await state.AssertSelectedCompletionItem(isSoftSelected:=True)
+                state.SendTypeChars("!")
+                Await state.AssertNoCompletionSession()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal("if (!Met", state.GetLineTextFromCaretPosition().Trim())
+                Assert.Equal("M", state.GetCaretPoint().BufferPosition.GetChar())
+            End Using
+        End Function
+
+        <WorkItem(622957, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/622957")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBangFiltersInDocComment() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System;
+
+/// $$
+/// TestDocComment
+/// </summary>
+class TestException : Exception { }
+]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("!")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("!--")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeCompletionDoesNotFilter() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class C
+{
+    public void Method()
+    {
+        string$$
+    }
+}
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("string")
+                state.CompletionItemsContainsAll({"integer", "Method"})
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeBeforeWordDoesNotSelect() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class C
+{
+    public void Method()
+    {
+        $$string
+    }
+}
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("AccessViolationException")
+                state.CompletionItemsContainsAll({"integer", "Method"})
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeCompletionSelectsWithoutRegardToCaretPosition() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class C
+{
+    public void Method()
+    {
+        s$$tring
+    }
+}
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("string")
+                state.CompletionItemsContainsAll({"integer", "Method"})
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TabAfterQuestionMark() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class C
+{
+    public void Method()
+    {
+        ?$$
+    }
+}
+            ]]></Document>)
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(state.GetLineTextFromCaretPosition(), "        ?" + vbTab)
+            End Using
+        End Function
+
+        <WorkItem(657658, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/657658")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function PreselectionIgnoresBrackets() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+ 
+class Program
+{
+    $$
+ 
+    static void Main(string[] args)
+    {
+      
+    }
+}]]></Document>)
+
+                state.SendTypeChars("static void F<T>(int a, Func<T, int> b) { }")
+                state.SendEscape()
+
+                state.TextView.Caret.MoveTo(New VisualStudio.Text.SnapshotPoint(state.SubjectBuffer.CurrentSnapshot, 220))
+
+                state.SendTypeChars("F")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("F<>")
+            End Using
+        End Function
+
+        <WorkItem(672474, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/672474")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestInvokeSnippetCommandDismissesCompletion() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>$$</Document>)
+
+                state.SendTypeChars("us")
+                Await state.AssertCompletionSession()
+                state.SendInsertSnippetCommand()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(672474, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/672474")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSurroundWithCommandDismissesCompletion() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>$$</Document>)
+
+                state.SendTypeChars("us")
+                Await state.AssertCompletionSession()
+                state.SendSurroundWithCommand()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(737239, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/737239")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function LetEditorHandleOpenParen() As Task
+            Dim expected = <Document><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        List<int> x = new List<int>(
+    }
+}]]></Document>.Value.Replace(vbLf, vbCrLf)
+
+            Using state = TestState.CreateCSharpTestState(<Document><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        List<int> x = new$$
+    }
+}]]></Document>)
+
+
+                state.SendTypeChars(" ")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("List<int>")
+                state.SendTypeChars("(")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(expected, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WorkItem(785637, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/785637")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitMovesCaretToWordEnd() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class C
+{
+    public void Main()
+    {
+        M$$ain
+    }
+}
+            ]]></Document>)
+                state.SendCommitUniqueCompletionListItem()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(state.GetLineFromCurrentCaretPosition().End, state.GetCaretPoint().BufferPosition)
+            End Using
+        End Function
+
+        <WorkItem(775370, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/775370")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function MatchingConsidersAtSign() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class C
+{
+    public void Main()
+    {
+        $$
+    }
+}
+            ]]></Document>)
+                state.SendTypeChars("var @this = ""goo""")
+                state.SendReturn()
+                state.SendTypeChars("string str = this.ToString();")
+                state.SendReturn()
+                state.SendTypeChars("str = @th")
+
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("@this")
+            End Using
+        End Function
+
+        <WorkItem(865089, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/865089")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AttributeFilterTextRemovesAttributeSuffix() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+[$$]
+class AtAttribute : System.Attribute { }]]></Document>)
+                state.SendTypeChars("At")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("At")
+                Assert.Equal("At", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
+            End Using
+        End Function
+
+        <WorkItem(852578, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/852578")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function PreselectExceptionOverSnippet() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class C
+{
+    Exception goo() {
+        return new $$
+    }
+}]]></Document>)
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("Exception")
+            End Using
+        End Function
+
+        <WorkItem(868286, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/868286")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitNameAfterAlias() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using goo = System$$]]></Document>)
+                state.SendTypeChars(".act<")
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "using goo = System.Action<")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCompletionInLinkedFiles() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="CSProj" PreprocessorSymbols="Thing2">
+                        <Document FilePath="C.cs">
+class C
+{
+    void M()
+    {
+        $$
+    }
+
+#if Thing1
+    void Thing1() { }
+#elif Thing2
+    void Thing2() { }
+#endif
+}
+                              </Document>
+                    </Project>
+                    <Project Language="C#" CommonReferences="true" PreprocessorSymbols="Thing1">
+                        <Document IsLinkFile="true" LinkAssemblyName="CSProj" LinkFilePath="C.cs"/>
+                    </Project>
+                </Workspace>)
+
+                Dim documents = state.Workspace.Documents
+                Dim linkDocument = documents.Single(Function(d) d.IsLinkFile)
+                state.SendTypeChars("Thing1")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("Thing1")
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendEscape()
+                state.Workspace.SetDocumentContext(linkDocument.Id)
+                state.SendTypeChars("Thing1")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("Thing1")
+                Assert.True(state.CurrentCompletionPresenterSession.SelectedItem.Tags.Contains(WellKnownTags.Warning))
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendTypeChars("M")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("M")
+                Assert.False(state.CurrentCompletionPresenterSession.SelectedItem.Tags.Contains(WellKnownTags.Warning))
+            End Using
+        End Function
+
+        <WorkItem(951726, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/951726")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DismissUponSave() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    $$
+}]]></Document>)
+                state.SendTypeChars("voi")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("void")
+                state.SendSave()
+                Await state.AssertNoCompletionSession()
+                state.AssertMatchesTextStartingAtLine(3, "    voi")
+            End Using
+        End Function
+
+        <WorkItem(930254, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/930254")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NoCompletionWithBoxSelection() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    {|Selection:$$int x;|}
+    {|Selection:int y;|}
+}]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("goo")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(839555, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/839555")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TriggeredOnHash() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+$$]]></Document>)
+                state.SendTypeChars("#")
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(771761, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/771761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function RegionCompletionCommitTriggersFormatting_1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    $$
+}]]></Document>)
+                state.SendTypeChars("#reg")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("region")
+                state.SendReturn()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(3, "    #region")
+            End Using
+        End Function
+
+        <WorkItem(771761, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/771761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function RegionCompletionCommitTriggersFormatting_2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    $$
+}]]></Document>)
+                state.SendTypeChars("#reg")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("region")
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(3, "    #region ")
+            End Using
+        End Function
+
+        <WorkItem(771761, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/771761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EndRegionCompletionCommitTriggersFormatting_2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    #region NameIt
+    $$
+}]]></Document>)
+                state.SendTypeChars("#endreg")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("endregion")
+                state.SendReturn()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(4, "    #endregion ")
+            End Using
+        End Function
+
+        Private Class SlowProvider
+            Inherits CommonCompletionProvider
+
+            Public checkpoint As Checkpoint = New Checkpoint()
+
+            Public Overrides Async Function ProvideCompletionsAsync(context As CompletionContext) As Task
+                Await checkpoint.Task.ConfigureAwait(False)
+            End Function
+
+            Friend Overrides Function IsInsertionTrigger(text As SourceText, characterPosition As Integer, options As OptionSet) As Boolean
+                Return True
+            End Function
+        End Class
+
+        <WorkItem(1015893, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1015893")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspaceDismissesIfComputationIsIncomplete() As Task
+            Dim slowProvider = New SlowProvider()
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void goo()
+    {
+        goo($$
+    }
+}]]></Document>, {slowProvider})
+
+                state.SendTypeChars("f")
+                state.SendBackspace()
+
+                ' Send a backspace that goes beyond the session's applicable span
+                ' before the model computation has finished. Then, allow the 
+                ' computation to complete. There should still be no session.
+                state.SendBackspace()
+                slowProvider.checkpoint.Release()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(1065600, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1065600")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitUniqueItemWithBoxSelection() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void goo(int x)
+    {
+       [|$$ |]
+    }
+}]]></Document>)
+                state.SendReturn()
+                state.TextView.Selection.Mode = VisualStudio.Text.Editor.TextSelectionMode.Box
+                state.SendCommitUniqueCompletionListItem()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(1594, "https://github.com/dotnet/roslyn/issues/1594")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NoPreselectionOnSpaceWhenAbuttingWord() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class Program
+{
+    void Main()
+    {
+        Program p = new $$Program();
+    }
+}]]></Document>)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(1594, "https://github.com/dotnet/roslyn/issues/1594")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function SpacePreselectionAtEndOfFile() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class Program
+{
+    void Main()
+    {
+        Program p = new $$]]></Document>)
+                state.SendTypeChars(" ")
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(1659, "https://github.com/dotnet/roslyn/issues/1659")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DismissOnSelectAllCommand() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void goo(int x)
+    {
+        $$]]></Document>)
+                ' Note: the caret is at the file, so the Select All command's movement
+                ' of the caret to the end of the selection isn't responsible for 
+                ' dismissing the session.
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendSelectAll()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionCommitAndFormatAreSeparateUndoTransactions() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void goo(int x)
+    {
+        int doodle;
+$$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendTypeChars("doo;")
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(6, "        doodle;")
+                state.SendUndo()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(6, "doo;")
+            End Using
+        End Function
+
+        <WorkItem(4978, "https://github.com/dotnet/roslyn/issues/4978")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function SessionNotStartedWhenCaretNotMappableIntoSubjectBuffer() As Task
+            ' In inline diff view, typing delete next to a "deletion",
+            ' can cause our CommandChain to be called with a subjectbuffer
+            ' and TextView such that the textView's caret can't be mapped
+            ' into our subject buffer. 
+            '
+            ' To test this, we create a projection buffer with 2 source 
+            ' spans: one of "text" content type and one based on a C#
+            ' buffer. We create a TextView with that projection as 
+            ' its buffer, setting the caret such that it maps only
+            ' into the "text" buffer. We then call the completion
+            ' command handlers with commandargs based on that TextView
+            ' but with the C# buffer as the SubjectBuffer.
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void goo(int x)
+    {$$
+        /********/
+        int doodle;
+        }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+
+                Dim textBufferFactoryService = state.GetExportedValue(Of ITextBufferFactoryService)()
+                Dim contentTypeService = state.GetExportedValue(Of IContentTypeRegistryService)()
+                Dim contentType = contentTypeService.GetContentType(ContentTypeNames.CSharpContentType)
+                Dim textViewFactory = state.GetExportedValue(Of ITextEditorFactoryService)()
+                Dim editorOperationsFactory = state.GetExportedValue(Of IEditorOperationsFactoryService)()
+
+                Dim otherBuffer = textBufferFactoryService.CreateTextBuffer("text", contentType)
+                Dim otherExposedSpan = otherBuffer.CurrentSnapshot.CreateTrackingSpan(0, 4, SpanTrackingMode.EdgeExclusive, TrackingFidelityMode.Forward)
+
+                Dim subjectBufferExposedSpan = state.SubjectBuffer.CurrentSnapshot.CreateTrackingSpan(0, state.SubjectBuffer.CurrentSnapshot.Length, SpanTrackingMode.EdgeExclusive, TrackingFidelityMode.Forward)
+
+                Dim projectionBufferFactory = state.GetExportedValue(Of IProjectionBufferFactoryService)()
+                Dim projection = projectionBufferFactory.CreateProjectionBuffer(Nothing, New Object() {otherExposedSpan, subjectBufferExposedSpan}.ToList(), ProjectionBufferOptions.None)
+
+                Using disposableView As DisposableTextView = textViewFactory.CreateDisposableTextView(projection)
+                    disposableView.TextView.Caret.MoveTo(New SnapshotPoint(disposableView.TextView.TextBuffer.CurrentSnapshot, 0))
+
+                    Dim editorOperations = editorOperationsFactory.GetEditorOperations(disposableView.TextView)
+                    state.CompletionCommandHandler.ExecuteCommand(New DeleteKeyCommandArgs(disposableView.TextView, state.SubjectBuffer), Sub() editorOperations.Delete(), TestCommandExecutionContext.Create())
+
+                    Await state.AssertNoCompletionSession()
+                End Using
+            End Using
+        End Function
+
+        <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround1() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestState.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class C
+        {
+            void goo(int x)
+            {
+                string.$$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("is")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("IsInterned")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround2() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestState.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class C
+        {
+            void goo(int x)
+            {
+                string.$$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("ı")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem()
+                End Using
+            End Using
+
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+using System.Threading;
+class Program
+{
+    void Cancel(int x, CancellationToken cancellationToken)
+    {
+        Cancel(x + 1, cancellationToken: $$)
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cancellationToken", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class Program
+{
+    static void Main(string[] args)
+    {
+        int aaz = 0;
+        args = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendTypeChars("a")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("args", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection_DoesNotOverrideEnumPreselection() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+enum E
+{
+
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        E e;
+        e = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("E", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection_DoesNotOverrideEnumPreselection2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+enum E
+{
+    A
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        E e = E.A;
+        if (e == $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("E", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection3() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class D {}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+       int cw = 7;
+       D cx = new D();
+       D cx2 = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionLocalsOverType() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class A {}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+       A cx = new A();
+       A cx2 = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionParameterOverMethod() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class Program
+{
+    bool f;
+
+    void goo(bool x) { }
+
+    void Main(string[] args) 
+    {
+        goo($$) // Not "Equals"
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("f", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/6942"), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionConvertibility1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+abstract class C {}
+class D : C {}
+class Program
+{
+    static void Main(string[] args)
+    {
+       D cx = new D();
+       C cx2 = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionLocalOverProperty() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class Program
+{
+    public int aaa { get; }
+
+     void Main(string[] args)
+    {
+        int aaq;
+
+        int y = a$$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("aaq", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(12254, "https://github.com/dotnet/roslyn/issues/12254")>
+        Public Async Function TestGenericCallOnTypeContainingAnonymousType() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        new[] { new { x = 1 } }.ToArr$$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+
+                state.SendInvokeCompletionList()
+                state.SendTypeChars("(")
+
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                state.AssertMatchesTextStartingAtLine(7, "new[] { new { x = 1 } }.ToArray(")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionSetterValuey() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class Program
+{
+    int _x;
+    int X
+    {
+        set
+        {
+            _x = $$
+        }
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("value", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(12530, "https://github.com/dotnet/roslyn/issues/12530")>
+        Public Async Function TestAnonymousTypeDescription() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        new[] { new { x = 1 } }.ToArr$$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(description:=
+$"({ CSharpFeaturesResources.extension }) 'a[] System.Collections.Generic.IEnumerable<'a>.ToArray<'a>()
+
+{ FeaturesResources.Anonymous_Types_colon }
+    'a { FeaturesResources.is_ } new {{ int x }}")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestRecursiveGenericSymbolKey() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+using System.Collections.Generic;
+
+class Program
+{
+    static void ReplaceInList<T>(List<T> list, T oldItem, T newItem)
+    {
+        $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+
+                state.SendTypeChars("list")
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("Add")
+
+                Await state.AssertSelectedCompletionItem("Add", description:="void List<T>.Add(T item)")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCommitNamedParameterWithColon() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main(int args)
+    {
+        Main(args$$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+
+                state.SendInvokeCompletionList()
+                state.SendTypeChars(":")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("args:", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(13481, "https://github.com/dotnet/roslyn/issues/13481")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBackspaceSelection1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        DateTimeOffset$$
+    }
+}
+            ]]></Document>)
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                For Each c In "Offset"
+                    state.SendBackspace()
+                    Await state.WaitForAsynchronousOperationsAsync()
+                Next
+
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("DateTime")
+            End Using
+        End Function
+
+        <WorkItem(13481, "https://github.com/dotnet/roslyn/issues/13481")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBackspaceSelection2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        DateTimeOffset.$$
+    }
+}
+            ]]></Document>)
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                For Each c In "Offset."
+                    state.SendBackspace()
+                    Await state.WaitForAsynchronousOperationsAsync()
+                Next
+
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("DateTime")
+            End Using
+        End Function
+
+        <WorkItem(14465, "https://github.com/dotnet/roslyn/issues/14465")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TypingNumberShouldNotDismiss1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void Moo1()
+    {
+        new C()$$
+    }
+}
+            ]]></Document>)
+
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("1")
+                Await state.AssertSelectedCompletionItem("Moo1")
+            End Using
+        End Function
+
+        <WorkItem(14085, "https://github.com/dotnet/roslyn/issues/14085")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypingDoesNotOverrideExactMatch() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+class C
+{
+    void Moo1()
+    {
+        string path = $$
+    }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("Path")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("Path")
+            End Using
+        End Function
+
+        <WorkItem(14085, "https://github.com/dotnet/roslyn/issues/14085")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function MRUOverTargetTyping() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+using System.Threading.Tasks;
+class C
+{
+    async Task Moo()
+    {
+        await Moo().$$
+    }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("Configure")
+                state.SendTab()
+                For i = 1 To "ConfigureAwait".Length
+                    state.SendBackspace()
+                Next
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("ConfigureAwait")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function MovingCaretToStartSoftSelects() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+using System;
+
+class C
+{
+    void M()
+    {
+        $$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("Conso")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Console", isHardSelected:=True)
+                For Each ch In "Conso"
+                    state.SendLeftKey()
+                Next
+
+                Await state.AssertSelectedCompletionItem(displayText:="Console", isHardSelected:=False)
+
+                state.SendRightKey()
+                Await state.AssertSelectedCompletionItem(displayText:="Console", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNoBlockOnCompletionItems1() As Task
+            Dim tcs = New TaskCompletionSource(Of Boolean)
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+                                  using $$
+                              </Document>, {New TaskControlledCompletionProvider(tcs.Task)})
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)
+
+                state.SendTypeChars("Sys.")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("Sys.", state.GetLineTextFromCaretPosition())
+
+                tcs.SetResult(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNoBlockOnCompletionItems2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+                                  using $$
+                              </Document>, {New TaskControlledCompletionProvider(Task.FromResult(True))})
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)
+
+                state.SendTypeChars("Sys")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars(".")
+                Assert.Contains("System.", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNoBlockOnCompletionItems4() As Task
+            Dim tcs = New TaskCompletionSource(Of Boolean)
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+                                  using $$
+                              </Document>, {New TaskControlledCompletionProvider(tcs.Task)})
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)
+
+                state.SendTypeChars("Sys")
+                state.SendCommitUniqueCompletionListItem()
+                Await Task.Delay(250)
+                Await state.AssertNoCompletionSession(block:=False)
+                Assert.Contains("Sys", state.GetLineTextFromCaretPosition())
+                Assert.DoesNotContain("System", state.GetLineTextFromCaretPosition())
+
+                tcs.SetResult(True)
+
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("System", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNoBlockOnCompletionItems3() As Task
+            Dim tcs = New TaskCompletionSource(Of Boolean)
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+                                  using $$
+                              </Document>, {New TaskControlledCompletionProvider(tcs.Task)})
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)
+
+                state.SendTypeChars("Sys")
+                state.SendCommitUniqueCompletionListItem()
+                Await Task.Delay(250)
+                Await state.AssertNoCompletionSession(block:=False)
+                Assert.Contains("Sys", state.GetLineTextFromCaretPosition())
+                Assert.DoesNotContain("System", state.GetLineTextFromCaretPosition())
+
+                state.SendTypeChars("a")
+
+                tcs.SetResult(True)
+
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertCompletionSession()
+                Assert.Contains("Sysa", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        Private Class TaskControlledCompletionProvider
+            Inherits CompletionProvider
+
+            Private ReadOnly _task As Task
+
+            Public Sub New(task As Task)
+                _task = task
+            End Sub
+
+            Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
+                Return _task
+            End Function
+        End Class
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function Filters_EmptyList1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+using System.Threading.Tasks;
+class C
+{
+    async Task Moo()
+    {
+        var x = asd$$
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Dim filters = state.CurrentCompletionPresenterSession.CompletionItemFilters
+                Dim dict = New Dictionary(Of CompletionItemFilter, Boolean)
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                dict(CompletionItemFilter.InterfaceFilter) = True
+
+                Dim args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SelectedItem)
+
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function Filters_EmptyList2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+using System.Threading.Tasks;
+class C
+{
+    async Task Moo()
+    {
+        var x = asd$$
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Dim filters = state.CurrentCompletionPresenterSession.CompletionItemFilters
+                Dim dict = New Dictionary(Of CompletionItemFilter, Boolean)
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                dict(CompletionItemFilter.InterfaceFilter) = True
+
+                Dim args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SelectedItem)
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function Filters_EmptyList3() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+using System.Threading.Tasks;
+class C
+{
+    async Task Moo()
+    {
+        var x = asd$$
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Dim filters = state.CurrentCompletionPresenterSession.CompletionItemFilters
+                Dim dict = New Dictionary(Of CompletionItemFilter, Boolean)
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                dict(CompletionItemFilter.InterfaceFilter) = True
+
+                Dim args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SelectedItem)
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function Filters_EmptyList4() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+using System.Threading.Tasks;
+class C
+{
+    async Task Moo()
+    {
+        var x = asd$$
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Dim filters = state.CurrentCompletionPresenterSession.CompletionItemFilters
+                Dim dict = New Dictionary(Of CompletionItemFilter, Boolean)
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                dict(CompletionItemFilter.InterfaceFilter) = True
+
+                Dim args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SelectedItem)
+                state.SendTypeChars(".")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(15881, "https://github.com/dotnet/roslyn/issues/15881")>
+        Public Async Function CompletionAfterDotBeforeAwaitTask() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.Threading.Tasks;
+
+class C
+{
+    async Task Moo()
+    {
+        Task.$$
+        await Task.Delay(50);
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(14704, "https://github.com/dotnet/roslyn/issues/14704")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspaceTriggerSubstringMatching() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+using System;
+class Program
+{
+    static void Main(string[] args)
+    {
+        if (Environment$$
+    }
+}
+                              </Document>)
+
+                Dim key = New OptionKey(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp)
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(key, True)
+
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem(displayText:="Environment", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WorkItem(16236, "https://github.com/dotnet/roslyn/issues/16236")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AttributeNamedParameterEqualsItemCommittedOnSpace() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+[A($$)]
+class AAttribute: Attribute
+{
+    public string Skip { get; set; }
+} </Document>)
+                state.SendTypeChars("Skip")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+                Assert.Equal("[A(Skip )]", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(362890, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=362890")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestFilteringAfterSimpleInvokeShowsAllItemsMatchingFilter() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+
+enum Color
+{
+    Red,
+    Green,
+    Blue
+}
+
+class C
+{
+    void M()
+    {
+        Color.Re$$d
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Red")
+                state.CompletionItemsContainsAll(displayText:={"Red", "Green", "Blue", "Equals"})
+
+                Dim filters = state.CurrentCompletionPresenterSession.CompletionItemFilters
+                Dim dict = New Dictionary(Of CompletionItemFilter, Boolean)
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                dict(CompletionItemFilter.EnumFilter) = True
+
+                Dim args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.AssertSelectedCompletionItem("Red")
+                state.CompletionItemsContainsAll(displayText:={"Red", "Green", "Blue"})
+                Assert.False(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "Equals"))
+
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.AssertSelectedCompletionItem("Red")
+                state.CompletionItemsContainsAll(displayText:={"Red", "Green", "Blue", "Equals"})
+
+            End Using
+        End Function
+
+        <WorkItem(16236, "https://github.com/dotnet/roslyn/issues/16236")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NameCompletionSorting() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+interface ISyntaxFactsService {}
+class C
+{
+    void M()
+    {
+        ISyntaxFactsService $$
+    }
+} </Document>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+
+                Dim expectedOrder =
+                    {
+                        "syntaxFactsService",
+                        "syntaxFacts",
+                        "factsService",
+                        "syntax",
+                        "service"
+                    }
+
+                state.AssertItemsInOrder(expectedOrder)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub TestLargeChangeBrokenUpIntoSmallTextChanges()
+            Dim provider = New MultipleChangeCompletionProvider()
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class C
+{
+    void goo() {
+        return $$
+    }
+}]]></Document>, {provider})
+
+                Dim testDocument = state.Workspace.Documents(0)
+                Dim textBuffer = testDocument.TextBuffer
+
+                Dim snapshotBeforeCommit = textBuffer.CurrentSnapshot
+                provider.SetInfo(snapshotBeforeCommit.GetText(), testDocument.CursorPosition.Value)
+
+                ' First send a space to trigger out special completion provider.
+                state.SendInvokeCompletionList()
+                state.SendTab()
+
+                ' Verify that we see the entire change
+                Dim finalText = textBuffer.CurrentSnapshot.GetText()
+                Assert.Equal(
+"using NewUsing;
+using System;
+class C
+{
+    void goo() {
+        return InsertedItem
+    }
+}", finalText)
+
+                ' This should have happened as two text changes to the buffer.
+                Dim changes = snapshotBeforeCommit.Version.Changes
+                Assert.Equal(2, changes.Count)
+
+                Dim actualChanges = changes.ToArray()
+                Dim firstChange = actualChanges(0)
+                Assert.Equal(New Span(0, 0), firstChange.OldSpan)
+                Assert.Equal("using NewUsing;", firstChange.NewText)
+
+                Dim secondChange = actualChanges(1)
+                Assert.Equal(New Span(testDocument.CursorPosition.Value, 0), secondChange.OldSpan)
+                Assert.Equal("InsertedItem", secondChange.NewText)
+
+                ' Make sure new edits happen after the text that was inserted.
+                state.SendTypeChars("1")
+
+                finalText = textBuffer.CurrentSnapshot.GetText()
+                Assert.Equal(
+"using NewUsing;
+using System;
+class C
+{
+    void goo() {
+        return InsertedItem1
+    }
+}", finalText)
+            End Using
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub TestLargeChangeBrokenUpIntoSmallTextChanges2()
+            Dim provider = New MultipleChangeCompletionProvider()
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+class C
+{
+    void goo() {
+        return Custom$$
+    }
+}]]></Document>, {provider})
+
+                Dim testDocument = state.Workspace.Documents(0)
+                Dim textBuffer = testDocument.TextBuffer
+
+                Dim snapshotBeforeCommit = textBuffer.CurrentSnapshot
+                provider.SetInfo(snapshotBeforeCommit.GetText(), testDocument.CursorPosition.Value)
+
+                ' First send a space to trigger out special completion provider.
+                state.SendInvokeCompletionList()
+                state.SendTab()
+
+                ' Verify that we see the entire change
+                Dim finalText = textBuffer.CurrentSnapshot.GetText()
+                Assert.Equal(
+"using NewUsing;
+using System;
+class C
+{
+    void goo() {
+        return InsertedItem
+    }
+}", finalText)
+
+                ' This should have happened as two text changes to the buffer.
+                Dim changes = snapshotBeforeCommit.Version.Changes
+                Assert.Equal(2, changes.Count)
+
+                Dim actualChanges = changes.ToArray()
+                Dim firstChange = actualChanges(0)
+                Assert.Equal(New Span(0, 0), firstChange.OldSpan)
+                Assert.Equal("using NewUsing;", firstChange.NewText)
+
+                Dim secondChange = actualChanges(1)
+                Assert.Equal(New Span(testDocument.CursorPosition.Value - "Custom".Length, "Custom".Length), secondChange.OldSpan)
+                Assert.Equal("InsertedItem", secondChange.NewText)
+
+                ' Make sure new edits happen after the text that was inserted.
+                state.SendTypeChars("1")
+
+                finalText = textBuffer.CurrentSnapshot.GetText()
+                Assert.Equal(
+"using NewUsing;
+using System;
+class C
+{
+    void goo() {
+        return InsertedItem1
+    }
+}", finalText)
+            End Using
+        End Sub
+
+        <WorkItem(296512, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=296512")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestRegionDirectiveIndentation() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    $$
+}
+                              </Document>, includeFormatCommandHandler:=True)
+
+                state.SendTypeChars("#")
+                Await state.WaitForAsynchronousOperationsAsync()
+
+                Assert.Equal("#", state.GetLineFromCurrentCaretPosition().GetText())
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("reg")
+                Await state.AssertSelectedCompletionItem(displayText:="region")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Assert.Equal("    #region", state.GetLineFromCurrentCaretPosition().GetText())
+                Assert.Equal(state.GetLineFromCurrentCaretPosition().End, state.GetCaretPoint().BufferPosition)
+
+                state.SendReturn()
+                Assert.Equal("", state.GetLineFromCurrentCaretPosition().GetText())
+                state.SendTypeChars("#")
+                Await state.WaitForAsynchronousOperationsAsync()
+
+                Assert.Equal("#", state.GetLineFromCurrentCaretPosition().GetText())
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("endr")
+                Await state.AssertSelectedCompletionItem(displayText:="endregion")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Assert.Equal("    #endregion", state.GetLineFromCurrentCaretPosition().GetText())
+                Assert.Equal(state.GetLineFromCurrentCaretPosition().End, state.GetCaretPoint().BufferPosition)
+
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AfterIdentifierInCaseLabel() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void M()
+    {
+        switch (true)
+        {
+            case identifier $$
+        }
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("w")
+                Await state.AssertSelectedCompletionItem(displayText:="when", isHardSelected:=False)
+
+                state.SendBackspace()
+                state.SendTypeChars("i")
+                Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
+
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AfterIdentifierInCaseLabel_ColorColor() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class identifier { }
+class C
+{
+    const identifier identifier = null;
+    void M()
+    {
+        switch (true)
+        {
+            case identifier $$
+        }
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("w")
+                Await state.AssertSelectedCompletionItem(displayText:="when", isHardSelected:=False)
+
+                state.SendBackspace()
+                state.SendTypeChars("i")
+                Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
+
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AfterIdentifierInCaseLabel_ClassNameOnly() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class identifier { }
+class C
+{
+    void M()
+    {
+        switch (true)
+        {
+            case identifier $$
+        }
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("w")
+                Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
+
+                state.SendBackspace()
+                state.SendTypeChars("i")
+                Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
+
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AfterDoubleIdentifierInCaseLabel() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void M()
+    {
+        switch (true)
+        {
+            case identifier identifier $$
+        }
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("w")
+                Await state.AssertSelectedCompletionItem(displayText:="when", isHardSelected:=True)
+
+            End Using
+        End Function
+
+        Private Class MultipleChangeCompletionProvider
+            Inherits CompletionProvider
+
+            Private _text As String
+            Private _caretPosition As Integer
+
+            Public Sub SetInfo(text As String, caretPosition As Integer)
+                _text = text
+                _caretPosition = caretPosition
+            End Sub
+
+            Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
+                context.AddItem(CompletionItem.Create(
+                    "CustomItem",
+                    rules:=CompletionItemRules.Default.WithMatchPriority(1000)))
+                Return Task.CompletedTask
+            End Function
+
+            Public Overrides Function ShouldTriggerCompletion(text As SourceText, caretPosition As Integer, trigger As CompletionTrigger, options As OptionSet) As Boolean
+                Return True
+            End Function
+
+            Public Overrides Function GetChangeAsync(document As Document, item As CompletionItem, commitKey As Char?, cancellationToken As CancellationToken) As Task(Of CompletionChange)
+                Dim newText =
+"using NewUsing;
+using System;
+class C
+{
+    void goo() {
+        return InsertedItem"
+
+                Dim change = CompletionChange.Create(
+                    New TextChange(New TextSpan(0, _caretPosition), newText))
+                Return Task.FromResult(change)
+            End Function
+
+            <WorkItem(15348, "https://github.com/dotnet/roslyn/issues/15348")>
+            <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+            Public Async Function TestAfterCasePatternSwitchLabel() As Task
+                Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void M()
+    {
+        object o = 1;
+        switch(o)
+        {
+            case int i:
+                $$
+                break;
+        }
+    }
+}
+                              </Document>)
+
+                    state.SendTypeChars("this")
+                    Await state.AssertSelectedCompletionItem(displayText:="this", isHardSelected:=True)
+                End Using
+            End Function
+        End Class
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -1,0 +1,605 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.OldCompletion
+    ''' <summary>
+    ''' This is a test file corresponding to the old Completion service which we are going to turn off after migration to the new one.
+    ''' We should keep this file up-to-date and on par with the new file until then.
+    ''' </summary>
+    <[UseExportProvider]>
+    Public Class CSharpCompletionCommandHandlerTests_InternalsVisibleTo
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOtherAssembliesOfSolution() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1", "ClassLibrary2", "ClassLibrary3"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOtherAssemblyIfAttributeSuffixIsPresent() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsTriggeredWhenDoubleQuoteIsEntered() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo($$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars(""""c)
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsEmptyUntilDoubleQuotesAreEntered() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                state.SendTypeChars("("c)
+                Await state.AssertNoCompletionSession()
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                state.SendTypeChars(""""c)
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsTriggeredWhenCharacterIsEnteredAfterOpeningDoubleQuote() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("a"c)
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsNotTriggeredWhenCharacterIsEnteredThatIsNotRightBesideTheOpeniningDoubleQuote() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("a$$")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("b"c)
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsNotTriggeredWhenDoubleQuoteIsEnteredAtStartOfFile() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("a"c)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsNotTriggeredByArrayElementAccess() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs"><![CDATA[
+namespace A
+{
+    public class C
+    {
+        public void M()
+        {
+            var d = new System.Collections.Generic.Dictionary<string, string>();
+            var v = d$$;
+        }
+    }
+}
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Dim AssertNoCompletionAndCompletionDoesNotContainClassLibrary1 As Func(Of Task) =
+                    Async Function()
+                        Await state.AssertNoCompletionSession()
+                        state.SendInvokeCompletionList()
+                        Await state.WaitForAsynchronousOperationsAsync()
+                        Assert.True(
+                            state.CurrentCompletionPresenterSession Is Nothing OrElse
+                            Not state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                    End Function
+                Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
+                state.SendTypeChars("["c)
+                Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
+                state.SendTypeChars(""""c)
+                Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
+            End Using
+        End Function
+
+        Private Async Function AssertCompletionListHasItems(code As String, hasItems As Boolean) As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
+<%= code %>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                If hasItems Then
+                    Await state.AssertCompletionSession()
+                    Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+                Else
+                    Await state.AssertNoCompletionSession
+                End If
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_AfterSingleDoubleQuoteAndClosing() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""$$)]", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_AfterText() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""Test$$)]", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfCursorIsInSecondParameter() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""Test"", ""$$", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasNoItems_IfCursorIsClosingDoubleQuote1() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""Test""$$", False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasNoItems_IfCursorIsClosingDoubleQuote2() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""""$$", False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfNamedParameterIsPresent() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""$$, AllInternalsVisible = true)]", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfNamedParameterAndNamedPositionalParametersArePresent() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(assemblyName: ""$$, AllInternalsVisible = true)]", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasNoItems_IfNumberIsEntered() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(1$$2)]", False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasNoItems_IfNotInternalsVisibleToAttribute() As Task
+            Await AssertCompletionListHasItems("[assembly: AssemblyVersion(""$$"")]", False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfOtherAttributeIsPresent1() As Task
+            Await AssertCompletionListHasItems("[assembly: AssemblyVersion(""1.0.0.0""), InternalsVisibleTo(""$$", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfOtherAttributeIsPresent2() As Task
+            Await AssertCompletionListHasItems("[assembly: InternalsVisibleTo(""$$""), AssemblyVersion(""1.0.0.0"")]", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfOtherAttributesAreAhead() As Task
+            Await AssertCompletionListHasItems("
+                [assembly: AssemblyVersion(""1.0.0.0"")]
+                [assembly: InternalsVisibleTo(""$$", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfOtherAttributesAreFollowing() As Task
+            Await AssertCompletionListHasItems("
+            [assembly: InternalsVisibleTo(""$$
+            [assembly: AssemblyVersion(""1.0.0.0"")]
+            [assembly: AssemblyCompany(""Test"")]", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfNamespaceIsFollowing() As Task
+            Await AssertCompletionListHasItems("
+            [assembly: InternalsVisibleTo(""$$
+            namespace A {            
+                public class A { }
+            }", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionHasItemsIfInteralVisibleToIsReferencedByTypeAlias() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
+[assembly: IVT("$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionDoesNotContainCurrentAssembly() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"TestAssembly"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionInsertsAssemblyNameOnCommit() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    </Project>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document>
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("ClassLibrary1")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1"")]")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionInsertsPublicKeyOnCommit() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
+                        <CompilationOptions
+                            CryptoKeyFile=<%= SigningTestHelpers.PublicKeyFile %>
+                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
+                    </Project>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document>
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("ClassLibrary1")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsPublicKeyIfKeyIsSpecifiedByAttribute() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
+                        <CompilationOptions
+                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
+                        <Document>
+                            [assembly: System.Reflection.AssemblyKeyFile("<%= SigningTestHelpers.PublicKeyFile.Replace("\", "\\") %>")]
+                        </Document>
+                    </Project>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document>
+    [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("ClassLibrary1")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsPublicKeyIfDelayedSigningIsEnabled() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1">
+                        <CompilationOptions
+                            CryptoKeyFile=<%= SigningTestHelpers.PublicKeyFile %>
+                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>
+                            DelaySign="True"/>
+                    </Project>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document>
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("ClassLibrary1")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionListIsEmptyIfAttributeIsNotTheBCLAttribute() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: Test.InternalsVisibleTo("$$")]
+namespace Test
+{
+    [System.AttributeUsage(System.AttributeTargets.Assembly)]
+    public sealed class InternalsVisibleToAttribute: System.Attribute
+    {
+        public InternalsVisibleToAttribute(string ignore)
+        {
+
+        }
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVT() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary1")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary3"}))
+            End Using
+        End Function
+
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTIfAssemblyNameIsAConstant() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <MetadataReferenceFromSource Language="C#" CommonReferences="true">
+                            <Document FilePath="ReferencedDocument.cs">
+namespace A {
+    public static class Constants
+    {
+        public const string AssemblyName1 = "ClassLibrary1";
+    }
+}
+                            </Document>
+                        </MetadataReferenceFromSource>
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(A.Constants.AssemblyName1)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary3"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTForDifferentSyntax() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary4"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary5"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary6"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary7"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary8"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary9"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+// Code comment
+using System.Runtime.CompilerServices;
+using System.Reflection;
+using IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute;
+// Code comment
+[assembly: InternalsVisibleTo("ClassLibrary1", AllInternalsVisible = true)]
+[assembly: InternalsVisibleTo(assemblyName: "ClassLibrary2", AllInternalsVisible = true)]
+[assembly: AssemblyVersion("1.0.0.0"), InternalsVisibleTo("ClassLibrary3")]
+[assembly: InternalsVisibleTo("ClassLibrary4"), AssemblyCopyright("Copyright")]
+[assembly: AssemblyDescription("Description")]
+[assembly: InternalsVisibleTo("ClassLibrary5")]
+[assembly: InternalsVisibleTo("ClassLibrary6, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb")]
+[assembly: InternalsVisibleTo("ClassLibrary" + "7")]
+[assembly: IVT("ClassLibrary8")]
+[assembly: InternalsVisibleTo("$$
+namespace A {
+    public class A { }
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2", "ClassLibrary3", "ClassLibrary4", "ClassLibrary5", "ClassLibrary6", "ClassLibrary7", "ClassLibrary8"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary9"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTWithSyntaxError() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
+
+[assembly: InternalsVisibleTo("ClassLibrary" + 1)] // Not a constant
+[assembly: InternalsVisibleTo("$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                ' ClassLibrary1 must be listed because the existing attribute argument can't be resolved to a constant.
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTWithMoreThanOneDocument() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="OtherDocument.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
+[assembly: InternalsVisibleTo("ClassLibrary1")]
+[assembly: AssemblyDescription("Description")]
+                        </Document>
+                        <Document FilePath="C.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
+[assembly: InternalsVisibleTo("$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary2"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIgnoresUnsupportedProjectTypes() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="NoCompilation" AssemblyName="ClassLibrary1"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+using System.Runtime.CompilerServices;
+using System.Reflection;
+[assembly: InternalsVisibleTo("$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpCompletionCommandHandlerTests_Projections.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpCompletionCommandHandlerTests_Projections.vb
@@ -1,0 +1,154 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.VisualStudio.Text.Projection
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.OldCompletion
+    ''' <summary>
+    ''' This is a test file corresponding to the old Completion service which we are going to turn off after migration to the new one.
+    ''' We should keep this file up-to-date and on par with the new file until then.
+    ''' </summary>
+    <[UseExportProvider]>
+    Public Class CSharpCompletionCommandHandlerTests_Projections
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSimpleWithJustSubjectBuffer() As System.Threading.Tasks.Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+
+public class _Page_Default_cshtml : System.Web.WebPages.WebPage {
+private static object @__o;
+#line hidden
+
+public override void Execute() {
+
+#line 1 "Default.cshtml"
+               __o = AppDomain$$
+#line default
+#line hidden
+}
+}]]></Document>)
+
+                state.SendTypeChars(".Curr")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="CurrentDomain")
+                state.SendTab()
+                Assert.Contains("__o = AppDomain.CurrentDomain", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestAfterDot() As System.Threading.Tasks.Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+{|S2:
+class C
+{
+    void Goo()
+    {
+        System$$
+    }
+}
+|}]]></Document>)
+                Dim subjectDocument = state.Workspace.Documents.First()
+                Dim firstProjection = state.Workspace.CreateProjectionBufferDocument(
+                    <Document>
+{|S1: &lt;html&gt;@|}
+{|S2:|}
+                    </Document>.NormalizedValue, {subjectDocument}, LanguageNames.CSharp, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+                Dim topProjectionBuffer = state.Workspace.CreateProjectionBufferDocument(
+                <Document>
+{|S1:|}
+{|S2:&lt;/html&gt;|}
+                              </Document>.NormalizedValue, {firstProjection}, LanguageNames.CSharp, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+
+                Dim view = topProjectionBuffer.GetTextView()
+                Dim buffer = subjectDocument.GetTextBuffer()
+
+                state.SendTypeCharsToSpecificViewAndBuffer(".", view, buffer)
+                Await state.AssertCompletionSession()
+
+                state.SendTypeCharsToSpecificViewAndBuffer("Cons", view, buffer)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Console")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestInObjectCreationExpression() As System.Threading.Tasks.Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+{|S2:
+class C
+{
+    void Goo()
+    {
+        string s = new$$
+    }
+}
+|}]]></Document>)
+                Dim subjectDocument = state.Workspace.Documents.First()
+                Dim firstProjection = state.Workspace.CreateProjectionBufferDocument(
+                    <Document>
+{|S1: &lt;html&gt;@|}
+{|S2:|}
+                    </Document>.NormalizedValue, {subjectDocument}, LanguageNames.CSharp, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+                Dim topProjectionBuffer = state.Workspace.CreateProjectionBufferDocument(
+                <Document>
+{|S1:|}
+{|S2:&lt;/html&gt;|}
+                              </Document>.NormalizedValue, {firstProjection}, LanguageNames.CSharp, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+
+                Dim view = topProjectionBuffer.GetTextView()
+                Dim buffer = subjectDocument.GetTextBuffer()
+
+                state.SendTypeCharsToSpecificViewAndBuffer(" ", view, buffer)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="string", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WorkItem(771761, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/771761")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/24846"), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestRegionCompletionCommitFormatting() As System.Threading.Tasks.Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+{|S2:
+class C
+{
+    void Goo()
+    {
+        $$
+    }
+}
+|}]]></Document>)
+                Dim subjectDocument = state.Workspace.Documents.First()
+                Dim firstProjection = state.Workspace.CreateProjectionBufferDocument(
+                    <Document>
+{|S1: &lt;html&gt;@|}
+{|S2:|}
+                    </Document>.NormalizedValue, {subjectDocument}, LanguageNames.CSharp, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+                Dim topProjectionBuffer = state.Workspace.CreateProjectionBufferDocument(
+                <Document>
+{|S1:|}
+{|S2:&lt;/html&gt;|}
+                              </Document>.NormalizedValue, {firstProjection}, LanguageNames.CSharp, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+
+                Dim view = topProjectionBuffer.GetTextView()
+                Dim buffer = subjectDocument.GetTextBuffer()
+
+                state.SendTypeCharsToSpecificViewAndBuffer("#reg", view, buffer)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="region", shouldFormatOnCommit:=True)
+
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpCompletionCommandHandlerTests_XmlDoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpCompletionCommandHandlerTests_XmlDoc.vb
@@ -1,0 +1,1245 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.OldCompletion
+    ''' <summary>
+    ''' This is a test file corresponding to the old Completion service which we are going to turn off after migration to the new one.
+    ''' We should keep this file up-to-date and on par with the new file until then.
+    ''' </summary>
+    <[UseExportProvider]>
+    Public Class CSharpCompletionCommandHandlerTests_XmlDoc
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSummary() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Await state.AssertLineTextAroundCaret("    /// summary", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSummaryOnTab() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' /// summary$$
+                Await state.AssertLineTextAroundCaret("    /// summary", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSummaryOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// summary>$$
+                Await state.AssertLineTextAroundCaret("    /// summary>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSummary() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <summary$$
+                Await state.AssertLineTextAroundCaret("    /// <summary", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSummaryOnTab() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <summary$$
+                Await state.AssertLineTextAroundCaret("    /// <summary", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSummaryOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <summary>$$
+                Await state.AssertLineTextAroundCaret("    /// <summary>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitRemarksOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("rema")
+                Await state.AssertSelectedCompletionItem(displayText:="remarks")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// remarks>$$
+                Await state.AssertLineTextAroundCaret("    /// remarks>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitRemarksOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("rema")
+                Await state.AssertSelectedCompletionItem(displayText:="remarks")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <remarks>$$
+                Await state.AssertLineTextAroundCaret("    /// <remarks>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitReturnsOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    int goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("retur")
+                Await state.AssertSelectedCompletionItem(displayText:="returns")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// returns>$$
+                Await state.AssertLineTextAroundCaret("    /// returns>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitReturnsOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    int goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("retur")
+                Await state.AssertSelectedCompletionItem(displayText:="returns")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <returns>$$
+                Await state.AssertLineTextAroundCaret("    /// <returns>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitExampleOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("examp")
+                Await state.AssertSelectedCompletionItem(displayText:="example")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// example>$$
+                Await state.AssertLineTextAroundCaret("    /// example>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitExampleOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("examp")
+                Await state.AssertSelectedCompletionItem(displayText:="example")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <example>$$
+                Await state.AssertLineTextAroundCaret("    /// <example>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitExceptionNoOpenAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("except")
+                Await state.AssertSelectedCompletionItem(displayText:="exception")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <exception cref="$$"
+                Await state.AssertLineTextAroundCaret("    /// <exception cref=""", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitExceptionOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("except")
+                Await state.AssertSelectedCompletionItem(displayText:="exception")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <exception cref=">$$"
+                Await state.AssertLineTextAroundCaret("    /// <exception cref="">", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitCommentNoOpenAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendSelectCompletionItem("!--")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <!--$$-->
+                Await state.AssertLineTextAroundCaret("    /// <!--", "-->")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitCommentOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendSelectCompletionItem("!--")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <!-->$$-->
+                Await state.AssertLineTextAroundCaret("    /// <!-->", "-->")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitCdataNoOpenAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("![CDAT")
+                Await state.AssertSelectedCompletionItem(displayText:="![CDATA[")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <![CDATA[$$]]>
+                Await state.AssertLineTextAroundCaret("    /// <![CDATA[", "]]>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitCdataOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("![CDAT")
+                Await state.AssertSelectedCompletionItem(displayText:="![CDATA[")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <![CDATA[>$$]]>
+                Await state.AssertLineTextAroundCaret("    /// <![CDATA[>", "]]>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitIncludeNoOpenAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("inclu")
+                Await state.AssertSelectedCompletionItem(displayText:="include")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <include file='$$' path='[@name=""]'/>
+                Await state.AssertLineTextAroundCaret("    /// <include file='", "' path='[@name=""""]'/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitIncludeOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("inclu")
+                Await state.AssertSelectedCompletionItem(displayText:="include")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <include file='>$$' path='[@name=""]'/>
+                Await state.AssertLineTextAroundCaret("    /// <include file='>", "' path='[@name=""""]'/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitPermissionNoOpenAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("permiss")
+                Await state.AssertSelectedCompletionItem(displayText:="permission")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <permission cref="$$"
+                Await state.AssertLineTextAroundCaret("    /// <permission cref=""", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitPermissionOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("permiss")
+                Await state.AssertSelectedCompletionItem(displayText:="permission")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <permission cref=">$$"
+                Await state.AssertLineTextAroundCaret("    /// <permission cref="">", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSeeNoOpenAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("see")
+                Await state.AssertSelectedCompletionItem(displayText:="see")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <see cref="$$"/>
+                Await state.AssertLineTextAroundCaret("    /// <see cref=""", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSeeOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("see")
+                Await state.AssertSelectedCompletionItem(displayText:="see")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <see cref=">$$"/>
+                Await state.AssertLineTextAroundCaret("    /// <see cref="">", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")>
+        Public Async Function InvokeWithOpenAngleCommitSeeOnTab() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("se")
+                Await state.AssertSelectedCompletionItem(displayText:="see")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <see cref="$$"/>
+                Await state.AssertLineTextAroundCaret("    /// <see cref=""", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSeeOnSpace() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// <summary>
+    /// $$
+    /// </summary>
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("see")
+                Await state.AssertSelectedCompletionItem(displayText:="see")
+                state.SendTypeChars(" ")
+
+                ' /// <see cref="$$"/>
+                Await state.AssertLineTextAroundCaret("    /// <see cref=""", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithNullKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("null")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithStaticKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("static")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithVirtualKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("virtual")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithTrueKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("true")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithFalseKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("false")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithAbstractKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("abstract")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithSealedKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("sealed")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithAsyncKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("async")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithAwaitKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("await")
+        End Function
+
+        Private Async Function InvokeWithKeywordCommitSeeLangword(keyword As String) As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// <summary>
+    /// $$
+    /// </summary>
+    void goo() { }
+}
+            ]]></Document>)
+
+                ' Omit the last letter of the keyword to make it easier to diagnose failures (inserted the wrong text,
+                ' or did not insert text at all).
+                state.SendTypeChars(keyword.Substring(0, keyword.Length - 1))
+                state.SendInvokeCompletionList()
+                state.SendCommitUniqueCompletionListItem()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <see langword="keyword"/>$$
+                Await state.AssertLineTextAroundCaret("    /// <see langword=""" + keyword + """/>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSeealsoNoOpenAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("seeal")
+                Await state.AssertSelectedCompletionItem(displayText:="seealso")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <seealso cref="$$"/>
+                Await state.AssertLineTextAroundCaret("    /// <seealso cref=""", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSeealsoOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("seeal")
+                Await state.AssertSelectedCompletionItem(displayText:="seealso")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <seealso cref=">$$"/>
+                Await state.AssertLineTextAroundCaret("    /// <seealso cref="">", """/>")
+            End Using
+        End Function
+
+        <WorkItem(623219, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/623219")>
+        <WorkItem(746919, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/746919")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitParam() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// <param$$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    /// <param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitParamNoOpenAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    /// param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitParamNoOpenAngleOnTab() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' /// param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    /// param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitParamNoOpenAngleOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// param name="bar">$$
+                Await state.AssertLineTextAroundCaret("    /// param name=""bar"">", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitParam() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    /// <param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitParamOnTab() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    /// <param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitParamOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <param name="bar">$$
+                Await state.AssertLineTextAroundCaret("    /// <param name=""bar"">", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitTypeparamNoOpenAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// typeparam name="T"$$
+                Await state.AssertLineTextAroundCaret("    /// typeparam name=""T""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitTypeparamNoOpenAngleOnTab() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' /// typeparam name="T"$$
+                Await state.AssertLineTextAroundCaret("    /// typeparam name=""T""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitTypeparamNoOpenAngleOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// typeparam name="T">$$
+                Await state.AssertLineTextAroundCaret("    /// typeparam name=""T"">", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitTypeparam() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <typeparam name="T"$$
+                Await state.AssertLineTextAroundCaret("    /// <typeparam name=""T""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitTypeparamOnTab() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <typeparam name="T"$$
+                Await state.AssertLineTextAroundCaret("    /// <typeparam name=""T""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitTypeparamOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// $$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <typeparam name="T">$$
+                Await state.AssertLineTextAroundCaret("    /// <typeparam name=""T"">", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitList() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// <summary>
+    /// $$
+    /// </summary>
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("lis")
+                Await state.AssertSelectedCompletionItem(displayText:="list")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <list type="$$"
+                Await state.AssertLineTextAroundCaret("    /// <list type=""", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitListOnCloseAngle() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// <summary>
+    /// $$
+    /// </summary>
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("lis")
+                Await state.AssertSelectedCompletionItem(displayText:="list")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <list type=">$$"
+                Await state.AssertLineTextAroundCaret("    /// <list type="">", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestTagCompletion1() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// <$$
+    /// </summary>
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summa")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <summary>$$
+                Await state.AssertLineTextAroundCaret("    /// <summary>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestTagCompletion2() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// <$$
+    /// <remarks></remarks>
+    /// </summary>
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summa")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <summary>$$
+                Await state.AssertLineTextAroundCaret("    /// <summary>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestTagCompletion3() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c<T>
+{
+    /// <$$
+    /// <remarks>
+    /// </summary>
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summa")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' /// <summary>$$
+                Await state.AssertLineTextAroundCaret("    /// <summary>", "")
+            End Using
+        End Function
+
+        <WorkItem(638653, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638653")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/21481"), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AllowTypingDoubleQuote() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// <param$$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTypeChars(" name=""")
+
+                ' /// <param name="$$
+                Await state.AssertLineTextAroundCaret("    /// <param name=""", "")
+
+                ' Because the item contains a double quote, the completion list should still be present with the same selection
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+            End Using
+        End Function
+
+        <WorkItem(638653, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638653")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AllowTypingSpace() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// <param$$
+    void goo<T>(T bar) { }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTypeChars(" ")
+
+                ' /// <param $$
+                Await state.AssertLineTextAroundCaret("    /// <param ", "")
+
+                ' Because the item contains a space, the completion list should still be present with the same selection
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpIntelliSenseCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/OldCompletion/CSharpIntelliSenseCommandHandlerTests.vb
@@ -1,0 +1,110 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.OldCompletion
+    ''' <summary>
+    ''' This is a test file corresponding to the old Completion service which we are going to turn off after migration to the new one.
+    ''' We should keep this file up-to-date and on par with the new file until then.
+    ''' </summary>
+    <[UseExportProvider]>
+    Public Class CSharpIntelliSenseCommandHandlerTests
+        <WpfFact>
+        Public Async Function TestOpenParenDismissesCompletionAndBringsUpSignatureHelp1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void Goo()
+    {
+        $$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("Go")
+                Await state.AssertCompletionSession()
+                Await state.AssertNoSignatureHelpSession()
+                state.SendTypeChars("(")
+                Await state.AssertNoCompletionSession()
+                Await state.AssertSignatureHelpSession()
+                Await state.AssertSelectedSignatureHelpItem(displayText:="void C.Goo()")
+                Assert.Contains("Goo(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(543913, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543913")>
+        <WpfFact>
+        Public Async Function TestEscapeDismissesCompletionFirst() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void Goo()
+    {
+        $$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("Goo(a")
+                Await state.AssertCompletionSession()
+                Await state.AssertSignatureHelpSession()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendEscape()
+                Await state.AssertNoCompletionSession()
+                Await state.AssertSignatureHelpSession()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendEscape()
+                Await state.AssertNoCompletionSession()
+                Await state.AssertNoSignatureHelpSession()
+            End Using
+        End Function
+
+        <WorkItem(531149, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531149")>
+        <WpfFact>
+        Public Async Function TestCutDismissesCompletion() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void Goo()
+    {
+        $$
+    }
+}
+                              </Document>)
+                state.SendTypeChars("Goo(a")
+                Await state.AssertCompletionSession()
+                Await state.AssertSignatureHelpSession()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendCut()
+                Await state.AssertNoCompletionSession()
+                Await state.AssertSignatureHelpSession()
+            End Using
+        End Function
+
+        <WorkItem(531149, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531149")>
+        <WpfFact>
+        Public Async Function TestPasteDismissesCompletion() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void Goo()
+    {
+        $$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("Goo(a")
+                Await state.AssertCompletionSession()
+                Await state.AssertSignatureHelpSession()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendPaste()
+                Await state.AssertNoCompletionSession()
+                Await state.AssertSignatureHelpSession()
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/OldCompletion/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/OldCompletion/VisualBasicCompletionCommandHandlerTests.vb
@@ -1,0 +1,2976 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Snippets
+Imports Microsoft.CodeAnalysis.Tags
+Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Operations
+Imports Microsoft.VisualStudio.Text.Projection
+Imports Roslyn.Utilities
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.OldCompletion
+    ''' <summary>
+    ''' This is a test file corresponding to the old Completion service which we are going to turn off after migration to the new one.
+    ''' We should keep this file up-to-date and on par with the new file until then.
+    ''' </summary>
+    <[UseExportProvider]>
+    Public Class VisualBasicCompletionCommandHandlerTests
+        <WorkItem(546208, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546208")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function MultiWordKeywordCommitBehavior() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Class C
+    Sub M()
+        $$
+    End Sub
+End Class
+                              </Document>)
+                state.SendTypeChars("on")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("On Error GoTo", description:=String.Format(FeaturesResources._0_Keyword, "On Error GoTo") + vbCrLf + VBFeaturesResources.Enables_the_error_handling_routine_that_starts_at_the_line_specified_in_the_line_argument_The_specified_line_must_be_in_the_same_procedure_as_the_On_Error_statement_On_Error_GoTo_bracket_label_0_1_bracket)
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("On Error GoTo", description:=String.Format(FeaturesResources._0_Keyword, "On Error GoTo") + vbCrLf + VBFeaturesResources.Enables_the_error_handling_routine_that_starts_at_the_line_specified_in_the_line_argument_The_specified_line_must_be_in_the_same_procedure_as_the_On_Error_statement_On_Error_GoTo_bracket_label_0_1_bracket)
+            End Using
+        End Function
+
+        <WorkItem(546208, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546208")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function MultiWordKeywordCommitBehavior2() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Class C
+    Sub M()
+        $$
+    End Sub
+End Class
+                              </Document>)
+
+                state.SendTypeChars("next")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("On Error Resume Next", description:=String.Format(FeaturesResources._0_Keyword, "On Error Resume Next") + vbCrLf + VBFeaturesResources.When_a_run_time_error_occurs_execution_transfers_to_the_statement_following_the_statement_or_procedure_call_that_resulted_in_the_error)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionNotShownWhenBackspacingThroughWhitespace() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                  Module M
+                                      Sub Goo()
+                                          If True Then $$Console.WriteLine()
+                                      End Sub
+                                  End Module
+                              </Document>)
+
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion), WorkItem(541032, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541032")>
+        Public Async Function CompletionNotShownWhenBackspacingThroughNewline() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Module Program
+    Sub Main()
+        If True And
+$$False Then
+         End If
+    End Sub
+End Module
+                              </Document>)
+
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionAdjustInsertionText_CommitsOnOpenParens1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                  Module M
+                                    Sub FogBar()
+                                    End Sub
+                                    Sub test()
+                                      $$
+                                    End Sub
+                                  End Module
+                              </document>)
+
+                state.SendTypeChars("Fog(")
+                Await state.AssertCompletionSession()
+
+                Assert.Contains("    FogBar(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionUpAfterDot() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                Class Program
+                                    Sub Main(args As String())
+                                        Program$$
+                                    End Sub
+                                End Class
+                              </document>)
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(546432, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546432")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub ImplementsCompletionFaultTolerance()
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                  Imports System
+                                  Class C
+                                      Sub Goo() Implements ICloneable$$
+                                  End Module
+                              </Document>)
+
+                state.SendTypeChars(".")
+            End Using
+        End Sub
+
+        <WorkItem(5487, "https://github.com/dotnet/roslyn/issues/5487")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCommitCharTypedAtTheBeginingOfTheFilterSpan() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Fuction F() As Boolean
+        If $$
+    End Function
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("tru")
+                Await state.AssertCompletionSession()
+                state.SendLeftKey()
+                state.SendLeftKey()
+                state.SendLeftKey()
+                Await state.AssertSelectedCompletionItem(isSoftSelected:=True)
+                state.SendTypeChars("(")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal("If (tru", state.GetLineTextFromCaretPosition().Trim())
+                Assert.Equal("t", state.GetCaretPoint().BufferPosition.GetChar())
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionAdjustInsertionText_CommitsOnOpenParens2() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                  Module M
+                                    Sub FogBar(Of T)()
+                                    End Sub
+                                    Sub test()
+                                      $$
+                                    End Sub
+                                  End Module
+                              </document>)
+
+                state.SendTypeChars("Fog(")
+                Await state.AssertCompletionSession()
+
+                Assert.Contains("    FogBar(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionDismissedAfterEscape1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                Class Program
+                                    Sub Main(args As String())
+                                        Program$$
+                                    End Sub
+                                End Class
+                              </document>)
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+                state.SendEscape()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(543497, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543497")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestEnterOnSoftSelection1() As Task
+            ' Code must be left-aligned because of https://github.com/dotnet/roslyn/issues/27988
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+Class Program
+    Shared Sub Main(args As String())
+        Program.$$
+    End Sub
+End Class
+                              </document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("Equals", isSoftSelected:=True)
+                Dim caretPos = state.GetCaretPoint().BufferPosition.Position
+                state.SendReturn()
+                state.Workspace.Documents.First().GetTextView().Caret.MoveTo(New SnapshotPoint(state.Workspace.Documents.First().TextBuffer.CurrentSnapshot, caretPos))
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Contains("Program." + vbCrLf, state.GetLineFromCurrentCaretPosition().GetTextIncludingLineBreak(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionTestTab1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                  Module M
+                                    Sub FogBar()
+                                    End Sub
+                                    Sub test()
+                                      $$
+                                    End Sub
+                                  End Module
+                              </document>)
+
+                state.SendTypeChars("Fog")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                Assert.Contains("    FogBar", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DotIsInserted() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                Class Program
+                                    Sub Main(args As String())
+                                        $$
+                                    End Sub
+                                End Class
+                              </document>)
+                state.SendTypeChars("Progra.")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="Equals", isSoftSelected:=True)
+                Assert.Contains("Program.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestReturn1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+Class Program
+    Sub Main(args As String())
+        $$
+    End Sub
+End Class
+                              </document>)
+                state.SendTypeChars("Progra")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains(<text>
+    Sub Main(args As String())
+        Program
+
+    End Sub</text>.NormalizedValue, state.GetDocumentText(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDown1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+Namespace N
+    Class A
+    End Class
+    Class B
+    End Class
+    Class C
+    End Class
+End Namespace
+Class Program
+    Sub Main(args As String())
+        N$$
+    End Sub
+End Class
+                              </document>)
+                state.SendTypeChars(".A")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+                state.SendDownKey()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="B", isHardSelected:=True)
+                state.SendDownKey()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True)
+                state.SendDownKey()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True)
+                state.SendPageUp()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+                state.SendUpKey()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestFirstCharacterDoesNotFilter1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+Namespace N
+    Class A
+    End Class
+    Class B
+    End Class
+    Class C
+    End Class
+End Namespace
+Class Program
+    Sub Main(args As String())
+        N$$
+    End Sub
+End Class
+                              </document>)
+                state.SendTypeChars(".A")
+                Await state.AssertCompletionSession()
+                Assert.Equal(3, state.CurrentCompletionPresenterSession.CompletionItems.Count)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSecondCharacterDoesFilter1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+Namespace N
+    Class AAA
+    End Class
+    Class AAB
+    End Class
+    Class BB
+    End Class
+    Class CC
+    End Class
+End Namespace
+Class Program
+    Sub Main(args As String())
+        N$$
+    End Sub
+End Class
+                              </document>)
+                state.SendTypeChars(".A")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(4, state.CurrentCompletionPresenterSession.CompletionItems.Count)
+                state.SendTypeChars("A")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(2, state.CurrentCompletionPresenterSession.CompletionItems.Count)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNavigateSoftToHard() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                Class Program
+                                    Shared Sub Main(args As String())
+                                        Program.$$
+                                    End Sub
+                                End Class
+                              </document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Equals", isSoftSelected:=True)
+                state.SendUpKey()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Equals", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBackspaceBeforeCompletedComputation() As Task
+            ' Simulate a very slow completion provider.
+            Dim e = New ManualResetEvent(False)
+            Dim provider = CreateTriggeredCompletionProvider(e)
+
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                Class Program
+                                    Shared Sub Main(args As String())
+                                        Program$$
+                                    End Sub
+                                End Class
+                              </document>, extraCompletionProviders:={provider})
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars(".M")
+
+                ' We should not have a session now.  Note: do not block as this will just hang things
+                ' since the provider will not return.
+                Await state.AssertNoCompletionSession(block:=False)
+
+                ' Now, navigate back.
+                state.SendBackspace()
+
+                ' allow the provider to continue
+                e.Set()
+
+                ' At this point, completion will be available since the caret is still within the model's span.
+                Await state.AssertCompletionSession()
+
+                ' Now, navigate back again.  Completion should be dismissed
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNavigationBeforeCompletedComputation() As Task
+            ' Simulate a very slow completion provider.
+            Dim e = New ManualResetEvent(False)
+            Dim provider = CreateTriggeredCompletionProvider(e)
+
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                Class Program
+                                    Shared Sub Main(args As String())
+                                        Program$$
+                                    End Sub
+                                End Class
+                              </document>, extraCompletionProviders:={provider})
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars(".Ma")
+
+                ' We should not have a session now.  Note: do not block as this will just hang things
+                ' since the provider will not return.
+                Await state.AssertNoCompletionSession(block:=False)
+
+                ' Now, navigate using the caret.
+                state.SendMoveToPreviousCharacter()
+
+                ' allow the provider to continue
+                e.Set()
+
+                ' We should not have a session since we tear things down if we see a caret move
+                ' before the providers have returned.
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNavigateOutOfItemChangeSpan() As Task
+            ' Code must be left-aligned because of https://github.com/dotnet/roslyn/issues/27988
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+Class Program
+    Shared Sub Main(args As String())
+        Program$$
+    End Sub
+End Class
+                              </document>)
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars(".Ma")
+                Await state.AssertCompletionSession()
+                state.SendMoveToPreviousCharacter()
+                Await state.AssertCompletionSession()
+                state.SendMoveToPreviousCharacter()
+                Await state.AssertCompletionSession()
+                state.SendMoveToPreviousCharacter()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestUndo1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                Class Program
+                                    Shared Sub Main(args As String())
+                                        Program$$
+                                    End Sub
+                                End Class
+                              </document>)
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars(".Ma(")
+                Await state.AssertCompletionSession()
+                Assert.Contains(".Main(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendUndo()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Contains(".Ma(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCommitAfterNavigation() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+Namespace N
+    Class A
+    End Class
+    Class B
+    End Class
+    Class C
+    End Class
+End Namespace
+Class Program
+    Sub Main(args As String())
+        N$$
+    End Sub
+End Class
+                              </document>)
+                state.SendTypeChars(".A")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+                state.SendDownKey()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="B", isHardSelected:=True)
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Contains(".B", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSelectCompletionItemThroughPresenter() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+Namespace N
+    Class A
+    End Class
+    Class B
+    End Class
+    Class C
+    End Class
+End Namespace
+Class Program
+    Sub Main(args As String())
+        N$$
+    End Sub
+End Class
+                              </document>)
+                state.SendTypeChars(".A")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendSelectCompletionItemThroughPresenterSession(state.CurrentCompletionPresenterSession.CompletionItems.First(
+                                                           Function(i) i.DisplayText = "B"))
+                state.SendTab()
+                Assert.Contains(".B", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestFiltering1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <document>
+Imports System
+
+Class c
+    Sub Main
+        $$
+    End Sub
+End Class</document>)
+                state.SendTypeChars("Sy")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"OperatingSystem", "System"}))
+                Assert.False(state.CompletionItemsContainsAny(displayText:={"Exception", "Activator"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMSCorLibTypes() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <document>
+Imports System
+
+Class c
+    Inherits$$
+End Class</document>)
+                state.SendTypeChars(" ")
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"Attribute", "Exception"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDescription1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <document>
+                      <![CDATA[Imports System
+
+''' <summary>
+''' TestDoc
+''' </summary>
+Class TestException
+    Inherits Exception
+End Class
+
+Class MyException
+    Inherits $$
+End Class]]></document>)
+                state.SendTypeChars("TestEx")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(description:="Class TestException" & vbCrLf & "TestDoc")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestObjectCreationPreselection1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim x As List(Of Integer) = New$$
+    End Sub
+End Module]]></Document>)
+
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True)
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"LinkedList(Of " & ChrW(&H2026) & ")", "List(Of " & ChrW(&H2026) & ")", "System"}))
+                state.SendTypeChars("Li")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True)
+                Assert.True(state.CompletionItemsContainsAll(displayText:={"LinkedList(Of " & ChrW(&H2026) & ")", "List(Of " & ChrW(&H2026) & ")"}))
+                Assert.False(state.CompletionItemsContainsAny(displayText:={"System"}))
+                state.SendTypeChars("n")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="LinkedList(Of " & ChrW(&H2026) & ")", isHardSelected:=True)
+                state.SendBackspace()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True)
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Contains("New List(Of Integer)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(287, "https://github.com/dotnet/roslyn/issues/287")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NotEnumPreselectionAfterBackspace() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Enum E
+    Bat
+End Enum
+ 
+Class C
+    Sub Test(param As E)
+        Dim b As E
+        Test(b.$$)
+    End Sub
+End Class]]></Document>)
+
+                state.SendBackspace()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="b", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WorkItem(543496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543496")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNumericLiteralWithNoMatch() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document>
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Dim i =$$
+    End Sub
+End Module</Document>)
+
+                state.SendTypeChars(" 0")
+                Await state.AssertNoCompletionSession()
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Assert.Equal(<Document>
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Dim i = 0
+
+    End Sub
+End Module</Document>.NormalizedValue, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WorkItem(543496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543496")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNumericLiteralWithPartialMatch() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document>
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Dim i =$$
+    End Sub
+End Module</Document>)
+
+                ' Could match Int32
+                ' kayleh 1/17/2013, but we decided to have #s always dismiss the list in bug 547287
+                state.SendTypeChars(" 3")
+                Await state.AssertNoCompletionSession()
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Assert.Equal(<Document>
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Dim i = 3
+
+    End Sub
+End Module</Document>.NormalizedValue, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WorkItem(543496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543496")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNumbersAfterLetters() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document>
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Dim i =$$
+    End Sub
+End Module</Document>)
+
+                ' Could match Int32
+                state.SendTypeChars(" I3")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="Int32", isHardSelected:=True)
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Assert.Equal(<Document>
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Dim i = Int32
+
+    End Sub
+End Module</Document>.NormalizedValue, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNotAfterTypingDotAfterIntegerLiteral() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+class c
+    sub M()
+        WriteLine(3$$
+    end sub
+end class
+                              </Document>)
+
+                state.SendTypeChars(".")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestAfterExplicitInvokeAfterDotAfterIntegerLiteral() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+class c
+    sub M()
+        WriteLine(3.$$
+    end sub
+end class
+                              </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ToString"}))
+            End Using
+        End Function
+
+        <WorkItem(543669, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543669")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDeleteWordToLeft() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+class c
+    sub M()
+        $$
+    end sub
+end class
+                              </Document>)
+                state.SendTypeChars("Dim i =")
+                Await state.AssertCompletionSession()
+                state.SendDeleteWordToLeft()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(543617, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543617")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCompletionGenericWithOpenParen() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+class c
+    sub Goo(Of X)()
+        $$
+    end sub
+end class
+                              </Document>)
+                state.SendTypeChars("Go(")
+                Await state.AssertCompletionSession()
+                Assert.Equal("        Goo(", state.GetLineTextFromCaretPosition())
+                Assert.DoesNotContain("Goo(Of", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(543617, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543617")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCompletionGenericWithSpace() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+class c
+    sub Goo(Of X)()
+        $$
+    end sub
+end class
+                              </Document>)
+                state.SendTypeChars("Go ")
+                Await state.AssertCompletionSession()
+                Assert.Equal("        Goo(Of ", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitForImportsStatement1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                  $$
+                              </Document>)
+
+                state.SendTypeChars("Imports Sys")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                state.SendTypeChars("(")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("Imports Sys(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitForImportsStatement2() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                  $$
+                              </Document>)
+
+                state.SendTypeChars("Imports Sys")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+                Assert.Contains("Imports System.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitForImportsStatement3() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document>
+                                $$
+                            </Document>)
+
+                state.SendTypeChars("Imports Sys")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("Imports Sys ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(544190, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544190")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DoNotInsertEqualsForNamedParameterCommitWithColon() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document>
+    Class Class1
+        Sub Method()
+            Test($$
+        End Sub
+        Sub Test(Optional x As Integer = 42)
+ 
+        End Sub
+    End Class 
+                            </Document>)
+
+                state.SendTypeChars("x:")
+                Await state.AssertNoCompletionSession()
+                Assert.DoesNotContain(":=", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(544190, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544190")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DoInsertEqualsForNamedParameterCommitWithSpace() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document>
+    Class Class1
+        Sub Method()
+            Test($$
+        End Sub
+        Sub Test(Optional x As Integer = 42)
+ 
+        End Sub
+    End Class 
+                            </Document>)
+
+                state.SendTypeChars("x")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains(":=", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(544150, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544150")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function ConsumeHashForPreprocessorCompletion() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document>
+$$
+                            </Document>)
+
+                state.SendTypeChars("#re")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Equal("#Region", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumCompletionTriggeredOnSpace() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Enum Numeros
+    Uno
+    Dos
+End Enum
+Class Goo
+    Sub Bar(a As Integer, n As Numeros)
+    End Sub
+    Sub Baz()
+        Bar(0$$
+    End Sub
+End Class
+                              </Document>)
+
+                state.SendTypeChars(", ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros.Dos", isSoftSelected:=True)
+            End Using
+        End Function
+
+        Private Function CreateTriggeredCompletionProvider(e As ManualResetEvent) As CompletionProvider
+            Return New MockCompletionProvider(getItems:=Function(t, p, c)
+                                                            e.WaitOne()
+                                                            Return Nothing
+                                                        End Function,
+                                              isTriggerCharacter:=Function(t, p) True)
+        End Function
+
+        <WorkItem(544297, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544297")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestVerbatimNamedIdentifierFiltering() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Class Class1
+    Private Sub Test([string] As String)
+        Test($$
+    End Sub
+End Class
+                              </Document>)
+
+                state.SendTypeChars("s")
+                Await state.AssertCompletionSession()
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "string:="))
+                state.SendTypeChars("t")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "string:="))
+            End Using
+        End Function
+
+        <WorkItem(544299, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544299")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestExclusiveNamedParameterCompletion() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Class Class1
+    Private Sub Test()
+        Goo(bool:=False,$$
+    End Sub
+ 
+    Private Sub Goo(str As String, character As Char)
+    End Sub
+ 
+    Private Sub Goo(str As String, bool As Boolean)
+    End Sub
+End Class
+                              </Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertCompletionSession()
+                Assert.Equal(1, state.CurrentCompletionPresenterSession.CompletionItems.Count)
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "str:="))
+            End Using
+        End Function
+
+        <WorkItem(544299, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544299")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestExclusiveNamedParameterCompletion2() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Class Goo
+    Private Sub Test()
+        Dim m As Object = Nothing
+        Method(obj:=m, $$
+    End Sub
+
+    Private Sub Method(obj As Object, num As Integer, str As String)
+    End Sub
+    Private Sub Method(dbl As Double, str As String)
+    End Sub
+    Private Sub Method(num As Integer, b As Boolean, str As String)
+    End Sub
+    Private Sub Method(obj As Object, b As Boolean, str As String)
+    End Sub
+End Class
+                              </Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertCompletionSession()
+                Assert.Equal(3, state.CurrentCompletionPresenterSession.CompletionItems.Count)
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "b:="))
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "num:="))
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "str:="))
+                Assert.False(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "dbl:="))
+            End Using
+        End Function
+
+        <WorkItem(544471, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544471")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDontCrashOnEmptyParameterList() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+&lt;Obsolete()$$&gt;
+                              </Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(544628, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544628")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function OnlyMatchOnLowercaseIfPrefixWordMatch() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Module Program
+    $$
+End Module
+                              </Document>)
+
+                state.SendTypeChars("z")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("#Const", isSoftSelected:=True)
+            End Using
+        End Function
+
+        <WorkItem(544989, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544989")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function MyBaseFinalize() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Class C
+    Protected Overrides Sub Finalize()
+        MyBase.Finalize$$
+    End Sub
+End Class
+                              </Document>)
+
+                state.SendTypeChars("(")
+                Await state.AssertSignatureHelpSession()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.True(state.SignatureHelpItemsContainsAll({"Object.Finalize()"}))
+            End Using
+        End Function
+
+        <WorkItem(551117, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/551117")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNamedParameterSortOrder() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Imports System
+Module Program
+    Sub Main(args As String())
+        Main($$
+    End Sub
+End Module
+                              </Document>)
+
+                state.SendTypeChars("a")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("args", isHardSelected:=True)
+                state.SendDownKey()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("args:=", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WorkItem(546810, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546810")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestLineContinuationCharacter() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Imports System
+Module Program
+    Sub Main()
+        Dim x = New $$
+    End Sub
+End Module
+                              </Document>)
+
+                state.SendTypeChars("_")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("_AppDomain", isHardSelected:=False)
+            End Using
+        End Function
+
+        <WorkItem(547287, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547287")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNumberDismissesCompletion() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Imports System
+Module Program
+    Sub Main()
+        Console.WriteLine$$
+    End Sub
+End Module
+                              </Document>)
+
+                state.SendTypeChars("(")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars(".")
+                Await state.AssertNoCompletionSession()
+                state.SendBackspace()
+                state.SendBackspace()
+
+                state.SendTypeChars("(")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("-")
+                Await state.AssertNoCompletionSession()
+                state.SendBackspace()
+                state.SendBackspace()
+
+                state.SendTypeChars("(")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("1")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestProjections() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+{|S1:
+Imports System
+Module Program
+    Sub Main(arg As String)
+        Dim bbb = 234
+        Console.WriteLine$$
+    End Sub
+End Module|}          </Document>)
+
+                Dim subjectDocument = state.Workspace.Documents.First()
+                Dim firstProjection = state.Workspace.CreateProjectionBufferDocument(
+                    <Document>
+{|S1:|}
+{|S2: some text that's mapped to the surface buffer |}
+
+                           </Document>.NormalizedValue, {subjectDocument}, LanguageNames.VisualBasic, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+                Dim topProjectionBuffer = state.Workspace.CreateProjectionBufferDocument(
+                <Document>
+{|S1:|}
+{|S2:|}
+                              </Document>.NormalizedValue, {firstProjection}, LanguageNames.VisualBasic, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+                ' Test a view that has a subject buffer with multiple projection buffers in between
+                Dim view = topProjectionBuffer.GetTextView()
+                Dim subjectBuffer = subjectDocument.GetTextBuffer()
+
+                state.SendTypeCharsToSpecificViewAndBuffer("(", view, subjectBuffer)
+                Await state.AssertCompletionSession()
+                state.SendTypeCharsToSpecificViewAndBuffer("a", view, subjectBuffer)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="arg")
+
+                Dim text = view.TextSnapshot.GetText()
+                Dim projection = DirectCast(topProjectionBuffer.TextBuffer, IProjectionBuffer)
+                Dim sourceSpans = projection.CurrentSnapshot.GetSourceSpans()
+
+                ' unmap our source spans without changing the top buffer
+                projection.ReplaceSpans(0, sourceSpans.Count, {text}, EditOptions.DefaultMinimalChange, editTag:=Nothing)
+
+                ' Make sure completion updates even though are subject buffer is not connected.
+                Dim editorOperations = state.GetService(Of IEditorOperationsFactoryService).GetEditorOperations(view)
+                editorOperations.Backspace()
+                editorOperations.InsertText("b")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="bbb")
+
+                ' prepare to remap our subject buffer
+                Dim subjectBufferText = subjectDocument.TextBuffer.CurrentSnapshot.GetText()
+                Using edit = subjectDocument.TextBuffer.CreateEdit(EditOptions.DefaultMinimalChange, reiteratedVersionNumber:=Nothing, editTag:=Nothing)
+                    edit.Replace(New Span(0, subjectBufferText.Length), subjectBufferText.Replace("Console.WriteLine(a", "Console.WriteLine(b"))
+                    edit.Apply()
+                End Using
+
+                Dim replacementSpans = sourceSpans.Select(Function(ss)
+                                                              If ss.Snapshot.TextBuffer.ContentType.TypeName = "inert" Then
+                                                                  Return DirectCast(ss.Snapshot.GetText(ss.Span), Object)
+                                                              Else
+                                                                  Return DirectCast(ss.Snapshot.CreateTrackingSpan(ss.Span, SpanTrackingMode.EdgeExclusive), Object)
+                                                              End If
+                                                          End Function).ToList()
+
+                projection.ReplaceSpans(0, 1, replacementSpans, EditOptions.DefaultMinimalChange, editTag:=Nothing)
+
+                ' the same completion session should still be active after the remapping.
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="bbb")
+                state.SendTypeCharsToSpecificViewAndBuffer("b", view, subjectBuffer)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="bbb")
+
+                ' verify we can commit even when unmapped
+                projection.ReplaceSpans(0, projection.CurrentSnapshot.GetSourceSpans.Count, {projection.CurrentSnapshot.GetText()}, EditOptions.DefaultMinimalChange, editTag:=Nothing)
+                state.SendCommitUniqueCompletionListItem()
+                Await state.WaitForAsynchronousOperationsAsync()
+
+                Assert.Contains(<text>
+Imports System
+Module Program
+    Sub Main(arg As String)
+        Dim bbb = 234
+        Console.WriteLine(bbb
+    End Sub
+End Module          </text>.NormalizedValue, state.GetDocumentText(), StringComparison.Ordinal)
+
+            End Using
+        End Function
+
+        <WorkItem(622957, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/622957")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBangFiltersInDocComment() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+''' $$
+Public Class TestClass
+End Class
+]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("!")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("!--")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionUpAfterBackSpacetoWord() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                  Public E$$
+                              </Document>)
+
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NoCompletionAfterBackspaceInStringLiteral() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                Sub Goo()
+                                    Dim z = "aa$$"
+                                End Sub
+                              </Document>)
+
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionUpAfterDeleteDot() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                Sub Goo()
+                                    Dim z = "a"
+                                     z.$$ToString()
+                                End Sub
+                              </Document>)
+
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NotCompletionUpAfterDeleteRParen() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                Sub Goo()
+                                    "a".ToString()$$
+                                End Sub
+                              </Document>)
+
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NotCompletionUpAfterDeleteLParen() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                Sub Goo()
+                                    "a".ToString($$
+                                End Sub
+                              </Document>)
+
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NotCompletionUpAfterDeleteComma() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                Sub Goo(x as Integer, y as Integer)
+                                    Goo(1,$$)
+                                End Sub
+                              </Document>)
+
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionAfterDeleteKeyword() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+                                Sub Goo(x as Integer, y as Integer)
+                                    Goo(1,2)
+                                End$$ Sub
+                              </Document>)
+
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("End", description:=String.Format(FeaturesResources._0_Keyword, "End") + vbCrLf + VBFeaturesResources.Stops_execution_immediately)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NoCompletionOnBackspaceAtBeginningOfFile() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>$$</Document>)
+
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+
+        <WpfFact(), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionUpAfterLeftCurlyBrace() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                Imports System
+                                Imports System.Collections.Generic
+                                Imports System.Linq
+
+                                Module Program
+                                    Sub Main(args As String())
+                                        Dim l As New List(Of Integer) From $$
+                                    End Sub
+                                End Module
+                              </document>)
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("{")
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact(), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionUpAfterLeftAngleBracket() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <document>
+                                $$
+                                Module Program
+                                    Sub Main(args As String())
+                                    End Sub
+                                End Module
+                              </document>)
+
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeCompletionDoesNotFilter() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as String$$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("String")
+                state.CompletionItemsContainsAll({"Integer", "G"})
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeCompletionSelectsWithoutRegardToCaretPosition() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as Str$$ing
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("String")
+                state.CompletionItemsContainsAll({"Integer", "G"})
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeCompletionBeforeWordDoesNotSelect() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as $$String
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("AccessViolationException")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspaceCompletionInvokedSelectedAndUnfiltered() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as String$$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendBackspace()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("String")
+                state.CompletionItemsContainsAll({"Integer", "G"})
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function ListDismissedIfNoMatches() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as $$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendTypeChars("str")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("String", isHardSelected:=True)
+                state.SendTypeChars("gg")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeCompletionComesUpEvenIfNoMatches() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as gggg$$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(674422, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/674422")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspaceInvokeCompletionComesUpEvenIfNoMatches() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as gggg$$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(674366, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/674366")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspaceCompletionSelects() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as Integrr$$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("Integer")
+            End Using
+        End Function
+
+        <WorkItem(675555, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/675555")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspaceCompletionNeverFilters() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as String$$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(c) c.DisplayText = "AccessViolationException"))
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(c) c.DisplayText = "AccessViolationException"))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TabAfterQuestionMarkInEmptyLine() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        ?$$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(state.GetLineTextFromCaretPosition(), "        ?" + vbTab)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TabAfterTextFollowedByQuestionMark() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        a?$$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(state.GetLineTextFromCaretPosition(), "        a")
+            End Using
+        End Function
+
+        <WorkItem(669942, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/669942")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DistinguishItemsWithDifferentGlyphs() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Imports System.Linq
+Class Test
+    Sub [Select]()
+    End Sub
+    Sub Goo()
+        Dim k As Integer = 1
+        $$
+    End Sub
+End Class
+
+            ]]></Document>)
+                state.SendTypeChars("selec")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(state.CurrentCompletionPresenterSession.CompletionItems.Count, 2)
+            End Using
+        End Function
+
+        <WorkItem(670149, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670149")>
+        <WpfFact(), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TabAfterNullableFollowedByQuestionMark() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Dim a As Integer?$$
+End Class
+            ]]></Document>)
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(state.GetLineTextFromCaretPosition(), "    Dim a As Integer?" + vbTab)
+            End Using
+        End Function
+
+        <WorkItem(672474, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/672474")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestInvokeSnippetCommandDismissesCompletion() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>$$</Document>)
+
+                state.SendTypeChars("Imp")
+                Await state.AssertCompletionSession()
+                state.SendInsertSnippetCommand()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(672474, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/672474")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSurroundWithCommandDismissesCompletion() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>$$</Document>)
+
+                state.SendTypeChars("Imp")
+                Await state.AssertCompletionSession()
+                state.SendSurroundWithCommand()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(716117, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/716117")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function XmlCompletionNotTriggeredOnBackspaceInText() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document><![CDATA[
+''' <summary>
+''' text$$
+''' </summary>
+Class G
+    Dim a As Integer?
+End Class]]></Document>)
+
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(716117, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/716117")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function XmlCompletionNotTriggeredOnBackspaceInTag() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document><![CDATA[
+''' <summary$$>
+''' text
+''' </summary>
+Class G
+    Dim a As Integer?
+End Class]]></Document>)
+
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("summary")
+            End Using
+        End Function
+
+        <WorkItem(674415, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/674415")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspacingLastCharacterDismisses() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>$$</Document>)
+
+                state.SendTypeChars("A")
+                Await state.AssertCompletionSession()
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(719977, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/719977")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function HardSelectionWithBuilderAndOneExactMatch() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+<Document>Module M
+    Public $$
+End Module</Document>)
+
+                state.SendTypeChars("sub")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("Sub")
+                Assert.True(state.CurrentCompletionPresenterSession.SuggestionModeItem IsNot Nothing)
+            End Using
+        End Function
+
+        <WorkItem(828603, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/828603")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function SoftSelectionWithBuilderAndNoExactMatch() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+<Document>Module M
+    Public $$
+End Module</Document>)
+
+                state.SendTypeChars("prop")
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("Property", isSoftSelected:=True)
+                Assert.True(state.CurrentCompletionPresenterSession.SuggestionModeItem IsNot Nothing)
+            End Using
+        End Function
+
+        <WorkItem(792569, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/792569")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitOnEnter() As Task
+            Dim expected = <Document>Module M
+    Sub Main()
+        Main()
+
+    End Sub
+End Module</Document>.Value.Replace(vbLf, vbCrLf)
+
+            Using state = TestState.CreateVisualBasicTestState(
+<Document>Module M
+    Sub Main()
+        Ma$$i
+    End Sub
+End Module</Document>)
+
+                state.SendInvokeCompletionList()
+                state.SendReturn()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(expected, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WorkItem(546208, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546208")>
+        <WpfFact(), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function SelectKeywordFirst() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Class C
+    Sub M()
+        $$
+    End Sub
+
+    Sub GetType()
+    End Sub
+End Class
+                              </Document>)
+
+                state.SendTypeChars("GetType")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("GetType", VBFeaturesResources.GetType_function + vbCrLf +
+                    VBWorkspaceResources.Returns_a_System_Type_object_for_the_specified_type_name + vbCrLf +
+                    $"GetType({VBWorkspaceResources.typeName}) As Type")
+            End Using
+        End Function
+
+        <WorkItem(828392, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/828392")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function ConstructorFiltersAsNew() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Public Class Base
+Public Sub New(x As Integer)
+End Sub
+End Class
+Public Class Derived
+Inherits Base
+Public Sub New(x As Integer)
+MyBase.$$
+End Sub
+End Class
+
+                              </Document>)
+
+                state.SendTypeChars("New")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("New", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NoUnmentionableTypeInObjectCreation() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Public Class C
+    Sub Goo()
+        Dim a = new$$
+    End Sub
+End Class
+
+                              </Document>)
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("AccessViolationException", isSoftSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function FilterPreferEnum() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Enum E
+    Goo
+    Bar
+End Enum
+
+Class Goo
+End Class
+
+Public Class C
+    Sub Goo()
+        E e = $$
+    End Sub
+End Class</Document>)
+                state.SendTypeChars("g")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("E.Goo", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WorkItem(883295, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/883295")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InsertOfOnSpace() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Imports System.Threading.Tasks
+Public Class C
+    Sub Goo()
+        Dim a as $$
+    End Sub
+End Class
+
+                              </Document>)
+                state.SendTypeChars("Task")
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendDownKey()
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal("        Dim a as Task(Of ", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(883295, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/883295")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DoNotInsertOfOnTab() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Imports System.Threading.Tasks
+Public Class C
+    Sub Goo()
+        Dim a as $$
+    End Sub
+End Class
+
+                              </Document>)
+                state.SendTypeChars("Task")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal(state.GetLineTextFromCaretPosition(), "        Dim a as Task")
+            End Using
+        End Function
+
+        <WorkItem(899414, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/899414")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NotInPartialMethodDeclaration() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Module Module1
+ 
+    Sub Main()
+ 
+    End Sub
+ 
+End Module
+ 
+Public Class Class2
+    Partial Private Sub PartialMethod(ByVal x As Integer)
+        $$
+    End Sub
+End Class</Document>)
+                state.SendInvokeCompletionList()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCompletionInLinkedFiles() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBProj" PreprocessorSymbols="Thing2=True">
+                        <Document FilePath="C.vb">
+Class C
+    Sub M()
+        $$
+    End Sub
+
+#If Thing1 Then
+    Sub Thing1()
+    End Sub
+#End If
+#If Thing2 Then
+    Sub Thing2()
+    End Sub
+#End If
+End Class
+                              </Document>
+                    </Project>
+                    <Project Language="Visual Basic" CommonReferences="true" PreprocessorSymbols="Thing1=True">
+                        <Document IsLinkFile="true" LinkAssemblyName="VBProj" LinkFilePath="C.vb"/>
+                    </Project>
+                </Workspace>)
+
+                Dim documents = state.Workspace.Documents
+                Dim linkDocument = documents.Single(Function(d) d.IsLinkFile)
+
+                state.SendTypeChars("Thi")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("Thing1")
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.Workspace.SetDocumentContext(linkDocument.Id)
+                state.SendTypeChars("Thi")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("Thing1")
+            End Using
+        End Function
+
+        <WorkItem(916452, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916452")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function SoftSelectedWithNoFilterText() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Imports System
+Class C
+    Public Sub M(day As DayOfWeek)
+        M$$
+    End Sub
+End Class</Document>)
+                state.SendTypeChars("(")
+                Await state.AssertCompletionSession()
+                Assert.True(state.CurrentCompletionPresenterSession.IsSoftSelected)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumSortingOrder() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                              <Document>
+Imports System
+Class C
+    Public Sub M(day As DayOfWeek)
+        M$$
+    End Sub
+End Class</Document>)
+                state.SendTypeChars("(")
+                Await state.AssertCompletionSession()
+                ' DayOfWeek.Monday should  immediately follow DayOfWeek.Friday
+                Dim friday = state.CurrentCompletionPresenterSession.CompletionItems.First(Function(i) i.DisplayText = "DayOfWeek.Friday")
+                Dim monday = state.CurrentCompletionPresenterSession.CompletionItems.First(Function(i) i.DisplayText = "DayOfWeek.Monday")
+                Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.IndexOf(friday) = state.CurrentCompletionPresenterSession.CompletionItems.IndexOf(monday) - 1)
+            End Using
+        End Function
+
+        <WorkItem(951726, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/951726")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DismissUponSave() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    $$
+End Class]]></Document>)
+                state.SendTypeChars("Su")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("Sub")
+                state.SendSave()
+                Await state.AssertNoCompletionSession(block:=True)
+                state.AssertMatchesTextStartingAtLine(2, "    Su")
+            End Using
+        End Function
+
+        <WorkItem(969794, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/969794")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DeleteCompletionInvokedSelectedAndUnfiltered() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub goo()
+        Dim x as Stri$$ng
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendDelete()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("String")
+            End Using
+        End Function
+
+        <WorkItem(871755, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/871755")>
+        <WorkItem(954556, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/954556")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function FilterPrefixOnlyOnBackspace1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Public Re$$
+End Class
+            ]]></Document>)
+                state.SendBackspace()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("ReadOnly")
+                state.SendTypeChars("a")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(969040, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/969040")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspaceTriggerOnlyIfOptionEnabled() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Public Re$$
+End Class
+            ]]></Document>)
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.TriggerOnTyping, LanguageNames.VisualBasic, False)
+                state.SendBackspace()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(957450, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/957450")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function KeywordsForIntrinsicsDeduplicated() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub Goo()
+        $$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                ' Should only have one item called 'Double' and it should have a keyword glyph
+                Dim doubleItem = state.CurrentCompletionPresenterSession.CompletionItems.Single(Function(c) c.DisplayText = "Double")
+                Assert.True(doubleItem.Tags.Contains(WellKnownTags.Keyword))
+            End Using
+        End Function
+
+        <WorkItem(957450, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/957450")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function KeywordDeduplicationLeavesEscapedIdentifiers() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class [Double]
+    Sub Goo()
+        Dim x as $$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                ' We should have gotten the item corresponding to [Double] and the item for the Double keyword
+                Dim doubleItems = state.CurrentCompletionPresenterSession.CompletionItems.Where(Function(c) c.DisplayText = "Double")
+                Assert.Equal(2, doubleItems.Count())
+                Assert.True(doubleItems.Any(Function(c) c.Tags.Contains(WellKnownTags.Keyword)))
+                Assert.True(doubleItems.Any(Function(c) c.Tags.Contains(WellKnownTags.Class) AndAlso c.Tags.Contains(WellKnownTags.Internal)))
+            End Using
+        End Function
+
+        <WorkItem(957450, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/957450")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestEscapedItemCommittedWithCloseBracket() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class [Interface]
+    Sub Goo()
+        Dim x As $$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendTypeChars("Interf]")
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(4, "Dim x As [Interface]")
+            End Using
+        End Function
+
+        <WorkItem(1075298, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1075298")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitOnQuestionMarkForConditionalAccess() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Class G
+    Sub Goo()
+        Dim x = String.$$
+    End Sub
+End Class
+            ]]></Document>)
+                state.SendTypeChars("emp?")
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(4, "Dim x = String.Empty?")
+            End Using
+        End Function
+
+        <WorkItem(1659, "https://github.com/dotnet/roslyn/issues/1659")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DismissOnSelectAllCommand() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    Sub goo()
+        $$]]></Document>)
+                ' Note: the caret is at the file, so the Select All command's movement
+                ' of the caret to the end of the selection isn't responsible for 
+                ' dismissing the session.
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendSelectAll()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WorkItem(3088, "https://github.com/dotnet/roslyn/issues/3088")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DoNotPreferParameterNames() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim Table As Integer
+        goo(table$$)
+    End Sub
+
+    Sub goo(table As String)
+
+    End Sub
+End Module]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("Table")
+            End Using
+        End Function
+
+        <WorkItem(4892, "https://github.com/dotnet/roslyn/issues/4892")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BooleanPreselection1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim x as boolean = $$
+    End Sub
+End Module]]></Document>)
+                state.SendTypeChars("f")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("False")
+                state.SendBackspace()
+                state.SendTypeChars("t")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("True")
+            End Using
+        End Function
+
+        <WorkItem(4892, "https://github.com/dotnet/roslyn/issues/4892")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BooleanPreselection2() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Module Program
+    Sub Main(args As String())
+        foot($$
+    End Sub
+
+    Sub foot(x as boolean)
+    End Sub
+End Module]]></Document>)
+                state.SendTypeChars("f")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("False")
+                state.SendBackspace()
+                state.SendTypeChars("t")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("True")
+            End Using
+        End Function
+
+        <WorkItem(4892, "https://github.com/dotnet/roslyn/issues/4892")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BooleanPreselection3() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+
+Module Program
+    Class F
+    End Class
+    Class T
+    End Class
+
+    Sub Main(args As String())
+        $$
+    End Sub
+End Module]]></Document>)
+                state.SendTypeChars("f")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("F")
+                state.SendBackspace()
+                state.SendTypeChars("t")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem("T")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Imports System.Threading
+Module Program
+    Sub Cancel(x As Integer, cancellationToken As CancellationToken)
+        Cancel(x + 1, $$)
+    End Sub
+End Module]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cancellationToken").ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection2() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim aaz As Integer
+        args = $$
+    End Sub
+End Module]]></Document>)
+                state.SendTypeChars("a")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("args").ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection3() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Class D
+End Class
+Class Program
+
+    Sub Main(string() args)
+    
+       Dim cw = 7
+       Dim cx as D = new D()
+       Dim  cx2 as D = $$
+    End Sub
+End Class
+]]></Document>)
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionLocalsOverType() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Class A 
+End Class
+Class Program
+
+    Sub Main(string() args)
+    
+       Dim  cx = new A()
+       Dim cx2 as A = $$
+    End Sub
+End Class
+]]></Document>)
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/6942"), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionConvertibility1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Mustinherit Class C 
+End Class
+Class D 
+inherits C
+End Class
+Class Program
+    Sub Main(string() args)
+    
+       Dim cx = new D()
+       Dim cx2 as C = $$
+    End Sub
+End Class
+]]></Document>)
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionParamsArray() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+
+Class Program
+
+    Sub Main(string() args)
+    
+       Dim azc as integer
+       M2(a$$
+    End Sub
+    Sub M2(params int() yx)  
+    End Sub
+End Class
+ 
+]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("azc", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionSetterValue() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Class Program
+    Private Async As Integer
+    Public Property NewProperty() As Integer
+        Get
+            Return Async
+        End Get
+        Set(ByVal value As Integer)
+            Async = $$
+        End Set
+    End Property
+End Class]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("value", isHardSelected:=False, isSoftSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(12530, "https://github.com/dotnet/roslyn/issues/12530")>
+        Public Async Function TestAnonymousTypeDescription() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Imports System.Linq
+
+Public Class Class1
+    Sub Method()
+        Dim x = {New With {.x = 1}}.ToArr$$
+    End Sub
+End Class
+]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(description:=
+$"<{ VBFeaturesResources.Extension }> Function IEnumerable(Of 'a).ToArray() As 'a()
+
+{ FeaturesResources.Anonymous_Types_colon }
+    'a { FeaturesResources.is_ } New With {{ .x As Integer }}")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(12530, "https://github.com/dotnet/roslyn/issues/12530")>
+        Public Async Function TestAnonymousTypeDescription2() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Imports System.Linq
+
+Public Class Class1
+    Sub Method()
+        Dim x = {New With { Key .x = 1}}.ToArr$$
+    End Sub
+End Class
+]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(description:=
+$"<{ VBFeaturesResources.Extension }> Function IEnumerable(Of 'a).ToArray() As 'a()
+
+{ FeaturesResources.Anonymous_Types_colon }
+    'a { FeaturesResources.is_ } New With {{ Key .x As Integer }}")
+            End Using
+        End Function
+
+        <WorkItem(11812, "https://github.com/dotnet/roslyn/issues/11812")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestObjectCreationQualifiedName() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document><![CDATA[
+ Class A
+     Sub Test()
+         Dim b As B.C(Of Integer) = New$$
+     End Sub
+ End Class
+ 
+ Namespace B
+     Class C(Of T)
+     End Class
+ End Namespace]]></Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("(")
+                state.AssertMatchesTextStartingAtLine(3, "Dim b As B.C(Of Integer) = New B.C(Of Integer)(")
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function TestNonTrailingNamedArgumentInVB15_3() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                 <Workspace>
+                     <Project Language="Visual Basic" LanguageVersion="VisualBasic15_3" CommonReferences="true" AssemblyName="VBProj">
+                         <Document FilePath="C.vb">
+Class C
+    Sub M()
+        Dim better As Integer = 2
+        M(a:=1, $$)
+    End Sub
+    Sub M(a As Integer, bar As Integer, c As Integer)
+    End Sub
+End Class
+                         </Document>
+                     </Project>
+                 </Workspace>)
+
+                state.SendTypeChars("b")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:=", isHardSelected:=True)
+                state.SendTypeChars("e")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function TestNonTrailingNamedArgumentInVB15_5() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                 <Workspace>
+                     <Project Language="Visual Basic" LanguageVersion="VisualBasic15_5" CommonReferences="true" AssemblyName="VBProj">
+                         <Document FilePath="C.vb">
+Class C
+    Sub M()
+        Dim better As Integer = 2
+        M(a:=1, $$)
+    End Sub
+    Sub M(a As Integer, bar As Integer, c As Integer)
+    End Sub
+End Class
+                         </Document>
+                     </Project>
+                 </Workspace>)
+
+                state.SendTypeChars("bar")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:=", isHardSelected:=True)
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendTypeChars("et")
+                Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
+                state.SendTypeChars(", ")
+                Assert.Contains("M(a:=1, better,", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSymbolInTupleLiteral() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+        Dim t = ($$)
+    End Sub
+End Class
+}]]></Document>)
+
+                state.SendTypeChars("Go")
+                Await state.AssertSelectedCompletionItem(displayText:="Goo", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(Go:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSymbolInTupleLiteralAfterComma() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+        Dim t = (1, $$)
+    End Sub
+End Class
+]]></Document>)
+
+                state.SendTypeChars("Go")
+                Await state.AssertSelectedCompletionItem(displayText:="Goo", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(1, Go:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSnippetInTupleLiteral() As Task
+            Dim snippetProvider As CompletionProvider =
+                New VisualStudio.LanguageServices.VisualBasic.Snippets.SnippetCompletionProvider(Nothing)
+
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+        Dim t = ($$)
+    End Sub
+End Class
+}]]></Document>,
+                  extraCompletionProviders:={snippetProvider},
+                  extraExportedTypes:={GetType(MockSnippetInfoService)}.ToList())
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.SnippetsBehavior,
+                                                                                    LanguageNames.VisualBasic,
+                                                                                    SnippetsRule.AlwaysInclude)
+
+                state.SendTypeChars("Shortcu")
+                Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(Shortcu:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSnippetInTupleLiteralAfterComma() As Task
+            Dim snippetProvider As CompletionProvider =
+                New VisualStudio.LanguageServices.VisualBasic.Snippets.
+                    SnippetCompletionProvider(editorAdaptersFactoryService:=Nothing)
+
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+        Dim t = (1, $$)
+    End Sub
+End Class
+}]]></Document>,
+                  extraCompletionProviders:={snippetProvider},
+                  extraExportedTypes:={GetType(MockSnippetInfoService)}.ToList())
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.SnippetsBehavior,
+                                                                                    LanguageNames.VisualBasic,
+                                                                                    SnippetsRule.AlwaysInclude)
+
+                state.SendTypeChars("Shortcu")
+                Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(1, Shortcu:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSnippetsNotExclusiveWhenAlwaysShowing() As Task
+            Dim snippetProvider As CompletionProvider =
+                New VisualStudio.LanguageServices.VisualBasic.Snippets.
+                    SnippetCompletionProvider(editorAdaptersFactoryService:=Nothing)
+
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+        Dim x as Integer = 3
+        Dim t = $$
+    End Sub
+End Class
+}]]></Document>,
+                  extraCompletionProviders:={snippetProvider},
+                  extraExportedTypes:={GetType(MockSnippetInfoService)}.ToList())
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.SnippetsBehavior,
+                                                                                    LanguageNames.VisualBasic,
+                                                                                    SnippetsRule.AlwaysInclude)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.True(state.CompletionItemsContainsAll({"x", "Shortcut"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBuiltInTypesKeywordInTupleLiteral() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+        Dim t = ($$)
+    End Sub
+End Class
+}]]></Document>)
+
+                state.SendTypeChars("Intege")
+                Await state.AssertSelectedCompletionItem(displayText:="Integer", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(Intege:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBuiltInTypesKeywordInTupleLiteralAfterComma() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+        Dim t = (1, $$)
+    End Sub
+End Class
+}]]></Document>)
+
+                state.SendTypeChars("Intege")
+                Await state.AssertSelectedCompletionItem(displayText:="Integer", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(1, Intege:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestFunctionKeywordInTupleLiteral() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+        Dim t = ($$)
+    End Sub
+End Class
+}]]></Document>)
+
+                state.SendTypeChars("Functio")
+                Await state.AssertSelectedCompletionItem(displayText:="Function", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(Functio:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestFunctionKeywordInTupleLiteralAfterComma() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+        Dim t = (1, $$)
+    End Sub
+End Class
+}]]></Document>)
+                state.SendTypeChars("Functio")
+                Await state.AssertSelectedCompletionItem(displayText:="Function", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(1, Functio:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSymbolInTupleType() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo()
+       Dim t As ($$)
+    End Sub
+End Class
+]]></Document>)
+                state.SendTypeChars("Integ")
+                Await state.AssertSelectedCompletionItem(displayText:="Integer", isHardSelected:=True)
+                state.SendTypeChars(",")
+                Assert.Contains("(Integer,", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestInvocationExpression() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo(Alice As Integer)
+       Goo($$)
+    End Sub
+End Class
+]]></Document>)
+
+                state.SendTypeChars("Alic")
+                Await state.AssertSelectedCompletionItem(displayText:="Alice", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("Goo(Alice:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestInvocationExpressionAfterComma() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Goo(Alice As Integer, Bob As Integer)
+       Goo(1, $$)
+    End Sub
+End Class
+]]></Document>)
+
+                state.SendTypeChars("B")
+                Await state.AssertSelectedCompletionItem(displayText:="Bob", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("Goo(1, Bob:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WorkItem(13161, "https://github.com/dotnet/roslyn/issues/13161")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitGenericDoesNotInsertEllipsis() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document><![CDATA[
+Interface Goo(Of T)
+End Interface
+
+Class Bar
+    Implements $$
+End Class]]></Document>)
+
+                Dim unicodeEllipsis = ChrW(&H2026).ToString()
+                state.SendTypeChars("Goo")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal("Implements Goo(Of", state.GetLineTextFromCaretPosition().Trim())
+                Assert.DoesNotContain(unicodeEllipsis, state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(13161, "https://github.com/dotnet/roslyn/issues/13161")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitGenericDoesNotInsertEllipsisCommitOnParen() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document><![CDATA[
+Interface Goo(Of T)
+End Interface
+
+Class Bar
+    Implements $$
+End Class]]></Document>)
+
+                Dim unicodeEllipsis = ChrW(&H2026).ToString()
+                state.SendTypeChars("Goo(")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal("Implements Goo(", state.GetLineTextFromCaretPosition().Trim())
+                Assert.DoesNotContain(unicodeEllipsis, state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(13161, "https://github.com/dotnet/roslyn/issues/13161")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitGenericItemDoesNotInsertEllipsisCommitOnTab() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document><![CDATA[
+Interface Goo(Of T)
+End Interface
+
+Class Bar
+    Dim x as $$
+End Class]]></Document>)
+
+                Dim unicodeEllipsis = ChrW(&H2026).ToString()
+                state.SendTypeChars("Goo")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal("Dim x as Goo(Of", state.GetLineTextFromCaretPosition().Trim())
+                Assert.DoesNotContain(unicodeEllipsis, state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(15011, "https://github.com/dotnet/roslyn/issues/15011")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function SymbolAndObjectPreselectionUnification() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document><![CDATA[
+Module Module1
+
+    Sub Main()
+        Dim x As ProcessStartInfo = New $$
+    End Sub
+
+End Module
+]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Dim psi = state.CurrentCompletionPresenterSession.CompletionItems.Where(Function(i) i.DisplayText.Contains("ProcessStartInfo")).ToArray()
+                Assert.Equal(1, psi.Length)
+            End Using
+        End Function
+
+        <WorkItem(394863, "https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=394863&triage=true")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function ImplementsClause() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document><![CDATA[
+Partial Class TestClass
+    Implements IComparable(Of TestClass)
+
+    Public Function CompareTo(other As TestClass) As Integer Implements I$$
+
+
+    End Function
+
+End Class
+]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendTab()
+                Assert.Contains("IComparable(Of TestClass)", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <WorkItem(18785, "https://github.com/dotnet/roslyn/issues/18785")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspaceSoftSelectionIfNotPrefixMatch() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document><![CDATA[
+Class C
+    Sub Do()
+        Dim x = new System.Collections.Generic.List(Of String)()
+        x.$$Add("stuff")
+    End Sub
+End Class
+]]></Document>)
+
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem("x", isSoftSelected:=True)
+                state.SendTypeChars(".")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Contains("x.Add", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <ExportLanguageService(GetType(ISnippetInfoService), LanguageNames.VisualBasic), System.Composition.Shared>
+        Friend Class MockSnippetInfoService
+            Implements ISnippetInfoService
+
+            Public Function GetSnippetsAsync_NonBlocking() As IEnumerable(Of SnippetInfo) Implements ISnippetInfoService.GetSnippetsIfAvailable
+                Return SpecializedCollections.SingletonEnumerable(New SnippetInfo("Shortcut", "Title", "Description", "Path"))
+            End Function
+
+            Public Function ShouldFormatSnippet(snippetInfo As SnippetInfo) As Boolean Implements ISnippetInfoService.ShouldFormatSnippet
+                Return False
+            End Function
+
+            Public Function SnippetShortcutExists_NonBlocking(shortcut As String) As Boolean Implements ISnippetInfoService.SnippetShortcutExists_NonBlocking
+                Return shortcut = "Shortcut"
+            End Function
+        End Class
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/OldCompletion/VisualBasicCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/OldCompletion/VisualBasicCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -1,0 +1,599 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.OldCompletion
+    ''' <summary>
+    ''' This is a test file corresponding to the old Completion service which we are going to turn off after migration to the new one.
+    ''' We should keep this file up-to-date and on par with the new file until then.
+    ''' </summary>
+    <[UseExportProvider]>
+    Public Class VisualBasicCompletionCommandHandlerTests_InternalsVisibleTo
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOtherAssembliesOfSolution() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1", "ClassLibrary2", "ClassLibrary3"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOtherAssemblyIfAttributeSuffixIsPresent() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("$$
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsTriggeredWhenDoubleQuoteIsEntered() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo($$
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars(""""c)
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsEmptyUntilDoubleQuotesAreEntered() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo$$
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                state.SendTypeChars("("c)
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                state.SendTypeChars(""""c)
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsTriggeredWhenCharacterIsEnteredAfterOpeningDoubleQuote() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("a"c)
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsNotTriggeredWhenCharacterIsEnteredThatIsNotRightBesideTheOpeniningDoubleQuote() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("a$$")>
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("b"c)
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsNotTriggeredWhenDoubleQuoteIsEnteredAtStartOfFile() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb">$$
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars("a"c)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionIsNotTriggeredByArrayElementAccess() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+Namespace A
+	Public Class C
+		Public Sub M()
+			Dim d = New System.Collections.Generic.Dictionary(Of String, String)()
+			Dim v = d$$
+		End Sub
+	End Class
+End Namespace
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                Dim AssertNoCompletionAndCompletionDoesNotContainClassLibrary1 As Func(Of Task) =
+                    Async Function()
+                        Await state.AssertNoCompletionSession()
+                        state.SendInvokeCompletionList()
+                        Await state.WaitForAsynchronousOperationsAsync()
+                        Assert.True(
+                            state.CurrentCompletionPresenterSession Is Nothing OrElse
+                            Not state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                    End Function
+                Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
+                state.SendTypeChars("("c)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                state.SendTypeChars(""""c)
+                Await AssertNoCompletionAndCompletionDoesNotContainClassLibrary1()
+            End Using
+        End Function
+
+        Private Async Function AssertCompletionListHasItems(code As String, hasItems As Boolean) As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb">
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
+<%= code %>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                If hasItems Then
+                    Await state.AssertCompletionSession()
+                    Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+                Else
+                    If Not state.CurrentCompletionPresenterSession Is Nothing Then
+                        Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                    End If
+                End If
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_AfterSingleDoubleQuoteAndClosing() As Task
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""$$)>", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_AfterText() As Task
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""Test$$)>", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfCursorIsInSecondParameter() As Task
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""Test"", ""$$", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasNoItems_IfCursorIsClosingDoubleQuote1() As Task
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""Test""$$", False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasNoItems_IfCursorIsClosingDoubleQuote2() As Task
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""""$$", False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfNamedParameterIsPresent() As Task
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""$$, AllInternalsVisible:=True)>", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasNoItems_IfNumberIsEntered() As Task
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(1$$2)>", False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasNoItems_IfNotInternalsVisibleToAttribute() As Task
+            Await AssertCompletionListHasItems("<Assembly: AssemblyVersion(""$$"")>", False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfOtherAttributeIsPresent1() As Task
+            Await AssertCompletionListHasItems("<Assembly: AssemblyVersion(""1.0.0.0""), InternalsVisibleTo(""$$", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfOtherAttributeIsPresent2() As Task
+            Await AssertCompletionListHasItems("<Assembly: InternalsVisibleTo(""$$""), AssemblyVersion(""1.0.0.0"")>", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfOtherAttributesAreAhead() As Task
+            Await AssertCompletionListHasItems("
+                <Assembly: AssemblyVersion(""1.0.0.0"")>
+                <Assembly: InternalsVisibleTo(""$$", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfOtherAttributesAreFollowing() As Task
+            Await AssertCompletionListHasItems("
+            <Assembly: InternalsVisibleTo(""$$
+            <Assembly: AssemblyVersion(""1.0.0.0"")>
+            <Assembly: AssemblyCompany(""Test"")>", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AssertCompletionListHasItems_IfNamespaceIsFollowing() As Task
+            Await AssertCompletionListHasItems("
+            <Assembly: InternalsVisibleTo(""$$
+            Namespace A             
+                Public Class A
+                End Class
+            End Namespace", True)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionHasItemsIfInteralVisibleToIsReferencedByTypeAlias() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
+<Assembly: IVT("$$
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionDoesNotContainCurrentAssembly() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"TestAssembly"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionInsertsAssemblyNameOnCommit() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
+                    </Project>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("ClassLibrary1")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1"")>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionInsertsPublicKeyOnCommit() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
+                        <CompilationOptions
+                            CryptoKeyFile=<%= SigningTestHelpers.PublicKeyFile %>
+                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
+                    </Project>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("ClassLibrary1")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsPublicKeyIfKeyIsSpecifiedByAttribute() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
+                        <CompilationOptions
+                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
+                        <Document>
+                            &lt;Assembly: System.Reflection.AssemblyKeyFile("<%= SigningTestHelpers.PublicKeyFile %>")&gt;
+                        </Document>
+                    </Project>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("ClassLibrary1")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsPublicKeyIfDelayedSigningIsEnabled() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1">
+                        <CompilationOptions
+                            CryptoKeyFile=<%= SigningTestHelpers.PublicKeyFile %>
+                            StrongNameProvider=<%= SigningTestHelpers.s_defaultDesktopProvider.GetType().AssemblyQualifiedName %>/>
+                            DelaySign="True"
+                        />
+                    </Project>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$")>
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("ClassLibrary1")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""ClassLibrary1, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionListIsEmptyIfAttributeIsNotTheBCLAttribute() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: Test.InternalsVisibleTo("$$")>
+Namespace Test
+	<System.AttributeUsage(System.AttributeTargets.Assembly)> _
+	Public NotInheritable Class InternalsVisibleToAttribute
+		Inherits System.Attribute
+
+		Public Sub New(ignore As String)
+		End Sub
+	End Class
+End Namespace
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVT() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary1")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary3"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTIfAssemblyNameIsAConstant() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <MetadataReferenceFromSource Language="Visual Basic" CommonReferences="true">
+                            <Document FilePath="ReferencedDocument.vb">
+Namespace A
+	Public NotInheritable Class Constants
+		Private Sub New()
+		End Sub
+		Public Const AssemblyName1 As String = "ClassLibrary1"
+	End Class
+End Namespace                            
+                            </Document>
+                        </MetadataReferenceFromSource>
+                        <Document FilePath="A.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(A.Constants.AssemblyName1)>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ClassLibrary2")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary3"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTForDifferentSyntax() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary3"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary4"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary5"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary6"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary7"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary8"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+' Code comment
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
+Imports IVT = System.Runtime.CompilerServices.InternalsVisibleToAttribute
+' Code comment
+<Assembly: InternalsVisibleTo("ClassLibrary1", AllInternalsVisible:=True)>
+<Assembly: AssemblyVersion("1.0.0.0"), Assembly: InternalsVisibleTo("ClassLibrary2")>
+<Assembly: InternalsVisibleTo("ClassLibrary3"), Assembly: AssemblyCopyright("Copyright")>
+<Assembly: AssemblyDescription("Description")>
+<Assembly: InternalsVisibleTo("ClassLibrary4")>
+<Assembly: InternalsVisibleTo("ClassLibrary5, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb")>
+<Assembly: InternalsVisibleTo("ClassLibrary" + "6")>
+<Assembly: IVT("ClassLibrary7")>
+<Assembly: InternalsVisibleTo("$$
+Namespace A
+    Public Class A
+End Class
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1", "ClassLibrary2", "ClassLibrary3", "ClassLibrary4", "ClassLibrary5", "ClassLibrary6", "ClassLibrary7"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary8"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTWithSyntaxError() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="A.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
+
+<Assembly: InternalsVisibleTo("ClassLibrary" + 1.ToString())> ' Not a constant
+<Assembly: InternalsVisibleTo("$$
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                ' ClassLibrary1 must be listed because the existing attribute argument can't be resolved to a constant.
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary1"}))
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionContainsOnlyAssembliesThatAreNotAlreadyIVTWithMoreThanOneDocument() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary1"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="ClassLibrary2"/>
+                    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="OtherDocument.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
+<Assembly: InternalsVisibleTo("ClassLibrary1")>
+<Assembly: AssemblyDescription("Description")>
+]]>
+                        </Document>
+                        <Document FilePath="A.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+Imports System.Reflection
+<Assembly: InternalsVisibleTo("$$
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Assert.False(state.CompletionItemsContainsAny({"ClassLibrary1"}))
+                Assert.True(state.CompletionItemsContainsAll({"ClassLibrary2"}))
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/OldCompletion/VisualBasicCompletionCommandHandlerTests_Projections.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/OldCompletion/VisualBasicCompletionCommandHandlerTests_Projections.vb
@@ -1,0 +1,124 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.VisualStudio.Text.Projection
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.OldCompletion
+    ''' <summary>
+    ''' This is a test file corresponding to the old Completion service which we are going to turn off after migration to the new one.
+    ''' We should keep this file up-to-date and on par with the new file until then.
+    ''' </summary>
+    <[UseExportProvider]>
+    Public Class VisualBasicCompletionCommandHandlerTests_Projections
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSimpleWithJustSubjectBuffer() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Option Strict Off
+Option Explicit On
+
+Imports System
+
+Namespace ASP
+    Public Class _Page_Views_Home_Index_vbhtml
+
+        Private Shared __o As Object
+
+        Public Sub Execute()
+#ExternalSource ("Index.vbhtml", 1)
+            __o = AppDomain$$
+
+#End ExternalSource
+
+        End Sub
+    End Class
+End Namespace
+]]></Document>)
+
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("Curr")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="CurrentDomain")
+                state.SendTab()
+                Assert.Contains("__o = AppDomain.CurrentDomain", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestAfterDot() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+{|S2:
+Class C
+    Sub Goo()
+        System$$
+    End Sub
+End Class
+|}]]></Document>)
+                Dim subjectDocument = state.Workspace.Documents.First()
+                Dim firstProjection = state.Workspace.CreateProjectionBufferDocument(
+                    <Document>
+{|S1: &lt;html&gt;@|}
+{|S2:|}
+                    </Document>.NormalizedValue, {subjectDocument}, LanguageNames.VisualBasic, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+                Dim topProjectionBuffer = state.Workspace.CreateProjectionBufferDocument(
+                <Document>
+{|S1:|}
+{|S2:&lt;/html&gt;|}
+                              </Document>.NormalizedValue, {firstProjection}, LanguageNames.VisualBasic, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+
+                Dim view = topProjectionBuffer.GetTextView()
+                Dim buffer = subjectDocument.GetTextBuffer()
+
+                state.SendTypeCharsToSpecificViewAndBuffer(".", view, buffer)
+                Await state.AssertCompletionSession()
+
+                state.SendTypeCharsToSpecificViewAndBuffer("Cons", view, buffer)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Console")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestInObjectCreationExpression() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+{|S2:
+Class C
+    Sub Goo()
+        Dim s As New$$
+    End Sub
+End Class
+|}]]></Document>)
+                Dim subjectDocument = state.Workspace.Documents.First()
+                Dim firstProjection = state.Workspace.CreateProjectionBufferDocument(
+                    <Document>
+{|S1: &lt;html&gt;@|}
+{|S2:|}
+                    </Document>.NormalizedValue, {subjectDocument}, LanguageNames.CSharp, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+                Dim topProjectionBuffer = state.Workspace.CreateProjectionBufferDocument(
+                <Document>
+{|S1:|}
+{|S2:&lt;/html&gt;|}
+                              </Document>.NormalizedValue, {firstProjection}, LanguageNames.CSharp, options:=ProjectionBufferOptions.WritableLiteralSpans)
+
+
+                Dim view = topProjectionBuffer.GetTextView()
+                Dim buffer = subjectDocument.GetTextBuffer()
+
+                state.SendTypeCharsToSpecificViewAndBuffer(" ", view, buffer)
+                Await state.AssertCompletionSession()
+
+                state.SendTypeCharsToSpecificViewAndBuffer("Str", view, buffer)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="String", isHardSelected:=True)
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/OldCompletion/VisualBasicCompletionCommandHandlerTests_XmlDoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/OldCompletion/VisualBasicCompletionCommandHandlerTests_XmlDoc.vb
@@ -1,0 +1,1221 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.OldCompletion
+    ''' <summary>
+    ''' This is a test file corresponding to the old Completion service which we are going to turn off after migration to the new one.
+    ''' We should keep this file up-to-date and on par with the new file until then.
+    ''' </summary>
+    <[UseExportProvider]>
+    Public Class VisualBasicCompletionCommandHandlerTests_XmlDoc
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSummary() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Await state.AssertLineTextAroundCaret("    ''' summary", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSummaryOnTab() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' summary$$
+                Await state.AssertLineTextAroundCaret("    ''' summary", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSummaryOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' summary>$$
+                Await state.AssertLineTextAroundCaret("    ''' summary>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSummary() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <summary$$
+                Await state.AssertLineTextAroundCaret("    ''' <summary", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSummaryOnTab() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <summary$$
+                Await state.AssertLineTextAroundCaret("    ''' <summary", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSummaryOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summ")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <summary>$$
+                Await state.AssertLineTextAroundCaret("    ''' <summary>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitRemarksOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("rema")
+                Await state.AssertSelectedCompletionItem(displayText:="remarks")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' remarks>$$
+                Await state.AssertLineTextAroundCaret("    ''' remarks>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitRemarksOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("rema")
+                Await state.AssertSelectedCompletionItem(displayText:="remarks")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <remarks>$$
+                Await state.AssertLineTextAroundCaret("    ''' <remarks>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitReturnsOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Function Goo() As Integer
+    End Function
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("retur")
+                Await state.AssertSelectedCompletionItem(displayText:="returns")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' returns>$$
+                Await state.AssertLineTextAroundCaret("    ''' returns>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitReturnsOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Function Goo() As Integer
+    End Function
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("retur")
+                Await state.AssertSelectedCompletionItem(displayText:="returns")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <returns>$$
+                Await state.AssertLineTextAroundCaret("    ''' <returns>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitExampleOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("examp")
+                Await state.AssertSelectedCompletionItem(displayText:="example")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' example>$$
+                Await state.AssertLineTextAroundCaret("    ''' example>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitExampleOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("examp")
+                Await state.AssertSelectedCompletionItem(displayText:="example")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <example>$$
+                Await state.AssertLineTextAroundCaret("    ''' <example>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitExceptionNoOpenAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("except")
+                Await state.AssertSelectedCompletionItem(displayText:="exception")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <exception cref="$$"
+                Await state.AssertLineTextAroundCaret("    ''' <exception cref=""", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitExceptionOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("except")
+                Await state.AssertSelectedCompletionItem(displayText:="exception")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <exception cref=">$$"
+                Await state.AssertLineTextAroundCaret("    ''' <exception cref="">", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitCommentNoOpenAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendSelectCompletionItem("!--")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <!--$$-->
+                Await state.AssertLineTextAroundCaret("    ''' <!--", "-->")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitCommentOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendSelectCompletionItem("!--")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <!-->$$-->
+                Await state.AssertLineTextAroundCaret("    ''' <!-->", "-->")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitCdataNoOpenAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendSelectCompletionItem("![CDATA[")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <![CDATA[$$]]>
+                Await state.AssertLineTextAroundCaret("    ''' <![CDATA[", "]]>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitCdataOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendSelectCompletionItem("![CDATA[")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <![CDATA[>$$]]>
+                Await state.AssertLineTextAroundCaret("    ''' <![CDATA[>", "]]>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitIncludeNoOpenAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("inclu")
+                Await state.AssertSelectedCompletionItem(displayText:="include")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <include file='$$' path='[@name=""]'/>
+                Await state.AssertLineTextAroundCaret("    ''' <include file='", "' path='[@name=""""]'/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitIncludeOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("inclu")
+                Await state.AssertSelectedCompletionItem(displayText:="include")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <include file='>$$' path='[@name=""]'/>
+                Await state.AssertLineTextAroundCaret("    ''' <include file='>", "' path='[@name=""""]'/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitPermissionNoOpenAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("permiss")
+                Await state.AssertSelectedCompletionItem(displayText:="permission")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <permission cref="$$"
+                Await state.AssertLineTextAroundCaret("    ''' <permission cref=""", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitPermissionOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("permiss")
+                Await state.AssertSelectedCompletionItem(displayText:="permission")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <permission cref=">$$"
+                Await state.AssertLineTextAroundCaret("    ''' <permission cref="">", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSeeNoOpenAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("see")
+                Await state.AssertSelectedCompletionItem(displayText:="see")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <see cref="$$"/>
+                Await state.AssertLineTextAroundCaret("    ''' <see cref=""", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSeeOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("see")
+                Await state.AssertSelectedCompletionItem(displayText:="see")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <see cref=">$$"/>
+                Await state.AssertLineTextAroundCaret("    ''' <see cref="">", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSeeOnSpace() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' <summary>
+    ''' $$
+    ''' </summary>
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("see")
+                Await state.AssertSelectedCompletionItem(displayText:="see")
+                state.SendTypeChars(" ")
+
+                ' ''' <see cref="$$"/>
+                Await state.AssertLineTextAroundCaret("    ''' <see cref=""", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithNothingKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("Nothing")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithSharedKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("Shared")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithOverridableKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("Overridable", unique:=False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithTrueKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("True")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithFalseKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("False")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithMustInheritKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("MustInherit")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithNotOverridableKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("NotOverridable")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithAsyncKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("Async")
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Function InvokeWithAwaitKeywordCommitSeeLangword() As Task
+            Return InvokeWithKeywordCommitSeeLangword("Await")
+        End Function
+
+        Private Async Function InvokeWithKeywordCommitSeeLangword(keyword As String, Optional unique As Boolean = True) As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' <summary>
+    ''' $$
+    ''' </summary>
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                ' Omit the last letter of the keyword to make it easier to diagnose failures (inserted the wrong text,
+                ' or did not insert text at all).
+                state.SendTypeChars(keyword.Substring(0, keyword.Length - 1))
+                state.SendInvokeCompletionList()
+                If unique Then
+                    state.SendCommitUniqueCompletionListItem()
+                Else
+                    Await state.AssertSelectedCompletionItem(displayText:=keyword)
+                    state.SendTab()
+                End If
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <see langword="keyword"/>$$
+                Await state.AssertLineTextAroundCaret("    ''' <see langword=""" + keyword + """/>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitSeealsoNoOpenAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("seeal")
+                Await state.AssertSelectedCompletionItem(displayText:="seealso")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <seealso cref="$$"/>
+                Await state.AssertLineTextAroundCaret("    ''' <seealso cref=""", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitSeealsoOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C
+    ''' $$
+    Sub Goo()
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("seeal")
+                Await state.AssertSelectedCompletionItem(displayText:="seealso")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <seealso cref=">$$"/>
+                Await state.AssertLineTextAroundCaret("    ''' <seealso cref="">", """/>")
+            End Using
+        End Function
+
+        <WorkItem(623219, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/623219")>
+        <WorkItem(746919, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/746919")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitParam() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' <param$$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    ''' <param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitParamNoOpenAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    ''' param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitParamNoOpenAngleOnTab() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    ''' param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitParamNoOpenAngleOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' param name="bar">$$
+                Await state.AssertLineTextAroundCaret("    ''' param name=""bar"">", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitParam() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    ''' <param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitParamOnTab() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <param name="bar"$$
+                Await state.AssertLineTextAroundCaret("    ''' <param name=""bar""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitParamOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("param")
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <param name="bar">$$
+                Await state.AssertLineTextAroundCaret("    ''' <param name=""bar"">", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitTypeparamNoOpenAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' typeparam name="T"$$
+                Await state.AssertLineTextAroundCaret("    ''' typeparam name=""T""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitTypeparamNoOpenAngleOnTab() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' typeparam name="T"$$
+                Await state.AssertLineTextAroundCaret("    ''' typeparam name=""T""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitTypeparamNoOpenAngleOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' typeparam name="T">$$
+                Await state.AssertLineTextAroundCaret("    ''' typeparam name=""T"">", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitTypeparam() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <typeparam name="T"$$
+                Await state.AssertLineTextAroundCaret("    ''' <typeparam name=""T""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitTypeparamOnTab() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <typeparam name="T"$$
+                Await state.AssertLineTextAroundCaret("    ''' <typeparam name=""T""", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function InvokeWithOpenAngleCommitTypeparamOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' $$
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("typepara")
+                Await state.AssertSelectedCompletionItem(displayText:="typeparam name=""T""")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <typeparam name="T">$$
+                Await state.AssertLineTextAroundCaret("    ''' <typeparam name=""T"">", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitList() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' <summary>
+    ''' $$
+    ''' </summary>
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("lis")
+                Await state.AssertSelectedCompletionItem(displayText:="list")
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <list type="$$"
+                Await state.AssertLineTextAroundCaret("    ''' <list type=""", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CommitListOnCloseAngle() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' <summary>
+    ''' $$
+    ''' </summary>
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("lis")
+                Await state.AssertSelectedCompletionItem(displayText:="list")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <list type=">$$"
+                Await state.AssertLineTextAroundCaret("    ''' <list type="">", """")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestTagCompletion1() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' <$$
+    ''' </summary>
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summa")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <summary>$$
+                Await state.AssertLineTextAroundCaret("    ''' <summary>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestTagCompletion2() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' <$$
+    ''' <remarks></remarks>
+    ''' </summary>
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summa")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <summary>$$
+                Await state.AssertLineTextAroundCaret("    ''' <summary>", "")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestTagCompletion3() As Task
+
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' <$$
+    ''' <remarks>
+    ''' </summary>
+    Sub Goo(Of T)(bar As T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("summa")
+                Await state.AssertSelectedCompletionItem(displayText:="summary")
+                state.SendTypeChars(">")
+                Await state.AssertNoCompletionSession()
+
+                ' ''' <summary>$$
+                Await state.AssertLineTextAroundCaret("    ''' <summary>", "")
+            End Using
+        End Function
+        <WorkItem(638653, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638653")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/21481"), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AllowTypingDoubleQuote() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' <param$$
+    Sub Goo(Of T)(bar as T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTypeChars(" name=""")
+
+                ' ''' <param name="$$
+                Await state.AssertLineTextAroundCaret("    ''' <param name=""", "")
+
+                ' Because the item contains a double quote, the completion list should still be present with the same selection
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+            End Using
+        End Function
+
+        <WorkItem(638653, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638653")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function AllowTypingSpace() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Class C(Of T)
+    ''' <param$$
+    Sub Goo(Of T)(bar as T)
+    End Sub
+End Class
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+                state.SendTypeChars(" ")
+
+                ' ''' <param $$
+                Await state.AssertLineTextAroundCaret("    ''' <param ", "")
+
+                ' Because the item contains a space, the completion list should still be present with the same selection
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="param name=""bar""")
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/CSharp/Test/Interactive/InteractiveWindowTestHost.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/InteractiveWindowTestHost.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.InteractiveWindow;
-using Microsoft.VisualStudio.Text.Utilities;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive
@@ -31,39 +28,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive
                 }
                 .Concat(TestExportProvider.GetCSharpAndVisualBasicAssemblies())
                 .Concat(MinimalTestExportProvider.GetEditorAssemblies())));
-
-        // Provide an export of ILoggingServiceInternal to work around https://devdiv.visualstudio.com/DevDiv/_workitems/edit/570290
-        [Export(typeof(ILoggingServiceInternal))]
-        private sealed class HACK_LoggingProvider : ILoggingServiceInternal
-        {
-            public void AdjustCounter(string key, string name, int delta = 1)
-            {
-            }
-
-            public void PostCounters()
-            {
-            }
-
-            public void PostEvent(string key, params object[] namesAndProperties)
-            {
-            }
-
-            public void PostEvent(string key, IReadOnlyList<object> namesAndProperties)
-            {
-            }
-
-            public void PostEvent(TelemetryEventType eventType, string eventName, TelemetryResult result = TelemetryResult.Success, params (string name, object property)[] namesAndProperties)
-            {
-            }
-
-            public void PostEvent(TelemetryEventType eventType, string eventName, TelemetryResult result, IReadOnlyList<(string name, object property)> namesAndProperties)
-            {
-            }
-
-            public void PostFault(string eventName, string description, Exception exceptionObject, string additionalErrorInfo, bool? isIncludedInWatsonSample)
-            {
-            }
-        }
 
         internal InteractiveWindowTestHost(ExportProvider exportProvider)
         {


### PR DESCRIPTION
This change improves our ability to review the async completion tests through GitHub. In particular, it preserves `git diff` and `git blame` functionality for both the "old tests" (which should be preserved without alterations) and the "new tests" (which will be modified to test the new async completion features).

Recommended review strategy:

* Review the first two commits individually.
* The final commit is an identity preservation of the result of the first two commits. GitHub cannot show this, so if you want to check my work, you'll need local tools.

After this change is merged, I will update #29016, and the result will be a *much* smaller review.