### PR TITLE
Register uses of ? annotation in constraints

### DIFF
--- a/docs/features/nullable-reference-types.md
+++ b/docs/features/nullable-reference-types.md
@@ -137,7 +137,7 @@ var x = optionalString!; // x is string!
 var y = obliviousString!; // y is string!
 var z = new [] { optionalString, obliviousString }!; // no change, z is string?[]!
 ```
-An error is reported whenever the `!` operator is applied to a reference type.
+An error is reported whenever the `!` operator is applied to a value type.
 A warning is reported when using the `!` operator absent a `NonNullTypes` context.
 
 _Should `!` suppress warnings for nested nullability?_

--- a/docs/features/nullable-reference-types.md
+++ b/docs/features/nullable-reference-types.md
@@ -8,6 +8,8 @@ In source, nullable reference types are annotated with `?`.
 string? OptString; // may be null
 Dictionary<string, object?>? OptDictionaryOptValues; // dictionary may be null, values may be null
 ```
+A warning is reported when annotating a reference type or unconstrained generic type with `?` outside a `NonNullTypes(true)` context.
+
 In metadata, nullable reference types are annotated with a `[Nullable]` attribute.
 ```c#
 namespace System.Runtime.CompilerServices
@@ -128,13 +130,16 @@ if (maybeNull == null) return;
 var t = maybeNull; // t is !
 ```
 
-### `!` operator
+### Suppression operator (`!`)
 The postfix `!` operator sets the top-level nullability to non-nullable.
 ```c#
 var x = optionalString!; // x is string!
 var y = obliviousString!; // y is string!
 var z = new [] { optionalString, obliviousString }!; // no change, z is string?[]!
 ```
+An error is reported whenever the `!` operator is applied to a reference type.
+A warning is reported when using the `!` operator absent a `NonNullTypes` context.
+
 _Should `!` suppress warnings for nested nullability?_
 _Should `nonNull!` result in a warning for unnecessary `!`?_
 _Should `!!` be an error?_

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private bool _needsGeneratedIsReadOnlyAttribute_Value;
         private bool _needsGeneratedIsUnmanagedAttribute_Value;
         private bool _needsGeneratedAttributes_IsFrozen;
+        private bool _needsGeneratedNullableAttribute_Value;
 
         /// <summary>
         /// Returns a value indicating whether this builder has a symbol that needs IsReadOnlyAttribute to be generated during emit phase.
@@ -84,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             get
             {
                 _needsGeneratedAttributes_IsFrozen = true;
-                if (Compilation.NeedsGeneratedNullableAttribute)
+                if (Compilation.NeedsGeneratedNullableAttribute || _needsGeneratedNullableAttribute_Value)
                 {
                     return true;
                 }
@@ -1601,7 +1602,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal void EnsureNullableAttributeExists()
         {
             Debug.Assert(!_needsGeneratedAttributes_IsFrozen);
-            // PROTOTYPE(NullableReferenceTypes): Remove method if not needed.
+
+            if (_needsGeneratedNullableAttribute_Value || Compilation.NeedsGeneratedNullableAttribute)
+            {
+                return;
+            }
+
+            // Don't report any errors. They should be reported during binding.
+            if (Compilation.CheckIfNullableAttributeShouldBeEmbedded(diagnosticsOpt: null, locationOpt: null))
+            {
+                _needsGeneratedNullableAttribute_Value = true;
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -239,6 +239,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _factory.CompilationState.ModuleBuilderOpt?.EnsureIsUnmanagedAttributeExists();
             }
 
+            if (hasConstraintsWithNullableReferenceTypes(node))
+            {
+                _factory.CompilationState.ModuleBuilderOpt?.EnsureNullableAttributeExists();
+            }
+
             var oldContainingSymbol = _factory.CurrentFunction;
             try
             {
@@ -248,6 +253,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             finally
             {
                 _factory.CurrentFunction = oldContainingSymbol;
+            }
+
+            bool hasConstraintsWithNullableReferenceTypes(BoundLocalFunctionStatement localFunction)
+            {
+                return localFunction.Symbol.TypeParameters.Any(
+                   typeParameter => typeParameter.ConstraintTypesNoUseSiteDiagnostics.Any(
+                       typeConstraint => typeConstraint.ContainsNullableReferenceTypes()));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -234,7 +234,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             _sawLocalFunctions = true;
             CheckRefReadOnlySymbols(node.Symbol);
 
-            if (node.Symbol.TypeParameters.Any(typeParameter => typeParameter.HasUnmanagedTypeConstraint))
+            bool hasUnmanagedConstraint = node.Symbol.TypeParameters.Any(typeParameter => typeParameter.HasUnmanagedTypeConstraint);
+            if (hasUnmanagedConstraint)
             {
                 _factory.CompilationState.ModuleBuilderOpt?.EnsureIsUnmanagedAttributeExists();
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -415,10 +415,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (constraintType.ContainsNullableReferenceTypes())
                 {
+                    // Note: Local functions register their need for the Nullable attribute on constraints in LocalRewriter
                     bool onLocalFunction = containingSymbol.Kind == SymbolKind.Method && ((MethodSymbol)containingSymbol).MethodKind == MethodKind.LocalFunction;
                     containingSymbol.DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, syntax.Location, modifyCompilation: !onLocalFunction);
+
                     if (!onLocalFunction)
                     {
+                        // Note: Misuse of ? annotation on declarations of local functions is reported when binding their types (since in executable context)
                         containingSymbol.ReportMissingNonNullTypesContextForAnnotation(diagnostics, syntax.Location);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -412,6 +412,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     containingSymbol.CheckConstraintTypeVisibility(syntax.Location, constraintType, diagnostics);
                     constraintTypeBuilder.Add(constraintType);
                 }
+
+                if (constraintType.ContainsNullableReferenceTypes())
+                {
+                    bool onLocalFunction = containingSymbol.Kind == SymbolKind.Method && ((MethodSymbol)containingSymbol).MethodKind == MethodKind.LocalFunction;
+                    containingSymbol.DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, syntax.Location, modifyCompilation: !onLocalFunction);
+                    if (!onLocalFunction)
+                    {
+                        containingSymbol.ReportMissingNonNullTypesContextForAnnotation(diagnostics, syntax.Location);
+                    }
+                }
             }
             if (constraintTypeBuilder.Count < n)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -273,6 +273,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool? NonNullTypes => ContainingSymbol.NonNullTypes;
+
         private void CheckUnmanagedConstraint(DiagnosticBag diagnostics)
         {
             if (this.HasUnmanagedTypeConstraint)

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -305,7 +305,6 @@ class C
     [System.Runtime.CompilerServices.NonNullTypes(true)]
     void M1()
     {
-        local(new C());
         void local<T>(T t) where T : I<C?>
         {
         }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -296,6 +296,30 @@ class C
         }
 
         [Fact]
+        public void EmitAttribute_LocalFunctionConstraints_Nested()
+        {
+            var source = @"
+interface I<T> { }
+class C
+{
+    [System.Runtime.CompilerServices.NonNullTypes(true)]
+    void M1()
+    {
+        local(new C());
+        void local<T>(T t) where T : I<C?>
+        {
+        }
+    }
+}";
+            var comp = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var assembly = module.ContainingAssembly;
+                Assert.NotNull(assembly.GetTypeByMetadataName("System.Runtime.CompilerServices.NullableAttribute"));
+            });
+        }
+
+        [Fact]
         public void EmitAttribute_LocalFunctionConstraints_NoAnnotation()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -273,6 +273,53 @@ class C
         }
 
         [Fact]
+        public void EmitAttribute_LocalFunctionConstraints()
+        {
+            var source = @"
+class C
+{
+    [System.Runtime.CompilerServices.NonNullTypes(true)]
+    void M1()
+    {
+        local(new C());
+        void local<T>(T t) where T : C?
+        {
+        }
+    }
+}";
+            var comp = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var assembly = module.ContainingAssembly;
+                Assert.NotNull(assembly.GetTypeByMetadataName("System.Runtime.CompilerServices.NullableAttribute"));
+            });
+        }
+
+        [Fact]
+        public void EmitAttribute_LocalFunctionConstraints_NoAnnotation()
+        {
+            var source = @"
+class C
+{
+    [System.Runtime.CompilerServices.NonNullTypes(true)]
+    void M1()
+    {
+        local(new C());
+        void local<T>(T t) where T : C
+        {
+        }
+    }
+}";
+            var comp = CreateCompilation(new[] { source, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var assembly = module.ContainingAssembly;
+                // PROTOTYPE(NullableReferenceTypes): The Nullable attribute shouldn't be synthesized
+                Assert.NotNull(assembly.GetTypeByMetadataName("System.Runtime.CompilerServices.NullableAttribute"));
+            });
+        }
+
+        [Fact]
         public void EmitAttribute_Module()
         {
             var source =
@@ -378,10 +425,13 @@ public class B2 : A<object?>
 public class A : I<object>
 {
 }
+[System.Runtime.CompilerServices.NonNullTypes(false)]
+public class AOblivious : I<object> { }
 public class B : I<object?>
 {
-}";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+}
+";
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8);
             CompileAndVerify(comp, validator: assembly =>
             {
                 var reader = assembly.GetMetadataReader();
@@ -395,16 +445,20 @@ public class B : I<object?>
             var source2 =
 @"class C
 {
-    static void F(I<object> x, I<object?> y)
-    {
-    }
-    static void G(A x, B y)
+    static void F(I<object> x, I<object?> y) { }
+    [System.Runtime.CompilerServices.NonNullTypes(false)]
+    static void FOblivious(I<object> x) { }
+    static void G(A x, B y, AOblivious z)
     {
         F(x, x);
         F(y, y);
+        F(z, z);
+        FOblivious(x);
+        FOblivious(y);
+        FOblivious(z);
     }
 }";
-            var comp2 = CreateCompilation(new[] { source2, NonNullTypesTrue, NonNullTypesAttributesDefinition }, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
+            var comp2 = CreateCompilation(new[] { source2, NonNullTypesTrue }, parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
                 // (8,14): warning CS8620: Nullability of reference types in argument of type 'A' doesn't match target type 'I<object?>' for parameter 'y' in 'void C.F(I<object> x, I<object?> y)'.
                 //         F(x, x);


### PR DESCRIPTION
While working to change the default test options to C# 8, I removed some logic that would cause the NullableAttribute to always be synthesized. This affected some tests where a `?` annotation only appeared in a constraint, because there would be no call to `EnsureNullableAttributeExists` to register the need for that attribute.

I'm splitting this fix to a separate PR for easier review.