### PR TITLE
Reduce number of TypeSymbolWithAnnotations.Create methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var type = symbol as TypeSymbol;
                 return type is null ?
                     new NamespaceOrTypeOrAliasSymbolWithAnnotations(default, symbol) :
-                    new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext, type), null);
+                    new NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations.Create(nonNullTypesContext, type), null);
             }
 
             public static implicit operator NamespaceOrTypeOrAliasSymbolWithAnnotations(TypeSymbolWithAnnotations type)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -250,13 +250,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbolWithAnnotations declType = BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar, out aliasOpt);
             if (isVar)
             {
-                declType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, operandType);
+                declType = TypeSymbolWithAnnotations.Create(NonNullTypesContext, operandType);
             }
 
             if (declType.IsNull)
             {
                 Debug.Assert(hasErrors);
-                declType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, this.CreateErrorType("var"));
+                declType = TypeSymbolWithAnnotations.Create(NonNullTypesContext, this.CreateErrorType("var"));
             }
 
             var boundDeclType = new BoundTypeExpression(typeSyntax, aliasOpt, inferredType: isVar, type: declType.TypeSymbol);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.PredefinedType:
                     {
                         var type = BindPredefinedTypeSymbol((PredefinedTypeSyntax)syntax, diagnostics);
-                        return TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, type);
+                        return TypeSymbolWithAnnotations.Create(NonNullTypesContext, type);
                     }
 
                 case SyntaxKind.IdentifierName:
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         BindNonGenericSimpleNamespaceOrTypeOrAliasSymbol((IdentifierNameSyntax)syntax, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics, qualifierOpt: null));
 
                 case SyntaxKind.GenericName:
-                    return TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext,
+                    return TypeSymbolWithAnnotations.Create(NonNullTypesContext,
                         BindGenericSimpleNamespaceOrTypeOrAliasSymbol((GenericNameSyntax)syntax, diagnostics, basesBeingResolved, qualifierOpt: null));
 
                 case SyntaxKind.AliasQualifiedName:
@@ -449,7 +449,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else
                             {
-                                type = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, array);
+                                type = TypeSymbolWithAnnotations.Create(NonNullTypesContext, array);
                             }
                         }
 
@@ -484,7 +484,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case SyntaxKind.TupleType:
                     {
-                        return TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, BindTupleType((TupleTypeSyntax)syntax, diagnostics));
+                        return TypeSymbolWithAnnotations.Create(NonNullTypesContext, BindTupleType((TupleTypeSyntax)syntax, diagnostics));
                     }
 
                 case SyntaxKind.RefType:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<Location> elementLocations = elements.SelectAsArray(e => e.Syntax.Location);
 
             var tuple = TupleTypeSymbol.Create(locationOpt: null,
-                elementTypes: convertedTypes.SelectAsArray((t, m) => TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: m, t), compilation.SourceModule),
+                elementTypes: convertedTypes.SelectAsArray((t, m) => TypeSymbolWithAnnotations.Create(nonNullTypesContext: m, t), compilation.SourceModule),
                 elementLocations, elementNames: names, compilation,
                 shouldCheckConstraints: true, errorPositions: default, syntax, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/BoundTree/OutDeconstructVarPendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutDeconstructVarPendingInference.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundDeconstructValuePlaceholder FailInference(Binder binder)
         {
-            return SetInferredType(TypeSymbolWithAnnotations.CreateUnannotated(binder.NonNullTypesContext, binder.CreateErrorType()), binder, success: false);
+            return SetInferredType(TypeSymbolWithAnnotations.Create(binder.NonNullTypesContext, binder.CreateErrorType()), binder, success: false);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var expression = node.ExpressionOpt;
                 var type = (expression is null) ?
-                    TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, NoReturnExpression) :
+                    TypeSymbolWithAnnotations.Create(NonNullTypesUnusedContext.Instance, NoReturnExpression) :
                     TypeSymbolWithAnnotations.Create(expression.Type?.SetUnknownNullabilityForReferenceTypes());
                 _builder.Add((node.RefKind, type));
                 return null;
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var returnType = inferredReturnType.Type;
             if (returnType.IsNull)
             {
-                returnType = TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesFalseContext.Instance, LambdaSymbol.InferenceFailureReturnType);
+                returnType = TypeSymbolWithAnnotations.Create(NonNullTypesFalseContext.Instance, LambdaSymbol.InferenceFailureReturnType);
             }
             lambdaSymbol.SetInferredReturnType(inferredReturnType.RefKind, returnType);
 

--- a/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (inferenceFailed)
             {
-                type = TypeSymbolWithAnnotations.CreateUnannotated(binderOpt.NonNullTypesContext, binderOpt.CreateErrorType("var"));
+                type = TypeSymbolWithAnnotations.Create(binderOpt.NonNullTypesContext, binderOpt.CreateErrorType("var"));
             }
 
             switch (this.VariableSymbol.Kind)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                 if (eventType.IsNil)
                 {
-                    _eventType = TypeSymbolWithAnnotations.CreateUnannotated(containingType, new UnsupportedMetadataTypeSymbol(mrEx));
+                    _eventType = TypeSymbolWithAnnotations.Create(containingType, new UnsupportedMetadataTypeSymbol(mrEx));
                 }
             }
 
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 var typeSymbol = DynamicTypeDecoder.TransformType(originalEventType, targetSymbolCustomModifierCount, handle, moduleSymbol);
 
                 // We start without annotation (they will be decoded below)
-                var type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: containingType, typeSymbol);
+                var type = TypeSymbolWithAnnotations.Create(nonNullTypesContext: containingType, typeSymbol);
 
                 // Decode nullable before tuple types to avoid converting between
                 // NamedTypeSymbol and TupleTypeSymbol unnecessarily.

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 typeSymbol = DynamicTypeDecoder.TransformType(typeSymbol, customModifiersArray.Length, _handle, moduleSymbol);
 
                 // We start without annotations
-                var type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, typeSymbol, customModifiersArray);
+                var type = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, typeSymbol, isAnnotated: false, customModifiersArray);
 
                 // Decode nullable before tuple types to avoid converting between
                 // NamedTypeSymbol and TupleTypeSymbol unnecessarily.

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 typeSymbol = DynamicTypeDecoder.TransformType(typeSymbol, customModifiersArray.Length, _handle, moduleSymbol);
 
                 // We start without annotations
-                var type = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, typeSymbol, isAnnotated: false, customModifiersArray);
+                var type = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, typeSymbol, customModifiers: customModifiersArray);
 
                 // Decode nullable before tuple types to avoid converting between
                 // NamedTypeSymbol and TupleTypeSymbol unnecessarily.

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -448,7 +448,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 if ((object)declaredBase != null)
                 {
                     declaredBase = (NamedTypeSymbol)NullableTypeDecoder.TransformType(
-                        TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, declaredBase), _handle, ContainingPEModule).TypeSymbol;
+                        TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, declaredBase), _handle, ContainingPEModule).TypeSymbol;
                 }
                 Interlocked.CompareExchange(ref _lazyDeclaredBaseTypeWithNullability, declaredBase, ErrorTypeSymbol.UnknownResultType);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             out bool isBad)
         {
             // We start without annotation (they will be decoded below)
-            var typeWithModifiers = TypeSymbolWithAnnotations.CreateUnannotated(containingSymbol, type, CSharpCustomModifier.Convert(customModifiers));
+            var typeWithModifiers = TypeSymbolWithAnnotations.Create(containingSymbol, type, isAnnotated: false, CSharpCustomModifier.Convert(customModifiers));
 
             PEParameterSymbol parameter = customModifiers.IsDefaultOrEmpty && refCustomModifiers.IsDefaultOrEmpty
                 ? new PEParameterSymbol(moduleSymbol, containingSymbol, ordinal, isByRef, typeWithModifiers, extraAnnotations, handle, 0, out isBad)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             out bool isBad)
         {
             // We start without annotation (they will be decoded below)
-            var typeWithModifiers = TypeSymbolWithAnnotations.Create(containingSymbol, type, isAnnotated: false, CSharpCustomModifier.Convert(customModifiers));
+            var typeWithModifiers = TypeSymbolWithAnnotations.Create(containingSymbol, type, customModifiers: CSharpCustomModifier.Convert(customModifiers));
 
             PEParameterSymbol parameter = customModifiers.IsDefaultOrEmpty && refCustomModifiers.IsDefaultOrEmpty
                 ? new PEParameterSymbol(moduleSymbol, containingSymbol, ordinal, isByRef, typeWithModifiers, extraAnnotations, handle, 0, out isBad)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             originalPropertyType = originalPropertyType.AsDynamicIfNoPia(_containingType);
 
             // We start without annotation (they will be decoded below)
-            var propertyType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, originalPropertyType, typeCustomModifiers);
+            var propertyType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, originalPropertyType, isAnnotated: false, typeCustomModifiers);
 
             // Decode nullable before tuple types to avoid converting between
             // NamedTypeSymbol and TupleTypeSymbol unnecessarily.

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         }
 
                         // PROTOTYPE(NullableReferenceTypes): Test different [NonNullTypes] on method and containing type.
-                        var type = TypeSymbolWithAnnotations.CreateUnannotated(_containingSymbol, typeSymbol);
+                        var type = TypeSymbolWithAnnotations.Create(_containingSymbol, typeSymbol);
                         if (moduleSymbol.UtilizesNullableReferenceTypes)
                         {
                             type = NullableTypeDecoder.TransformType(type, constraintHandle, moduleSymbol);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             // NonNullTypesContext is unset because the actual context will
             // be set when these types are transformed by the caller.
-            return TypeSymbolWithAnnotations.Create(NonNullTypesFalseContext.Instance, type, isAnnotated: false, CSharpCustomModifier.Convert(customModifiers));
+            return TypeSymbolWithAnnotations.Create(NonNullTypesFalseContext.Instance, type, customModifiers: CSharpCustomModifier.Convert(customModifiers));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             // NonNullTypesContext is unset because the actual context will
             // be set when these types are transformed by the caller.
-            return TypeSymbolWithAnnotations.Create(type, NonNullTypesFalseContext.Instance, isAnnotated: false, CSharpCustomModifier.Convert(customModifiers));
+            return TypeSymbolWithAnnotations.Create(NonNullTypesFalseContext.Instance, type, isAnnotated: false, CSharpCustomModifier.Convert(customModifiers));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             TypeSymbol decoded = DecodeTupleTypesInternal(type, elementNames, hasTupleElementNamesAttribute);
             return (object)decoded == (object)type ?
                 metadataType :
-                TypeSymbolWithAnnotations.Create(decoded, metadataType.NonNullTypesContext, isAnnotated: metadataType.IsAnnotated, metadataType.CustomModifiers);
+                TypeSymbolWithAnnotations.Create(metadataType.NonNullTypesContext, decoded, isAnnotated: metadataType.IsAnnotated, metadataType.CustomModifiers);
         }
 
         public static TypeSymbol DecodeTupleTypesIfApplicable(
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             TypeSymbol decoded = DecodeType(type);
             return ReferenceEquals(decoded, type) ?
                 typeWithAnnotations :
-                TypeSymbolWithAnnotations.Create(decoded, typeWithAnnotations.NonNullTypesContext, isAnnotated: typeWithAnnotations.IsAnnotated, typeWithAnnotations.CustomModifiers);
+                TypeSymbolWithAnnotations.Create(typeWithAnnotations.NonNullTypesContext, decoded, isAnnotated: typeWithAnnotations.IsAnnotated, typeWithAnnotations.CustomModifiers);
         }
 
         private ImmutableArray<string> EatElementNamesIfAvailable(int numberOfElements)

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1054,7 +1054,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // PROTOTYPE(NullableReferenceTypes): Set IsNullable=null always, even in C#8,
             // and set TypeSymbolWithAnnotations.WithCustomModifiers.Is() => false.
-            return this.TypeParameters.SelectAsArray((typeParameter, module) => TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: module, typeParameter), ContainingModule);
+            return this.TypeParameters.SelectAsArray((typeParameter, module) => TypeSymbolWithAnnotations.Create(nonNullTypesContext: module, typeParameter), ContainingModule);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (isVar)
                 {
                     diagnostics.Add(ErrorCode.ERR_RecursivelyTypedVariable, this.ErrorLocation, this);
-                    type = TypeSymbolWithAnnotations.CreateUnannotated(binder.NonNullTypesContext, binder.CreateErrorType("var"));
+                    type = TypeSymbolWithAnnotations.Create(binder.NonNullTypesContext, binder.CreateErrorType("var"));
                 }
 
                 SetType(compilation, diagnostics, type);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _messageID = unboundLambda.Data.MessageID;
             _syntax = unboundLambda.Syntax;
             _refKind = refKind;
-            _returnType = returnType.IsNull ? TypeSymbolWithAnnotations.CreateUnannotated(NonNullTypesUnusedContext.Instance, ReturnTypeIsBeingInferred) : returnType;
+            _returnType = returnType.IsNull ? TypeSymbolWithAnnotations.Create(NonNullTypesUnusedContext.Instance, ReturnTypeIsBeingInferred) : returnType;
             _isSynthesized = unboundLambda.WasCompilerGenerated;
             _isAsync = unboundLambda.IsAsync;
             // No point in making this lazy. We are always going to need these soon after creation of the symbol.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics: diagnostics);
 
             _lazyIsVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
-            _lazyReturnType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            _lazyReturnType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
 
             var location = this.Locations[0];
             if (MethodKind == MethodKind.StaticConstructor && (_lazyParameters.Length != 0))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -49,10 +49,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var returnType = binder.BindType(returnTypeSyntax, diagnostics);
 
             // reuse types to avoid reporting duplicate errors if missing:
-            var voidType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            var voidType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
             // PROTOTYPE(NullableReferenceTypes): Should the 'object' parameter be considered nullable?
-            var objectType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_Object, diagnostics, syntax));
-            var intPtrType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_IntPtr, diagnostics, syntax));
+            var objectType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_Object, diagnostics, syntax));
+            var intPtrType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_IntPtr, diagnostics, syntax));
 
             if (returnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
@@ -74,8 +74,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // WinRT delegates don't have Begin/EndInvoke methods
                 !delegateType.IsCompilationOutputWinMdObj())
             {
-                var iAsyncResultType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_IAsyncResult, diagnostics, syntax));
-                var asyncCallbackType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_AsyncCallback, diagnostics, syntax));
+                var iAsyncResultType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_IAsyncResult, diagnostics, syntax));
+                var asyncCallbackType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_AsyncCallback, diagnostics, syntax));
 
                 // (3) BeginInvoke
                 symbols.Add(new BeginInvokeMethod(invoke, iAsyncResultType, objectType, asyncCallbackType, syntax));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // EventRegistrationToken add_E(EventDelegate d);
 
                         // Leave the returns void bit in this.flags false.
-                        _lazyReturnType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, eventTokenType);
+                        _lazyReturnType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, eventTokenType);
 
                         var parameter = new SynthesizedAccessorValueParameterSymbol(this, _event.Type, 0);
                         _lazyParameters = ImmutableArray.Create<ParameterSymbol>(parameter);
@@ -77,10 +77,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         TypeSymbol voidType = compilation.GetSpecialType(SpecialType.System_Void);
                         Binder.ReportUseSiteDiagnostics(voidType, diagnostics, this.Location);
-                        _lazyReturnType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, voidType);
+                        _lazyReturnType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, voidType);
                         this.SetReturnsVoid(returnsVoid: true);
 
-                        var parameter = new SynthesizedAccessorValueParameterSymbol(this, TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, eventTokenType), 0);
+                        var parameter = new SynthesizedAccessorValueParameterSymbol(this, TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, eventTokenType), 0);
                         _lazyParameters = ImmutableArray.Create<ParameterSymbol>(parameter);
                     }
                 }
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     TypeSymbol voidType = compilation.GetSpecialType(SpecialType.System_Void);
                     Binder.ReportUseSiteDiagnostics(voidType, diagnostics, this.Location);
-                    _lazyReturnType = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, voidType);
+                    _lazyReturnType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, voidType);
                     this.SetReturnsVoid(returnsVoid: true);
 
                     var parameter = new SynthesizedAccessorValueParameterSymbol(this, _event.Type, 0);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -473,7 +473,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 if ((object)initializerOpt.Type != null && !initializerOpt.Type.IsErrorType())
                                 {
-                                    type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, initializerOpt.Type);
+                                    type = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, initializerOpt.Type);
                                 }
 
                                 _lazyFieldTypeInferred = 1;
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         if (type.IsNull)
                         {
-                            type = TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: this, binder.CreateErrorType("var"));
+                            type = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, binder.CreateErrorType("var"));
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else
             {
                 var binder = GetBinder();
-                return TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, binder.GetSpecialType(SpecialType.System_Void, diagnostics, this.GetSyntax()));
+                return TypeSymbolWithAnnotations.Create(nonNullTypesContext: ContainingModule, binder.GetSpecialType(SpecialType.System_Void, diagnostics, this.GetSyntax()));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return default;
             }
 
-            // PROTOTYPE(NullableReferenceTypes): Should be using fine-grained NonNullTypesContext
+            // PROTOTYPE(NullableReferenceTypes): Use NonNullTypesNullContext.Instance if we still need a non-null context.
             var context = isNullableIfReferenceType == null ? NonNullTypesFalseContext.Instance : NonNullTypesTrueContext.Instance;
             bool isAnnotated = isNullableIfReferenceType == true;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else
             {
                 var systemVoid = Binder.GetSpecialType(compilation, SpecialType.System_Void, DummySyntax(), diagnostics);
-                return new ScriptEntryPoint(containingType, TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: containingType, systemVoid));
+                return new ScriptEntryPoint(containingType, TypeSymbolWithAnnotations.Create(nonNullTypesContext: containingType, systemVoid));
             }
         }
 
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override ImmutableArray<ParameterSymbol> Parameters => _parameters;
 
-            public override TypeSymbolWithAnnotations ReturnType => TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, _getAwaiterGetResultCall.Type);
+            public override TypeSymbolWithAnnotations ReturnType => TypeSymbolWithAnnotations.Create(nonNullTypesContext: ContainingModule, _getAwaiterGetResultCall.Type);
 
             internal override BoundBlock CreateBody(DiagnosticBag diagnostics)
             {
@@ -496,7 +496,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(containingType.IsSubmissionClass);
                 Debug.Assert(returnType.SpecialType != SpecialType.System_Void);
                 _parameters = ImmutableArray.Create(SynthesizedParameterSymbol.Create(this,
-                    TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, submissionArrayType), 0, RefKind.None, "submissionArray"));
+                    TypeSymbolWithAnnotations.Create(nonNullTypesContext: ContainingModule, submissionArrayType), 0, RefKind.None, "submissionArray"));
 
                 _returnType = returnType;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override TypeSymbolWithAnnotations ReturnType
         {
-            get { return TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
+            get { return TypeSymbolWithAnnotations.Create(nonNullTypesContext: ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
         }
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext: ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void));
+                return TypeSymbolWithAnnotations.Create(nonNullTypesContext: ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeMap.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal static ImmutableArray<TypeSymbolWithAnnotations> TypeParametersAsTypeSymbolsWithAnnotations(INonNullTypesContext nonNullTypesContext, ImmutableArray<TypeParameterSymbol> typeParameters)
         {
             return typeParameters.SelectAsArray((tp, c) =>
-                TypeSymbolWithAnnotations.Create(tp, nonNullTypesContext: c, isAnnotated: false, customModifiers: ImmutableArray<CustomModifier>.Empty),
+                TypeSymbolWithAnnotations.Create(nonNullTypesContext: c, tp, isAnnotated: false, customModifiers: ImmutableArray<CustomModifier>.Empty),
                 nonNullTypesContext);
         }
 
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var newTp = synthesized ?
                     new SynthesizedSubstitutedTypeParameterSymbol(newOwner, result, tp, ordinal) :
                     new SubstitutedTypeParameterSymbol(newOwner, result, tp, ordinal);
-                result.Mapping.Add(tp, TypeSymbolWithAnnotations.CreateUnannotated(nonNullTypesContext, newTp));
+                result.Mapping.Add(tp, TypeSymbolWithAnnotations.Create(nonNullTypesContext, newTp));
                 newTypeParametersBuilder.Add(newTp);
                 ordinal++;
             }


### PR DESCRIPTION
Reduce the number of `TypeSymbolWithAnnotations.Create` overloads. 

This PR reduces the number of overloads to 3.

The first two have distinct uses, depending on whether `IsNullable` is set indirectly from `NonNullTypesContext` and `IsAnnotated` (when binding declarations for instance) or directly (from flow analysis for instance). When set indirectly, `IsNullable` is calculated lazily.
```c#
/// <summary>
/// Create an instance setting <see cref="IsNullable"/> lazily from
/// <see cref="NonNullTypesContext"/> and <see cref="IsAnnotated"/>.
/// </summary>
internal static TypeSymbolWithAnnotations Create(
    INonNullTypesContext nonNullTypesContext,
    TypeSymbol typeSymbol,
    bool isAnnotated = false,
    ImmutableArray<CustomModifier> customModifiers = default) { }

/// <summary>
/// Create an instance setting <see cref="IsNullable"/> directly.
/// </summary>
/// <remarks>
public static TypeSymbolWithAnnotations Create(
    TypeSymbol typeSymbol,
    bool? isNullableIfReferenceType,
    bool treatUnconstrainedTypeParameterAsNullable = true,
    ImmutableArray<CustomModifier> customModifiers = default) { }
```

The third overload is an existing placeholder for all callers that should be calling one of the other two.
```c#
[Obsolete] 
public static TypeSymbolWithAnnotations Create(
    TypeSymbol typeSymbol,
    ImmutableArray<CustomModifier> customModifiers = default) { }
```

Next steps:
1. Store `IsNullable` directly in `TypeSymbolWithAnnotations` for the second overload rather than converting internally to `NonNullTypesContext` and `IsAnnotated`.
1. Migrate callers of the third overload to the other two overloads and remove the third overload.