### PR TITLE
Use UTC time in fallback build number

### DIFF
--- a/build/Targets/RepoToolset/Version.props
+++ b/build/Targets/RepoToolset/Version.props
@@ -27,7 +27,7 @@
           and should only be enabled when it's necessary to test-install the MSIs produced by the build.
         -->
         <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
-        <_BuildNumber Condition="'$(OfficialBuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
+        <_BuildNumber Condition="'$(OfficialBuildId)' == ''">$([System.DateTime]::UtcNow.ToString(yyyyMMdd)).1</_BuildNumber>
 
         <!--
           Split the build parts out from the BuildNumber which is given to us by VSTS in the format of yyyymmdd.nn


### PR DESCRIPTION
The build number should not be dependent on local time zone.