### PR TITLE
Ensure we have no `null` positions in source parameter symbols.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 
                 var name = unboundLambda.ParameterName(p);
                 var location = unboundLambda.ParameterLocation(p);
-                var locations = ImmutableArray.Create<Location>(location);
+                var locations = location == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create<Location>(location);
                 var parameter = new SourceSimpleParameterSymbol(this, type, p, refKind, name, locations);
 
                 builder.Add(parameter);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
@@ -97,6 +97,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<Location> locations)
             : base(owner, ordinal)
         {
+#if DEBUG
+            foreach (var location in locations)
+            {
+                Debug.Assert(location != null);
+            }
+#endif
             Debug.Assert((owner.Kind == SymbolKind.Method) || (owner.Kind == SymbolKind.Property));
             this.parameterType = parameterType;
             _refKind = refKind;


### PR DESCRIPTION
No tests are added specifically for this fix, as the new assertions would be thrown on many existing tests.
Fixes #28862 

@dotnet/roslyn-compiler May I please have a couple of reviews for this tiny bug fix?
