### PR TITLE
Avoid reentrancy in ConditionalWeakTable

### DIFF
--- a/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
+++ b/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
@@ -34,11 +34,6 @@ namespace Microsoft.CodeAnalysis.Text
             private readonly Encoding _encodingOpt;
             private readonly TextBufferContainer _containerOpt;
 
-            private SnapshotSourceText(ITextBufferCloneService textBufferCloneServiceOpt, ITextSnapshot editorSnapshot) :
-                this(textBufferCloneServiceOpt, editorSnapshot, TextBufferContainer.From(editorSnapshot.TextBuffer))
-            {
-            }
-
             private SnapshotSourceText(ITextBufferCloneService textBufferCloneServiceOpt, ITextSnapshot editorSnapshot, TextBufferContainer container)
             {
                 Contract.ThrowIfNull(editorSnapshot);
@@ -79,9 +74,13 @@ namespace Microsoft.CodeAnalysis.Text
 
                 if (!s_textSnapshotMap.TryGetValue(editorSnapshot, out var snapshot))
                 {
+                    // Explicitly obtain the TextBufferContainer before calling GetValue to avoid reentrancy in
+                    // ConditionalWeakTable. https://github.com/dotnet/roslyn/issues/28256
+                    var container = TextBufferContainer.From(editorSnapshot.TextBuffer);
+
                     // Avoid capturing `textBufferCloneServiceOpt` on the fast path
                     var tempTextBufferCloneServiceOpt = textBufferCloneServiceOpt;
-                    snapshot = s_textSnapshotMap.GetValue(editorSnapshot, s => new SnapshotSourceText(tempTextBufferCloneServiceOpt, s));
+                    snapshot = s_textSnapshotMap.GetValue(editorSnapshot, s => new SnapshotSourceText(tempTextBufferCloneServiceOpt, s, container));
                 }
 
                 return snapshot;


### PR DESCRIPTION
Fixes #28256 

### Customer scenario

Runs Visual Studio for Mac on Mono.

### Bugs this fixes

#28256

### Workarounds, if any

None

### Risk

Low. A call sequence is split to break recursion without changing the overall algorithm.

### Performance impact

Negligible.

### Is this a regression from a previous update?

No.

### Root cause analysis

The .NET Framework supports the case in question without causing problems. The bug only appears in certain cases when running on Mono.

### How was the bug found?

Reported by @KirillOsenkov from a review of Visual Studio for Mac customer reports.

### Test documentation updated?

N/A

</details>