### PR TITLE
Fix casing for System.Xml.dll

### DIFF
--- a/src/Compilers/VisualBasic/vbc/vbc.rsp
+++ b/src/Compilers/VisualBasic/vbc/vbc.rsp
@@ -30,7 +30,7 @@
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
 /r:System.Windows.Forms.dll
-/r:System.XML.dll
+/r:System.Xml.dll
 
 /r:System.Workflow.Activities.dll
 /r:System.Workflow.ComponentModel.dll


### PR DESCRIPTION
This fix allows the rsp file to be used on case sensitive file systems like Linux.