### PR TITLE
 Remove spurious "cast is redundant" when conditionally accessing hidden members

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4687,5 +4687,108 @@ class C
     }
 }" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task InlineVariableAddsCastToInvokeHiddenMember()
+        {
+            await TestInRegularAndScriptAsync(@"
+class R
+{
+    public void Yikes() { }
+}
+
+class B
+{
+    public R Method() { return null; }
+}
+
+class D : B
+{
+    public new R Method() { return null; }
+}
+
+class T
+{
+    void M()
+    {
+        B [|b|] = new D();
+        b.Method().Yikes();
+    }
+}", @"
+class R
+{
+    public void Yikes() { }
+}
+
+class B
+{
+    public R Method() { return null; }
+}
+
+class D : B
+{
+    public new R Method() { return null; }
+}
+
+class T
+{
+    void M()
+    {
+        ((B)new D()).Method().Yikes();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task InlineVariableAddsCastToConditionallyInvokeHiddenMember()
+        {
+            await TestInRegularAndScriptAsync(@"
+class R
+{
+    public void Yikes() { }
+}
+
+class B
+{
+    public R Method() { return null; }
+}
+
+class D : B
+{
+    public new R Method() { return null; }
+}
+
+class T
+{
+    void M()
+    {
+        B [|b|] = new D();
+        b?.Method().Yikes();
+    }
+}", @"
+class R
+{
+    public void Yikes() { }
+}
+
+class B
+{
+    public R Method() { return null; }
+}
+
+class D : B
+{
+    public new R Method() { return null; }
+}
+
+class T
+{
+    void M()
+    {
+        ((B)new D())?.Method().Yikes();
+    }
+}");
+        }
+
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -4607,5 +4607,29 @@ class Tester
     }
 }");
         }
+
+        [WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontOfferToRemoveCastWhenConditionallyAccessingHiddenProperty()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+using System.Collections.Generic;
+class Fruit
+{
+    public IDictionary<string, object> Properties { get; set; }
+}
+class Apple : Fruit
+{
+    public new IDictionary<string, object> Properties { get; }
+}
+class Tester
+{
+    public void Test()
+    {
+        var a = new Apple();
+        ([|(Fruit)a|])?.Properties[""Color""] = ""Red"";
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
@@ -490,6 +490,106 @@ class Program
 ", replacementExpression: "b", semanticChanges: true);
         }
 
+        [Fact, WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")]
+        public void SpeculationAnalyzerConditionalIndexerPropertyWithRedundantCast()
+        {
+            Test(code: @"
+class Indexer
+{
+    public int this[int x] { get { return x; } }
+}
+class A
+{
+    public Indexer Foo { get; } = new Indexer();
+}
+class B : A
+{
+}
+class Program
+{
+    static void Main(string[] args)
+    {
+        var b = new B();
+        var y = ([|(A)b|])?.Foo[1];
+    }
+}
+", replacementExpression: "b", semanticChanges: false);
+        }
+
+        [Fact, WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")]
+        public void SpeculationAnalyzerConditionalIndexerPropertyWithRequiredCast()
+        {
+            Test(code: @"
+class Indexer
+{
+    public int this[int x] { get { return x; } }
+}
+class A
+{
+    public Indexer Foo { get; } = new Indexer();
+}
+class B : A
+{
+    public new Indexer Foo { get; } = new Indexer();
+}
+class Program
+{
+    static void Main(string[] args)
+    {
+        var b = new B();
+        var y = ([|(A)b|])?.Foo[1];
+    }
+}
+", replacementExpression: "b", semanticChanges: true);
+        }
+
+        [Fact, WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")]
+        public void SpeculationAnalyzerConditionalDelegatePropertyWithRedundantCast()
+        {
+            Test(code: @"
+public delegate void MyDelegate();
+class A
+{
+    public MyDelegate Foo { get; }
+}
+class B : A
+{
+}
+class Program
+{
+    static void Main(string[] args)
+    {
+        var b = new B();
+        ([|(A)b|])?.Foo();
+    }
+}
+", replacementExpression: "b", semanticChanges: false);
+        }
+
+        [Fact, WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")]
+        public void SpeculationAnalyzerConditionalDelegatePropertyWithRequiredCast()
+        {
+            Test(code: @"
+public delegate void MyDelegate();
+class A
+{
+    public MyDelegate Foo { get; }
+}
+class B : A
+{
+    public new MyDelegate Foo { get; }
+}
+class Program
+{
+    static void Main(string[] args)
+    {
+        var b = new B();
+        ([|(A)b|])?.Foo();
+    }
+}
+", replacementExpression: "b", semanticChanges: true);
+        }
+
         protected override SyntaxTree Parse(string text)
         {
             return SyntaxFactory.ParseSyntaxTree(text);

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -4425,5 +4425,60 @@ End Class
             Await TestInRegularAndScriptAsync(code, expected)
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Async Function InlineVariableAddsCastToConditionallyInvokeHiddenMember() As Task
+            Dim code = "
+Class R
+    Public Sub Yikes()
+    End Sub
+End Class
+
+Class B
+    Public Function Method() As R
+        Return Nothing
+    End Function
+End Class
+
+Class D
+    Inherits B
+    Public Shadows Function Method() As R
+        Return Nothing
+    End Function
+End Class
+
+Class T
+    Sub M()
+        Dim [|b|] As B = New D()
+        b?.Method()?.Yikes()
+    End Sub
+End Class"
+
+            Dim expected = "
+Class R
+    Public Sub Yikes()
+    End Sub
+End Class
+
+Class B
+    Public Function Method() As R
+        Return Nothing
+    End Function
+End Class
+
+Class D
+    Inherits B
+    Public Shadows Function Method() As R
+        Return Nothing
+    End Function
+End Class
+
+Class T
+    Sub M()
+        CType(New D(), B)?.Method()?.Yikes()
+    End Sub
+End Class"
+
+            Await TestInRegularAndScriptAsync(code, expected)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
@@ -2986,5 +2986,25 @@ Class Tester
 End Class
 </Code>.Value)
         End Function
+        
+        Public Async Function DontOfferToRemoveCastWhenConditionallyAccessingHiddenProperty() As Task
+            Await TestMissingInRegularAndScriptAsync(
+<Code>
+Imports System.Collections.Generic
+Class Fruit
+    Public Property Properties As IDictionary(Of String, Object)
+End Class
+Class Apple
+    Inherits Fruit
+    Public Shadows Property Properties As IDictionary(Of String, Object)
+End Class
+Class Tester
+    Public Sub Test()
+        Dim a = New Apple()
+        [|CType(a, Fruit)|]?.Properties(""Color"") = ""Red""
+    End Sub
+End Class
+</Code>.Value)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Semantics/SpeculationAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Semantics/SpeculationAnalyzerTests.vb
@@ -206,6 +206,27 @@ End Class
             </Code>.Value, "b", True)
         End Sub
 
+        <Fact, WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")>
+        Public Sub SpeculationAnalyzerConditionalFunctionInvocationWithRequiredCast()
+            Test(<Code>
+Class MyString
+    Public Overrides Function ToString() As String
+        Return String.Empty
+    End Function
+
+    Public Shared Widening Operator CType(ByVal val As MyString) As String
+        Return val.ToString()
+    End Operator
+End Class
+Class Program
+    Sub Main()
+        Dim b As MyString = New MyString()
+        [|CStr(b)|]?.ToString()
+    End Sub
+End Class
+            </Code>.Value, "b", True)
+        End Sub
+
         Protected Overrides Function Parse(text As String) As SyntaxTree
             Return SyntaxFactory.ParseSyntaxTree(text)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Semantics/SpeculationAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Semantics/SpeculationAnalyzerTests.vb
@@ -116,6 +116,96 @@ End Class
             </Code>.Value, "b", True)
         End Sub
 
+        <Fact, WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")>
+        Public Sub SpeculationAnalyzerConditionalIndexerPropertyWithRedundantCast()
+            Test(<Code>
+Class Indexer
+    Default Public ReadOnly Property Item(ByVal x As Integer) As Integer
+        Get
+            Return x
+        End Get
+    End Property
+End Class
+Class A
+    Public ReadOnly Property Foo As Indexer
+End Class
+Class B
+    Inherits A
+End Class
+Class Program
+    Sub Main()
+        Dim b As B = New B()
+        Dim y As Integer = [|DirectCast(b, A)|]?.Foo(2)
+    End Sub
+End Class
+            </Code>.Value, "b", False)
+        End Sub
+
+        <Fact, WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")>
+        Public Sub SpeculationAnalyzerConditionalIndexerPropertyWithRequiredCast()
+            Test(<Code>
+Class Indexer
+    Default Public ReadOnly Property Item(ByVal x As Integer) As Integer
+        Get
+            Return x
+        End Get
+    End Property
+End Class
+Class A
+    Public ReadOnly Property Foo As Indexer
+End Class
+Class B
+    Inherits A
+    Public Shadows ReadOnly Property Foo As Indexer
+End Class
+Class Program
+    Sub Main()
+        Dim b As B = New B()
+        Dim y As Integer = [|DirectCast(b, A)|]?.Foo(2)
+    End Sub
+End Class
+            </Code>.Value, "b", True)
+        End Sub
+
+        <Fact, WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")>
+        Public Sub SpeculationAnalyzerConditionalDelegatePropertyWithRedundantCast()
+            Test(<Code>
+Public Delegate Sub MyDelegate()
+Class A
+    Public ReadOnly Property Foo As MyDelegate
+End Class
+Class B
+    Inherits A
+End Class
+Class Program
+    Sub Main()
+        Dim b As B = New B()
+        [|DirectCast(b, A)|]?.Foo.Invoke()
+    End Sub
+End Class
+            </Code>.Value, "b", False)
+        End Sub
+
+        <Fact, WorkItem(11008, "https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")>
+        Public Sub SpeculationAnalyzerConditionalDelegatePropertyWithRequiredCast()
+            Test(<Code>
+Public Delegate Sub MyDelegate()
+Class A
+    Public ReadOnly Property Foo As MyDelegate
+End Class
+Class B
+    Inherits A
+    Public Shadows ReadOnly Property Foo As MyDelegate
+End Class
+Class Program
+    Sub Main()
+        Dim b As B = New B()
+        [|DirectCast(b, A)|]?.Foo.Invoke()
+    End Sub
+End Class
+            </Code>.Value, "b", True)
+        End Sub
+
         Protected Overrides Function Parse(text As String) As SyntaxTree
             Return SyntaxFactory.ParseSyntaxTree(text)
         End Function

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -637,6 +637,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         private bool ReplacementChangesSemanticsOfWhenNotNull(ExpressionSyntax originalWhenNotNull, ExpressionSyntax newWhenNotNull)
         {
+            // We want to look at the first symbol following the `?.` and determine whether the symbols are compatible
             var originalFirstNode = originalWhenNotNull.GetFirstToken().Parent;
             var newFirstNode = newWhenNotNull.GetFirstToken().Parent;
 

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -635,15 +635,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 ReplacementChangesSemanticsOfWhenNotNull(conditionalAccessExpression.WhenNotNull, newConditionalAccessExpression.WhenNotNull);
         }
 
-        private bool ReplacementChangesSemanticsOfWhenNotNull(ExpressionSyntax originalWhenNotNull, ExpressionSyntax newWhenNotNull)
-        {
-            // We want to look at the first symbol following the `?.` and determine whether the symbols are compatible
-            var originalFirstNode = originalWhenNotNull.GetFirstToken().Parent;
-            var newFirstNode = newWhenNotNull.GetFirstToken().Parent;
-
-            return !SymbolsAreCompatible(originalFirstNode, newFirstNode);
-        }
-
         private bool ReplacementBreaksInterpolation(InterpolationSyntax interpolation, InterpolationSyntax newInterpolation)
         {
             return !TypesAreCompatible(interpolation.Expression, newInterpolation.Expression);

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -640,7 +640,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             var originalFirstNode = originalWhenNotNull.GetFirstToken().Parent;
             var newFirstNode = newWhenNotNull.GetFirstToken().Parent;
 
-            return ReplacementChangesSemantics(originalFirstNode, newFirstNode, originalWhenNotNull, false);
+            return !SymbolsAreCompatible(originalFirstNode, newFirstNode);
         }
 
         private bool ReplacementBreaksInterpolation(InterpolationSyntax interpolation, InterpolationSyntax newInterpolation)

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -513,7 +513,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             return node.IsKind(SyntaxKind.InvocationExpression) ||
                 node.IsKind(SyntaxKind.ElementAccessExpression) ||
                 node.IsKind(SyntaxKind.SimpleMemberAccessExpression) ||
-                node.IsKind(SyntaxKind.ImplicitElementAccess);
+                node.IsKind(SyntaxKind.ImplicitElementAccess) ||
+                node.IsKind(SyntaxKind.MemberBindingExpression);
         }
 
         protected override ImmutableArray<ArgumentSyntax> GetArguments(ExpressionSyntax expression)
@@ -631,8 +632,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         {
             return !SymbolsAreCompatible(conditionalAccessExpression, newConditionalAccessExpression) ||
                 !TypesAreCompatible(conditionalAccessExpression, newConditionalAccessExpression) ||
-                !SymbolsAreCompatible(conditionalAccessExpression.WhenNotNull, newConditionalAccessExpression.WhenNotNull) ||
-                !TypesAreCompatible(conditionalAccessExpression.WhenNotNull, newConditionalAccessExpression.WhenNotNull);
+                ReplacementChangesSemanticsOfWhenNotNull(conditionalAccessExpression.WhenNotNull, newConditionalAccessExpression.WhenNotNull);
+        }
+
+        private bool ReplacementChangesSemanticsOfWhenNotNull(ExpressionSyntax originalWhenNotNull, ExpressionSyntax newWhenNotNull)
+        {
+            var originalFirstNode = originalWhenNotNull.GetFirstToken().Parent;
+            var newFirstNode = newWhenNotNull.GetFirstToken().Parent;
+
+            return ReplacementChangesSemantics(originalFirstNode, newFirstNode, originalWhenNotNull, false);
         }
 
         private bool ReplacementBreaksInterpolation(InterpolationSyntax interpolation, InterpolationSyntax newInterpolation)

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -449,6 +449,15 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             return false;
         }
 
+        protected bool ReplacementChangesSemanticsOfWhenNotNull(TExpressionSyntax originalWhenNotNull, TExpressionSyntax newWhenNotNull)
+        {
+            // We want to look at the first symbol following the `?.` and determine whether the symbols are compatible
+            var originalFirstNode = originalWhenNotNull.GetFirstToken().Parent;
+            var newFirstNode = newWhenNotNull.GetFirstToken().Parent;
+
+            return !SymbolsAreCompatible(originalFirstNode, newFirstNode);
+        }
+
         /// <summary>
         /// Checks whether the semantic symbols for the <see cref="OriginalExpression"/> and <see cref="ReplacedExpression"/> are non-null and compatible.
         /// </summary>

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -516,6 +516,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
         End Function
 
         Private Function ReplacementChangesSemanticsOfWhenNotNull(originalWhenNotNull As ExpressionSyntax, newWhenNotNull As ExpressionSyntax) As Boolean
+            ' We want to look at the first symbol following the `?.` and determine whether the symbols are compatible
             Dim originalFirstNode = originalWhenNotNull.GetFirstToken().Parent
             Dim newFirstNode = newWhenNotNull.GetFirstToken().Parent
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -515,14 +515,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
                 ReplacementChangesSemanticsOfWhenNotNull(conditionalAccessExpression.WhenNotNull, newConditionalAccessExpression.WhenNotNull)
         End Function
 
-        Private Function ReplacementChangesSemanticsOfWhenNotNull(originalWhenNotNull As ExpressionSyntax, newWhenNotNull As ExpressionSyntax) As Boolean
-            ' We want to look at the first symbol following the `?.` and determine whether the symbols are compatible
-            Dim originalFirstNode = originalWhenNotNull.GetFirstToken().Parent
-            Dim newFirstNode = newWhenNotNull.GetFirstToken().Parent
-
-            Return Not SymbolsAreCompatible(originalFirstNode, newFirstNode)
-        End Function
-
         Private Function ReplacementBreaksInterpolation(interpolation As InterpolationSyntax, newInterpolation As InterpolationSyntax) As Boolean
             Return Not TypesAreCompatible(interpolation.Expression, newInterpolation.Expression)
         End Function

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -512,8 +512,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
             Return _
                 Not SymbolsAreCompatible(conditionalAccessExpression, newConditionalAccessExpression) OrElse
                 Not TypesAreCompatible(conditionalAccessExpression, newConditionalAccessExpression) OrElse
-                Not SymbolsAreCompatible(conditionalAccessExpression.WhenNotNull, newConditionalAccessExpression.WhenNotNull) OrElse
-                Not TypesAreCompatible(conditionalAccessExpression.WhenNotNull, newConditionalAccessExpression.WhenNotNull)
+                ReplacementChangesSemanticsOfWhenNotNull(conditionalAccessExpression.WhenNotNull, newConditionalAccessExpression.WhenNotNull)
+        End Function
+
+        Private Function ReplacementChangesSemanticsOfWhenNotNull(originalWhenNotNull As ExpressionSyntax, newWhenNotNull As ExpressionSyntax) As Boolean
+            Dim originalFirstNode = originalWhenNotNull.GetFirstToken().Parent
+            Dim newFirstNode = newWhenNotNull.GetFirstToken().Parent
+
+            Return ReplacementChangesSemantics(originalFirstNode, newFirstNode, originalWhenNotNull, False)
         End Function
 
         Private Function ReplacementBreaksInterpolation(interpolation As InterpolationSyntax, newInterpolation As InterpolationSyntax) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -519,7 +519,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
             Dim originalFirstNode = originalWhenNotNull.GetFirstToken().Parent
             Dim newFirstNode = newWhenNotNull.GetFirstToken().Parent
 
-            Return ReplacementChangesSemantics(originalFirstNode, newFirstNode, originalWhenNotNull, False)
+            Return Not SymbolsAreCompatible(originalFirstNode, newFirstNode)
         End Function
 
         Private Function ReplacementBreaksInterpolation(interpolation As InterpolationSyntax, newInterpolation As InterpolationSyntax) As Boolean


### PR DESCRIPTION
The CSharp and VB SpeculationAnalyzers would check whether replacing a
ConditionalAccess expression's WhenNotNull expression would change the
referenced symbol or type. However this check needs to begin with the
first node in the WhenNotNull which could be lower in the tree.
This change looks for the first node in the WhenNotNull expressions and
checks that symbols are compatible.