### PR TITLE
Remove default handling for bound nodes in (CS/VB)OperstionFactory.CreateInternal.

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -254,7 +254,26 @@ namespace Microsoft.CodeAnalysis.Operations
                 case BoundKind.DiscardExpression:
                     return CreateDiscardExpressionOperation((BoundDiscardExpression)boundNode);
 
-                default:
+                case BoundKind.Attribute:
+                case BoundKind.ArgList:
+                case BoundKind.ArgListOperator:
+                case BoundKind.ConvertedStackAllocExpression:
+                case BoundKind.FixedLocalCollectionInitializer:
+                case BoundKind.GlobalStatementInitializer:
+                case BoundKind.HostObjectMemberReference:
+                case BoundKind.MakeRefOperator:
+                case BoundKind.MethodGroup:
+                case BoundKind.NamespaceExpression:
+                case BoundKind.PointerElementAccess:
+                case BoundKind.PointerIndirectionOperator:
+                case BoundKind.PreviousSubmissionReference:
+                case BoundKind.RefTypeOperator:
+                case BoundKind.RefValueOperator:
+                case BoundKind.Sequence:
+                case BoundKind.StackAllocArrayCreation:
+                case BoundKind.TypeExpression:
+                case BoundKind.TypeOrValueExpression:
+
                     Optional<object> constantValue = ConvertToOptional((boundNode as BoundExpression)?.ConstantValue);
                     bool isImplicit = boundNode.WasCompilerGenerated;
 
@@ -269,6 +288,9 @@ namespace Microsoft.CodeAnalysis.Operations
                     }
 
                     return Operation.CreateOperationNone(_semanticModel, boundNode.Syntax, constantValue, getChildren: () => GetIOperationChildren(boundNode), isImplicit: isImplicit);
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(boundNode.Kind); 
             }
         }
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -294,10 +294,44 @@ Namespace Microsoft.CodeAnalysis.Operations
                     Return Create(DirectCast(boundNode, BoundBadVariable).Expression)
                 Case BoundKind.NullableIsTrueOperator
                     Return CreateBoundNullableIsTrueOperator(DirectCast(boundNode, BoundNullableIsTrueOperator))
-                Case Else
+
+                Case BoundKind.AddressOfOperator,
+                     BoundKind.ArrayLiteral,
+                     BoundKind.Attribute,
+                     BoundKind.ByRefArgumentWithCopyBack,
+                     BoundKind.CompoundAssignmentTargetPlaceholder,
+                     BoundKind.EraseStatement,
+                     BoundKind.Label,
+                     BoundKind.LateAddressOfOperator,
+                     BoundKind.MethodGroup,
+                     BoundKind.MidResult,
+                     BoundKind.NamespaceExpression,
+                     BoundKind.OnErrorStatement,
+                     BoundKind.PropertyGroup,
+                     BoundKind.RangeVariable,
+                     BoundKind.RedimClause,
+                     BoundKind.RedimStatement,
+                     BoundKind.ResumeStatement,
+                     BoundKind.TypeAsValueExpression,
+                     BoundKind.TypeExpression,
+                     BoundKind.TypeOrValueExpression,
+                     BoundKind.XmlCData,
+                     BoundKind.XmlComment,
+                     BoundKind.XmlDocument,
+                     BoundKind.XmlElement,
+                     BoundKind.XmlEmbeddedExpression,
+                     BoundKind.XmlMemberAccess,
+                     BoundKind.XmlNamespace,
+                     BoundKind.XmlProcessingInstruction,
+                     BoundKind.UnboundLambda,
+                     BoundKind.UnstructuredExceptionHandlingStatement
+
                     Dim constantValue = ConvertToOptional(TryCast(boundNode, BoundExpression)?.ConstantValueOpt)
                     Dim isImplicit As Boolean = boundNode.WasCompilerGenerated
                     Return Operation.CreateOperationNone(_semanticModel, boundNode.Syntax, constantValue, Function() GetIOperationChildren(boundNode), isImplicit)
+
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(boundNode.Kind)
             End Select
         End Function
 


### PR DESCRIPTION
Add explicit case clause(s) for all the bound nodes for which right now we fall back to creating operation None node. Throw from default case.