### PR TITLE
Document new warning on `e is _`.

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - VS2019.md
@@ -1,4 +1,4 @@
-**This document lists known breaking changes in Roslyn vNext (VS2019) from Roslyn 2.9 (VS2017) and native C# compiler (VS2013 and previous).**
+**This document lists known breaking changes in Roslyn vNext (VS2019) from Roslyn 2.9 (VS2017).**
 
 
 - https://github.com/dotnet/roslyn/issues/27800 C# will now preserve left-to-right evaluation for compound assignment addition/subtraction expressions where the left-hand side is dynamic. In this example code:
@@ -21,3 +21,11 @@
     2. get_Property
     3. GetInt()
     4. set_Property
+
+
+- https://github.com/dotnet/roslyn/issues/27748 C# will now produce a warning for an expression of the form `e is _`. The *is_type_expression* can be used with a type named `_`. However, in C# 8 we are introducing a discard pattern written `_` (which cannot be used as the *pattern* of an *is_pattern_expression*). To reduce confusion, there is a new warning when you write `e is _`:
+
+    ``` none
+    // (11,31): error CS8413: The name '_' refers to the type 'Program1._', not the discard pattern. Use '@_' for the type, or 'var _' to discard.
+    //     bool M1(object o) => o is _;
+    ```


### PR DESCRIPTION
Fixes #27748

@dotnet/roslyn-compiler May I please have one review for this small doc change?
