### PR TITLE
Get ASP.NET contained language wireup working again

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.IServiceProvider.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.IServiceProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 {
@@ -10,8 +12,25 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
     {
         public int QueryService(ref Guid guidService, ref Guid riid, out IntPtr ppvObject)
         {
-            var serviceProvider = (Microsoft.VisualStudio.OLE.Interop.IServiceProvider)ServiceProvider;
-            return serviceProvider.QueryService(ref guidService, ref riid, out ppvObject);
+            if (riid == typeof(IVsContainedLanguageFactory).GUID)
+            {
+                int hr = Shell.ServiceProvider.GlobalProvider.QueryService(guidService, out var serviceObject);
+                if (ErrorHandler.Succeeded(hr))
+                {
+                    ppvObject = Marshal.GetComInterfaceForObject(serviceObject, typeof(IVsContainedLanguageFactory));
+                }
+                else
+                {
+                    ppvObject = IntPtr.Zero;
+                }
+
+                return hr;
+            }
+            else
+            {
+                ppvObject = IntPtr.Zero;
+                return VSConstants.E_FAIL;
+            }
         }
     }
 }


### PR DESCRIPTION
ASP.NET tries using our types as a site to fetch the IVsContainedLanguageFactory, which doesn't quite work correctly once we moved to AsyncPackage. Since we only need this to work for exactly one interface, we can just do it directly.