### PR TITLE
Wait for workspace operations during integration test initialization

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Roslyn.Test.Utilities;
@@ -68,6 +69,7 @@ namespace Roslyn.VisualStudio.IntegrationTests
             VisualStudio.Workspace.SetPrettyListing(LanguageName, false);
             try
             {
+                VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
                 VisualStudio.Editor.SetText(code);
                 VisualStudio.Editor.MoveCaret(caretPosition);
                 VisualStudio.Editor.Activate();

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -43,7 +43,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             => _inProc.OpenSolution(path, saveExistingSolutionIfExists);
 
         public void AddProject(ProjectUtils.Project projectName, string projectTemplate, string languageName)
-            => _inProc.AddProject(projectName.Name, projectTemplate, languageName);
+        {
+            _inProc.AddProject(projectName.Name, projectTemplate, languageName);
+            _instance.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+        }
 
         public void AddProjectReference(ProjectUtils.Project fromProjectName, ProjectUtils.ProjectReference toProjectName)
         {


### PR DESCRIPTION
This change attempts to stabilize some of the flaky integration tests by introducing two wait operations that first appeared to help in #28173.