### PR TITLE
Limit use of GetTypeAndNullability(BoundExpression)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -532,7 +532,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var typesBuilder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(count);
             var locationsBuilder = ArrayBuilder<Location>.GetInstance(count);
             var namesBuilder = ArrayBuilder<string>.GetInstance(count);
-            bool includeNullability = Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking);
 
             foreach (var variable in variables)
             {
@@ -548,7 +547,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     namesBuilder.Add(ExtractDeconstructResultElementName(value));
                 }
                 valuesBuilder.Add(value);
-                typesBuilder.Add(value.GetTypeAndNullability(includeNullability));
+                typesBuilder.Add(value.GetTypeAndNullability());
                 locationsBuilder.Add(variable.Syntax.Location);
             }
             ImmutableArray<BoundExpression> arguments = valuesBuilder.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2718,6 +2718,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, ErrorCode.ERR_ArrayElementCantBeRefAny, node, bestType);
             }
 
+            // Element type nullability will be inferred in flow analysis and does not need to be set here.
             var arrayType = ArrayTypeSymbol.CreateCSharpArray(Compilation.Assembly, TypeSymbolWithAnnotations.Create(bestType, isNullableIfReferenceType: null), rank);
             return BindArrayCreationWithInitializer(diagnostics, node, initializer, arrayType,
                 sizes: ImmutableArray<BoundExpression>.Empty, boundInitExprOpt: boundInitializerExpressions);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3642,15 +3642,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 bool hadMultipleCandidates;
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                var bestType = BestTypeInferrer.InferBestTypeForConditionalOperator(
-                    trueExpr,
-                    falseExpr,
-                    this.Conversions,
-                    hadMultipleCandidates: out hadMultipleCandidates,
-                    useSiteDiagnostics: ref useSiteDiagnostics);
+                TypeSymbol bestType = BestTypeInferrer.InferBestTypeForConditionalOperator(trueExpr, falseExpr, this.Conversions, out hadMultipleCandidates, ref useSiteDiagnostics);
                 diagnostics.Add(node, useSiteDiagnostics);
 
-                if (bestType.IsNull)
+                if ((object)bestType == null)
                 {
                     // CONSIDER: Dev10 suppresses ERR_InvalidQM unless the following is true for both trueType and falseType
                     // (!T->type->IsErrorType() || T->type->AsErrorType()->HasTypeParent() || T->type->AsErrorType()->HasNSParent())
@@ -3680,7 +3675,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (bestType.IsErrorType())
                 {
-                    type = bestType.TypeSymbol;
+                    type = bestType;
                     hasErrors = true;
                 }
                 else if (isRef)
@@ -3693,15 +3688,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        Debug.Assert(Conversions.HasIdentityConversion(trueType, bestType.TypeSymbol));
-                        Debug.Assert(Conversions.HasIdentityConversion(falseType, bestType.TypeSymbol));
-                        type = bestType.TypeSymbol;
+                        Debug.Assert(Conversions.HasIdentityConversion(trueType, bestType));
+                        Debug.Assert(Conversions.HasIdentityConversion(falseType, bestType));
+                        type = bestType;
                     }
                 }
                 else
                 {
-                    trueExpr = GenerateConversionForAssignment(bestType.TypeSymbol, trueExpr, diagnostics);
-                    falseExpr = GenerateConversionForAssignment(bestType.TypeSymbol, falseExpr, diagnostics);
+                    trueExpr = GenerateConversionForAssignment(bestType, trueExpr, diagnostics);
+                    falseExpr = GenerateConversionForAssignment(bestType, falseExpr, diagnostics);
 
                     if (trueExpr.HasAnyErrors || falseExpr.HasAnyErrors)
                     {
@@ -3712,7 +3707,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        type = bestType.TypeSymbol;
+                        type = bestType;
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -886,7 +886,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 initializerOpt = BindInferredVariableInitializer(diagnostics, value, valueKind, localSymbol.RefKind, declarator);
 
                 // If we got a good result then swap the inferred type for the "var" 
-                var initializerType = initializerOpt?.Type;
+                TypeSymbol initializerType = initializerOpt?.Type;
                 if ((object)initializerType != null)
                 {
                     declTypeOpt = TypeSymbolWithAnnotations.Create(initializerType, isNullableIfReferenceType: null);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -886,9 +886,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 initializerOpt = BindInferredVariableInitializer(diagnostics, value, valueKind, localSymbol.RefKind, declarator);
 
                 // If we got a good result then swap the inferred type for the "var" 
-                if ((object)initializerOpt?.Type != null)
+                var initializerType = initializerOpt?.Type;
+                if ((object)initializerType != null)
                 {
-                    declTypeOpt = initializerOpt.GetTypeAndNullability(declarator.IsFeatureStaticNullCheckingEnabled());
+                    declTypeOpt = TypeSymbolWithAnnotations.Create(initializerType, isNullableIfReferenceType: null);
 
                     if (declTypeOpt.SpecialType == SpecialType.System_Void)
                     {
@@ -901,7 +902,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (declTypeOpt.IsStatic)
                         {
-                            Error(localDiagnostics, ErrorCode.ERR_VarDeclIsStaticClass, typeSyntax, initializerOpt.Type);
+                            Error(localDiagnostics, ErrorCode.ERR_VarDeclIsStaticClass, typeSyntax, initializerType);
                             hasErrors = true;
                         }
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return default;
             }
-            return TypeSymbolWithAnnotations.Create(bestType, isNullableIfReferenceType: GetIsNullable(types));
+            return TypeSymbolWithAnnotations.Create(bestType, isNullableIfReferenceType: conversions.IncludeNullability ? GetIsNullable(types) : null);
         }
 
         private static bool? GetIsNullable(ImmutableArray<TypeSymbolWithAnnotations> types)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1718,10 +1718,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case BoundKind.ExpressionWithNullability:
                     return ((BoundExpressionWithNullability)expr).IsNullable;
+                case BoundKind.MethodGroup:
                 case BoundKind.UnboundLambda:
                     return null;
                 default:
-                    throw ExceptionUtilities.UnexpectedValue(expr.Kind);
+                    Debug.Assert(false); // unexpected value
+                    return null;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1285,6 +1285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
+                    // Mark the error type as null-oblivious.
                     bestType = TypeSymbolWithAnnotations.Create(bestType.TypeSymbol, isNullableIfReferenceType: null);
                 }
                 // PROTOTYPE(NullableReferenceTypes): Report a special ErrorCode.WRN_NoBestNullabilityArrayElements
@@ -1688,6 +1689,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        /// <summary>
+        /// Return top-level nullability for the expression. This method should be called on a limited
+        /// set of expressions only. It should not be called on expressions tracked by flow analysis
+        /// other than <see cref="BoundKind.ExpressionWithNullability"/> which is an expression
+        /// specifically created in NullableWalker to represent the flow analysis state.
+        /// </summary>
         private static bool? GetIsNullable(BoundExpression expr)
         {
             switch (expr.Kind)
@@ -1711,8 +1718,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case BoundKind.ExpressionWithNullability:
                     return ((BoundExpressionWithNullability)expr).IsNullable;
-                default:
+                case BoundKind.UnboundLambda:
                     return null;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(expr.Kind);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -524,7 +524,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var initializerOpt = this._initializerBinder.BindInferredVariableInitializer(diagnostics, RefKind, _initializer, _initializer);
                 return initializerOpt == null ?
                     default :
-                    initializerOpt.GetTypeAndNullability(_initializer.IsFeatureStaticNullCheckingEnabled());
+                    initializerOpt.GetTypeAndNullability();
             }
 
             internal override SyntaxNode ForbiddenZone => _initializer;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -16774,19 +16774,7 @@ class C
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, "new[] { x1, y1 }").WithLocation(5, 18),
                 // (7,18): error CS0826: No best type found for implicitly-typed array
                 //         var b1 = new[] { y1, x1 };
-                Diagnostic(ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, "new[] { y1, x1 }").WithLocation(7, 18),
-                // (5,30): warning CS8601: Possible null reference assignment.
-                //         var a1 = new[] { x1, y1 };
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(5, 30),
-                // (7,26): warning CS8601: Possible null reference assignment.
-                //         var b1 = new[] { y1, x1 };
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y1").WithLocation(7, 26),
-                // (12,26): warning CS8601: Possible null reference assignment.
-                //         var a2 = new[] { x2, y2 };
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(12, 26),
-                // (14,30): warning CS8601: Possible null reference assignment.
-                //         var b2 = new[] { y2, x2 };
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x2").WithLocation(14, 30));
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, "new[] { y1, x1 }").WithLocation(7, 18));
         }
 
         [Fact]
@@ -33091,9 +33079,9 @@ class C
     static void F(object? x)
     {
         var y = (x, x);
-        y.F1.ToString();
-        y.P1.ToString();
-        y.E2?.Invoke().ToString();
+        y.F1.ToString(); // 1
+        y.P1.ToString(); // 2
+        y.E2?.Invoke().ToString(); // 3
         if (x == null) return;
         var z = (x, x);
         z.F1.ToString();
@@ -33101,27 +33089,21 @@ class C
         z.E2?.Invoke().ToString();
     }
 }";
-            // PROTOTYPE(NullableReferenceTypes): Should not report warnings for `z.E2?.Invoke()`.
+            // PROTOTYPE(NullableReferenceTypes): Should report WRN_NullReferenceReceiver for `y.E2?.Invoke()`.
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition }, targetFramework: TargetFramework.Mscorlib46);
             comp.VerifyDiagnostics(
-                // (27,11): error CS0070: The event '(object?, object?).E2' can only appear on the left hand side of += or -= (except when used from within the type '(object?, object?)')
-                //         y.E2?.Invoke().ToString();
-                Diagnostic(ErrorCode.ERR_BadEventUsage, "E2").WithArguments("(object?, object?).E2", "(object?, object?)").WithLocation(27, 11),
-                // (32,11): error CS0070: The event '(object?, object?).E2' can only appear on the left hand side of += or -= (except when used from within the type '(object?, object?)')
+                // (27,11): error CS0070: The event '(object, object).E2' can only appear on the left hand side of += or -= (except when used from within the type '(object, object)')
+                //         y.E2?.Invoke().ToString(); // 3
+                Diagnostic(ErrorCode.ERR_BadEventUsage, "E2").WithArguments("(object, object).E2", "(object, object)").WithLocation(27, 11),
+                // (32,11): error CS0070: The event '(object, object).E2' can only appear on the left hand side of += or -= (except when used from within the type '(object, object)')
                 //         z.E2?.Invoke().ToString();
-                Diagnostic(ErrorCode.ERR_BadEventUsage, "E2").WithArguments("(object?, object?).E2", "(object?, object?)").WithLocation(32, 11),
+                Diagnostic(ErrorCode.ERR_BadEventUsage, "E2").WithArguments("(object, object).E2", "(object, object)").WithLocation(32, 11),
                 // (25,9): warning CS8602: Possible dereference of a null reference.
-                //         y.F1.ToString();
+                //         y.F1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F1").WithLocation(25, 9),
                 // (26,9): warning CS8602: Possible dereference of a null reference.
-                //         y.P1.ToString();
+                //         y.P1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.P1").WithLocation(26, 9),
-                // (27,14): warning CS8602: Possible dereference of a null reference.
-                //         y.E2?.Invoke().ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".Invoke()").WithLocation(27, 14),
-                // (32,14): warning CS8602: Possible dereference of a null reference.
-                //         z.E2?.Invoke().ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".Invoke()").WithLocation(32, 14),
                 // (17,31): warning CS0414: The field 'ValueTuple<T1, T2>.E2' is assigned but its value is never used
                 //         internal event D<T2>? E2;
                 Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "E2").WithArguments("System.ValueTuple<T1, T2>.E2").WithLocation(17, 31));


### PR DESCRIPTION
Remove uses of `GetTypeAndNullability(BoundExpression)` and `IsNullable(BoundExpression)` extension methods.

There are only two uses of `GetTypeAndNullability()` remaining, for inferring top-level nullability of locals in initial binding. Those uses can be removed once the `SemanticModel` exposes inferred nullability from flow analysis. The other uses of `GetTypeAndNullability()` were in `NullableWalker` which now handles a very limited set of `BoundExpression` types.

The PR also removes several calls to `IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking)`. And removes handling of top-level nullability from `BestTypeInferrer`, which is now largely unchanged from master.