### PR TITLE
Refactor assignment warnings

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -494,8 +494,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private bool ReportNullableAssignmentIfNecessary(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings, AssignmentKind assignmentKind = AssignmentKind.Assignment, Symbol target = null)
         {
-            // PROTOTYPE(NullableReferenceTypes): Need to discuss
-            //Debug.Assert(!IsConditionalState);
             if (value == null)
             {
                 return false;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -494,7 +494,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private bool ReportNullableAssignmentIfNecessary(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings, AssignmentKind assignmentKind = AssignmentKind.Assignment, Symbol target = null)
         {
-            Debug.Assert(!IsConditionalState);
+            // PROTOTYPE(NullableReferenceTypes): Need to discuss
+            //Debug.Assert(!IsConditionalState);
             if (value == null)
             {
                 return false;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -502,7 +502,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (targetType.IsNull ||
                 targetType.IsValueType ||
                 targetType.IsNullable != false ||
-                (!valueType.IsNull && valueType.IsNullable != true && !valueType.TypeSymbol.IsUnconstrainedTypeParameter()))
+                valueType.IsNull ||
+                valueType.IsNullable != true)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -494,8 +494,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private bool ReportNullableAssignmentIfNecessary(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings, AssignmentKind assignmentKind = AssignmentKind.Assignment, Symbol target = null)
         {
-            Debug.Assert(value != null);
             Debug.Assert(!IsConditionalState);
+            if (value == null)
+            {
+                return false;
+            }
 
             if (targetType.IsNull ||
                 targetType.IsValueType ||

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -482,36 +482,87 @@ namespace Microsoft.CodeAnalysis.CSharp
             return typeOpt ?? (object)"<null>";
         }
 
+        private enum AssignmentKind
+        {
+            Assignment,
+            Return,
+            Argument
+        }
+
         /// <summary>
         /// Reports top-level nullability problem in assignment.
         /// </summary>
-        private bool ReportNullReferenceAssignmentIfNecessary(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings)
+        private bool ReportNullableAssignmentIfNecessary(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings, AssignmentKind assignmentKind = AssignmentKind.Assignment, Symbol target = null)
         {
             Debug.Assert(value != null);
             Debug.Assert(!IsConditionalState);
 
-            if (targetType.IsNull || valueType.IsNull)
+            if (targetType.IsNull ||
+                targetType.IsValueType ||
+                targetType.IsNullable != false ||
+                (!valueType.IsNull && valueType.IsNullable != true && !valueType.TypeSymbol.IsUnconstrainedTypeParameter()))
             {
                 return false;
             }
 
-            if (targetType.IsReferenceType && targetType.IsNullable == false && valueType.IsNullable == true)
+            var unwrappedValue = SkipReferenceConversions(value);
+            if (unwrappedValue.Kind == BoundKind.SuppressNullableWarningExpression)
+            {
+                return false;
+            }
+
+            if (reportNullLiteralAssignmentIfNecessary())
+            {
+                return true;
+            }
+
+            if (valueType.IsNull)
+            {
+                return false;
+            }
+
+            if (assignmentKind == AssignmentKind.Argument)
+            {
+                ReportDiagnostic(ErrorCode.WRN_NullReferenceArgument, value.Syntax,
+                    new FormattedSymbol(target, SymbolDisplayFormat.ShortFormat),
+                    new FormattedSymbol(target.ContainingSymbol, SymbolDisplayFormat.MinimallyQualifiedFormat));
+            }
+            else
             {
                 if (useLegacyWarnings)
                 {
                     ReportWWarning(value.Syntax);
                 }
-                else if (!ReportNullAsNonNullableReferenceIfNecessary(value))
+                else
                 {
-                    ReportDiagnostic(ErrorCode.WRN_NullReferenceAssignment, value.Syntax);
+                    ReportDiagnostic(assignmentKind == AssignmentKind.Return ? ErrorCode.WRN_NullReferenceReturn : ErrorCode.WRN_NullReferenceAssignment, value.Syntax);
+                }
+            }
+
+            return true;
+
+            // Report warning converting null literal to non-nullable reference type.
+            // target (e.g.: `object x = null;` or calling `void F(object y)` with `F(null)`).
+            bool reportNullLiteralAssignmentIfNecessary()
+            {
+                if (value.ConstantValue?.IsNull != true && !IsDefaultOfUnconstrainedTypeParameter(value))
+                {
+                    return false;
+                }
+
+                if (useLegacyWarnings)
+                {
+                    ReportWWarning(value.Syntax);
+                }
+                else
+                {
+                    ReportDiagnostic(assignmentKind == AssignmentKind.Return ? ErrorCode.WRN_NullReferenceReturn : ErrorCode.WRN_NullAsNonNullable, value.Syntax);
                 }
                 return true;
             }
-
-            return false;
         }
 
-        private void ReportAssignmentWarnings(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings)
+        private void ReportAssignmentWarnings(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings, AssignmentKind assignmentKind = AssignmentKind.Assignment)
         {
             Debug.Assert(value != null);
             Debug.Assert(!IsConditionalState);
@@ -523,9 +574,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return;
                 }
 
-                ReportNullReferenceAssignmentIfNecessary(value, targetType, valueType, useLegacyWarnings);
-                ReportNullabilityMismatchInAssignmentIfNecessary(value, valueType.TypeSymbol, targetType.TypeSymbol);
+                ReportNullableAssignmentIfNecessary(value, targetType, valueType, useLegacyWarnings, assignmentKind);
+                reportNullabilityMismatchInAssignmentIfNecessary();
             }
+
+            // Report warning assigning value where nested nullability does not match
+            // target (e.g.: `object[] a = new[] { maybeNull }`).
+            void reportNullabilityMismatchInAssignmentIfNecessary()
+            {
+                var sourceType = valueType.TypeSymbol;
+                var destinationType = targetType.TypeSymbol;
+                if ((object)sourceType != null && IsNullabilityMismatch(destinationType, sourceType))
+                {
+                    ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, value.Syntax, sourceType, destinationType);
+                }
+            }
+
+
         }
 
         /// <summary>
@@ -891,21 +956,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            // Convert to method return type.
             var returnType = GetReturnType();
             TypeSymbolWithAnnotations resultType = ApplyConversion(expr, expr, conversion, returnType.TypeSymbol, result, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
             if (!canConvertNestedNullability)
             {
                 ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, expr.Syntax, GetTypeAsDiagnosticArgument(result.TypeSymbol), returnType.TypeSymbol);
             }
-
-            bool returnTypeIsNonNullable = IsNonNullable(returnType);
-            if (returnTypeIsNonNullable &&
-                !ReportNullAsNonNullableReferenceIfNecessary(node.ExpressionOpt) &&
-                IsNullable(resultType))
-            {
-                ReportDiagnostic(ErrorCode.WRN_NullReferenceReturn, node.ExpressionOpt.Syntax);
-            }
+            ReportNullableAssignmentIfNecessary(expr, returnType, resultType, useLegacyWarnings: false, assignmentKind: AssignmentKind.Return);
 
             return null;
         }
@@ -933,18 +990,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static bool IsUnconstrainedTypeParameter(TypeSymbol typeOpt)
         {
             return typeOpt?.IsUnconstrainedTypeParameter() == true;
-        }
-
-        /// <summary>
-        /// Report warning assigning value where nested nullability does not match
-        /// target (e.g.: `object[] a = new[] { maybeNull }`).
-        /// </summary>
-        private void ReportNullabilityMismatchInAssignmentIfNecessary(BoundExpression node, TypeSymbol sourceType, TypeSymbol destinationType)
-        {
-            if ((object)sourceType != null && IsNullabilityMismatch(destinationType, sourceType))
-            {
-                ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, node.Syntax, sourceType, destinationType);
-            }
         }
 
         public override BoundNode VisitLocal(BoundLocal node)
@@ -989,7 +1034,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var unconvertedType = valueType;
                 valueType = ApplyConversion(initializer, initializer, conversion, type.TypeSymbol, valueType, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
                 // Need to report all warnings that apply since the warnings can be suppressed individually.
-                ReportNullReferenceAssignmentIfNecessary(initializer, type, valueType, useLegacyWarnings: true);
+                ReportNullableAssignmentIfNecessary(initializer, type, valueType, useLegacyWarnings: true);
                 if (!canConvertNestedNullability)
                 {
                     ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, initializer.Syntax, GetTypeAsDiagnosticArgument(unconvertedType.TypeSymbol), type.TypeSymbol);
@@ -1310,7 +1355,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (elementTypeIsReferenceType)
                     {
                         resultType = ApplyConversion(element, element, conversion, elementType.TypeSymbol, resultType, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
-                        ReportNullReferenceAssignmentIfNecessary(element, elementType, resultType, useLegacyWarnings: false);
+                        ReportNullableAssignmentIfNecessary(element, elementType, resultType, useLegacyWarnings: false);
                         if (!canConvertNestedNullability)
                         {
                             ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, element.Syntax, sourceType, elementType.TypeSymbol);
@@ -2338,10 +2383,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             _variableTypes[local.LocalSymbol] = parameterType;
                             resultType = parameterType;
                         }
-                        if (argument.Kind != BoundKind.SuppressNullableWarningExpression)
-                        {
-                            reportedWarning = ReportNullReferenceAssignmentIfNecessary(argument, resultType, parameterType, useLegacyWarnings: UseLegacyWarnings(argument));
-                        }
+                        reportedWarning = ReportNullableAssignmentIfNecessary(argument, resultType, parameterType, useLegacyWarnings: UseLegacyWarnings(argument));
                         if (!reportedWarning)
                         {
                             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
@@ -2360,7 +2402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (argument.Kind != BoundKind.SuppressNullableWarningExpression)
                         {
                             reportedWarning = ReportNullReferenceArgumentIfNecessary(argument, resultType, parameter, parameterType) ||
-                                ReportNullReferenceAssignmentIfNecessary(argument, resultType, parameterType, useLegacyWarnings: UseLegacyWarnings(argument));
+                                ReportNullableAssignmentIfNecessary(argument, resultType, parameterType, useLegacyWarnings: UseLegacyWarnings(argument));
                         }
                         if (!reportedWarning)
                         {
@@ -3256,7 +3298,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbolWithAnnotations rightType = ApplyConversion(right, right, conversion, leftType.TypeSymbol, rightResult, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
                 // Need to report all warnings that apply since the warnings can be suppressed individually.
-                ReportNullReferenceAssignmentIfNecessary(right, leftType, rightType, UseLegacyWarnings(left));
+                ReportNullableAssignmentIfNecessary(right, leftType, rightType, UseLegacyWarnings(left));
                 if (!canConvertNestedNullability)
                 {
                     ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, right.Syntax, GetTypeAsDiagnosticArgument(rightResult.TypeSymbol), leftType.TypeSymbol);
@@ -3453,20 +3495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private bool ReportNullReferenceArgumentIfNecessary(BoundExpression argument, TypeSymbolWithAnnotations argumentType, ParameterSymbol parameter, TypeSymbolWithAnnotations paramType)
         {
-            if (argumentType.IsNullable == true)
-            {
-                if (paramType.IsReferenceType && paramType.IsNullable == false)
-                {
-                    if (!ReportNullAsNonNullableReferenceIfNecessary(argument))
-                    {
-                        ReportDiagnostic(ErrorCode.WRN_NullReferenceArgument, argument.Syntax,
-                            new FormattedSymbol(parameter, SymbolDisplayFormat.ShortFormat),
-                            new FormattedSymbol(parameter.ContainingSymbol, SymbolDisplayFormat.MinimallyQualifiedFormat));
-                    }
-                    return true;
-                }
-            }
-            return false;
+            return ReportNullableAssignmentIfNecessary(argument, paramType, argumentType, useLegacyWarnings: false, assignmentKind: AssignmentKind.Argument, target: parameter);
         }
 
         private void ReportArgumentWarnings(BoundExpression argument, TypeSymbolWithAnnotations argumentType, ParameterSymbol parameter)
@@ -4148,25 +4177,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ReportDiagnostic(ErrorCode.WRN_NullReferenceReceiver, receiverOpt.Syntax);
                 }
             }
-        }
-
-        /// <summary>
-        /// Report warning converting null literal to non-nullable reference type.
-        /// target (e.g.: `object x = null;` or calling `void F(object y)` with `F(null)`).
-        /// </summary>
-        private bool ReportNullAsNonNullableReferenceIfNecessary(BoundExpression value)
-        {
-            if (value.ConstantValue?.IsNull != true && !IsDefaultOfUnconstrainedTypeParameter(value))
-            {
-                return false;
-            }
-            var unwrappedValue = SkipReferenceConversions(value);
-            if (unwrappedValue.Kind == BoundKind.SuppressNullableWarningExpression)
-            {
-                return false;
-            }
-            ReportDiagnostic(ErrorCode.WRN_NullAsNonNullable, value.Syntax);
-            return true;
         }
 
         private static bool IsDefaultOfUnconstrainedTypeParameter(BoundExpression expr)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -50,6 +50,25 @@ class C
         }
 
         [Fact]
+        public void TestUnaryNegation()
+        {
+            var source = @"
+public class C<T>
+{
+    C(C<object> c) => throw null;
+    void M(bool b)
+    {
+        _ = new C<object>(!b);
+    }
+    public static implicit operator C<T>(T x) => throw null;
+}
+";
+ 
+            var c = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            c.VerifyDiagnostics( );
+        }
+
+        [Fact]
         public void NoNullableAnalysisWithoutNonNullTypes()
         {
             CSharpCompilation c = CreateCompilation(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -19056,9 +19056,9 @@ class C
                 // (21,26): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //                     p2 = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(21, 26),
-                // (22,28): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (22,28): warning CS8603: Possible null reference return.
                 //                     return null; // 2
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(22, 28)
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(22, 28)
                 );
         }
 
@@ -28930,30 +28930,30 @@ class Program
                 new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (10,27): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (10,27): warning CS8603: Possible null reference return.
                 //     static string F1() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 27),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(10, 27),
                 // (11,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //     static string F2() => (string)null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(11, 27),
-                // (11,27): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (11,27): warning CS8603: Possible null reference return.
                 //     static string F2() => (string)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(11, 27),
-                // (12,27): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "(string)null").WithLocation(11, 27),
+                // (12,27): warning CS8603: Possible null reference return.
                 //     static string F3() => (string?)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(12, 27),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "(string?)null").WithLocation(12, 27),
                 // (13,27): warning CS8603: Possible null reference return.
                 //     static string F4() => null as string;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string").WithLocation(13, 27),
                 // (14,27): warning CS8603: Possible null reference return.
                 //     static string F5() => null as string?;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string?").WithLocation(14, 27),
-                // (15,27): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (15,27): warning CS8603: Possible null reference return.
                 //     static string F6() => default(string);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(15, 27),
-                // (16,27): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "default(string)").WithLocation(15, 27),
+                // (16,27): warning CS8603: Possible null reference return.
                 //     static string F7() => default;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(16, 27),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "default").WithLocation(16, 27),
                 // (17,36): hidden CS8605: Result of the comparison is possibly always true.
                 //     static string F8(Person p) => (p != null) ? p.MiddleName : null;
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(17, 36),
@@ -30501,9 +30501,9 @@ End Class";
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
             comp.VerifyDiagnostics(
-                // (3,17): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (3,17): warning CS8603: Possible null reference return.
                 //     object P => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(3, 17));
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(3, 17));
         }
 
         [Fact]
@@ -30700,9 +30700,9 @@ class C
                 new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition },
                 parseOptions: TestOptions.Regular8.WithFeature("staticNullChecking"));
             comp.VerifyDiagnostics(
-                // (3,26): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (3,26): warning CS8603: Possible null reference return.
                 //     static object F() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(3, 26),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(3, 26),
                 // (4,35): warning CS8603: Possible null reference return.
                 //     static object F(object? o) => o;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "o").WithLocation(4, 35));
@@ -30711,9 +30711,9 @@ class C
                 new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition },
                 parseOptions: TestOptions.Regular8.WithFeature("staticNullChecking", "0"));
             comp.VerifyDiagnostics(
-                // (3,26): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (3,26): warning CS8603: Possible null reference return.
                 //     static object F() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(3, 26),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(3, 26),
                 // (4,35): warning CS8603: Possible null reference return.
                 //     static object F(object? o) => o;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "o").WithLocation(4, 35));
@@ -30722,9 +30722,9 @@ class C
                 new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition },
                 parseOptions: TestOptions.Regular8.WithFeature("staticNullChecking", "1"));
             comp.VerifyDiagnostics(
-                // (3,26): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (3,26): warning CS8603: Possible null reference return.
                 //     static object F() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(3, 26),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(3, 26),
                 // (4,35): warning CS8603: Possible null reference return.
                 //     static object F(object? o) => o;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "o").WithLocation(4, 35));
@@ -31600,9 +31600,9 @@ class A : System.Attribute
                 // (1,2): error CS1729: 'A' does not contain a constructor that takes 1 arguments
                 // [A(P)]
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, "A(P)").WithArguments("A", "1").WithLocation(1, 2),
-                // (4,17): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (4,17): warning CS8603: Possible null reference return.
                 //     string P => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(4, 17));
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(4, 17));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Should not report warning for
@@ -32020,27 +32020,27 @@ class C
 }";
             var comp = CreateCompilationWithMscorlib46(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
             comp.VerifyDiagnostics(
-                // (4,25): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (4,25): warning CS8603: Possible null reference return.
                 //     static Task F0() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(4, 25),
-                // (5,33): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(4, 25),
+                // (5,33): warning CS8603: Possible null reference return.
                 //     static Task<string> F1() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(5, 33),
-                // (6,40): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(5, 33),
+                // (6,40): warning CS8603: Possible null reference return.
                 //     static Task<string?> F2() { return null; }
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 40),
-                // (7,37): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(6, 40),
+                // (7,37): warning CS8603: Possible null reference return.
                 //     static Task<T> F3<T>() { return default; }
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(7, 37),
-                // (8,37): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "default").WithLocation(7, 37),
+                // (8,37): warning CS8603: Possible null reference return.
                 //     static Task<T> F4<T>() { return default(Task<T>); }
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(Task<T>)").WithLocation(8, 37),
-                // (9,53): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "default(Task<T>)").WithLocation(8, 37),
+                // (9,53): warning CS8603: Possible null reference return.
                 //     static Task<T> F5<T>() where T : class { return null; }
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 53),
-                // (10,48): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(9, 53),
+                // (10,48): warning CS8603: Possible null reference return.
                 //     static Task<T?> F6<T>() where T : class => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 48));
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(10, 48));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Should not report WRN_NullAsNonNullable for F0.
@@ -32070,27 +32070,27 @@ class C
                 // (5,30): error CS1997: Since 'C.F0()' is an async method that returns 'Task', a return keyword must not be followed by an object expression. Did you intend to return 'Task<T>'?
                 //     static async Task F0() { return null; }
                 Diagnostic(ErrorCode.ERR_TaskRetNoObjectRequired, "return").WithArguments("C.F0()").WithLocation(5, 30),
-                // (5,37): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (5,37): warning CS8603: Possible null reference return.
                 //     static async Task F0() { return null; }
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(5, 37),
-                // (6,39): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(5, 37),
+                // (6,39): warning CS8603: Possible null reference return.
                 //     static async Task<string> F1() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 39),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(6, 39),
                 // (8,43): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     static async Task<T> F3<T>() { return default; }
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(8, 43),
                 // (9,43): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     static async Task<T> F4<T>() { return default(T); }
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T)").WithLocation(9, 43),
-                // (10,59): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (10,59): warning CS8603: Possible null reference return.
                 //     static async Task<T> F5<T>() where T : class { return null; }
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 59),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(10, 59),
                 // (12,31): error CS1997: Since 'C.G0()' is an async method that returns 'Task', a return keyword must not be followed by an object expression. Did you intend to return 'Task<T>'?
                 //     static async Task? G0() { return null; }
                 Diagnostic(ErrorCode.ERR_TaskRetNoObjectRequired, "return").WithArguments("C.G0()").WithLocation(12, 31),
-                // (13,40): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // (13,40): warning CS8603: Possible null reference return.
                 //     static async Task<string>? G1() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 40),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(13, 40),
                 // (14,44): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     static async Task<T>? G3<T>() { return default; }
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(14, 44));
@@ -36509,48 +36509,48 @@ class A
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
             // PROTOTYPE(NullableReferenceTypes): missing warnings
             comp.VerifyDiagnostics(
-                // (14,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //     static T2 F1() => default; // warn: return type T2 may be non-null
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(14, 23),
-                // (24,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //     static T3 F1() => default; // warn: return type T3 may be non-null
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(24, 23),
-                // (25,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //     static T3 F2() => default(T3); // warn: return type T3 may be non-null
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T3)").WithLocation(25, 23),
-                // (15,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //     static T2 F2() => default(T2); // warn: return type T2 may be non-null
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T2)").WithLocation(15, 23),
+                // (45,23): warning CS8603: Possible null reference return.
+                //     static T5 F1() => default; // warn: return type T5 may be non-null
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "default").WithLocation(45, 23),
                 // (35,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     static T4 F1() => default; // warn: return type T4 may be non-null
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(35, 23),
-                // (18,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         T2 t2 = (T2)NullableObject(); // warn: T2 may be non-null
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(T2)NullableObject()").WithLocation(18, 17),
-                // (18,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         T2 t2 = (T2)NullableObject(); // warn: T2 may be non-null
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(T2)NullableObject()").WithLocation(18, 17),
-                // (45,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //     static T5 F1() => default; // warn: return type T5 may be non-null
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(45, 23),
-                // (46,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //     static T5 F2() => default(T5); // warn: return type T5 may be non-null
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T5)").WithLocation(46, 23),
+                // (24,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //     static T3 F1() => default; // warn: return type T3 may be non-null
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(24, 23),
+                // (14,23): warning CS8603: Possible null reference return.
+                //     static T2 F1() => default; // warn: return type T2 may be non-null
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "default").WithLocation(14, 23),
                 // (4,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     static T1 F1() => default; // warn: return type T1 may be non-null
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(4, 23),
+                // (46,23): warning CS8603: Possible null reference return.
+                //     static T5 F2() => default(T5); // warn: return type T5 may be non-null
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "default(T5)").WithLocation(46, 23),
+                // (25,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //     static T3 F2() => default(T3); // warn: return type T3 may be non-null
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T3)").WithLocation(25, 23),
+                // (36,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //     static T4 F2() => default(T4); // warn: return type T4 may be non-null
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T4)").WithLocation(36, 23),
                 // (5,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     static T1 F2() => default(T1); // warn: return type T1 may be non-null
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T1)").WithLocation(5, 23),
+                // (15,23): warning CS8603: Possible null reference return.
+                //     static T2 F2() => default(T2); // warn: return type T2 may be non-null
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "default(T2)").WithLocation(15, 23),
                 // (49,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T5 t5 = (T5)NullableObject(); // warn: T5 may be non-null
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(T5)NullableObject()").WithLocation(49, 17),
                 // (49,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T5 t5 = (T5)NullableObject(); // warn: T5 may be non-null
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(T5)NullableObject()").WithLocation(49, 17),
-                // (36,23): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //     static T4 F2() => default(T4); // warn: return type T4 may be non-null
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T4)").WithLocation(36, 23)
+                // (18,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         T2 t2 = (T2)NullableObject(); // warn: T2 may be non-null
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(T2)NullableObject()").WithLocation(18, 17),
+                // (18,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         T2 t2 = (T2)NullableObject(); // warn: T2 may be non-null
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(T2)NullableObject()").WithLocation(18, 17)
             );
         }
 

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -21,9 +21,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.DeclareAsNullable), Shared]
     internal class CSharpDeclareAsNullableCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
-        // warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+        // warning CS8603: Possible null reference return.
         // warning CS8600: Converting null literal or possible null value to non-nullable type.
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("CS8625", "CS8600");
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("CS8603", "CS8600");
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {


### PR DESCRIPTION
From discussion with @cston, there is more work to do to factor the logic and checks whenever assigning/converting a value (assignment, local declaration, return, yield return, argument passing, foreach variable initialization, ...), so that it can easily be re-used.
This PR is a small step in that direction.