### PR TITLE
Remove obsolete TypeSymbolWithAnnotations.Create method

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -457,7 +457,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             int leftLength = lhsVariables.Count;
             int rightLength = rhsLiteral.Arguments.Length;
 
-            var typesBuilder = ArrayBuilder<TypeSymbol>.GetInstance(leftLength);
+            var typesBuilder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(leftLength);
             var locationsBuilder = ArrayBuilder<Location>.GetInstance(leftLength);
             for (int i = 0; i < rightLength; i++)
             {
@@ -498,11 +498,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                typesBuilder.Add(mergedType);
+                typesBuilder.Add(TypeSymbolWithAnnotations.Create(mergedType));
                 locationsBuilder.Add(element.Syntax.Location);
             }
 
-            if (typesBuilder.Any(t => t == null))
+            if (typesBuilder.Any(t => t.IsNull))
             {
                 typesBuilder.Free();
                 locationsBuilder.Free();
@@ -514,7 +514,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // tree of types used for figuring out natural types in tuple literal.
             return TupleTypeSymbol.Create(
                 locationOpt: null,
-                elementTypes: typesBuilder.ToImmutableAndFree().SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations), // PROTOTYPE(NullableTypeReferences): Not including nullability.
+                elementTypes: typesBuilder.ToImmutableAndFree(),
                 elementLocations: locationsBuilder.ToImmutableAndFree(),
                 elementNames: default(ImmutableArray<string>),
                 compilation: compilation,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -779,7 +779,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 boundArguments.Add(boundArgument);
 
-                var elementType = TypeSymbolWithAnnotations.Create(boundArgument.Type, isNullableIfReferenceType: null);
+                var elementType = TypeSymbolWithAnnotations.Create(boundArgument.Type);
                 elementTypes.Add(elementType);
 
                 if (elementType.IsNull)
@@ -2719,7 +2719,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Element type nullability will be inferred in flow analysis and does not need to be set here.
-            var arrayType = ArrayTypeSymbol.CreateCSharpArray(Compilation.Assembly, TypeSymbolWithAnnotations.Create(bestType, isNullableIfReferenceType: null), rank);
+            var arrayType = ArrayTypeSymbol.CreateCSharpArray(Compilation.Assembly, TypeSymbolWithAnnotations.Create(bestType), rank);
             return BindArrayCreationWithInitializer(diagnostics, node, initializer, arrayType,
                 sizes: ImmutableArray<BoundExpression>.Empty, boundInitExprOpt: boundInitializerExpressions);
         }
@@ -2747,7 +2747,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return BindStackAllocWithInitializer(
                 node,
                 initializer,
-                type: GetStackAllocType(node, TypeSymbolWithAnnotations.Create(bestType, isNullableIfReferenceType: null), diagnostics, out bool hasErrors),
+                type: GetStackAllocType(node, TypeSymbolWithAnnotations.Create(bestType), diagnostics, out bool hasErrors),
                 elementType: bestType,
                 sizeOpt: null,
                 diagnostics,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2152,9 +2152,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            TypeSymbol pointerType = new PointerTypeSymbol(TypeSymbolWithAnnotations.Create(isManagedType && allowManagedAddressOf
+            TypeSymbol pointedAtType = isManagedType && allowManagedAddressOf
                 ? GetSpecialType(SpecialType.System_IntPtr, diagnostics, node)
-                : operandType ?? CreateErrorType()));
+                : operandType ?? CreateErrorType();
+            TypeSymbol pointerType = new PointerTypeSymbol(TypeSymbolWithAnnotations.Create(pointedAtType));
 
             return new BoundAddressOfOperator(node, operand, pointerType, hasErrors);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -889,7 +889,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TypeSymbol initializerType = initializerOpt?.Type;
                 if ((object)initializerType != null)
                 {
-                    declTypeOpt = TypeSymbolWithAnnotations.Create(initializerType, isNullableIfReferenceType: null);
+                    declTypeOpt = TypeSymbolWithAnnotations.Create(initializerType);
 
                     if (declTypeOpt.SpecialType == SpecialType.System_Void)
                     {

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (isVar)
                         {
-                            declType = inferredType.IsNull ? TypeSymbolWithAnnotations.Create(CreateErrorType("var"), isNullableIfReferenceType: null) : inferredType;
+                            declType = inferredType.IsNull ? TypeSymbolWithAnnotations.Create(CreateErrorType("var")) : inferredType;
                         }
                         else
                         {
@@ -497,7 +497,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else if (collectionExpr.HasDynamicType())
             {
                 // If the enumerator is dynamic, it yields dynamic values 
-                inferredType = TypeSymbolWithAnnotations.Create(DynamicTypeSymbol.Instance, isNullableIfReferenceType: null);
+                inferredType = TypeSymbolWithAnnotations.Create(DynamicTypeSymbol.Instance);
             }
             else if (collectionExpr.Type.SpecialType == SpecialType.System_String && builder.CollectionType.SpecialType == SpecialType.System_Collections_IEnumerable)
             {
@@ -505,7 +505,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // over the string's Chars indexer.  Therefore, we should infer "char", regardless of what the spec
                 // indicates the element type is.  This actually matters in practice because the System.String in
                 // the portable library doesn't have a pattern GetEnumerator method or implement IEnumerable<char>.
-                inferredType = TypeSymbolWithAnnotations.Create(GetSpecialType(SpecialType.System_Char, diagnostics, collectionExpr.Syntax), isNullableIfReferenceType: null);
+                inferredType = TypeSymbolWithAnnotations.Create(GetSpecialType(SpecialType.System_Char, diagnostics, collectionExpr.Syntax));
             }
             else
             {
@@ -746,7 +746,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 builder.ElementType = collectionExprType.SpecialType == SpecialType.System_String ?
-                    TypeSymbolWithAnnotations.Create(GetSpecialType(SpecialType.System_Char, diagnostics, _syntax), isNullableIfReferenceType: null) :
+                    TypeSymbolWithAnnotations.Create(GetSpecialType(SpecialType.System_Char, diagnostics, _syntax)) :
                     ((ArrayTypeSymbol)collectionExprType).ElementType;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -740,8 +740,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 builder.ElementType = TypeSymbolWithAnnotations.Create(
                     ((_syntax as ForEachStatementSyntax)?.Type.IsVar == true) ?
                         (TypeSymbol)DynamicTypeSymbol.Instance :
-                        GetSpecialType(SpecialType.System_Object, diagnostics, _syntax),
-                    isNullableIfReferenceType: null);
+                        GetSpecialType(SpecialType.System_Object, diagnostics, _syntax));
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // If we don't have System.Object, then we'll get an error type, which will cause overload resolution to fail, 
                     // which will cause some error to be reported.  That's sufficient (i.e. no need to specifically report its absence here).
                     parameter = new SignatureOnlyParameterSymbol(
-                        TypeSymbolWithAnnotations.Create(compilation.GetSpecialType(SpecialType.System_Object), parameter.Type.CustomModifiers), parameter.RefCustomModifiers, parameter.IsParams, parameter.RefKind);
+                        TypeSymbolWithAnnotations.Create(compilation.GetSpecialType(SpecialType.System_Object), customModifiers: parameter.Type.CustomModifiers), parameter.RefCustomModifiers, parameter.IsParams, parameter.RefKind);
             }
 
             analyzedArguments.Arguments.Add(new BoundParameter(syntax, parameter) { WasCompilerGenerated = true });

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2822,7 +2822,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // extension method of x, at least until we have more information.
         //
         // Clearly it is pointless to run multiple phases
-        public static ImmutableArray<TypeSymbol> InferTypeArgumentsFromFirstArgument(
+        public static ImmutableArray<TypeSymbolWithAnnotations> InferTypeArgumentsFromFirstArgument(
             ConversionsBase conversions,
             MethodSymbol method,
             ImmutableArray<BoundExpression> arguments,
@@ -2835,7 +2835,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We need at least one formal parameter type and at least one argument.
             if ((method.ParameterCount < 1) || (arguments.Length < 1))
             {
-                return default(ImmutableArray<TypeSymbol>);
+                return default(ImmutableArray<TypeSymbolWithAnnotations>);
             }
 
             Debug.Assert(!method.ParameterTypes[0].IsDynamic());
@@ -2853,7 +2853,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!inferrer.InferTypeArgumentsFromFirstArgument(ref useSiteDiagnostics))
             {
-                return default(ImmutableArray<TypeSymbol>);
+                return default(ImmutableArray<TypeSymbolWithAnnotations>);
             }
 
             return inferrer.GetInferredTypeArguments();
@@ -2899,14 +2899,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Return the inferred type arguments using null
         /// for any type arguments that were not inferred.
         /// </summary>
-        private ImmutableArray<TypeSymbol> GetInferredTypeArguments()
+        private ImmutableArray<TypeSymbolWithAnnotations> GetInferredTypeArguments()
         {
-            var builder = ArrayBuilder<TypeSymbol>.GetInstance();
-            foreach (var fixedResult in _fixedResults)
-            {
-                builder.Add(fixedResult.TypeSymbol);
-            }
-            return builder.ToImmutableAndFree();
+            return _fixedResults.AsImmutable();
         }
 
         private static bool IsReallyAType(TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var resultType = (object)taskType != null && taskType.Arity == 0 ?
                     taskType :
                     compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
-                return TypeSymbolWithAnnotations.Create(resultType);
+                return TypeSymbolWithAnnotations.Create(resultType, isNullableIfReferenceType: false);
             }
 
             if (bestResultType.IsNull || bestResultType.SpecialType == SpecialType.System_Void)
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var taskTypeT = (object)taskType != null && taskType.Arity == 1 ?
                 taskType :
                 compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
-            return TypeSymbolWithAnnotations.Create(taskTypeT.Construct(ImmutableArray.Create(bestResultType)));
+            return TypeSymbolWithAnnotations.Create(taskTypeT.Construct(ImmutableArray.Create(bestResultType)), isNullableIfReferenceType: false);
         }
 
         internal sealed class BlockReturns : BoundTreeWalker
@@ -251,9 +251,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var expression = node.ExpressionOpt;
                 var type = (expression is null) ?
-                    TypeSymbolWithAnnotations.Create(NonNullTypesUnusedContext.Instance, NoReturnExpression) :
-                    TypeSymbolWithAnnotations.Create(expression.Type?.SetUnknownNullabilityForReferenceTypes());
-                _builder.Add((node.RefKind, type));
+                    NoReturnExpression :
+                    expression.Type?.SetUnknownNullabilityForReferenceTypes();
+                _builder.Add((node.RefKind, TypeSymbolWithAnnotations.Create(type)));
                 return null;
             }
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var resultType = (object)taskType != null && taskType.Arity == 0 ?
                     taskType :
                     compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
-                return TypeSymbolWithAnnotations.Create(resultType, isNullableIfReferenceType: false);
+                return TypeSymbolWithAnnotations.Create(resultType);
             }
 
             if (bestResultType.IsNull || bestResultType.SpecialType == SpecialType.System_Void)
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var taskTypeT = (object)taskType != null && taskType.Arity == 1 ?
                 taskType :
                 compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
-            return TypeSymbolWithAnnotations.Create(taskTypeT.Construct(ImmutableArray.Create(bestResultType)), isNullableIfReferenceType: false);
+            return TypeSymbolWithAnnotations.Create(taskTypeT.Construct(ImmutableArray.Create(bestResultType)));
         }
 
         internal sealed class BlockReturns : BoundTreeWalker

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -464,7 +464,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics: context.Diagnostics,
                     fromImplements: true);
 
-                var type = TypeSymbolWithAnnotations.Create(@interface, isNullableIfReferenceType: null);
+                var type = TypeSymbolWithAnnotations.Create(@interface);
                 yield return type.GetTypeRefWithAttributes(
                     moduleBeingBuilt,
                     declaringSymbol: this,

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -317,8 +317,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             var boolArray = TypeSymbolWithAnnotations.Create(
                 ArrayTypeSymbol.CreateSZArray(
                     boolType.ContainingAssembly,
-                    TypeSymbolWithAnnotations.Create(boolType)),
-                isNullableIfReferenceType: null);
+                    TypeSymbolWithAnnotations.Create(boolType)));
             return ImmutableArray.Create<MethodSymbol>(
                 new SynthesizedEmbeddedAttributeConstructorSymbol(
                     containingType,

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -317,7 +317,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             var boolArray = TypeSymbolWithAnnotations.Create(
                 ArrayTypeSymbol.CreateSZArray(
                     boolType.ContainingAssembly,
-                    TypeSymbolWithAnnotations.Create(boolType)));
+                    TypeSymbolWithAnnotations.Create(boolType)),
+                isNullableIfReferenceType: null);
             return ImmutableArray.Create<MethodSymbol>(
                 new SynthesizedEmbeddedAttributeConstructorSymbol(
                     containingType,

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                     (CSharpSyntaxNode)context.SyntaxNodeOpt,
                     context.Diagnostics);
 
-                var type = TypeSymbolWithAnnotations.Create(@interface, isNullableIfReferenceType: null);
+                var type = TypeSymbolWithAnnotations.Create(@interface);
                 yield return type.GetTypeRefWithAttributes(
                     moduleBeingBuilt,
                     declaringSymbol: UnderlyingNamedType,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.ObjectCreationPlaceholderLocal.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.ObjectCreationPlaceholderLocal.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public ObjectCreationPlaceholderLocal(Symbol containingSymbol, BoundExpression objectCreationExpression)
             {
                 _containingSymbol = containingSymbol;
-                _type = TypeSymbolWithAnnotations.Create(objectCreationExpression.Type);
+                _type = TypeSymbolWithAnnotations.Create(objectCreationExpression.Type, isNullableIfReferenceType: false);
                 ObjectCreationExpression = objectCreationExpression;
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1079,7 +1079,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitObjectCreationInitializer(receiver, slot, initializerOpt);
             }
 
-            _resultType = TypeSymbolWithAnnotations.Create(type);
+            _resultType = TypeSymbolWithAnnotations.Create(type, isNullableIfReferenceType: false);
         }
 
         private void VisitObjectCreationInitializer(Symbol containingSymbol, int containingSlot, BoundExpression node)
@@ -1227,7 +1227,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // PROTOTYPE(NullableReferenceTypes): _result may need to be a new anonymous
             // type since the properties may have distinct nullability from original.
             // (See StaticNullChecking_FlowAnalysis.AnonymousObjectCreation_02.)
-            _resultType = TypeSymbolWithAnnotations.Create(node.Type);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: false);
             return null;
         }
 
@@ -1238,7 +1238,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitRvalue(expr);
             }
             TypeSymbol resultType = (node.InitializerOpt == null) ? node.Type : VisitArrayInitializer(node);
-            _resultType = TypeSymbolWithAnnotations.Create(resultType);
+            _resultType = TypeSymbolWithAnnotations.Create(resultType, isNullableIfReferenceType: false);
             return null;
         }
 
@@ -1286,7 +1286,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     // Mark the error type as null-oblivious.
-                    bestType = TypeSymbolWithAnnotations.Create(bestType.TypeSymbol, isNullableIfReferenceType: null);
+                    bestType = TypeSymbolWithAnnotations.Create(bestType.TypeSymbol);
                 }
                 // PROTOTYPE(NullableReferenceTypes): Report a special ErrorCode.WRN_NoBestNullabilityArrayElements
                 // when InferBestType fails, and avoid reporting conversion warnings for each element in those cases.
@@ -1374,7 +1374,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (operatorKind.IsLifted())
                 {
                     // PROTOTYPE(NullableReferenceTypes): Conversions: Lifted operator
-                    return TypeSymbolWithAnnotations.Create(resultType, isNullableIfReferenceType: null);
+                    return TypeSymbolWithAnnotations.Create(resultType);
                 }
                 // PROTOTYPE(NullableReferenceTypes): Update method based on operand types.
                 if ((object)methodOpt != null && methodOpt.ParameterCount == 2)
@@ -2840,7 +2840,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var tupleOpt = (TupleTypeSymbol)node.Type;
             _resultType = (tupleOpt is null) ?
                 default :
-                TypeSymbolWithAnnotations.Create(tupleOpt.WithElementTypes(elementTypes));
+                TypeSymbolWithAnnotations.Create(tupleOpt.WithElementTypes(elementTypes), isNullableIfReferenceType: false);
         }
 
         public override BoundNode VisitTupleBinaryOperator(BoundTupleBinaryOperator node)
@@ -3153,7 +3153,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             base.VisitDelegateCreationExpression(node);
-            SetResult(node);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: false);
             return null;
         }
 
@@ -3221,7 +3221,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void VisitThisOrBaseReference(BoundExpression node)
         {
-            _resultType = TypeSymbolWithAnnotations.Create(node.Type);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: false);
         }
 
         public override BoundNode VisitParameter(BoundParameter node)
@@ -3621,7 +3621,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitBadExpression(BoundBadExpression node)
         {
             var result = base.VisitBadExpression(node);
-            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: null);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type);
             return result;
         }
 
@@ -3660,7 +3660,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            _resultType = resultType.IsNull ? TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: null) : resultType;
+            _resultType = resultType.IsNull ? TypeSymbolWithAnnotations.Create(node.Type) : resultType;
             return null;
         }
 
@@ -3704,7 +3704,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.OperatorKind.IsLifted())
             {
                 // PROTOTYPE(NullableReferenceTypes): Conversions: Lifted operator
-                return TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: null);
+                return TypeSymbolWithAnnotations.Create(node.Type);
             }
             // PROTOTYPE(NullableReferenceTypes): Update method based on inferred operand types.
             if ((object)node.LogicalOperator != null && node.LogicalOperator.ParameterCount == 2)
@@ -3808,7 +3808,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitTypeOfOperator(BoundTypeOfOperator node)
         {
             var result = base.VisitTypeOfOperator(node);
-            SetResult(node);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: false);
             return result;
         }
 
@@ -4007,7 +4007,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             CheckPossibleNullReceiver(receiver);
 
             Debug.Assert(node.Type.IsDynamic());
-            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: null);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type);
             return null;
         }
 
@@ -4085,7 +4085,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitNoPiaObjectCreationExpression(BoundNoPiaObjectCreationExpression node)
         {
             var result = base.VisitNoPiaObjectCreationExpression(node);
-            SetResult(node);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: false);
             return result;
         }
 
@@ -4247,7 +4247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitNameOfOperator(BoundNameOfOperator node)
         {
             var result = base.VisitNameOfOperator(node);
-            SetResult(node);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: false);
             return result;
         }
 
@@ -4261,7 +4261,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitInterpolatedString(BoundInterpolatedString node)
         {
             var result = base.VisitInterpolatedString(node);
-            SetResult(node);
+            _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: false);
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -626,7 +626,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundNode IntroduceFrame(BoundNode node, Analysis.ClosureEnvironment env, Func<ArrayBuilder<BoundExpression>, ArrayBuilder<LocalSymbol>, BoundNode> F)
         {
             var frame = env.SynthesizedEnvironment;
-            var frameTypeParameters = ImmutableArray.Create(_currentTypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations), 0, frame.Arity);
+            var frameTypeParameters = ImmutableArray.Create(_currentTypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)), 0, frame.Arity);
             NamedTypeSymbol frameType = frame.ConstructIfGeneric(frameTypeParameters);
 
             Debug.Assert(frame.ScopeSyntaxOpt != null);
@@ -960,7 +960,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // All of _currentTypeParameters might not be preserved here due to recursively calling upwards in the chain of local functions/lambdas
             Debug.Assert((typeArgumentsOpt.IsDefault && !originalMethod.IsGenericMethod) || (typeArgumentsOpt.Length == originalMethod.Arity));
             var totalTypeArgumentCount = (containerAsFrame?.Arity ?? 0) + synthesizedMethod.Arity;
-            var realTypeArguments = ImmutableArray.Create(_currentTypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations), 0, totalTypeArgumentCount - originalMethod.Arity);
+            var realTypeArguments = ImmutableArray.Create(_currentTypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)), 0, totalTypeArgumentCount - originalMethod.Arity);
             if (!typeArgumentsOpt.IsDefault)
             {
                 realTypeArguments = realTypeArguments.Concat(typeArgumentsOpt);

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 methodName,
                 args,
                 diagnostics,
-                typeArgs: typeArgs.IsDefault ? default(ImmutableArray<TypeSymbolWithAnnotations>) : typeArgs.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations),
+                typeArgs: typeArgs.IsDefault ? default(ImmutableArray<TypeSymbolWithAnnotations>) : typeArgs.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)),
                 allowFieldsAndProperties: false,
                 allowUnexpandedForm: allowUnexpandedForm);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -141,14 +141,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal TypeSymbolWithAnnotations SubstituteType(TypeSymbol previous, bool withTupleUnification)
         {
             var result = SubstituteType(previous);
-
             // Make it a tuple if it became compatible with one.
-            if (withTupleUnification && !previous.IsTupleCompatible())
-            {
-                return result.TransformToTupleIfCompatible();
-            }
-
-            return result;
+            return withTupleUnification ? result.TransformToTupleIfCompatible() : result;
         }
 
         internal TypeSymbolWithAnnotations SubstituteTypeWithTupleUnification(TypeSymbolWithAnnotations previous)

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.EqualsMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.EqualsMethodSymbol.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 : base(container, WellKnownMemberNames.ObjectEquals)
             {
                 _parameters = ImmutableArray.Create<ParameterSymbol>(
-                    SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(this.Manager.System_Object), 0, RefKind.None, "value"));
+                    SynthesizedParameterSymbol.Create(this, TypeSymbolWithAnnotations.Create(this.Manager.System_Object, isNullableIfReferenceType: true), 0, RefKind.None, "value"));
             }
 
             public override MethodKind MethodKind

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.ToStringMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.ToStringMethodSymbol.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override TypeSymbolWithAnnotations ReturnType
             {
-                get { return TypeSymbolWithAnnotations.Create(this.Manager.System_String); }
+                get { return TypeSymbolWithAnnotations.Create(this.Manager.System_String, isNullableIfReferenceType: false); }
             }
 
             public override ImmutableArray<ParameterSymbol> Parameters

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal virtual TypeSymbolWithAnnotations Substitute(AbstractTypeMap typeMap)
         {
-            return TypeSymbolWithAnnotations.Create((ErrorTypeSymbol)typeMap.SubstituteNamedType(this), isNullableIfReferenceType: null);
+            return TypeSymbolWithAnnotations.Create((ErrorTypeSymbol)typeMap.SubstituteNamedType(this));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // bad metadata
             if (hasTupleElementNamesAttribute && elementNames.IsDefaultOrEmpty)
             {
-                return TypeSymbolWithAnnotations.Create(new UnsupportedMetadataTypeSymbol(), isNullableIfReferenceType: null);
+                return TypeSymbolWithAnnotations.Create(new UnsupportedMetadataTypeSymbol());
             }
 
             TypeSymbol type = metadataType.TypeSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -749,6 +749,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return this.Construct(ImmutableArray.Create(typeArguments));
         }
 
+        // PROTOTYPE(NullableReferenceTypes): Replace with Construct(ImmutableArray<TypeSymbolWithAnnotations>).
         /// <summary>
         /// Apply type substitution to a generic method to create an method symbol with the given type parameters supplied.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // This prevents constraint checking from failing for corresponding type parameters. 
             var notInferredTypeParameters = PooledHashSet<TypeParameterSymbol>.GetInstance();
             var typeParams = method.TypeParameters;
-            var typeArgsForConstraintsCheck = typeArgs.SelectAsArray(a => TypeSymbolWithAnnotations.Create(a));
+            var typeArgsForConstraintsCheck = typeArgs;
             for (int i = 0; i < typeArgsForConstraintsCheck.Length; i++)
             {
                 if (typeArgsForConstraintsCheck[i].IsNull)
@@ -140,12 +140,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var typeArgsForConstruct = typeArgs;
             if (firstNullInTypeArgs != -1)
             {
-                var builder = ArrayBuilder<TypeSymbol>.GetInstance();
+                var builder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
                 builder.AddRange(typeArgs, firstNullInTypeArgs);
 
                 for (int i = firstNullInTypeArgs; i < typeArgsForConstruct.Length; i++)
                 {
-                    builder.Add(typeArgsForConstruct[i] ?? typeParams[i]);
+                    var typeArgForConstruct = typeArgsForConstruct[i];
+                    builder.Add(!typeArgForConstruct.IsNull ? typeArgForConstruct : TypeSymbolWithAnnotations.Create(typeParams[i]));
                 }
 
                 typeArgsForConstruct = builder.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics: diagnostics);
 
             _lazyIsVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
-            _lazyReturnType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            _lazyReturnType = TypeSymbolWithAnnotations.Create(bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
 
             var location = this.Locations[0];
             if (MethodKind == MethodKind.StaticConstructor && (_lazyParameters.Length != 0))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -49,10 +49,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var returnType = binder.BindType(returnTypeSyntax, diagnostics);
 
             // reuse types to avoid reporting duplicate errors if missing:
-            var voidType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            var voidType = TypeSymbolWithAnnotations.Create(binder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
             // PROTOTYPE(NullableReferenceTypes): Should the 'object' parameter be considered nullable?
             var objectType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_Object, diagnostics, syntax));
-            var intPtrType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: delegateType, binder.GetSpecialType(SpecialType.System_IntPtr, diagnostics, syntax));
+            var intPtrType = TypeSymbolWithAnnotations.Create(binder.GetSpecialType(SpecialType.System_IntPtr, diagnostics, syntax));
 
             if (returnType.IsRestrictedType(ignoreSpanLikeTypes: true))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var syntax = GetSyntax();
             var bodyBinder = this.DeclaringCompilation.GetBinderFactory(syntaxReferenceOpt.SyntaxTree).GetBinder(syntax, syntax, this);
-            _lazyReturnType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            _lazyReturnType = TypeSymbolWithAnnotations.Create(bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
         }
 
         internal DestructorDeclarationSyntax GetSyntax()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var syntax = GetSyntax();
             var bodyBinder = this.DeclaringCompilation.GetBinderFactory(syntaxReferenceOpt.SyntaxTree).GetBinder(syntax, syntax, this);
-            _lazyReturnType = TypeSymbolWithAnnotations.Create(bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
+            _lazyReturnType = TypeSymbolWithAnnotations.Create(nonNullTypesContext: this, bodyBinder.GetSpecialType(SpecialType.System_Void, diagnostics, syntax));
         }
 
         internal DestructorDeclarationSyntax GetSyntax()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else
             {
                 var binder = GetBinder();
-                return TypeSymbolWithAnnotations.Create(nonNullTypesContext: ContainingModule, binder.GetSpecialType(SpecialType.System_Void, diagnostics, this.GetSyntax()));
+                return TypeSymbolWithAnnotations.Create(binder.GetSpecialType(SpecialType.System_Void, diagnostics, this.GetSyntax()));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override TypeSymbolWithAnnotations Type
         {
-            get { return TypeSymbolWithAnnotations.Create(_containingType); }
+            get { return TypeSymbolWithAnnotations.Create(_containingType, isNullableIfReferenceType: false); }
         }
 
         public override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override TypeSymbolWithAnnotations ReturnType
         {
-            get { return TypeSymbolWithAnnotations.Create(nonNullTypesContext: ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
+            get { return TypeSymbolWithAnnotations.Create(ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
         }
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return TypeSymbolWithAnnotations.Create(nonNullTypesContext: ContainingModule, ContainingAssembly.GetSpecialType(SpecialType.System_Void));
+                return TypeSymbolWithAnnotations.Create(ContainingAssembly.GetSpecialType(SpecialType.System_Void));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var typeArgumentsBuilder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(RestPosition);
             var arguments = tupleCompatibleType.TypeArgumentsNoUseSiteDiagnostics;
             typeArgumentsBuilder.AddRange(arguments, RestPosition - 1);
-            typeArgumentsBuilder.Add(TypeSymbolWithAnnotations.Create(extensionTuple, arguments[RestPosition - 1].CustomModifiers));
+            typeArgumentsBuilder.Add(TypeSymbolWithAnnotations.Create(extensionTuple, customModifiers: arguments[RestPosition - 1].CustomModifiers));
 
             tupleCompatibleType = tupleCompatibleType.ConstructedFrom.Construct(typeArgumentsBuilder.ToImmutableAndFree(), unbound: false);
             return tupleCompatibleType;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeMap.cs
@@ -16,8 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class TypeMap : AbstractTypeParameterMap
     {
-        // PROTOTYPE(NullableReferenceTypes): [Obsolete("Use TypeParametersAsTypeSymbolsWithAnnotations")]
-        public static readonly System.Func<TypeSymbol, TypeSymbolWithAnnotations> AsTypeSymbolWithAnnotations = t => TypeSymbolWithAnnotations.Create(t);
         public static readonly System.Func<TypeSymbolWithAnnotations, TypeSymbol> AsTypeSymbol = t => t.TypeSymbol;
 
         internal static ImmutableArray<TypeSymbolWithAnnotations> TypeParametersAsTypeSymbolsWithAnnotations(INonNullTypesContext nonNullTypesContext, ImmutableArray<TypeParameterSymbol> typeParameters)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1500,7 +1500,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var type = typeWithAnnotations.TypeSymbol;
             if (NormalizeTaskTypesInType(compilation, ref type))
             {
-                typeWithAnnotations = TypeSymbolWithAnnotations.Create(type, typeWithAnnotations.CustomModifiers);
+                typeWithAnnotations = TypeSymbolWithAnnotations.Create(type, customModifiers: typeWithAnnotations.CustomModifiers);
                 return true;
             }
             return false;
@@ -1524,7 +1524,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         hasChanged = true;
                         // Preserve custom modifiers but without normalizing those types.
-                        typeArgumentsBuilder[i] = TypeSymbolWithAnnotations.Create(typeArgNormalized, typeWithModifier.CustomModifiers);
+                        typeArgumentsBuilder[i] = TypeSymbolWithAnnotations.Create(typeArgNormalized, customModifiers: typeWithModifier.CustomModifiers);
                     }
                 }
                 if (hasChanged)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -21,9 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             MutableTypeMap substitution = null;
-            bool result = CanUnifyHelper(TypeSymbolWithAnnotations.Create(t1),
-                                         TypeSymbolWithAnnotations.Create(t2), 
-                                         ref substitution);
+            bool result = CanUnifyHelper(t1, t2, ref substitution);
 #if DEBUG
             if (result && ((object)t1 != null && (object)t2 != null))
             {
@@ -53,6 +51,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return type;
         }
 #endif
+
+        private static bool CanUnifyHelper(TypeSymbol t1, TypeSymbol t2, ref MutableTypeMap substitution)
+        {
+            return CanUnifyHelper(TypeSymbolWithAnnotations.Create(t1), TypeSymbolWithAnnotations.Create(t2), ref substitution);
+        }
 
         /// <summary>
         /// Determine whether there is any substitution of type parameters that will
@@ -156,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 return false;
                             }
 
-                            return CanUnifyHelper(TypeSymbolWithAnnotations.Create(nt1.TupleUnderlyingType), TypeSymbolWithAnnotations.Create(nt2.TupleUnderlyingType), ref substitution);
+                            return CanUnifyHelper(nt1.TupleUnderlyingType, nt2.TupleUnderlyingType, ref substitution);
                         }
 
                         if (!nt1.IsGenericType)
@@ -190,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         // Note: Dev10 folds this into the loop since GetTypeArgsAll includes type args for containing types
                         // TODO: Calling CanUnifyHelper for the containing type is an overkill, we simply need to go through type arguments for all containers.
-                        return (object)nt1.ContainingType == null || CanUnifyHelper(TypeSymbolWithAnnotations.Create(nt1.ContainingType), TypeSymbolWithAnnotations.Create(nt2.ContainingType), ref substitution);
+                        return (object)nt1.ContainingType == null || CanUnifyHelper(nt1.ContainingType, nt2.ContainingType, ref substitution);
                     }
                 case SymbolKind.TypeParameter:
                     {
@@ -225,8 +228,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             t1.CustomModifiers.SequenceEqual(t2.CustomModifiers.Take(t1.CustomModifiers.Length)))
                         {
                             AddSubstitution(ref substitution, tp1,
-                                            TypeSymbolWithAnnotations.Create(t2.TypeSymbol,
-                                                                  ImmutableArray.Create(t2.CustomModifiers, t1.CustomModifiers.Length, t2.CustomModifiers.Length - t1.CustomModifiers.Length)));
+                                TypeSymbolWithAnnotations.Create(t2.TypeSymbol,
+                                    customModifiers: ImmutableArray.Create(t2.CustomModifiers, t1.CustomModifiers.Length, t2.CustomModifiers.Length - t1.CustomModifiers.Length)));
                             return true;
                         }
 
@@ -244,8 +247,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 t2.CustomModifiers.SequenceEqual(t1.CustomModifiers.Take(t2.CustomModifiers.Length)))
                             {
                                 AddSubstitution(ref substitution, tp2,
-                                                TypeSymbolWithAnnotations.Create(t1.TypeSymbol,
-                                                                      ImmutableArray.Create(t1.CustomModifiers, t2.CustomModifiers.Length, t1.CustomModifiers.Length - t2.CustomModifiers.Length)));
+                                    TypeSymbolWithAnnotations.Create(t1.TypeSymbol,
+                                        customModifiers: ImmutableArray.Create(t1.CustomModifiers, t2.CustomModifiers.Length, t1.CustomModifiers.Length - t2.CustomModifiers.Length)));
                                 return true;
                             }
                         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -5270,12 +5270,12 @@ class B : A
             foreach (string memberName in new[] { "M1", "M2" })
             {
                 var member = b.GetMember<MethodSymbol>(memberName);
-                Assert.False(member.ReturnType.Equals(member.OverriddenMethod.ConstructIfGeneric(member.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations)).ReturnType,
+                Assert.False(member.ReturnType.Equals(member.OverriddenMethod.ConstructIfGeneric(member.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t))).ReturnType,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
 
             var m3 = b.GetMember<MethodSymbol>("M3");
-            Assert.True(m3.ReturnType.Equals(m3.OverriddenMethod.ConstructIfGeneric(m3.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations)).ReturnType,
+            Assert.True(m3.ReturnType.Equals(m3.OverriddenMethod.ConstructIfGeneric(m3.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t))).ReturnType,
                 TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
         }
 
@@ -5387,7 +5387,7 @@ class B : IA
             {
                 var member = ia.GetMember<MethodSymbol>(memberName);
                 var implementing = (MethodSymbol)b.FindImplementationForInterfaceMember(member);
-                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)));
                 Assert.False(implementing.ReturnType.Equals(implemented.ReturnType,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
@@ -5395,7 +5395,7 @@ class B : IA
             {
                 var member = ia.GetMember<MethodSymbol>("M3");
                 var implementing = (MethodSymbol)b.FindImplementationForInterfaceMember(member);
-                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)));
                 Assert.True(implementing.ReturnType.Equals(implemented.ReturnType,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
@@ -5455,7 +5455,7 @@ class B : IA
             {
                 var member = ia.GetMember<MethodSymbol>(memberName);
                 var implementing = (MethodSymbol)b.FindImplementationForInterfaceMember(member);
-                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)));
                 Assert.False(implementing.ReturnType.Equals(implemented.ReturnType,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
@@ -5463,7 +5463,7 @@ class B : IA
             {
                 var member = ia.GetMember<MethodSymbol>("M3");
                 var implementing = (MethodSymbol)b.FindImplementationForInterfaceMember(member);
-                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)));
                 Assert.True(implementing.ReturnType.Equals(implemented.ReturnType,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
@@ -5620,12 +5620,12 @@ class B : A
             foreach (string memberName in new[] { "M1", "M2" })
             {
                 var member = b.GetMember<MethodSymbol>(memberName);
-                Assert.False(member.Parameters[0].Type.Equals(member.OverriddenMethod.ConstructIfGeneric(member.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations)).Parameters[0].Type,
+                Assert.False(member.Parameters[0].Type.Equals(member.OverriddenMethod.ConstructIfGeneric(member.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t))).Parameters[0].Type,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
 
             var m3 = b.GetMember<MethodSymbol>("M3");
-            Assert.True(m3.Parameters[0].Type.Equals(m3.OverriddenMethod.ConstructIfGeneric(m3.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations)).Parameters[0].Type,
+            Assert.True(m3.Parameters[0].Type.Equals(m3.OverriddenMethod.ConstructIfGeneric(m3.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t))).Parameters[0].Type,
                 TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
         }
 
@@ -5839,7 +5839,7 @@ class B : IA
             {
                 var member = ia.GetMember<MethodSymbol>(memberName);
                 var implementing = (MethodSymbol)b.FindImplementationForInterfaceMember(member);
-                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)));
                 Assert.False(implementing.Parameters[0].Type.Equals(implemented.Parameters[0].Type,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
@@ -5847,7 +5847,7 @@ class B : IA
             {
                 var member = ia.GetMember<MethodSymbol>("M3");
                 var implementing = (MethodSymbol)b.FindImplementationForInterfaceMember(member);
-                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)));
                 Assert.True(implementing.Parameters[0].Type.Equals(implemented.Parameters[0].Type,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
@@ -5902,7 +5902,7 @@ class B : IA
             {
                 var member = ia.GetMember<MethodSymbol>(memberName);
                 var implementing = (MethodSymbol)b.FindImplementationForInterfaceMember(member);
-                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)));
                 Assert.False(implementing.Parameters[0].Type.Equals(implemented.Parameters[0].Type,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
@@ -5910,7 +5910,7 @@ class B : IA
             {
                 var member = ia.GetMember<MethodSymbol>("M3");
                 var implementing = (MethodSymbol)b.FindImplementationForInterfaceMember(member);
-                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+                var implemented = member.ConstructIfGeneric(implementing.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)));
                 Assert.True(implementing.Parameters[0].Type.Equals(implemented.Parameters[0].Type,
                     TypeCompareKind.AllIgnoreOptions | TypeCompareKind.CompareNullableModifiersForReferenceTypes));
             }
@@ -6210,7 +6210,7 @@ partial class C1
 
             var m1 = c1.GetMember<MethodSymbol>("M1");
             var m1Impl = m1.PartialImplementationPart;
-            var m1Def = m1.ConstructIfGeneric(m1Impl.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations));
+            var m1Def = m1.ConstructIfGeneric(m1Impl.TypeParameters.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t)));
 
             for (int i = 0; i < 3; i++)
             {
@@ -19614,15 +19614,11 @@ static class E
         var z = y => y ?? x.ToString();
     }
 }";
-            // PROTOTYPE(NullableReferenceTypes): Should not report HDN_ExpressionIsProbablyNeverNull for `y`.
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
             comp.VerifyDiagnostics(
                 // (5,13): error CS0815: Cannot assign lambda expression to an implicitly-typed variable
                 //         var z = y => y ?? x.ToString();
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, "z = y => y ?? x.ToString()").WithArguments("lambda expression").WithLocation(5, 13),
-                // (5,22): hidden CS8607: Expression is probably never null.
-                //         var z = y => y ?? x.ToString();
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y").WithLocation(5, 22),
                 // (5,27): warning CS8602: Possible dereference of a null reference.
                 //         var z = y => y ?? x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(5, 27));
@@ -30947,16 +30943,11 @@ class C
         F(v).ToString();
     }
 }";
-            // ErrorCode.WRN_NullReferenceReceiver is reported for F(v).ToString() because F(v)
-            // has type T from initial binding (see https://github.com/dotnet/roslyn/issues/25778).
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
             comp.VerifyDiagnostics(
                 // (12,21): error CS8197: Cannot infer the type of implicitly-typed out variable 'v'.
                 //         d.F(out var v);
-                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedOutVariable, "v").WithArguments("v").WithLocation(12, 21),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
-                //         F(v).ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(v)").WithLocation(13, 9));
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedOutVariable, "v").WithArguments("v").WithLocation(12, 21));
         }
 
         [Fact]
@@ -35093,8 +35084,6 @@ class C
         F(default).ToString();
     }
 }";
-            // ErrorCode.WRN_NullReferenceReceiver is reported for F(default).ToString() because F(v)
-            // has type T from initial binding (see https://github.com/dotnet/roslyn/issues/25778).
             var comp = CreateCompilation(
                 new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition },
                 parseOptions: TestOptions.Regular8);
@@ -35107,10 +35096,7 @@ class C
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(default(object))").WithLocation(6, 9),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         F(default(string)).ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(default(string))").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
-                //         F(default).ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(default)").WithLocation(9, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(default(string))").WithLocation(8, 9));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
@@ -149,8 +149,8 @@ struct S<T> where T : struct
             var structType = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("S");
             var typeParamType = structType.TypeParameters.Single();
 
-            var pointerType = new PointerTypeSymbol(TypeSymbolWithAnnotations.Create(typeParamType, customModifiers)); // NOTE: We're constructing this manually, since it's illegal.
-            var arrayType = ArrayTypeSymbol.CreateCSharpArray(comp.Assembly, TypeSymbolWithAnnotations.Create(typeParamType, customModifiers)); // This is legal, but we're already manually constructing types.
+            var pointerType = new PointerTypeSymbol(TypeSymbolWithAnnotations.Create(typeParamType, customModifiers: customModifiers)); // NOTE: We're constructing this manually, since it's illegal.
+            var arrayType = ArrayTypeSymbol.CreateCSharpArray(comp.Assembly, TypeSymbolWithAnnotations.Create(typeParamType, customModifiers: customModifiers)); // This is legal, but we're already manually constructing types.
 
             var typeMap = new TypeMap(ImmutableArray.Create(typeParamType), ImmutableArray.Create(TypeSymbolWithAnnotations.Create(intType)));
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/TypeMapTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/TypeMapTests.cs
@@ -90,7 +90,7 @@ public class Top : A<E> { // base is A<E>
             Assert.True(type.IsDefinition);
             var allTypeParameters = ArrayBuilder<TypeParameterSymbol>.GetInstance();
             type.GetAllTypeParameters(allTypeParameters);
-            return new TypeMap(allTypeParameters.ToImmutableAndFree(), typeArguments.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations)).SubstituteNamedType(type);
+            return new TypeMap(allTypeParameters.ToImmutableAndFree(), typeArguments.SelectAsArray(t => TypeSymbolWithAnnotations.Create(t))).SubstituteNamedType(type);
         }
 
         [Fact]

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var methodArgumentStartIndex = typeParameters.Length - methodArity;
             var typeMap = new TypeMap(
                 ImmutableArray.Create(typeParameters, 0, methodArgumentStartIndex),
-                ImmutableArray.CreateRange(typeArguments, 0, methodArgumentStartIndex, TypeMap.AsTypeSymbolWithAnnotations));
+                ImmutableArray.CreateRange(typeArguments, 0, methodArgumentStartIndex, t  => TypeSymbolWithAnnotations.Create(t)));
             var substitutedType = typeMap.SubstituteNamedType(method.ContainingType);
             method = method.AsMember(substitutedType);
             if (methodArity > 0)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override ImmutableArray<TypeSymbolWithAnnotations> TypeArguments
         {
-            get { return _typeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations); }
+            get { return GetTypeParametersAsTypeArguments(); }
         }
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override ImmutableArray<TypeSymbolWithAnnotations> TypeArgumentsNoUseSiteDiagnostics
         {
-            get { return _typeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations); }
+            get { return GetTypeParametersAsTypeArguments(); }
         }
 
         public override NamedTypeSymbol ConstructedFrom

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override ImmutableArray<TypeSymbolWithAnnotations> TypeArguments
         {
-            get { return _typeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations); }
+            get { return GetTypeParametersAsTypeArguments(); }
         }
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters


### PR DESCRIPTION
`TypeSymbolWithAnnotations.Create(referenceType)` now creates an instance with `IsNullable==null`.