### PR TITLE
Remove explicit version of Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -90,7 +90,6 @@
     <MicrosoftVisualStudioGraphModelVersion>15.0.26730-alpha</MicrosoftVisualStudioGraphModelVersion>
     <MicrosoftVisualStudioImageCatalogVersion>15.0.26730-alpha</MicrosoftVisualStudioImageCatalogVersion>
     <MicrosoftVisualStudioImagingVersion>15.0.26730-alpha</MicrosoftVisualStudioImagingVersion>
-    <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>15.0.25726-Preview5</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
     <MicrosoftVisualStudioInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioInteractiveWindowVersion>
     <MicrosoftVisualStudioLanguageCallHierarchyVersion>15.3.1710.203</MicrosoftVisualStudioLanguageCallHierarchyVersion>
     <MicrosoftVisualStudioLanguageIntellisenseVersion>15.8.238-preview</MicrosoftVisualStudioLanguageIntellisenseVersion>

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Version="$(MicrosoftCodeAnalysisElfieVersion)" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="$(ICSharpCodeDecompilerVersion)" />

--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -72,7 +72,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.CallHierarchy" Version="$(MicrosoftVisualStudioLanguageCallHierarchyVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />

--- a/src/EditorFeatures/TestUtilities2/ServicesTestUtilities2.vbproj
+++ b/src/EditorFeatures/TestUtilities2/ServicesTestUtilities2.vbproj
@@ -49,7 +49,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.CallHierarchy" Version="$(MicrosoftVisualStudioLanguageCallHierarchyVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
@@ -21,7 +21,6 @@
       <dependency id="Microsoft.CodeAnalysis.Elfie" version="$MicrosoftCodeAnalysisElfieVersion$" />
       <dependency id="Microsoft.VisualStudio.Language.StandardClassification" version="$MicrosoftVisualStudioLanguageStandardClassificationVersion$" />
       <dependency id="Microsoft.VisualStudio.Language.Intellisense" version="$MicrosoftVisualStudioLanguageIntellisenseVersion$" />
-      <dependency id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="$MicrosoftVisualStudioImagingInterop140DesignTimeVersion$" />
       <dependency id="ICSharpCode.Decompiler" version="$ICSharpCodeDecompilerVersion$" />
       <!--This package depends on the following editor package, however we can not enforce them in there.
       Roslyn depends on Editor packages which are not released yet, enforcing these dependenceis will delay the release of roslyn package,

--- a/src/NuGet/NuGetProjectPackUtil.csproj
+++ b/src/NuGet/NuGetProjectPackUtil.csproj
@@ -56,7 +56,6 @@
       <NuspecProperties>$(NuspecProperties);MicrosoftCodeAnalysisAnalyzersVersion=$(MicrosoftCodeAnalysisAnalyzersVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);MicrosoftCodeAnalysisElfieVersion=$(MicrosoftCodeAnalysisElfieVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);MicrosoftVisualBasicVersion=$(MicrosoftVisualBasicVersion)</NuspecProperties>
-      <NuspecProperties>$(NuspecProperties);MicrosoftVisualStudioImagingInterop140DesignTimeVersion=$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);MicrosoftVisualStudioLanguageIntellisenseVersion=$(MicrosoftVisualStudioLanguageIntellisenseVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);MicrosoftVisualStudioLanguageStandardClassificationVersion=$(MicrosoftVisualStudioLanguageStandardClassificationVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);MicrosoftVisualStudioSetupConfigurationInteropVersion=$(MicrosoftVisualStudioSetupConfigurationInteropVersion)</NuspecProperties>

--- a/src/VisualStudio/TestUtilities2/VisualStudioTestUtilities2.vbproj
+++ b/src/VisualStudio/TestUtilities2/VisualStudioTestUtilities2.vbproj
@@ -91,7 +91,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(MicrosoftVisualStudioTextLogicVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />


### PR DESCRIPTION
Our dependency Microsoft.VisualStudio.Language.Intellisense already carries forward the version we should be referencing; this seems to be an oversight of a generic upgrade to higher packages that now means we're trying to reference something higher than it.