### PR TITLE
Make copies of AnalyzedArguments to store in MethodGroupResolution

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -271,6 +271,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        /// <summary>
+        /// The result of this method captures some AnalyzedArguments, which must be free'ed by the caller.
+        /// </summary>
         private AnalyzedAttributeArguments BindAttributeArguments(
             AttributeArgumentListSyntax attributeArgumentList,
             NamedTypeSymbol attributeType,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7110,7 +7110,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics.AddRange(methodResolution.Diagnostics); // Could still have use site warnings.
                 BindMemberAccessReportError(node, diagnostics);
 
-                // Note: no need to free `methodResolution`, we're transfering the pooled objects it owned
+                // Note: no need to free `methodResolution`, we're transferring the pooled objects it owned
                 return new MethodGroupResolution(methodResolution.MethodGroup, methodResolution.OtherSymbol, methodResolution.OverloadResolutionResult, methodResolution.AnalyzedArguments, methodResolution.ResultKind, diagnostics.ToReadOnlyAndFree());
             }
             return methodResolution;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6053,17 +6053,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     returnType: returnType);
                 diagnostics.Add(expression, useSiteDiagnostics);
                 var sealedDiagnostics = diagnostics.ToReadOnlyAndFree();
-                var result = new MethodGroupResolution(methodGroup, null, overloadResolutionResult, actualArguments, methodGroup.ResultKind, sealedDiagnostics);
 
-                // If the search in the current scope resulted in any applicable method (regardless of whether a best 
+                // Note: the MethodGroupResolution instance is responsible for freeing its copy of actual arguments
+                var result = new MethodGroupResolution(methodGroup, null, overloadResolutionResult, AnalyzedArguments.GetInstance().Copy(actualArguments), methodGroup.ResultKind, sealedDiagnostics);
+
+                // If the search in the current scope resulted in any applicable method (regardless of whether a best
                 // applicable method could be determined) then our search is complete. Otherwise, store aside the
                 // first non-applicable result and continue searching for an applicable result.
                 if (result.HasAnyApplicableMethod)
                 {
                     if (!firstResult.IsEmpty)
                     {
-                        // Free parts of the previous result but do not free AnalyzedArguments
-                        // since we're using the same arguments for the returned result.
                         firstResult.MethodGroup.Free();
                         firstResult.OverloadResolutionResult.Free();
                     }
@@ -6082,6 +6082,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Debug.Assert((actualArguments == null) || !firstResult.IsEmpty);
+            actualArguments?.Free();
             return firstResult;
         }
 
@@ -7108,6 +7109,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var diagnostics = DiagnosticBag.GetInstance();
                 diagnostics.AddRange(methodResolution.Diagnostics); // Could still have use site warnings.
                 BindMemberAccessReportError(node, diagnostics);
+
+                // Note: no need to free `methodResolution`, we're transfering the pooled objects it owned
                 return new MethodGroupResolution(methodResolution.MethodGroup, methodResolution.OtherSymbol, methodResolution.OverloadResolutionResult, methodResolution.AnalyzedArguments, methodResolution.ResultKind, diagnostics.ToReadOnlyAndFree());
             }
             return methodResolution;
@@ -7251,7 +7254,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     allowUnexpandedForm: allowUnexpandedForm,
                     returnRefKind: returnRefKind,
                     returnType: returnType);
-                return new MethodGroupResolution(methodGroup, null, result, analyzedArguments, methodGroup.ResultKind, sealedDiagnostics);
+
+                // Note: the MethodGroupResolution instance is responsible for freeing its copy of analyzed arguments
+                return new MethodGroupResolution(methodGroup, null, result, AnalyzedArguments.GetInstance().Copy(analyzedArguments), methodGroup.ResultKind, sealedDiagnostics);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6055,7 +6055,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var sealedDiagnostics = diagnostics.ToReadOnlyAndFree();
 
                 // Note: the MethodGroupResolution instance is responsible for freeing its copy of actual arguments
-                var result = new MethodGroupResolution(methodGroup, null, overloadResolutionResult, AnalyzedArguments.GetInstance().Copy(actualArguments), methodGroup.ResultKind, sealedDiagnostics);
+                var result = new MethodGroupResolution(methodGroup, null, overloadResolutionResult, AnalyzedArguments.GetInstance(actualArguments), methodGroup.ResultKind, sealedDiagnostics);
 
                 // If the search in the current scope resulted in any applicable method (regardless of whether a best
                 // applicable method could be determined) then our search is complete. Otherwise, store aside the
@@ -7256,7 +7256,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     returnType: returnType);
 
                 // Note: the MethodGroupResolution instance is responsible for freeing its copy of analyzed arguments
-                return new MethodGroupResolution(methodGroup, null, result, AnalyzedArguments.GetInstance().Copy(analyzedArguments), methodGroup.ResultKind, sealedDiagnostics);
+                return new MethodGroupResolution(methodGroup, null, result, AnalyzedArguments.GetInstance(analyzedArguments), methodGroup.ResultKind, sealedDiagnostics);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/MethodGroupResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/MethodGroupResolution.cs
@@ -21,21 +21,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly LookupResultKind ResultKind;
 
         public MethodGroupResolution(MethodGroup methodGroup, ImmutableArray<Diagnostic> diagnostics)
-            : this(methodGroup, null, null, null, methodGroup.ResultKind, diagnostics)
-        {
-        }
-
-        public MethodGroupResolution(
-            MethodGroup methodGroup,
-            OverloadResolutionResult<MethodSymbol> overloadResolutionResult,
-            AnalyzedArguments analyzedArguments,
-            ImmutableArray<Diagnostic> diagnostics)
-            : this(methodGroup, null, overloadResolutionResult, analyzedArguments, methodGroup.ResultKind, diagnostics)
+            : this(methodGroup, otherSymbol: null, overloadResolutionResult: null, analyzedArguments: null, methodGroup.ResultKind, diagnostics)
         {
         }
 
         public MethodGroupResolution(Symbol otherSymbol, LookupResultKind resultKind, ImmutableArray<Diagnostic> diagnostics)
-            : this(null, otherSymbol, null, null, resultKind, diagnostics)
+            : this(methodGroup: null, otherSymbol, overloadResolutionResult: null, analyzedArguments: null, resultKind, diagnostics)
         {
         }
 
@@ -93,23 +84,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public void Free()
         {
-            if (this.MethodGroup != null)
-            {
-                if (this.MethodGroup.IsExtensionMethodGroup)
-                {
-                    // Arguments are only owned by this instance if the arguments are for
-                    // extension methods. Otherwise, the caller supplied the arguments.
-                    if (this.AnalyzedArguments != null)
-                    {
-                        this.AnalyzedArguments.Free();
-                    }
-                }
-                this.MethodGroup.Free();
-            }
-            if (this.OverloadResolutionResult != null)
-            {
-                this.OverloadResolutionResult.Free();
-            }
+            this.AnalyzedArguments?.Free();
+            this.MethodGroup?.Free();
+            this.OverloadResolutionResult?.Free();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
@@ -24,6 +24,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.RefKinds = new ArrayBuilder<RefKind>(32);
         }
 
+        internal AnalyzedArguments Copy(AnalyzedArguments original)
+        {
+            this.Arguments.AddRange(original.Arguments);
+            this.Names.AddRange(original.Names);
+            this.RefKinds.AddRange(original.RefKinds);
+            this.IsExtensionMethodInvocation = original.IsExtensionMethodInvocation;
+            this._lazyHasDynamicArgument = original._lazyHasDynamicArgument;
+            return this;
+        }
+
         public void Clear()
         {
             this.Arguments.Clear();

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
@@ -24,16 +24,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.RefKinds = new ArrayBuilder<RefKind>(32);
         }
 
-        internal AnalyzedArguments Copy(AnalyzedArguments original)
-        {
-            this.Arguments.AddRange(original.Arguments);
-            this.Names.AddRange(original.Names);
-            this.RefKinds.AddRange(original.RefKinds);
-            this.IsExtensionMethodInvocation = original.IsExtensionMethodInvocation;
-            this._lazyHasDynamicArgument = original._lazyHasDynamicArgument;
-            return this;
-        }
-
         public void Clear()
         {
             this.Arguments.Clear();
@@ -135,6 +125,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static AnalyzedArguments GetInstance()
         {
             return Pool.Allocate();
+        }
+
+        public static AnalyzedArguments GetInstance(AnalyzedArguments original)
+        {
+            var instance = GetInstance();
+            instance.Arguments.AddRange(original.Arguments);
+            instance.Names.AddRange(original.Names);
+            instance.RefKinds.AddRange(original.RefKinds);
+            instance.IsExtensionMethodInvocation = original.IsExtensionMethodInvocation;
+            instance._lazyHasDynamicArgument = original._lazyHasDynamicArgument;
+            return instance;
         }
 
         public void Free()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -185,5 +185,49 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 ToArray();
             comp.VerifyDiagnostics(diagnostics);
         }
+
+        [Fact, WorkItem(29360, "https://github.com/dotnet/roslyn/pull/29360")]
+        public void RaceConditionOnImproperlyCapturedAnalyzedArguments()
+        {
+            const int n = 6;
+            var builder = new StringBuilder();
+            builder.AppendLine("using System;");
+
+            for (int i = 0; i < n; i++)
+            {
+                builder.AppendLine($"public class C{i}");
+                builder.AppendLine("{");
+
+                for (int j = 0; j < n; j++)
+                {
+                    builder.AppendLine($"    public string M{j}()");
+                    builder.AppendLine( "    {");
+
+                    for (int k = 0; k < n; k++)
+                    {
+                        for (int l = 0; l < n; l++)
+                        {
+                            builder.AppendLine($"        Class.Method((C{k} x{k}) => x{k}.M{l});");
+                        }
+                    }
+
+                    builder.AppendLine("        return null;");
+                    builder.AppendLine("    }");
+                }
+
+                builder.AppendLine("}");
+            }
+
+            builder.AppendLine(@"
+public static class Class
+{
+    public static void Method<TClass>(Func<TClass, Func<string>> method) { }
+    public static void Method<TClass>(Func<TClass, Func<string, string>> method) { }
+}
+");
+            var source = builder.ToString();
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
We have an issue where `MethodGroupResolution` keeps a handle on an `AnalyzedArguments` instance beyond the point where our codepath releases the `AnalyzedArguments`. Specifically, in `Conversions`:
```C#
    private static MethodGroupResolution ResolveDelegateMethodGroup(Binder binder, BoundMethodGroup source, MethodSymbol delegateInvokeMethodOpt, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
        {
            if ((object)delegateInvokeMethodOpt != null)
            {
                var analyzedArguments = AnalyzedArguments.GetInstance();
                GetDelegateArguments(source.Syntax, analyzedArguments, delegateInvokeMethodOpt.Parameters, binder.Compilation);
                var resolution = binder.ResolveMethodGroup(source, analyzedArguments, useSiteDiagnostics: ref useSiteDiagnostics, inferWithDynamic: true,
                    isMethodGroupConversion: true, returnRefKind: delegateInvokeMethodOpt.RefKind, returnType: delegateInvokeMethodOpt.ReturnType);
                analyzedArguments.Free();
                return resolution; // we're still holding onto analyzedArguments
            }
            else
            {
                return binder.ResolveMethodGroup(source, analyzedArguments: null, isMethodGroupConversion: true, ref useSiteDiagnostics);
            }
        }
```
Fixes https://github.com/dotnet/roslyn/issues/28419