### PR TITLE
Fix crash with 'use conditional' in a VB property

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.vb
@@ -549,5 +549,34 @@ class C
     end sub
 end class")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnAssignmentToContainingProperty() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    public theemployee as string
+
+    public readonly property employee as string
+        get
+            [||]if theemployee is nothing then
+                employee = ""1""
+            else
+                employee = ""2""
+            end if
+        end get
+    end property
+end class",
+"
+class C
+    public theemployee as string
+
+    public readonly property employee as string
+        get
+            employee = If(theemployee is nothing, ""1"", ""2"")
+        end get
+    end property
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.vb
@@ -550,6 +550,7 @@ class C
 end class")
         End Function
 
+        <WorkItem(29376, "https://github.com/dotnet/roslyn/issues/29376")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
         Public Async Function TestOnAssignmentToContainingProperty() As Task
             Await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.vb
@@ -552,7 +552,7 @@ end class")
 
         <WorkItem(29376, "https://github.com/dotnet/roslyn/issues/29376")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
-        Public Async Function TestOnAssignmentToContainingProperty() As Task
+        Public Async Function TestOnAssignmentToImplicitLocalInContainingProperty() As Task
             Await TestInRegularAndScriptAsync(
 "
 class C
@@ -577,6 +577,92 @@ class C
             employee = If(theemployee is nothing, ""1"", ""2"")
         end get
     end property
+end class")
+        End Function
+
+        <WorkItem(29376, "https://github.com/dotnet/roslyn/issues/29376")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnAssignmentToImplicitLocalInContainingFunction() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    public theemployee as string
+
+    Public Function employee() As String
+        [||]If theemployee Is Nothing Then
+            employee = ""1""
+        Else
+            employee = ""2""
+        End If
+    End Function
+end class",
+"
+class C
+    public theemployee as string
+
+    Public Function employee() As String
+        employee = If(theemployee Is Nothing, ""1"", ""2"")
+    End Function
+end class")
+        End Function
+
+        <WorkItem(29376, "https://github.com/dotnet/roslyn/issues/29376")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnAssignmentToImplicitLocalInContainingSub1() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Option Explicit Off
+
+class C
+    public theemployee as string
+
+    Public Sub F()
+        [||]If theemployee Is Nothing Then
+            employee = ""1""
+        Else
+            employee = ""2""
+        End If
+    End Sub
+end class",
+"
+Option Explicit Off
+
+class C
+    public theemployee as string
+
+    Public Sub F()
+        employee = If(theemployee Is Nothing, ""1"", ""2"")
+    End Sub
+end class")
+        End Function
+
+        <WorkItem(29376, "https://github.com/dotnet/roslyn/issues/29376")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseConditionalExpression)>
+        Public Async Function TestOnAssignmentToImplicitLocalInContainingSub2() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Option Explicit Off
+
+class C
+    public theemployee as string
+
+    Public Sub employee()
+        [||]If theemployee Is Nothing Then
+            employee = ""1""
+        Else
+            employee = ""2""
+        End If
+    End Sub
+end class",
+"
+Option Explicit Off
+
+class C
+    public theemployee as string
+
+    Public Sub employee()
+        employee = If(theemployee Is Nothing, ""1"", ""2"")
+    End Sub
 end class")
         End Function
     End Class

--- a/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
@@ -168,6 +168,11 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
                 return false;
             }
 
+            if (localDeclaration.IsImplicit)
+            {
+                return false;
+            }
+
             if (localDeclaration.Declarations.Length != 1)
             {
                 return false;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/29376

--

VB IOperation tree is 'interesting' for properties.  There is an implicit local declaration as the first statement in the body, containing a variable.  Reads/writes to that property are actually represented in the iop tree as reads/writes to that variable.  This threw off 'use conditional' which then wanted to merge the conditional into that local declaration statement.  Of course, since this wasn't a real local declaration statement, this blew up.