### PR TITLE
Refactoring .editorconfig Tools->Options export feature

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -33,8 +34,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
         private static void GetCurrentEditorConfigOptionsCSharp(OptionSet optionSet, StringBuilder editorconfig)
         {
             editorconfig.AppendLine();
-            editorconfig.AppendLine("# C# Coding Conventions");
 
+            editorconfig.AppendLine("# C# Coding Conventions");
             editorconfig.AppendLine("# " + CSharpVSResources.var_preferences_colon);
             // csharp_style_var_for_built_in_types
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, editorconfig);
@@ -42,8 +43,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, editorconfig);
             // csharp_style_var_elsewhere
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.UseImplicitTypeWherePossible, editorconfig);
-
             editorconfig.AppendLine();
+
             editorconfig.AppendLine("# Expression-bodied members:");
             // csharp_style_expression_bodied_methods
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedMethods, editorconfig);
@@ -57,27 +58,27 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, editorconfig);
             // csharp_style_expression_bodied_accessors
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, editorconfig);
-
             editorconfig.AppendLine();
+
             editorconfig.AppendLine("# Pattern matching preferences:");
             // csharp_style_pattern_matching_over_is_with_cast_check
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck, editorconfig);
             // csharp_style_pattern_matching_over_as_with_null_check
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck, editorconfig);
-
             editorconfig.AppendLine();
+
             editorconfig.AppendLine("# Null-checking preferences:");
             // csharp_style_throw_expression
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferThrowExpression, editorconfig);
             // csharp_style_conditional_delegate_call
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferConditionalDelegateCall, editorconfig);
-
             editorconfig.AppendLine();
+
             editorconfig.AppendLine("# Modifier preferences:");
             // csharp_preferred_modifier_order
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferredModifierOrder, editorconfig);
-
             editorconfig.AppendLine();
+
             editorconfig.AppendLine("# Expression-level preferences:");
             // csharp_prefer_braces
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferBraces, editorconfig);
@@ -89,8 +90,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CSharpCodeStyleOptions.PreferLocalOverAnonymousFunction, editorconfig);
             // csharp_style_inlined_variable_declaration
             CSharpCodeStyleOptions_GenerateEditorconfig(optionSet, CodeStyleOptions.PreferInlinedVariableDeclaration, editorconfig);
-
             editorconfig.AppendLine();
+
             editorconfig.AppendLine("# C# Formatting Rules");
             editorconfig.AppendLine("# New line preferences:");
             // csharp_new_line_before_open_brace
@@ -107,8 +108,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.NewLineForMembersInAnonymousTypes, editorconfig);
             // csharp_new_line_between_query_expression_clauses
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.NewLineForClausesInQuery, editorconfig);
-
             editorconfig.AppendLine();
+
             editorconfig.AppendLine("# Indentation preferences:");
             // csharp_indent_case_contents
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.IndentSwitchCaseSection, editorconfig);
@@ -116,8 +117,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.IndentSwitchSection, editorconfig);
             // csharp_indent_labels
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.LabelPositioning, editorconfig);
-
             editorconfig.AppendLine();
+
             editorconfig.AppendLine("# Space preferences:");
             // csharp_space_after_cast
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceAfterCast, editorconfig);
@@ -128,7 +129,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             // csharp_space_between_method_declaration_parameter_list_parentheses
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceWithinMethodDeclarationParenthesis, editorconfig);
             // csharp_space_between_parentheses
-            CSharpFormattingOptions_GenerateEditorconfig(optionSet, editorconfig);
+            CSharpSpaceBetweenParentheses_GenerateEditorconfig(optionSet, editorconfig);
             // csharp_space_before_colon_in_inheritance_clause
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceBeforeColonInBaseTypeDeclaration, editorconfig);
             // csharp_space_after_colon_in_inheritance_clause
@@ -141,8 +142,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceAfterMethodCallName, editorconfig);
             // csharp_space_between_method_call_empty_parameter_list_parentheses
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.SpaceBetweenEmptyMethodCallParentheses, editorconfig);
-
             editorconfig.AppendLine();
+
             editorconfig.AppendLine("# Wrapping preferences:");
             // csharp_preserve_single_line_statements
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine, editorconfig);
@@ -150,72 +151,46 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             CSharpFormattingOptions_GenerateEditorconfig(optionSet, CSharpFormattingOptions.WrappingPreserveSingleLine, editorconfig);
         }
 
-        private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<bool> option, StringBuilder editorconfig)
-        {
-            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<bool>>().FirstOrDefault();
-            if (element != null)
-            {
-                editorconfig.Append(element.KeyName + " = ");
-
-                editorconfig.AppendLine(optionSet.GetOption(option).ToString().ToLowerInvariant());
-            }
-        }
-
         private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option, StringBuilder editorconfig)
         {
             var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<bool>>>().FirstOrDefault();
             if (element != null)
             {
-                editorconfig.Append(element.KeyName + " = ");
+                GridOptionPreviewControl.AppendName(element.KeyName, editorconfig);
 
                 var curSetting = optionSet.GetOption(option, LanguageNames.CSharp);
-                editorconfig.AppendLine(curSetting.Value.ToString().ToLowerInvariant() + ":" + curSetting.Notification.ToString().ToLowerInvariant());
+                editorconfig.AppendLine(curSetting.Value.ToString().ToLower() + ":" + GridOptionPreviewControl.NotificationOptionToString(curSetting.Notification));
             }
         }
 
-        private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<bool>> option, StringBuilder editorconfig)
+        private static void CSharpCodeStyleOptions_GenerateEditorconfig<T>(OptionSet optionSet, Option<CodeStyleOption<T>> option, StringBuilder editorconfig)
         {
-            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<bool>>>().FirstOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<T>>>().FirstOrDefault();
             if (element != null)
             {
-                editorconfig.Append(element.KeyName + " = ");
+                GridOptionPreviewControl.AppendName(element.KeyName, editorconfig);
 
                 var curSetting = optionSet.GetOption(option);
-                editorconfig.AppendLine(curSetting.Value.ToString().ToLowerInvariant() + ":" + curSetting.Notification.ToString().ToLowerInvariant());
-            }
-        }
-
-        private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<string>> option, StringBuilder editorconfig)
-        {
-            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<string>>>().FirstOrDefault();
-            if (element != null)
-            {
-                editorconfig.Append(element.KeyName + " = ");
-
-                var curSetting = optionSet.GetOption(option);
-                editorconfig.AppendLine(curSetting.Value.ToString().ToLowerInvariant() + ":" + curSetting.Notification.ToString().ToLowerInvariant());
-            }
-        }
-
-        private static void CSharpCodeStyleOptions_GenerateEditorconfig(OptionSet optionSet, Option<CodeStyleOption<ExpressionBodyPreference>> option, StringBuilder editorconfig)
-        {
-            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>>().FirstOrDefault();
-            if (element != null)
-            {
-                editorconfig.Append(element.KeyName + " = ");
-
-                var curSetting = optionSet.GetOption(option);
-                if (curSetting.Value == ExpressionBodyPreference.Never)
+                if (typeof(T) == typeof(ExpressionBodyPreference))
                 {
-                    editorconfig.AppendLine("false" + ":" + curSetting.Notification.ToString().ToLowerInvariant());
+                    switch((ExpressionBodyPreference)(object) curSetting.Value)
+                    {
+                        case ExpressionBodyPreference.Never:
+                            editorconfig.AppendLine("false" + ":" + GridOptionPreviewControl.NotificationOptionToString(curSetting.Notification));
+                            break;
+                        case ExpressionBodyPreference.WhenPossible:
+                            editorconfig.AppendLine("true" + ":" + GridOptionPreviewControl.NotificationOptionToString(curSetting.Notification));
+                            break;
+                        case ExpressionBodyPreference.WhenOnSingleLine:
+                            editorconfig.AppendLine("when_on_single_line" + ":" + GridOptionPreviewControl.NotificationOptionToString(curSetting.Notification));
+                            break;
+                        default:
+                            throw new NotSupportedException();
+                    };
                 }
-                else if (curSetting.Value == ExpressionBodyPreference.WhenPossible)
+                else if (typeof(T) == typeof(bool) || typeof(T) == typeof(string))
                 {
-                    editorconfig.AppendLine("true" + ":" + curSetting.Notification.ToString().ToLowerInvariant());
-                }
-                else if (curSetting.Value == ExpressionBodyPreference.WhenOnSingleLine)
-                {
-                    editorconfig.AppendLine("when_on_single_line" + ":" + curSetting.Notification.ToString().ToLowerInvariant());
+                    editorconfig.AppendLine(curSetting.Value.ToString().ToLowerInvariant() + ":" + GridOptionPreviewControl.NotificationOptionToString(curSetting.Notification));
                 }
                 else
                 {
@@ -224,24 +199,51 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             }
         }
 
-        private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<LabelPositionOptions> option, StringBuilder editorconfig)
+        private static void CSharpFormattingOptions_GenerateEditorconfig<T>(OptionSet optionSet, Option<T> option, StringBuilder editorconfig)
         {
-            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<LabelPositionOptions>>().FirstOrDefault();
+            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<T>>().FirstOrDefault();
             if (element != null)
             {
-                editorconfig.Append(element.KeyName + " = ");
+                GridOptionPreviewControl.AppendName(element.KeyName, editorconfig);
+
                 var curSetting = optionSet.GetOption(option);
-                if (curSetting == LabelPositionOptions.LeftMost)
+                if (typeof(T) == typeof(LabelPositionOptions))
                 {
-                    editorconfig.AppendLine("flush_left");
+                    switch((LabelPositionOptions)(object) curSetting)
+                    {
+                        case LabelPositionOptions.LeftMost:
+                            editorconfig.AppendLine("flush_left");
+                            break;
+                        case LabelPositionOptions.OneLess:
+                            editorconfig.AppendLine("one_less_than_current");
+                            break;
+                        case LabelPositionOptions.NoIndent:
+                            editorconfig.AppendLine("no_change");
+                            break;
+                        default:
+                            throw new NotSupportedException();
+                    };
                 }
-                else if (curSetting == LabelPositionOptions.OneLess)
+                else if (typeof(T) == typeof(BinaryOperatorSpacingOptions))
                 {
-                    editorconfig.AppendLine("one_less_than_current");
+                    switch((BinaryOperatorSpacingOptions)(object) curSetting)
+                    {
+                        case BinaryOperatorSpacingOptions.Single:
+                            editorconfig.AppendLine("before_and_after");
+                            break;
+                        case BinaryOperatorSpacingOptions.Remove:
+                            editorconfig.AppendLine("none");
+                            break;
+                        case BinaryOperatorSpacingOptions.Ignore:
+                            editorconfig.AppendLine("ignore");
+                            break;
+                        default:
+                            throw new NotSupportedException();
+                    };
                 }
-                else if (curSetting == LabelPositionOptions.NoIndent)
+                else if (typeof(T) == typeof(bool))
                 {
-                    editorconfig.AppendLine("no_change");
+                    editorconfig.AppendLine(optionSet.GetOption(option).ToString().ToLowerInvariant());
                 }
                 else
                 {
@@ -250,73 +252,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             }
         }
 
-        private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, Option<BinaryOperatorSpacingOptions> option, StringBuilder editorconfig)
-        {
-            var element = option.StorageLocations.OfType<EditorConfigStorageLocation<BinaryOperatorSpacingOptions>>().FirstOrDefault();
-            if (element != null)
-            {
-                editorconfig.Append(element.KeyName + " = ");
-                var curSetting = optionSet.GetOption(option);
-                if (curSetting == BinaryOperatorSpacingOptions.Single)
-                {
-                    editorconfig.AppendLine("before_and_after");
-                }
-                else if (curSetting == BinaryOperatorSpacingOptions.Remove)
-                {
-                    editorconfig.AppendLine("none");
-                }
-                else if (curSetting == BinaryOperatorSpacingOptions.Ignore)
-                {
-                    editorconfig.AppendLine("ignore");
-                }
-                else
-                {
-                    throw new NotSupportedException();
-                }
-            }
-        }
-
-        private static void CSharpFormattingOptions_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
+        private static void CSharpSpaceBetweenParentheses_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
         {
             var element = CSharpFormattingOptions.SpaceWithinOtherParentheses.StorageLocations.OfType<EditorConfigStorageLocation<bool>>().FirstOrDefault();
             if (element != null)
             {
-                editorconfig.Append(element.KeyName + " = ");
+                GridOptionPreviewControl.AppendName(element.KeyName, editorconfig);
 
-                var firstRule = true;
-                if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinOtherParentheses))
-                {
-                    editorconfig.Append("control_flow_statements");
-                    firstRule = false;
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinExpressionParentheses))
-                {
-                    if (firstRule)
-                    {
-                        firstRule = false;
-                    }
-                    else
-                    {
-                        editorconfig.Append(",");
-                    }
+                var valuesApplied = JoinMultipleValues(OptionToValue(), optionSet, editorconfig);
 
-                    editorconfig.Append("expressions");
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.SpaceWithinCastParentheses))
-                {
-                    if (firstRule)
-                    {
-                        firstRule = false;
-                    }
-                    else
-                    {
-                        editorconfig.Append(",");
-                    }
-
-                    editorconfig.Append("type_casts");
-                }
-
-                if (firstRule)
+                if (valuesApplied == 0)
                 {
                     editorconfig.AppendLine("false");
                 }
@@ -325,6 +270,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                     editorconfig.AppendLine();
                 }
             }
+
+            Dictionary<Option<bool>, string> OptionToValue()
+            {
+                return new Dictionary<Option<bool>, string>()
+                {
+                { CSharpFormattingOptions.SpaceWithinOtherParentheses, "control_flow_statements" },
+                { CSharpFormattingOptions.SpaceWithinExpressionParentheses, "expressions" },
+                { CSharpFormattingOptions.SpaceWithinCastParentheses, "type_casts" }
+                };
+            }
         }
 
         private static void CSharpNewLineBeforeOpenBrace_GenerateEditorconfig(OptionSet optionSet, StringBuilder editorconfig)
@@ -332,101 +287,17 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
             var element = CSharpFormattingOptions.NewLinesForBracesInAccessors.StorageLocations.OfType<EditorConfigStorageLocation<bool>>().FirstOrDefault();
             if (element != null)
             {
-                editorconfig.Append(element.KeyName + " = ");
-                const int totalRules = 9;
-                var rulesApplied = 0;
+                GridOptionPreviewControl.AppendName(element.KeyName, editorconfig);
+
+                var allOptions = OptionToValue();
                 var ruleString = new StringBuilder();
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAccessors))
-                {
-                    ++rulesApplied;
-                    ruleString.Append("accessors");
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods))
-                {
-                    if (ruleString.Length != 0)
-                    {
-                        ruleString.Append(",");
-                    }
+                var valuesApplied = JoinMultipleValues(allOptions, optionSet, ruleString);
 
-                    ++rulesApplied;
-                    ruleString.Append("anonymous_methods");
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAnonymousTypes))
-                {
-                    if (ruleString.Length != 0)
-                    {
-                        ruleString.Append(",");
-                    }
-
-                    ++rulesApplied;
-                    ruleString.Append("anonymous_types");
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInControlBlocks))
-                {
-                    if (ruleString.Length != 0)
-                    {
-                        ruleString.Append(",");
-                    }
-
-                    ++rulesApplied;
-                    ruleString.Append("control_blocks");
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInLambdaExpressionBody))
-                {
-                    if (ruleString.Length != 0)
-                    {
-                        ruleString.Append(",");
-                    }
-
-                    ++rulesApplied;
-                    ruleString.Append("lambdas");
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
-                {
-                    if (ruleString.Length != 0)
-                    {
-                        ruleString.Append(",");
-                    }
-
-                    ++rulesApplied;
-                    ruleString.Append("methods");
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInObjectCollectionArrayInitializers))
-                {
-                    if (ruleString.Length != 0)
-                    {
-                        ruleString.Append(",");
-                    }
-
-                    ++rulesApplied;
-                    ruleString.Append("object_collection");
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInProperties))
-                {
-                    if (ruleString.Length != 0)
-                    {
-                        ruleString.Append(",");
-                    }
-
-                    ++rulesApplied;
-                    ruleString.Append("properties");
-                }
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInTypes))
-                {
-                    if (ruleString.Length != 0)
-                    {
-                        ruleString.Append(",");
-                    }
-
-                    ++rulesApplied;
-                    ruleString.Append("types");
-                }
-
-                if (rulesApplied == totalRules)
+                if (valuesApplied == allOptions.Count())
                 {
                     editorconfig.AppendLine("all");
                 }
-                else if (rulesApplied == 0)
+                else if (valuesApplied == 0)
                 {
                     editorconfig.AppendLine("none");
                 }
@@ -435,6 +306,40 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                     editorconfig.AppendLine(ruleString.ToString());
                 }
             }
+
+            Dictionary<Option<bool>, string> OptionToValue()
+            {
+                return new Dictionary<Option<bool>, string>()
+                {
+                { CSharpFormattingOptions.NewLinesForBracesInAccessors, "accessors" },
+                { CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods, "anonymous_methods" },
+                { CSharpFormattingOptions.NewLinesForBracesInAnonymousTypes, "anonymous_types" },
+                { CSharpFormattingOptions.NewLinesForBracesInControlBlocks, "control_blocks" },
+                { CSharpFormattingOptions.NewLinesForBracesInLambdaExpressionBody, "lambdas" },
+                { CSharpFormattingOptions.NewLinesForBracesInMethods, "methods" },
+                { CSharpFormattingOptions.NewLinesForBracesInObjectCollectionArrayInitializers, "object_collection" },
+                { CSharpFormattingOptions.NewLinesForBracesInProperties, "properties" },
+                { CSharpFormattingOptions.NewLinesForBracesInTypes, "types" }
+                };
+            }
+        }
+
+        private static int JoinMultipleValues(Dictionary<Option<bool>, string> allOptions, OptionSet optionSet, StringBuilder ruleString)
+        {
+            var valuesApplied = 0;
+            foreach (var curValue in allOptions)
+            {
+                if (optionSet.GetOption(curValue.Key))
+                {
+                    if (ruleString.Length != 0)
+                    {
+                        ruleString.Append(",");
+                    }
+                    ruleString.Append(curValue.Value);
+                    ++valuesApplied;
+                }
+            }
+            return valuesApplied;
         }
     }
 }

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -46,8 +46,9 @@
             <Hyperlink RequestNavigate="LearnMoreHyperlink_RequestNavigate" NavigateUri="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreUri}">
                 <TextBlock Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreText}"/>
             </Hyperlink>
+            <Run Text="&#x0a;" />
+            <Button Content="Generate .editorconfig file from settings" HorizontalAlignment="Left" Margin="5" VerticalAlignment="Center" Padding="5" Click="Generate_Save_Editorconfig" />
         </TextBlock>
-        <Button Content="Generate .editorconfig file from settings" HorizontalAlignment="Left" Margin="20,35,0,0" VerticalAlignment="Center" Padding="5" Click="Generate_Save_Editorconfig" />
         <DataGrid
             x:Uid="CodeStyleContent"
             x:Name="CodeStyleMembers"

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsCSharp.vb
@@ -31,23 +31,23 @@ insert_final_newline = false
 dotnet_sort_system_directives_first = true
 
 # this. preferences:
-dotnet_style_qualification_for_field = false:none
-dotnet_style_qualification_for_property = false:none
-dotnet_style_qualification_for_method = false:none
-dotnet_style_qualification_for_event = false:none
+dotnet_style_qualification_for_field = false:refactoring_only
+dotnet_style_qualification_for_property = false:refactoring_only
+dotnet_style_qualification_for_method = false:refactoring_only
+dotnet_style_qualification_for_event = false:refactoring_only
 
 # Language keywords vs BCL types preferences:
-dotnet_style_predefined_type_for_locals_parameters_members = true:none
-dotnet_style_predefined_type_for_member_access = true:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:refactoring_only
+dotnet_style_predefined_type_for_member_access = true:refactoring_only
 
 # Parentheses preferences:
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:refactoring_only
 
 # Modifier preferences:
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:refactoring_only
 dotnet_style_readonly_field = true:suggestion
 
 # Expression-level preferences:
@@ -59,23 +59,23 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:none
-dotnet_style_prefer_conditional_expression_over_assignment = true:none
-dotnet_style_prefer_conditional_expression_over_return = true:none
+dotnet_style_prefer_auto_properties = true:refactoring_only
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring_only
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring_only
 
 # C# Coding Conventions
 # 'var' preferences:
-csharp_style_var_for_built_in_types = false:none
-csharp_style_var_when_type_is_apparent = false:none
-csharp_style_var_elsewhere = false:none
+csharp_style_var_for_built_in_types = false:refactoring_only
+csharp_style_var_when_type_is_apparent = false:refactoring_only
+csharp_style_var_elsewhere = false:refactoring_only
 
 # Expression-bodied members:
-csharp_style_expression_bodied_methods = false:none
-csharp_style_expression_bodied_constructors = false:none
-csharp_style_expression_bodied_operators = false:none
-csharp_style_expression_bodied_properties = true:none
-csharp_style_expression_bodied_indexers = true:none
-csharp_style_expression_bodied_accessors = true:none
+csharp_style_expression_bodied_methods = false:refactoring_only
+csharp_style_expression_bodied_constructors = false:refactoring_only
+csharp_style_expression_bodied_operators = false:refactoring_only
+csharp_style_expression_bodied_properties = true:refactoring_only
+csharp_style_expression_bodied_indexers = true:refactoring_only
+csharp_style_expression_bodied_accessors = true:refactoring_only
 
 # Pattern matching preferences:
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
@@ -86,10 +86,10 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Modifier preferences:
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:none
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:refactoring_only
 
 # Expression-level preferences:
-csharp_prefer_braces = true:none
+csharp_prefer_braces = true:refactoring_only
 csharp_style_deconstructed_variable_declaration = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
@@ -153,23 +153,23 @@ insert_final_newline = false
 dotnet_sort_system_directives_first = true
 
 # this. preferences:
-dotnet_style_qualification_for_field = false:none
-dotnet_style_qualification_for_property = false:none
-dotnet_style_qualification_for_method = false:none
-dotnet_style_qualification_for_event = false:none
+dotnet_style_qualification_for_field = false:refactoring_only
+dotnet_style_qualification_for_property = false:refactoring_only
+dotnet_style_qualification_for_method = false:refactoring_only
+dotnet_style_qualification_for_event = false:refactoring_only
 
 # Language keywords vs BCL types preferences:
-dotnet_style_predefined_type_for_locals_parameters_members = true:none
-dotnet_style_predefined_type_for_member_access = true:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:refactoring_only
+dotnet_style_predefined_type_for_member_access = true:refactoring_only
 
 # Parentheses preferences:
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:refactoring_only
 
 # Modifier preferences:
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:refactoring_only
 dotnet_style_readonly_field = true:suggestion
 
 # Expression-level preferences:
@@ -181,23 +181,23 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:none
-dotnet_style_prefer_conditional_expression_over_assignment = true:none
-dotnet_style_prefer_conditional_expression_over_return = true:none
+dotnet_style_prefer_auto_properties = true:refactoring_only
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring_only
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring_only
 
 # C# Coding Conventions
 # 'var' preferences:
-csharp_style_var_for_built_in_types = false:none
-csharp_style_var_when_type_is_apparent = false:none
-csharp_style_var_elsewhere = false:none
+csharp_style_var_for_built_in_types = false:refactoring_only
+csharp_style_var_when_type_is_apparent = false:refactoring_only
+csharp_style_var_elsewhere = false:refactoring_only
 
 # Expression-bodied members:
-csharp_style_expression_bodied_methods = false:none
-csharp_style_expression_bodied_constructors = false:none
-csharp_style_expression_bodied_operators = false:none
-csharp_style_expression_bodied_properties = true:none
-csharp_style_expression_bodied_indexers = true:none
-csharp_style_expression_bodied_accessors = true:none
+csharp_style_expression_bodied_methods = false:refactoring_only
+csharp_style_expression_bodied_constructors = false:refactoring_only
+csharp_style_expression_bodied_operators = false:refactoring_only
+csharp_style_expression_bodied_properties = true:refactoring_only
+csharp_style_expression_bodied_indexers = true:refactoring_only
+csharp_style_expression_bodied_accessors = true:refactoring_only
 
 # Pattern matching preferences:
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
@@ -208,10 +208,10 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Modifier preferences:
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:none
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:refactoring_only
 
 # Expression-level preferences:
-csharp_prefer_braces = true:none
+csharp_prefer_braces = true:refactoring_only
 csharp_style_deconstructed_variable_declaration = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion

--- a/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
+++ b/src/VisualStudio/Core/Test/Options/EditorConfigGeneratorTestsVB.vb
@@ -31,23 +31,23 @@ insert_final_newline = false
 dotnet_sort_system_directives_first = true
 
 # Me. preferences:
-dotnet_style_qualification_for_field = false:none
-dotnet_style_qualification_for_property = false:none
-dotnet_style_qualification_for_method = false:none
-dotnet_style_qualification_for_event = false:none
+dotnet_style_qualification_for_field = false:refactoring_only
+dotnet_style_qualification_for_property = false:refactoring_only
+dotnet_style_qualification_for_method = false:refactoring_only
+dotnet_style_qualification_for_event = false:refactoring_only
 
 # Language keywords vs BCL types preferences:
-dotnet_style_predefined_type_for_locals_parameters_members = true:none
-dotnet_style_predefined_type_for_member_access = true:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:refactoring_only
+dotnet_style_predefined_type_for_member_access = true:refactoring_only
 
 # Parentheses preferences:
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:refactoring_only
 
 # Modifier preferences:
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:refactoring_only
 dotnet_style_readonly_field = true:suggestion
 
 # Expression-level preferences:
@@ -59,13 +59,13 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:none
-dotnet_style_prefer_conditional_expression_over_assignment = true:none
-dotnet_style_prefer_conditional_expression_over_return = true:none
+dotnet_style_prefer_auto_properties = true:refactoring_only
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring_only
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring_only
 
 # VB Coding Conventions
 # Modifier preferences:
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:refactoring_only
 "
                 Dim actualText = New StringBuilder()
                 VisualBasic.Options.Formatting.CodeStylePage.Generate_Editorconfig(workspace.Options, LanguageNames.VisualBasic, actualText)
@@ -93,23 +93,23 @@ insert_final_newline = false
 dotnet_sort_system_directives_first = true
 
 # Me. preferences:
-dotnet_style_qualification_for_field = false:none
-dotnet_style_qualification_for_property = false:none
-dotnet_style_qualification_for_method = false:none
-dotnet_style_qualification_for_event = false:none
+dotnet_style_qualification_for_field = false:refactoring_only
+dotnet_style_qualification_for_property = false:refactoring_only
+dotnet_style_qualification_for_method = false:refactoring_only
+dotnet_style_qualification_for_event = false:refactoring_only
 
 # Language keywords vs BCL types preferences:
-dotnet_style_predefined_type_for_locals_parameters_members = true:none
-dotnet_style_predefined_type_for_member_access = true:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:refactoring_only
+dotnet_style_predefined_type_for_member_access = true:refactoring_only
 
 # Parentheses preferences:
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:refactoring_only
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:refactoring_only
 
 # Modifier preferences:
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:none
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:refactoring_only
 dotnet_style_readonly_field = true:suggestion
 
 # Expression-level preferences:
@@ -121,13 +121,13 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:none
-dotnet_style_prefer_conditional_expression_over_assignment = true:none
-dotnet_style_prefer_conditional_expression_over_return = true:none
+dotnet_style_prefer_auto_properties = true:refactoring_only
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring_only
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring_only
 
 # VB Coding Conventions
 # Modifier preferences:
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:none
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async,Iterator:refactoring_only
 "
                 Dim actualText = New StringBuilder()
                 VisualBasic.Options.Formatting.CodeStylePage.Generate_Editorconfig(changedOptions, LanguageNames.VisualBasic, actualText)

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -33,10 +33,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
         Private Shared Sub VBCodeStyleOptions_GenerateEditorconfig(ByVal optionSet As OptionSet, ByVal [option] As [Option](Of CodeStyleOption(Of String)), ByVal editorconfig As StringBuilder)
             Dim element = [option].StorageLocations.OfType(Of EditorConfigStorageLocation(Of CodeStyleOption(Of String)))().FirstOrDefault()
             If element IsNot Nothing Then
-                editorconfig.Append(element.KeyName & " = ")
+                GridOptionPreviewControl.AppendName(element.KeyName, editorconfig)
 
                 Dim curSetting = optionSet.GetOption([option])
-                editorconfig.AppendLine(curSetting.Value + ":" + curSetting.Notification.ToString().ToLowerInvariant())
+                editorconfig.AppendLine(curSetting.Value + ":" + GridOptionPreviewControl.NotificationOptionToString(curSetting.Notification))
             End If
         End Sub
     End Class


### PR DESCRIPTION
Refactored .editorconfig Tools->Options export feature based on feedback from [previous pull request](https://github.com/dotnet/roslyn/pull/28472). Also changed code to reflect the new "refactoring only" option.

This PR does not contain localization, though this may come later.