### PR TITLE
Fix #29390, add space after tuple type and identifier

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -402,6 +402,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return true;
             }
 
+            // We don't want to add extra space after cast, we want space only after tuple
+            if (token.IsKind(SyntaxKind.CloseParenToken) && IsWord(next.Kind()) && token.Parent.IsKind(SyntaxKind.TupleType) == true)
+            {
+                return true;
+            }
+
             if ((next.IsKind(SyntaxKind.QuestionToken) || next.IsKind(SyntaxKind.ColonToken))
                 && (next.Parent.IsKind(SyntaxKind.ConditionalExpression)))
             {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     !next.IsKind(SyntaxKind.QuestionToken) &&
                     !next.IsKind(SyntaxKind.SemicolonToken) &&
                     !next.IsKind(SyntaxKind.OpenBracketToken) &&
-                    (!next.IsKind(SyntaxKind.OpenParenToken) || KeywordNeedsSeparatorBeforeOpenParen(token.Kind())) &&
+                    (!next.IsKind(SyntaxKind.OpenParenToken) || KeywordNeedsSeparatorBeforeOpenParen(token.Kind()) || next.Parent.IsKind(SyntaxKind.TupleType)) &&
                     !next.IsKind(SyntaxKind.CloseParenToken) &&
                     !next.IsKind(SyntaxKind.CloseBraceToken) &&
                     !next.IsKind(SyntaxKind.ColonColonToken) &&

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -549,6 +549,17 @@ $"  ///  </summary>{Environment.NewLine}" +
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        [WorkItem(29390, "https://github.com/dotnet/roslyn/issues/29390")]
+        public void TestNormalizeTuples()
+        {
+            TestNormalizeDeclaration("(string prefix,string uri)[]ns", "(string prefix, string uri)[] ns");
+            TestNormalizeDeclaration("(string prefix,(string uri,string help))ns", "(string prefix, (string uri, string help)) ns");
+            TestNormalizeDeclaration("(string prefix,string uri)ns", "(string prefix, string uri) ns");
+            TestNormalizeDeclaration("public void Foo((string prefix,string uri)ns)", "public void Foo((string prefix, string uri) ns)");
+            TestNormalizeDeclaration("public (string prefix,string uri)Foo()", "public (string prefix, string uri) Foo()");
+        }
+
         private void TestNormalize(CSharpSyntaxNode node, string expected)
         {
             var actual = node.NormalizeWhitespace("  ").ToFullString();

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -553,6 +553,7 @@ $"  ///  </summary>{Environment.NewLine}" +
         [WorkItem(29390, "https://github.com/dotnet/roslyn/issues/29390")]
         public void TestNormalizeTuples()
         {
+            TestNormalizeDeclaration("new(string prefix,string uri)[10]", "new (string prefix, string uri)[10]");
             TestNormalizeDeclaration("(string prefix,string uri)[]ns", "(string prefix, string uri)[] ns");
             TestNormalizeDeclaration("(string prefix,(string uri,string help))ns", "(string prefix, (string uri, string help)) ns");
             TestNormalizeDeclaration("(string prefix,string uri)ns", "(string prefix, string uri) ns");


### PR DESCRIPTION
Fix for #29390

But I don't know what to do with this:
```csharp
var a = new(string a, int b)[10];
```

From my point of view it should have space:
```csharp
var a = new (string a, int b)[10];
```

Completely similar to:
```csharp
var a = new string[10];
var b = new Lazy<int>[10];
// etc.
```

We don't have spaces only in 2 cases:
```csharp
class Foo<T>
    where T : new() // case #1
{
    public Foo()
    {
        var a = new[2] { 1, 2 }; // case #2
    }
}
```

In both cases we don't specify any type here, so skip space looks natural.
But for tuple from my point of view it is unnatural, because tuple - is just a type, and for types we have extract space.

I've found a few discussions:
from @jcouv: https://github.com/dotnet/csharplang/issues/100#issuecomment-350823105
and @sharwell : https://github.com/dotnet/roslyn/pull/23686#discussion_r156090382

But I can't find final decision

Right now I'll leave test code commented. And will not add whitespace before tuple in `new` expression. I need your input on this.