### PR TITLE
Add benchmark allocation support and improve Emit table size

### DIFF
--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -176,7 +176,11 @@ namespace Microsoft.CodeAnalysis.Emit
         /// provide a basis for approximating the capacities of
         /// various databases used during Emit.
         /// </summary>
-        public int HintNumberOfMethodDefinitions => _methodBodyMap.Count;
+        public int HintNumberOfMethodDefinitions
+            // Try to guess at the size of tables to prevent re-allocation. The method body
+            // map is pretty close, but unfortunately it tends to undercount. x1.5 seems like
+            // a healthy amount of room based on compiling Roslyn.
+            => (int)(_methodBodyMap.Count * 1.5);
 
         internal Cci.IMethodBody GetMethodBody(IMethodSymbol methodSymbol)
         {

--- a/src/Tools/CompilerBenchmarks/Program.cs
+++ b/src/Tools/CompilerBenchmarks/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
@@ -20,7 +21,11 @@ namespace CompilerBenchmarks
                 Add(DefaultConfig.Instance.GetLoggers().ToArray());
                 Add(DefaultConfig.Instance.GetExporters().ToArray());
                 Add(DefaultConfig.Instance.GetColumnProviders().ToArray());
-                Add(new Job { Infrastructure = { Toolchain = FixedCsProjGenerator.Default } });
+                Add(MemoryDiagnoser.Default);
+                Add(new Job
+                {
+                    Infrastructure = { Toolchain = FixedCsProjGenerator.Default }
+                });
             }
         }
 
@@ -36,6 +41,7 @@ namespace CompilerBenchmarks
             // Benchmark.NET creates a new process to run the benchmark, so the easiest way
             // to communicate information is pass by environment variable
             Environment.SetEnvironmentVariable(Helpers.TestProjectEnvVarName, projectPath);
+
             _ = BenchmarkRunner.Run<EmitBenchmark>(config);
         }
     }


### PR DESCRIPTION
After I added support for measuring allocations in the compiler
benchmark suite I noticed in a PerfView trace that we were often
resizing the arrays we used for the Emit tables. Looking more closely at
how we allocate the tables, I found that we were using an approximation
that was very close to the actual size of the tables needed, but
systemically undercounted. Ironically, this may be worse than being
farther off since it meant that we were getting right to the edge of
available space, before requiring a resize, meaning a new large
allocation, and copies from all of the entries in the old tables to the
new tables.

By applying a multiplier to the table size and allocating more memory
for the tables, I've actually decreased the total amount of memory
allocated during emit.

Before:

```
BenchmarkDotNet=v0.11.0, OS=Windows 10.0.17134.228 (1803/April2018Update/Redstone4)
AMD Ryzen 7 1800X Eight-Core Processor (Max: 3.60GHz), 1 CPU, 16 logical and 8 physical cores
Frequency=3509032 Hz, Resolution=284.9789 ns, Timer=TSC
.NET Core SDK=2.1.300-rtm-008866
  [Host]     : .NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT
  Job-ZXPACQ : .NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT

Toolchain=FixedCsProjToolchain

  Method |     Selection |     Mean |     Error |   StdDev |      Gen 0 |      Gen 1 | Allocated |
-------- |-------------- |---------:|----------:|---------:|-----------:|-----------:|----------:|
 RunEmit |      FullEmit | 823.4 ms | 16.046 ms | 21.96 ms | 43000.0000 | 10000.0000 |  40.68 MB |
 RunEmit | SerializeOnly | 210.0 ms |  5.215 ms | 15.38 ms |  2000.0000 |  1000.0000 |  18.23 MB |
```

After:

```
BenchmarkDotNet=v0.11.0, OS=Windows 10.0.17134.228 (1803/April2018Update/Redstone4)
AMD Ryzen 7 1800X Eight-Core Processor (Max: 3.60GHz), 1 CPU, 16 logical and 8 physical cores
Frequency=3509032 Hz, Resolution=284.9789 ns, Timer=TSC
.NET Core SDK=2.1.300-rtm-008866
  [Host]     : .NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT
  Job-IELZBC : .NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT

Toolchain=FixedCsProjToolchain

  Method |     Selection |     Mean |     Error |    StdDev |      Gen 0 |     Gen 1 | Allocated |
-------- |-------------- |---------:|----------:|----------:|-----------:|----------:|----------:|
 RunEmit |      FullEmit | 852.0 ms | 16.915 ms | 38.864 ms | 43000.0000 | 9000.0000 |  39.54 MB |
 RunEmit | SerializeOnly | 193.0 ms |  2.448 ms |  2.044 ms |  2000.0000 | 1000.0000 |  17.08 MB |
```

You can ignore the timing differences in the benchmark here, that's just noise on my machine. The
benchmark won't reflect larger GC costs because usually no collections are done during the
benchmark runs. (Benchmark.NET calls GC.Collect() after each run)
