### PR TITLE
Add NullableWalker.VisitOptionalConversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1461,7 +1461,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)sourceType != null)
             {
-                Debug.Assert(!IncludeNullability); // PROTOTYPE(NullableReferenceTypes): Should fail in StaticNullChecking_FlowAnalysis.Conversions_TupleLiteralExtensionThis.
+                Debug.Assert(!IncludeNullability); // PROTOTYPE(NullableReferenceTypes): Should fail in NullableReferenceTypesTests.Conversions_TupleLiteralExtensionThis.
                 var tupleConversion = ClassifyTupleConversion(
                     sourceType,
                     destination,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -562,6 +562,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        // PROTOTYPE(NullableReferenceTypes): Can this method be replaced by VisitOptionalImplicitConversion or ApplyConversion?
         private void ReportAssignmentWarnings(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings)
         {
             Debug.Assert(value != null);
@@ -3037,7 +3038,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             operandType,
                             checkConversion: false,
                             fromExplicitCast: false,
-                            useLegacyWarnings: false,
+                            useLegacyWarnings,
                             assignmentKind);
 
                         // PROTOTYPE(NullableReferenceTypes): Update method based on operandType

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -565,7 +565,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void ReportAssignmentWarnings(BoundExpression value, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations valueType, bool useLegacyWarnings)
         {
             Debug.Assert(value != null);
-            Debug.Assert(!IsConditionalState);
 
             if (this.State.Reachable)
             {
@@ -625,7 +624,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // PROTOTYPE(NullableReferenceTypes): We should copy all tracked state from `value`,
                     // regardless of BoundNode type, but we'll need to handle cycles. (For instance, the
-                    // assignment to C.F below. See also StaticNullChecking_Members.FieldCycle_01.)
+                    // assignment to C.F below. See also NullableReferenceTypesTests.Members_FieldCycle_01.)
                     // class C
                     // {
                     //     C? F;
@@ -933,31 +932,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            Conversion conversion;
-            (expr, conversion) = RemoveConversion(expr, includeExplicitConversions: false);
-            TypeSymbolWithAnnotations result = VisitRvalueWithResult(expr);
-
-            //if (this.State.Reachable) // PROTOTYPE(NullableReferenceTypes): Consider reachability?
-            if (expr.Type?.IsErrorType() == true)
-            {
-                return null;
-            }
-
             if (_returnTypes != null)
             {
                 // Inferring return type. Should not convert to method return type.
+                TypeSymbolWithAnnotations result = VisitRvalueWithResult(expr);
                 _returnTypes.Add((node.RefKind, result));
                 return null;
             }
 
-            var returnType = GetReturnType();
-            TypeSymbolWithAnnotations resultType = ApplyConversion(expr, expr, conversion, returnType.TypeSymbol, result, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
-            if (!canConvertNestedNullability)
-            {
-                ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, expr.Syntax, GetTypeAsDiagnosticArgument(result.TypeSymbol), returnType.TypeSymbol);
-            }
-            ReportNullableAssignmentIfNecessary(expr, returnType, resultType, useLegacyWarnings: false, assignmentKind: AssignmentKind.Return);
-
+            TypeSymbolWithAnnotations returnType = GetReturnType();
+            VisitOptionalConversion(expr, returnType, useLegacyWarnings: false, AssignmentKind.Return);
             return null;
         }
 
@@ -1006,15 +990,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            Conversion conversion;
-            (initializer, conversion) = RemoveConversion(initializer, includeExplicitConversions: false);
-
-            TypeSymbolWithAnnotations valueType = VisitRvalueWithResult(initializer);
+            bool inferredType = node.DeclaredType.InferredType;
             TypeSymbolWithAnnotations type = local.Type;
+            TypeSymbolWithAnnotations valueType = VisitOptionalConversion(initializer, targetTypeOpt: inferredType ? default : type, useLegacyWarnings: true, AssignmentKind.Assignment);
 
-            if (node.DeclaredType.InferredType)
+            if (inferredType)
             {
-                Debug.Assert(conversion.IsIdentity);
                 if (valueType.IsNull)
                 {
                     Debug.Assert(type.IsErrorType());
@@ -1022,17 +1003,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 _variableTypes[local] = valueType;
                 type = valueType;
-            }
-            else
-            {
-                var unconvertedType = valueType;
-                valueType = ApplyConversion(initializer, initializer, conversion, type.TypeSymbol, valueType, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
-                // Need to report all warnings that apply since the warnings can be suppressed individually.
-                ReportNullableAssignmentIfNecessary(initializer, type, valueType, useLegacyWarnings: true);
-                if (!canConvertNestedNullability)
-                {
-                    ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, initializer.Syntax, GetTypeAsDiagnosticArgument(unconvertedType.TypeSymbol), type.TypeSymbol);
-                }
             }
 
             TrackNullableStateForAssignment(initializer, type, slot, valueType, MakeSlot(initializer));
@@ -1265,7 +1235,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // PROTOTYPE(NullableReferenceTypes): _result may need to be a new anonymous
             // type since the properties may have distinct nullability from original.
-            // (See StaticNullChecking_FlowAnalysis.AnonymousObjectCreation_02.)
+            // (See NullableReferenceTypesTests.AnonymousObjectCreation_02.)
             _resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: false);
             return null;
         }
@@ -1337,24 +1307,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 arrayType = arrayType.WithElementType(elementType);
             }
 
-            if (!elementType.IsNull)
+            if (!elementType.IsNull && !elementType.IsValueType)
             {
-                bool elementTypeIsReferenceType = elementType.IsReferenceType == true;
                 for (int i = 0; i < n; i++)
                 {
                     var conversion = conversionBuilder[i];
                     var element = elementBuilder[i];
                     var resultType = resultBuilder[i];
-                    var sourceType = resultType.TypeSymbol;
-                    if (elementTypeIsReferenceType)
-                    {
-                        resultType = ApplyConversion(element, element, conversion, elementType.TypeSymbol, resultType, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
-                        ReportNullableAssignmentIfNecessary(element, elementType, resultType, useLegacyWarnings: false);
-                        if (!canConvertNestedNullability)
-                        {
-                            ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, element.Syntax, sourceType, elementType.TypeSymbol);
-                        }
-                    }
+                    ApplyConversion(element, element, conversion, elementType, resultType, checkConversion: true, fromExplicitCast: false, useLegacyWarnings: false);
                 }
             }
 
@@ -1947,7 +1907,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (ImmutableArray<BoundExpression> arguments, ImmutableArray<Conversion> conversions) = RemoveArgumentConversions(node.Arguments, refKindsOpt);
                 ImmutableArray<int> argsToParamsOpt = node.ArgsToParamsOpt;
 
-                method = VisitArguments(node, arguments, refKindsOpt, method.Parameters, argsToParamsOpt, node.Expanded, method, conversions);
+                method = VisitArguments(node, arguments, refKindsOpt, method.Parameters, argsToParamsOpt, node.Expanded, conversions, method);
             }
 
             UpdateStateForCall(node);
@@ -2088,8 +2048,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<int> argsToParamsOpt,
             bool expanded)
         {
-            // PROTOTYPE(NullableReferenceTypes): What about conversions here?
-            VisitArguments(node, arguments, refKindsOpt, method is null ? default : method.Parameters, argsToParamsOpt, expanded);
+            ImmutableArray<Conversion> conversions;
+            (arguments, conversions) = RemoveArgumentConversions(arguments, refKindsOpt);
+            VisitArguments(node, arguments, refKindsOpt, method is null ? default : method.Parameters, argsToParamsOpt, expanded, conversions);
         }
 
         private void VisitArguments(
@@ -2100,8 +2061,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<int> argsToParamsOpt,
             bool expanded)
         {
-            // PROTOTYPE(NullableReferenceTypes): What about conversions here?
-            VisitArguments(node, arguments, refKindsOpt, property is null ? default : property.Parameters, argsToParamsOpt, expanded);
+            ImmutableArray<Conversion> conversions;
+            (arguments, conversions) = RemoveArgumentConversions(arguments, refKindsOpt);
+            VisitArguments(node, arguments, refKindsOpt, property is null ? default : property.Parameters, argsToParamsOpt, expanded, conversions);
         }
 
         /// <summary>
@@ -2114,8 +2076,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<ParameterSymbol> parameters,
             ImmutableArray<int> argsToParamsOpt,
             bool expanded,
-            MethodSymbol method = null,
-            ImmutableArray<Conversion> conversions = default)
+            ImmutableArray<Conversion> conversions,
+            MethodSymbol method = null)
         {
             Debug.Assert(!arguments.IsDefault);
             var savedState = this.State.Clone();
@@ -2361,12 +2323,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case RefKind.None:
                 case RefKind.In:
                     {
-                        resultType = ApplyConversion(argument, argument, conversion, parameterType.TypeSymbol, resultType, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
-                        if (!ReportNullReferenceArgumentIfNecessary(argument, resultType, parameter, parameterType) &&
-                            !canConvertNestedNullability)
-                        {
-                            ReportNullabilityMismatchInArgument(argument, argumentType, parameter, parameterType.TypeSymbol);
-                        }
+                        ApplyConversion(argument, argument, conversion, parameterType, resultType, checkConversion: true, fromExplicitCast: false, useLegacyWarnings: false, AssignmentKind.Argument, target: parameter);
                     }
                     break;
                 case RefKind.Out:
@@ -2394,7 +2351,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         bool reportedWarning = false;
                         if (argument.Kind != BoundKind.SuppressNullableWarningExpression)
                         {
-                            reportedWarning = ReportNullReferenceArgumentIfNecessary(argument, resultType, parameter, parameterType) ||
+                            reportedWarning = ReportNullableAssignmentIfNecessary(argument, parameterType, resultType, useLegacyWarnings: false, assignmentKind: AssignmentKind.Argument, target: parameter) ||
                                 ReportNullableAssignmentIfNecessary(argument, resultType, parameterType, useLegacyWarnings: UseLegacyWarnings(argument));
                         }
                         if (!reportedWarning)
@@ -2826,34 +2783,58 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitConversion(BoundConversion node)
         {
-            if (node.ConversionKind == ConversionKind.MethodGroup
-                && node.SymbolOpt?.MethodKind == MethodKind.LocalFunction)
-            {
-                var localFunc = (LocalFunctionSymbol)node.SymbolOpt.OriginalDefinition;
-                var syntax = node.Syntax;
-                ReplayReadsAndWrites(localFunc, syntax, writes: false);
-            }
+            // PROTOTYPE(NullableReferenceTypes): Assert VisitConversion is only used for explicit conversions.
+            //Debug.Assert(node.ExplicitCastInCode);
+            //Debug.Assert(node.ConversionGroupOpt != null);
+            //Debug.Assert(!node.ConversionGroupOpt.ExplicitType.IsNull);
 
-            (BoundExpression operand, Conversion conversion) = RemoveConversion(node, includeExplicitConversions: true);
-            Debug.Assert(operand != null);
-
-            Visit(operand);
-            TypeSymbolWithAnnotations operandType = _resultType;
             TypeSymbolWithAnnotations explicitType = node.ConversionGroupOpt?.ExplicitType ?? default;
             bool fromExplicitCast = !explicitType.IsNull;
-            TypeSymbolWithAnnotations resultType = ApplyConversion(node, operand, conversion, explicitType.TypeSymbol ?? node.Type, operandType, checkConversion: !fromExplicitCast, fromExplicitCast: fromExplicitCast, out bool _);
+            TypeSymbolWithAnnotations targetType = fromExplicitCast ? explicitType : TypeSymbolWithAnnotations.Create(node.Type);
+            Debug.Assert(!targetType.IsNull);
 
-            if (fromExplicitCast && explicitType.IsNullable == false)
+            (BoundExpression operand, Conversion conversion) = RemoveConversion(node, includeExplicitConversions: true);
+            TypeSymbolWithAnnotations operandType = VisitRvalueWithResult(operand);
+            _resultType = ApplyConversion(
+                node,
+                operand,
+                conversion,
+                targetType,
+                operandType,
+                checkConversion: !fromExplicitCast,
+                fromExplicitCast: fromExplicitCast,
+                useLegacyWarnings: fromExplicitCast,
+                AssignmentKind.Assignment,
+                reportTopLevelWarnings: fromExplicitCast,
+                reportNestedWarnings: true);
+            return null;
+        }
+
+        /// <summary>
+        /// Visit an expression. If an explicit target type is provided, the expression is converted
+        /// to that type. This method should be called whenever an expression may contain
+        /// an implicit conversion, even if that conversion was omitted from the bound tree,
+        /// so the conversion can be re-classified with nullability.
+        /// </summary>
+        private TypeSymbolWithAnnotations VisitOptionalConversion(BoundExpression expr, TypeSymbolWithAnnotations targetTypeOpt, bool useLegacyWarnings, AssignmentKind assignmentKind)
+        {
+            if (targetTypeOpt.IsNull)
             {
-                TypeSymbol targetType = explicitType.TypeSymbol;
-                if (!targetType.IsValueType && resultType.IsNullable == true)
-                {
-                    ReportWWarning(node.Syntax);
-                }
+                return VisitRvalueWithResult(expr);
             }
 
-            _resultType = resultType;
-            return null;
+            (BoundExpression operand, Conversion conversion) = RemoveConversion(expr, includeExplicitConversions: false);
+            var operandType = VisitRvalueWithResult(operand);
+            return ApplyConversion(
+                expr,
+                operand,
+                conversion,
+                targetTypeOpt,
+                operandType,
+                checkConversion: true,
+                fromExplicitCast: false,
+                useLegacyWarnings: useLegacyWarnings,
+                assignmentKind);
         }
 
         public override BoundNode VisitTupleLiteral(BoundTupleLiteral node)
@@ -2975,15 +2956,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Re-calculate and apply the conversion to the type of the operand and return the resulting type.
-        /// </summary>
-        private TypeSymbolWithAnnotations ApplyConversion(BoundExpression operand, Conversion conversion, TypeSymbol targetType, TypeSymbolWithAnnotations operandType)
-        {
-            Debug.Assert(operand != null);
-            return ApplyConversion(operand, operand, conversion, targetType, operandType, checkConversion: true, fromExplicitCast: false, out _);
-        }
-
-        /// <summary>
         /// Apply the conversion to the type of the operand and return the resulting type. (If the
         /// operand does not have an explicit type, the operand expression is used for the type.)
         /// If `checkConversion` is set, the incoming conversion is assumed to be from binding and will be
@@ -2993,22 +2965,27 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// considering nested nullability succeeded. `node` is used only for the location of diagnostics.
         /// </summary>
         private TypeSymbolWithAnnotations ApplyConversion(
-            BoundNode node,
+            BoundExpression node,
             BoundExpression operandOpt,
             Conversion conversion,
-            TypeSymbol targetType,
+            TypeSymbolWithAnnotations targetTypeWithNullability,
             TypeSymbolWithAnnotations operandType,
             bool checkConversion,
             bool fromExplicitCast,
-            out bool canConvertNestedNullability)
+            bool useLegacyWarnings,
+            AssignmentKind assignmentKind = AssignmentKind.Assignment,
+            Symbol target = null,
+            bool reportTopLevelWarnings = true,
+            bool reportNestedWarnings = true)
         {
             Debug.Assert(node != null);
             Debug.Assert(operandOpt != null || !operandType.IsNull);
-            Debug.Assert((object)targetType != null);
+            Debug.Assert(!targetTypeWithNullability.IsNull);
 
             bool? isNullableIfReferenceType = null;
-            canConvertNestedNullability = true;
+            bool canConvertNestedNullability = true;
 
+            TypeSymbol targetType = targetTypeWithNullability.TypeSymbol;
             switch (conversion.Kind)
             {
                 case ConversionKind.MethodGroup:
@@ -3056,35 +3033,34 @@ namespace Microsoft.CodeAnalysis.CSharp
                             node,
                             operandOpt,
                             conversion.UserDefinedFromConversion,
-                            conversion.BestUserDefinedConversionAnalysis.FromType,
+                            TypeSymbolWithAnnotations.Create(conversion.BestUserDefinedConversionAnalysis.FromType),
                             operandType,
                             checkConversion: false,
                             fromExplicitCast: false,
-                            out _);
+                            useLegacyWarnings: false);
 
                         // PROTOTYPE(NullableReferenceTypes): Update method based on operandType
-                        // (see StaticNullChecking_FlowAnalysis.Conversions_07).
+                        // (see NullableReferenceTypesTests.ImplicitConversions_07).
                         var methodOpt = conversion.Method;
                         Debug.Assert((object)methodOpt != null);
                         Debug.Assert(methodOpt.ParameterCount == 1);
                         var parameter = methodOpt.Parameters[0];
 
                         // conversion "from" type -> method parameter type
-                        operandType = ClassifyAndApplyConversion(node, parameter.Type.TypeSymbol, operandType);
-                        ReportNullReferenceArgumentIfNecessary(operandOpt, operandType, parameter, parameter.Type);
+                        operandType = ClassifyAndApplyConversion(operandOpt ?? node, parameter.Type, operandType, useLegacyWarnings, AssignmentKind.Argument, target: parameter);
 
                         // method parameter type -> method return type
                         operandType = methodOpt.ReturnType;
 
                         // method return type -> conversion "to" type
                         // May be distinct from method return type for Nullable<T>.
-                        operandType = ClassifyAndApplyConversion(node, conversion.BestUserDefinedConversionAnalysis.ToType, operandType);
+                        operandType = ClassifyAndApplyConversion(operandOpt ?? node, TypeSymbolWithAnnotations.Create(conversion.BestUserDefinedConversionAnalysis.ToType), operandType, useLegacyWarnings, assignmentKind, target: null);
 
                         // conversion "to" type -> final type
                         // PROTOTYPE(NullableReferenceTypes): If the original conversion was
                         // explicit, this conversion should not report nested nullability mismatches.
                         // (see NullableReferenceTypesTests.ExplicitCast_UserDefined_02).
-                        operandType = ClassifyAndApplyConversion(node, targetType, operandType);
+                        operandType = ClassifyAndApplyConversion(node, targetTypeWithNullability, operandType, useLegacyWarnings, assignmentKind, target);
                         return operandType;
                     }
 
@@ -3162,20 +3138,54 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
-            return TypeSymbolWithAnnotations.Create(targetType, isNullableIfReferenceType);
+            var resultType = TypeSymbolWithAnnotations.Create(targetType, isNullableIfReferenceType);
+
+            // Need to report all warnings that apply since the warnings can be suppressed individually.
+            if (reportTopLevelWarnings)
+            {
+                ReportNullableAssignmentIfNecessary(node, targetTypeWithNullability, resultType, useLegacyWarnings: useLegacyWarnings, assignmentKind, target);
+            }
+            if (reportNestedWarnings && !canConvertNestedNullability)
+            {
+                if (assignmentKind == AssignmentKind.Argument)
+                {
+                    ReportNullabilityMismatchInArgument(node, operandType.TypeSymbol, target, targetType);
+                }
+                else
+                {
+                    ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, node.Syntax, GetTypeAsDiagnosticArgument(operandType.TypeSymbol), targetType);
+                }
+            }
+
+            return resultType;
         }
 
-        private TypeSymbolWithAnnotations ClassifyAndApplyConversion(BoundNode node, TypeSymbol targetType, TypeSymbolWithAnnotations operandType)
+        private TypeSymbolWithAnnotations ClassifyAndApplyConversion(BoundExpression node, TypeSymbolWithAnnotations targetType, TypeSymbolWithAnnotations operandType, bool useLegacyWarnings, AssignmentKind assignmentKind, Symbol target)
         {
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            var conversion = _conversions.ClassifyStandardConversion(null, operandType.TypeSymbol, targetType, ref useSiteDiagnostics);
+            var conversion = _conversions.ClassifyStandardConversion(null, operandType.TypeSymbol, targetType.TypeSymbol, ref useSiteDiagnostics);
             if (!conversion.Exists)
             {
-                // PROTOTYPE(NullableReferenceTypes): Not necessarily an assignment
-                // (see StaticNullChecking_FlowAnalysis.Conversions_07).
-                ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, node.Syntax, operandType.TypeSymbol, targetType);
+                if (assignmentKind == AssignmentKind.Argument)
+                {
+                    ReportNullabilityMismatchInArgument(node, operandType.TypeSymbol, target, targetType.TypeSymbol);
+                }
+                else
+                {
+                    ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, node.Syntax, operandType.TypeSymbol, targetType.TypeSymbol);
+                }
             }
-            return ApplyConversion(node, operandOpt: null, conversion, targetType, operandType, checkConversion: false, fromExplicitCast: false, out _);
+            return ApplyConversion(
+                node,
+                operandOpt: null,
+                conversion,
+                targetType,
+                operandType,
+                checkConversion: false,
+                fromExplicitCast: false,
+                useLegacyWarnings: useLegacyWarnings,
+                assignmentKind,
+                target);
         }
 
         public override BoundNode VisitDelegateCreationExpression(BoundDelegateCreationExpression node)
@@ -3273,29 +3283,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!IsConditionalState);
 
             var left = node.Left;
+            var right = node.Right;
             VisitLvalue(left);
             TypeSymbolWithAnnotations leftType = _resultType;
-
-            (BoundExpression right, Conversion conversion) = RemoveConversion(node.Right, includeExplicitConversions: false);
-            VisitRvalue(right);
-            TypeSymbolWithAnnotations rightResult = _resultType;
 
             if (left.Kind == BoundKind.EventAccess && ((BoundEventAccess)left).EventSymbol.IsWindowsRuntimeEvent)
             {
                 // Event assignment is a call to an Add method. (Note that assignment
                 // of non-field-like events uses BoundEventAssignmentOperator
                 // rather than BoundAssignmentOperator.)
+                VisitRvalue(right);
                 SetResult(node);
             }
             else
             {
-                TypeSymbolWithAnnotations rightType = ApplyConversion(right, right, conversion, leftType.TypeSymbol, rightResult, checkConversion: true, fromExplicitCast: false, out bool canConvertNestedNullability);
-                // Need to report all warnings that apply since the warnings can be suppressed individually.
-                ReportNullableAssignmentIfNecessary(right, leftType, rightType, UseLegacyWarnings(left));
-                if (!canConvertNestedNullability)
-                {
-                    ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, right.Syntax, GetTypeAsDiagnosticArgument(rightResult.TypeSymbol), leftType.TypeSymbol);
-                }
+                TypeSymbolWithAnnotations rightType = VisitOptionalConversion(right, leftType, UseLegacyWarnings(left), AssignmentKind.Assignment);
                 TrackNullableStateForAssignment(right, leftType, MakeSlot(left), rightType, MakeSlot(right));
                 // PROTOTYPE(NullableReferenceTypes): Check node.Type.IsErrorType() instead?
                 _resultType = node.HasErrors ? TypeSymbolWithAnnotations.Create(node.Type) : rightType;
@@ -3342,29 +3344,45 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // PROTOTYPE(NullableReferenceTypes): Update increment method based on operand type.
                 MethodSymbol incrementOperator = (node.OperatorKind.IsUserDefined() && (object)node.MethodOpt != null && node.MethodOpt.ParameterCount == 1) ? node.MethodOpt : null;
-                TypeSymbol targetTypeOfOperandConversion;
+                TypeSymbolWithAnnotations targetTypeOfOperandConversion;
+                AssignmentKind assignmentKind = AssignmentKind.Assignment;
+                Symbol target = null;
 
                 // PROTOTYPE(NullableReferenceTypes): Update conversion method based on operand type.
                 if (node.OperandConversion.IsUserDefined && (object)node.OperandConversion.Method != null && node.OperandConversion.Method.ParameterCount == 1)
                 {
-                    targetTypeOfOperandConversion = node.OperandConversion.Method.ReturnType.TypeSymbol;
+                    targetTypeOfOperandConversion = node.OperandConversion.Method.ReturnType;
                 }
                 else if ((object)incrementOperator != null)
                 {
-                    targetTypeOfOperandConversion = incrementOperator.Parameters[0].Type.TypeSymbol;
+                    targetTypeOfOperandConversion = incrementOperator.Parameters[0].Type;
+                    assignmentKind = AssignmentKind.Argument;
+                    target = incrementOperator.Parameters[0];
                 }
                 else
                 {
                     // Either a built-in increment, or an error case.
-                    targetTypeOfOperandConversion = null;
+                    targetTypeOfOperandConversion = default;
                 }
 
                 TypeSymbolWithAnnotations resultOfOperandConversionType;
 
-                if ((object)targetTypeOfOperandConversion != null)
+                if (!targetTypeOfOperandConversion.IsNull)
                 {
                     // PROTOTYPE(NullableReferenceTypes): Should something special be done for targetTypeOfOperandConversion for lifted case?
-                    resultOfOperandConversionType = ApplyConversion(node.Operand, node.OperandConversion, targetTypeOfOperandConversion, operandType);
+                    resultOfOperandConversionType = ApplyConversion(
+                        node.Operand,
+                        node.Operand,
+                        node.OperandConversion,
+                        targetTypeOfOperandConversion,
+                        operandType,
+                        checkConversion: true,
+                        fromExplicitCast: false,
+                        useLegacyWarnings: false,
+                        assignmentKind,
+                        target,
+                        reportTopLevelWarnings: true,
+                        reportNestedWarnings: true);
                 }
                 else
                 {
@@ -3378,12 +3396,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    ReportArgumentWarnings(node.Operand, resultOfOperandConversionType, incrementOperator.Parameters[0]);
-
                     resultOfIncrementType = incrementOperator.ReturnType;
                 }
 
-                resultOfIncrementType = ApplyConversion(node, node.ResultConversion, node.Type, resultOfIncrementType);
+                resultOfIncrementType = ApplyConversion(
+                    node,
+                    node,
+                    node.ResultConversion,
+                    operandType,
+                    resultOfIncrementType,
+                    checkConversion: true,
+                    fromExplicitCast: false,
+                    useLegacyWarnings: false);
 
                 // PROTOTYPE(NullableReferenceTypes): Check node.Type.IsErrorType() instead?
                 if (!node.HasErrors)
@@ -3392,7 +3416,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _resultType = (op == UnaryOperatorKind.PrefixIncrement || op == UnaryOperatorKind.PrefixDecrement) ? resultOfIncrementType : operandType;
                     setResult = true;
 
-                    ReportAssignmentWarnings(node, operandType, valueType: resultOfIncrementType, useLegacyWarnings: false);
                     TrackNullableStateForAssignment(node, operandType, MakeSlot(node.Operand), valueType: resultOfIncrementType);
                 }
             }
@@ -3421,7 +3444,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if ((object)node.Operator.LeftType != null)
                 {
                     // PROTOTYPE(NullableReferenceTypes): Ignoring top-level nullability of operator left parameter.
-                    leftOnRightType = ApplyConversion(node.Left, node.LeftConversion, node.Operator.LeftType, leftOnRightType);
+                    leftOnRightType = ApplyConversion(
+                        node.Left,
+                        node.Left,
+                        node.LeftConversion,
+                        TypeSymbolWithAnnotations.Create(node.Operator.LeftType),
+                        leftOnRightType,
+                        checkConversion: true,
+                        fromExplicitCast: false,
+                        useLegacyWarnings: false,
+                        reportTopLevelWarnings: false,
+                        reportNestedWarnings: false);
                 }
                 else
                 {
@@ -3440,10 +3473,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     resultType = InferResultNullability(node.Operator.Kind, node.Operator.Method, node.Operator.ReturnType, leftOnRightType, rightType);
-
-                    // PROTOTYPE(NullableReferenceTypes): Ignoring top-level nullability of operator.
-                    resultType = ApplyConversion(node, node.FinalConversion, node.Type, resultType);
-                    ReportAssignmentWarnings(node, leftType, resultType, useLegacyWarnings: false);
+                    resultType = ApplyConversion(
+                        node,
+                        node,
+                        node.FinalConversion,
+                        leftType,
+                        resultType,
+                        checkConversion: true,
+                        fromExplicitCast: false,
+                        useLegacyWarnings: false);
                 }
                 else
                 {
@@ -3482,20 +3520,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        /// <summary>
-        /// Report warning passing nullable argument to non-nullable parameter
-        /// (e.g.: calling `void F(string s)` with `F(maybeNull)`).
-        /// </summary>
-        private bool ReportNullReferenceArgumentIfNecessary(BoundExpression argument, TypeSymbolWithAnnotations argumentType, ParameterSymbol parameter, TypeSymbolWithAnnotations paramType)
-        {
-            return ReportNullableAssignmentIfNecessary(argument, paramType, argumentType, useLegacyWarnings: false, assignmentKind: AssignmentKind.Argument, target: parameter);
-        }
-
         private void ReportArgumentWarnings(BoundExpression argument, TypeSymbolWithAnnotations argumentType, ParameterSymbol parameter)
         {
             var paramType = parameter.Type;
-
-            ReportNullReferenceArgumentIfNecessary(argument, argumentType, parameter, paramType);
+            ReportNullableAssignmentIfNecessary(argument, paramType, argumentType, useLegacyWarnings: false, assignmentKind: AssignmentKind.Argument, target: parameter);
 
             if (!argumentType.IsNull && IsNullabilityMismatch(paramType.TypeSymbol, argumentType.TypeSymbol))
             {
@@ -3507,7 +3535,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Report warning passing argument where nested nullability does not match
         /// parameter (e.g.: calling `void F(object[] o)` with `F(new[] { maybeNull })`).
         /// </summary>
-        private void ReportNullabilityMismatchInArgument(BoundExpression argument, TypeSymbol argumentType, ParameterSymbol parameter, TypeSymbol parameterType)
+        private void ReportNullabilityMismatchInArgument(BoundNode argument, TypeSymbol argumentType, Symbol parameter, TypeSymbol parameterType)
         {
             ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, argument.Syntax, argumentType, parameterType,
                 new FormattedSymbol(parameter, SymbolDisplayFormat.ShortFormat),
@@ -3617,7 +3645,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     TypeSymbolWithAnnotations destinationType = iterationVariable.Type;
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                     Conversion conversion = _conversions.ClassifyImplicitConversionFromType(sourceType.TypeSymbol, destinationType.TypeSymbol, ref useSiteDiagnostics);
-                    TypeSymbolWithAnnotations result = ApplyConversion(node.IterationVariableType, operandOpt: null, conversion, destinationType.TypeSymbol, sourceType, checkConversion: false, fromExplicitCast: true, out bool canConvertNestedNullability);
+                    TypeSymbolWithAnnotations result = ApplyConversion(
+                        node.IterationVariableType,
+                        operandOpt: null,
+                        conversion,
+                        destinationType,
+                        sourceType,
+                        checkConversion: false,
+                        fromExplicitCast: true,
+                        useLegacyWarnings: false,
+                        reportTopLevelWarnings: false,
+                        reportNestedWarnings: false);
                     if (destinationType.IsReferenceType && destinationType.IsNullable == false && sourceType.IsNullable == true)
                     {
                         ReportWWarning(node.IterationVariableType.Syntax);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -7104,6 +7104,9 @@ class C
                 // (10,20): warning CS8604: Possible null reference argument for parameter 'y' in 'void C.G(I<object> x, params I<object?>[] y)'.
                 //         G(x, x, y, z, w);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "z").WithArguments("y", "void C.G(I<object> x, params I<object?>[] y)").WithLocation(10, 20),
+                // (10,20): warning CS8620: Nullability of reference types in argument of type 'I<object>' doesn't match target type 'I<object?>' for parameter 'y' in 'void C.G(I<object> x, params I<object?>[] y)'.
+                //         G(x, x, y, z, w);
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "z").WithArguments("I<object>", "I<object?>", "y", "void C.G(I<object> x, params I<object?>[] y)").WithLocation(10, 20),
                 // (10,23): warning CS8604: Possible null reference argument for parameter 'y' in 'void C.G(I<object> x, params I<object?>[] y)'.
                 //         G(x, x, y, z, w);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "w").WithArguments("y", "void C.G(I<object> x, params I<object?>[] y)").WithLocation(10, 23),
@@ -14979,8 +14982,6 @@ public class NotNull
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y9.String").WithLocation(46, 10));
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Conversions: Conversion
-        // (VisitConversion does not report nullability mismatch for the conversion in node.Right.)
         [Fact]
         public void ImplicitConversion_NullCoalescingOperator_02()
         {
@@ -14995,13 +14996,13 @@ class C
 {
     static void F(A<object>? x, B<object?> y)
     {
-        (x ?? y).F.ToString();
-        (y ?? x).F.ToString();
+        (x ?? y).F.ToString(); // 1
+        (y ?? x).F.ToString(); // 2
     }
     static void G(A<object?> z, B<object>? w)
     {
-        (z ?? w).F.ToString();
-        (w ?? z).F.ToString();
+        (z ?? w).F.ToString(); // 3
+        (w ?? z).F.ToString(); // 4
     }
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
@@ -15010,33 +15011,31 @@ class C
                 // class A<T>
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "A").WithArguments("field", "F").WithLocation(2, 7),
                 // (11,15): warning CS8619: Nullability of reference types in value of type 'B<object?>' doesn't match target type 'A<object>'.
-                //         (x ?? y).F.ToString();
-                //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("B<object?>", "A<object>").WithLocation(11, 15),
+                //         (x ?? y).F.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("B<object?>", "A<object>").WithLocation(11, 15),
                 // (12,10): hidden CS8607: Expression is probably never null.
-                //         (y ?? x).F.ToString();
+                //         (y ?? x).F.ToString(); // 2
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y").WithLocation(12, 10),
                 // (12,10): warning CS8619: Nullability of reference types in value of type 'B<object?>' doesn't match target type 'A<object>'.
-                //         (y ?? x).F.ToString();
+                //         (y ?? x).F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("B<object?>", "A<object>").WithLocation(12, 10),
                 // (16,10): hidden CS8607: Expression is probably never null.
-                //         (z ?? w).F.ToString();
+                //         (z ?? w).F.ToString(); // 3
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "z").WithLocation(16, 10),
                 // (16,15): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'A<object?>'.
-                //         (z ?? w).F.ToString();
-                //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "w").WithArguments("B<object>", "A<object?>").WithLocation(16, 15),
+                //         (z ?? w).F.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "w").WithArguments("B<object>", "A<object?>").WithLocation(16, 15),
                 // (16,9): warning CS8602: Possible dereference of a null reference.
-                //         (z ?? w).F.ToString();
+                //         (z ?? w).F.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(z ?? w).F").WithLocation(16, 9),
                 // (17,10): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'A<object?>'.
-                //         (w ?? z).F.ToString();
+                //         (w ?? z).F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "w").WithArguments("B<object>", "A<object?>").WithLocation(17, 10),
                 // (17,9): warning CS8602: Possible dereference of a null reference.
-                //         (w ?? z).F.ToString();
+                //         (w ?? z).F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(w ?? z).F").WithLocation(17, 9));
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Conversions: Conversion
-        // (VisitConversion does not report nullability mismatch for the conversion in node.Right.)
         [Fact]
         public void ImplicitConversion_NullCoalescingOperator_03()
         {
@@ -15069,20 +15068,18 @@ class C
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y").WithLocation(10, 10),
                 // (10,15): warning CS8619: Nullability of reference types in value of type 'IIn<object>' doesn't match target type 'IIn<string?>'.
                 //         (y ?? x)/*T:IIn<string?>!*/.F(string.Empty, null);
-                //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("IIn<object>", "IIn<string?>").WithLocation(10, 15),
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("IIn<object>", "IIn<string?>").WithLocation(10, 15),
                 // (14,10): hidden CS8607: Expression is probably never null.
                 //         (z ?? w)/*T:IIn<string!>!*/.F(string.Empty, null);
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "z").WithLocation(14, 10),
-                // (14,53): warning CS8600: Cannot convert null to non-nullable reference.
+                // (14,53): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //         (z ?? w)/*T:IIn<string!>!*/.F(string.Empty, null);
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(14, 53),
-                // (15,53): warning CS8600: Cannot convert null to non-nullable reference.
+                // (15,53): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //         (w ?? z)/*T:IIn<string!>!*/.F(string.Empty, null);
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(15, 53));
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Conversions: Conversion
-        // (VisitConversion does not report nullability mismatch for the conversion in node.Right.)
         [Fact]
         public void ImplicitConversion_NullCoalescingOperator_04()
         {
@@ -15109,7 +15106,7 @@ class C
             comp.VerifyDiagnostics(
                 // (9,15): warning CS8619: Nullability of reference types in value of type 'IOut<string?>' doesn't match target type 'IOut<object>'.
                 //         (x ?? y)/*T:IOut<object!>!*/.P.ToString();
-                //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("IOut<string?>", "IOut<object>").WithLocation(9, 15),
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("IOut<string?>", "IOut<object>").WithLocation(9, 15),
                 // (10,10): hidden CS8607: Expression is probably never null.
                 //         (y ?? x)/*T:IOut<object!>!*/.P.ToString();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y").WithLocation(10, 10),
@@ -16481,6 +16478,51 @@ class CL0<T>
         }
 
         [Fact]
+        public void Array_10()
+        {
+            var source =
+@"class C
+{
+    static void F1<T>()
+    {
+        T[] a1;
+        a1 = new T[] { default }; // 1
+        a1 = new T[] { default(T) }; // 2
+    }
+    static void F2<T>() where T : class
+    {
+        T[] a2;
+        a2 = new T[] { null }; // 3
+        a2 = new T[] { default }; // 4
+        a2 = new T[] { default(T) }; // 5
+    }
+    static void F3<T>() where T : struct
+    {
+        T[] a3;
+        a3 = new T[] { default };
+        a3 = new T[] { default(T) };
+    }
+}";
+            var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
+            comp.VerifyDiagnostics(
+                // (6,24): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //         a1 = new T[] { default }; // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(6, 24),
+                // (7,24): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //         a1 = new T[] { default(T) }; // 2
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T)").WithLocation(7, 24),
+                // (12,24): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //         a2 = new T[] { null }; // 3
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 24),
+                // (13,24): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //         a2 = new T[] { default }; // 4
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(13, 24),
+                // (14,24): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //         a2 = new T[] { default(T) }; // 5
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(T)").WithLocation(14, 24));
+        }
+
+        [Fact]
         public void ImplicitlyTypedArrayCreation_01()
         {
             var source =
@@ -17282,20 +17324,19 @@ class C
     {
         var c = new List<A<object>>
         {
-            x,
-            y,
+            x, // 1
+            y, // 2
         };
     }
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
-            // PROTOTYPE(NullableReferenceTypes): Should report WRN_NullabilityMismatchInArgument for `y`.
             comp.VerifyDiagnostics(
                 // (10,13): warning CS8604: Possible null reference argument for parameter 'item' in 'void List<A<object>>.Add(A<object> item)'.
-                //             x,
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("item", "void List<A<object>>.Add(A<object> item)").WithLocation(10, 13));
-            //// (11,13): warning CS8620: Nullability of reference types in argument of type 'B<object?>' doesn't match target type 'A<object>' for parameter 'item' in 'void List<A<object>>.Add(A<object> item)'.
-            ////             y,
-            //Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("B<object?>", "A<object>", "item", "void List<A<object>>.Add(A<object> item)").WithLocation(11, 13));
+                //             x, // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("item", "void List<A<object>>.Add(A<object> item)").WithLocation(10, 13),
+                // (11,13): warning CS8620: Nullability of reference types in argument of type 'B<object?>' doesn't match target type 'A<object>' for parameter 'item' in 'void List<A<object>>.Add(A<object> item)'.
+                //             y, // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("B<object?>", "A<object>", "item", "void List<A<object>>.Add(A<object> item)").WithLocation(11, 13));
         }
 
         [Fact]
@@ -23383,16 +23424,15 @@ class C
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
             // PROTOTYPE(NullableReferenceTypes): Several issues with implicit user-defined conversions and
             // nested nullability: should report `'A<object?>' doesn't match ... 'A<object>'` rather than
-            // `'A<object>' doesn't match ... 'A<object?>'`; should report warning for `G(y)` only, not `G(z)`; and
-            // should be reported as WRN_NullabilityMismatchInArgument not WRN_NullabilityMismatchInAssignment
+            // `'A<object>' doesn't match ... 'A<object?>'`; should report warning for `G(y)` only, not `G(z)`
             // (see NullabilityWalker.ApplyConversion).
             comp.VerifyDiagnostics(
-                // (15,11): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'A<object?>'.
+                // (15,11): warning CS8620: Nullability of reference types in argument of type 'A<object>' doesn't match target type 'A<object?>' for parameter 'a' in 'void C.G(A<object?> a)'.
                 //         G(y); // warning
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("A<object>", "A<object?>").WithLocation(15, 11),
-                // (18,11): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'A<object?>'.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("A<object>", "A<object?>", "a", "void C.G(A<object?> a)").WithLocation(15, 11),
+                // (18,11): warning CS8620: Nullability of reference types in argument of type 'A<object>' doesn't match target type 'A<object?>' for parameter 'a' in 'void C.G(A<object?> a)'.
                 //         G(z); // ok
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "z").WithArguments("A<object>", "A<object?>").WithLocation(18, 11));
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "z").WithArguments("A<object>", "A<object?>", "a", "void C.G(A<object?> a)").WithLocation(18, 11));
         }
 
         [Fact]
@@ -24735,19 +24775,20 @@ class C
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
             // PROTOTYPE(NullableReferenceTypes): Report WRN_NullabilityMismatchInAssignment for compound assignment.
-            comp.VerifyDiagnostics();
-            //// (12,9): warning CS8619: Nullability of reference types in value of type 'I<object?>' doesn't match target type 'I<object>'.
-            ////         y += c;
-            //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("I<object?>", "I<object>").WithLocation(12, 9),
-            //// (12,9): warning CS8619: Nullability of reference types in value of type 'I<object>' doesn't match target type 'I<object?>'.
-            ////         y += c;
-            //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y += c").WithArguments("I<object>", "I<object?>").WithLocation(12, 9),
-            //// (17,9): warning CS8619: Nullability of reference types in value of type 'IIn<object>' doesn't match target type 'IIn<object?>'.
-            ////         y += c;
-            //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y += c").WithArguments("IIn<object>", "IIn<object?>").WithLocation(17, 9),
-            //// (22,9): warning CS8619: Nullability of reference types in value of type 'IOut<object?>' doesn't match target type 'IOut<object>'.
-            ////         y += c;
-            //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("IOut<object?>", "IOut<object>").WithLocation(22, 9));
+            comp.VerifyDiagnostics(
+                //// (12,9): warning CS8619: Nullability of reference types in value of type 'I<object?>' doesn't match target type 'I<object>'.
+                ////         y += c;
+                //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("I<object?>", "I<object>").WithLocation(12, 9),
+                // (12,9): warning CS8619: Nullability of reference types in value of type 'I<object>' doesn't match target type 'I<object?>'.
+                //         y += c;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y += c").WithArguments("I<object>", "I<object?>").WithLocation(12, 9),
+                // (17,9): warning CS8619: Nullability of reference types in value of type 'IIn<object>' doesn't match target type 'IIn<object?>'.
+                //         y += c;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y += c").WithArguments("IIn<object>", "IIn<object?>").WithLocation(17, 9)
+                //// (22,9): warning CS8619: Nullability of reference types in value of type 'IOut<object?>' doesn't match target type 'IOut<object>'.
+                ////         y += c;
+                //Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("IOut<object?>", "IOut<object>").WithLocation(22, 9)
+                );
         }
 
         [Fact]
@@ -29512,9 +29553,15 @@ class D<T> : IEnumerable
                 // (9,28): warning CS8604: Possible null reference argument for parameter 'key' in 'void C<int>.Add(C<object?> key, params C<object?>[] value)'.
                 //         _ = new C<int>() { x, x }; // warn 1 and 2
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("key", "void C<int>.Add(C<object?> key, params C<object?>[] value)").WithLocation(9, 28),
+                // (9,28): warning CS8620: Nullability of reference types in argument of type 'C<object>' doesn't match target type 'C<object?>' for parameter 'key' in 'void C<int>.Add(C<object?> key, params C<object?>[] value)'.
+                //         _ = new C<int>() { x, x }; // warn 1 and 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("C<object>", "C<object?>", "key", "void C<int>.Add(C<object?> key, params C<object?>[] value)").WithLocation(9, 28),
                 // (9,31): warning CS8604: Possible null reference argument for parameter 'key' in 'void C<int>.Add(C<object?> key, params C<object?>[] value)'.
                 //         _ = new C<int>() { x, x }; // warn 1 and 2
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("key", "void C<int>.Add(C<object?> key, params C<object?>[] value)").WithLocation(9, 31),
+                // (9,31): warning CS8620: Nullability of reference types in argument of type 'C<object>' doesn't match target type 'C<object?>' for parameter 'key' in 'void C<int>.Add(C<object?> key, params C<object?>[] value)'.
+                //         _ = new C<int>() { x, x }; // warn 1 and 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("C<object>", "C<object?>", "key", "void C<int>.Add(C<object?> key, params C<object?>[] value)").WithLocation(9, 31),
                 // (10,28): warning CS8620: Nullability of reference types in argument of type 'C<object>' doesn't match target type 'C<object?>' for parameter 'key' in 'void C<int>.Add(C<object?> key, params C<object?>[] value)'.
                 //         _ = new C<int>() { x!, x! }; // warn 3 and 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x!").WithArguments("C<object>", "C<object?>", "key", "void C<int>.Add(C<object?> key, params C<object?>[] value)").WithLocation(10, 28),
@@ -32598,28 +32645,28 @@ static class E
 {
     static void F(string x, string? y)
     {
-        E1((x, y));
+        E1((x, y)); // 1
         E2((x, y));
     }
     static void E1((object, object) t) { }
     static void E2((object?, object?) t) { }
     static void FA(A<object> x, A<object?> y)
     {
-        EA1((x, y));
-        EA2((x, y));
+        EA1((x, y)); // 2
+        EA2((x, y)); // 3
     }
     static void EA1((I<object>, I<object>) t) { }
     static void EA2((I<object?>, I<object?>) t) { }
     static void FB(B<object> x, B<object?> y)
     {
         EB1((x, y));
-        EB2((x, y));
+        EB2((x, y)); // 4
     }
     static void EB1((IIn<object>, IIn<object>) t) { }
     static void EB2((IIn<object?>, IIn<object?>) t) { }
     static void FC(C<object> x, C<object?> y)
     {
-        EC1((x, y));
+        EC1((x, y)); // 5
         EC2((x, y));
     }
     static void EC1((IOut<object>, IOut<object>) t) { }
@@ -32627,7 +32674,21 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
             // PROTOTYPE(NullableReferenceTypes): NullableWalker should call ConversionsBase.GetTupleLiteralConversion.
-            comp.VerifyDiagnostics(/* PROTOTYPE(NullableReferenceType) */);
+            // PROTOTYPE(NullableReferenceTypes): Report WRN_NullabilityMismatchInArgument rather than ...Assignment.
+            // PROTOTYPE(NullableReferenceTypes): Not reporting warning for // 1
+            comp.VerifyDiagnostics(
+                // (18,17): warning CS8619: Nullability of reference types in value of type 'A<object?>' doesn't match target type 'I<object>'.
+                //         EA1((x, y)); // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("A<object?>", "I<object>").WithLocation(18, 17),
+                // (19,14): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'I<object?>'.
+                //         EA2((x, y)); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("A<object>", "I<object?>").WithLocation(19, 14),
+                // (26,14): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'IIn<object?>'.
+                //         EB2((x, y)); // 4
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("B<object>", "IIn<object?>").WithLocation(26, 14),
+                // (32,17): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'IOut<object>'.
+                //         EC1((x, y)); // 5
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("C<object?>", "IOut<object>").WithLocation(32, 17));
         }
 
         [Fact]
@@ -32644,28 +32705,28 @@ static class E
 {
     static void F(string x, string? y)
     {
-        (x, y).E1();
+        (x, y).E1(); // 1
         (x, y).E2();
     }
     static void E1(this (object, object) t) { }
     static void E2(this (object?, object?) t) { }
     static void FA(A<object> x, A<object?> y)
     {
-        (x, y).EA1();
-        (x, y).EA2();
+        (x, y).EA1(); // 2
+        (x, y).EA2(); // 3
     }
     static void EA1(this (I<object>, I<object>) t) { }
     static void EA2(this (I<object?>, I<object?>) t) { }
     static void FB(B<object> x, B<object?> y)
     {
         (x, y).EB1();
-        (x, y).EB2();
+        (x, y).EB2(); // 4
     }
     static void EB1(this (IIn<object>, IIn<object>) t) { }
     static void EB2(this (IIn<object?>, IIn<object?>) t) { }
     static void FC(C<object> x, C<object?> y)
     {
-        (x, y).EC1();
+        (x, y).EC1(); // 5
         (x, y).EC2();
     }
     static void EC1(this (IOut<object>, IOut<object>) t) { }
@@ -32673,7 +32734,21 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
             // PROTOTYPE(NullableReferenceTypes): NullableWalker should call ConversionsBase.ClassifyImplicitExtensionMethodThisArgConversion.
-            comp.VerifyDiagnostics(/* PROTOTYPE(NullableReferenceType) */);
+            // PROTOTYPE(NullableReferenceTypes): Report WRN_NullabilityMismatchInArgument rather than ...Assignment.
+            // PROTOTYPE(NullableReferenceTypes): Not reporting warning for // 1
+            comp.VerifyDiagnostics(
+                // (18,13): warning CS8619: Nullability of reference types in value of type 'A<object?>' doesn't match target type 'I<object>'.
+                //         (x, y).EA1(); // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("A<object?>", "I<object>").WithLocation(18, 13),
+                // (19,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'I<object?>'.
+                //         (x, y).EA2(); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("A<object>", "I<object?>").WithLocation(19, 10),
+                // (26,10): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'IIn<object?>'.
+                //         (x, y).EB2(); // 4
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("B<object>", "IIn<object?>").WithLocation(26, 10),
+                // (32,13): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'IOut<object>'.
+                //         (x, y).EC1(); // 5
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("C<object?>", "IOut<object>").WithLocation(32, 13));
         }
 
         [Fact]
@@ -32989,19 +33064,18 @@ class C
         C c;
         c = new C((x, x));
         c = new C((x, y));
-        c = new C((y, x));
-        c = new C((y, y));
+        c = new C((y, x)); // 1
+        c = new C((y, y)); // 2
     }
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
-            // PROTOTYPE(NullableReferenceTypes): Should report WRN_NullabilityMismatchInArgument for `(y, x)` and `(y, y)`.
-            comp.VerifyDiagnostics();
-            //// (9,19): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string x, string? y)' for parameter 't' in 'C.C((string x, string? y) t)'.
-            ////         c = new C((y, x));
-            //Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string x, string? y)", "t", "C.C((string x, string? y) t)").WithLocation(9, 19),
-            //// (10,19): warning CS8620: Nullability of reference types in argument of type '(string?, string?)' doesn't match target type '(string x, string? y)' for parameter 't' in 'C.C((string x, string? y) t)'.
-            ////         c = new C((y, y));
-            //Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, y)").WithArguments("(string?, string?)", "(string x, string? y)", "t", "C.C((string x, string? y) t)").WithLocation(10, 19));
+            comp.VerifyDiagnostics(
+                // (9,19): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string x, string? y)' for parameter 't' in 'C.C((string x, string? y) t)'.
+                //         c = new C((y, x)); // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string x, string? y)", "t", "C.C((string x, string? y) t)").WithLocation(9, 19),
+                // (10,19): warning CS8620: Nullability of reference types in argument of type '(string?, string?)' doesn't match target type '(string x, string? y)' for parameter 't' in 'C.C((string x, string? y) t)'.
+                //         c = new C((y, y)); // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, y)").WithArguments("(string?, string?)", "(string x, string? y)", "t", "C.C((string x, string? y) t)").WithLocation(10, 19));
         }
 
         [Fact]
@@ -33017,19 +33091,18 @@ class C
         object? o;
         o = c[(x, x)];
         o = c[(x, y)];
-        o = c[(y, x)];
-        o = c[(y, y)];
+        o = c[(y, x)]; // 1
+        o = c[(y, y)]; // 2
     }
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
-            // PROTOTYPE(NullableReferenceTypes): Should report WRN_NullabilityMismatchInArgument for `(y, x)` and `(y, y)`.
-            comp.VerifyDiagnostics();
-            //// (10,15): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string x, string? y)' for parameter 't' in 'object? C.this[(string x, string? y) t].get'.
-            ////         o = c[(y, x)];
-            //Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string x, string? y)", "t", "object? C.this[(string x, string? y) t].get").WithLocation(10, 15),
-            //// (11,15): warning CS8620: Nullability of reference types in argument of type '(string?, string?)' doesn't match target type '(string x, string? y)' for parameter 't' in 'object? C.this[(string x, string? y) t].get'.
-            ////         o = c[(y, y)];
-            //Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, y)").WithArguments("(string?, string?)", "(string x, string? y)", "t", "object? C.this[(string x, string? y) t].get").WithLocation(11, 15));
+            comp.VerifyDiagnostics(
+                // (10,15): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string x, string? y)' for parameter 't' in 'object? C.this[(string x, string? y) t]'.
+                //         o = c[(y, x)]; // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string x, string? y)", "t", "object? C.this[(string x, string? y) t]").WithLocation(10, 15),
+                // (11,15): warning CS8620: Nullability of reference types in argument of type '(string?, string?)' doesn't match target type '(string x, string? y)' for parameter 't' in 'object? C.this[(string x, string? y) t]'.
+                //         o = c[(y, y)]; // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, y)").WithArguments("(string?, string?)", "(string x, string? y)", "t", "object? C.this[(string x, string? y) t]").WithLocation(11, 15));
         }
 
         [Fact]
@@ -33045,19 +33118,18 @@ class C
         {
             (x, x),
             (x, y),
-            (y, x),
-            (y, y),
+            (y, x), // 1
+            (y, y), // 2
         };
     }
 }";
             var comp = CreateCompilation(new[] { source, NonNullTypesTrue, NonNullTypesAttributesDefinition });
-            // PROTOTYPE(NullableReferenceTypes): Should report WRN_NullabilityMismatchInArgument for `(y, x)`.
             comp.VerifyDiagnostics(
-                //// (10,13): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string, string?)' for parameter 'item' in 'void List<(string, string?)>.Add((string, string?) item)'.
-                ////             (y, x),
-                //Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string, string?)", "item", "void List<(string, string?)>.Add((string, string?) item)").WithLocation(10, 13),
+                // (10,13): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string, string?)' for parameter 'item' in 'void List<(string, string?)>.Add((string, string?) item)'.
+                //             (y, x), // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string, string?)", "item", "void List<(string, string?)>.Add((string, string?) item)").WithLocation(10, 13),
                 // (11,13): warning CS8620: Nullability of reference types in argument of type '(string?, string?)' doesn't match target type '(string, string?)' for parameter 'item' in 'void List<(string, string?)>.Add((string, string?) item)'.
-                //             (y, y),
+                //             (y, y), // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, y)").WithArguments("(string?, string?)", "(string, string?)", "item", "void List<(string, string?)>.Add((string, string?) item)").WithLocation(11, 13));
         }
 


### PR DESCRIPTION
Additional changes to conversion handling in `NullableWalker`. In particular, moved more of the conversion warnings to `ApplyConversion` and added `VisitOptionalConversion` which visits the expression and calls `ApplyConversion`.