### PR TITLE
InteralsVisibleToCompletionProvider: Fix insertion of wrong assembly name if name has dots

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -854,5 +854,50 @@ using System.Reflection;
                 state.AssertMatchesTextStartingAtLine(2, "                                                              ""0000000602000000240000525341310004000"" +")
             End Using
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_OpenEndedStringFollowedByEOF() As Task
+            ' Source https://msdn.microsoft.com/de-de/library/system.runtime.compilerservices.internalsvisibletoattribute(v=vs.110).aspx
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Friend1$$</Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_OpenEndedStringFollowedByNewLines() As Task
+            ' Source https://msdn.microsoft.com/de-de/library/system.runtime.compilerservices.internalsvisibletoattribute(v=vs.110).aspx
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs"><![CDATA[
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Friend1$$
+
+
+]]>
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3")
+                state.AssertMatchesTextStartingAtLine(2, "")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -799,5 +799,25 @@ using System.Reflection;
                 state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3")
             End Using
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_AndPublicKey_OpenEnded() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Company.Asse$$mbly, PublicKey=123
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -819,5 +819,36 @@ using System.Reflection;
                 state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3")
             End Using
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_AndPublicKey_LineBreakExampleFromMSDN() As Task
+            ' Source https://msdn.microsoft.com/de-de/library/system.runtime.compilerservices.internalsvisibletoattribute(v=vs.110).aspx
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("$$Friend1, PublicKey=002400000480000094" +
+                                                              "0000000602000000240000525341310004000" +
+                                                              "001000100bf8c25fcd44838d87e245ab35bf7" +
+                                                              "3ba2615707feea295709559b3de903fb95a93" +
+                                                              "3d2729967c3184a97d7b84c7547cd87e435b5" +
+                                                              "6bdf8621bcb62b59c00c88bd83aa62c4fcdd4" +
+                                                              "712da72eec2533dc00f8529c3a0bbb4103282" +
+                                                              "f0d894d5f34e9f0103c473dce9f4b457a5dee" +
+                                                              "fd8f920d8681ed6dfcb0a81e96bd9b176525a" +
+                                                              "26e0b3")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3"" +")
+                state.AssertMatchesTextStartingAtLine(2, "                                                              ""0000000602000000240000525341310004000"" +")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -760,7 +760,7 @@ using System.Reflection;
             End Using
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WpfFact(Skip:="Escaped double quotes are not supported."), Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
         Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_EscapeSequence_1() As Task
             Using state = TestState.CreateTestStateFromWorkspace(

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -641,6 +641,7 @@ using System.Reflection;
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
         Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_1() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
@@ -660,6 +661,7 @@ using System.Reflection;
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
         Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_2() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
@@ -679,6 +681,7 @@ using System.Reflection;
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
         Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_3() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
@@ -698,6 +701,7 @@ using System.Reflection;
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
         Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_4() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -760,9 +760,13 @@ using System.Reflection;
             End Using
         End Function
 
-        <WpfFact(Skip:="Escaped double quotes are not supported."), Trait(Traits.Feature, Traits.Features.Completion)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
         Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_EscapeSequence_1() As Task
+            ' Escaped double quotes are not handled properly: The selection is expanded from the cursor position until
+            ' a double quote or new line is reached. But because double quotes are not allowed in this context this 
+            ' case is rare enough to ignore. Supporting it would require more complicated code that was reverted in
+            ' https://github.com/dotnet/roslyn/pull/29447/commits/e7a852a7e83fffe1f25a8dee0aaec68f67fcc1d8
             Using state = TestState.CreateTestStateFromWorkspace(
                 <Workspace>
                     <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
@@ -776,7 +780,7 @@ using System.Reflection;
                 Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync()
-                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3"")]")
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""\""Dotted1.Dotted2.Assembly.Dotted3"""")]")
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -639,5 +639,81 @@ using System.Reflection;
                 Await state.AssertNoCompletionSession()
             End Using
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_1() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted.Assembly.Name"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Dotted.Assem$$bly")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted.Assembly.Name")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted.Assembly.Name"")]")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_2() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted.Assembly.Name"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Dotted.Assem$$bly
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted.Assembly.Name")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted.Assembly.Name")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_3() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted.Assembly.Name"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("  Dotted.Assem$$bly  ")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted.Assembly.Name")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted.Assembly.Name"")]")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_4() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Dotted1.Dotted2.Assem$$bly.Dotted")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3"")]")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_InternalsVisibleTo.vb
@@ -719,5 +719,85 @@ using System.Reflection;
                 state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3"")]")
             End Using
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_Verbatim_1() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Dotted1.Dotted2.Assem$$bly.Dotted")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@""Dotted1.Dotted2.Assembly.Dotted3"")]")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_Verbatim_2() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Dotted1.Dotted2.Assem$$bly
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@""Dotted1.Dotted2.Assembly.Dotted3")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_EscapeSequence_1() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("\"Dotted1.Dotted2.Assem$$bly\"")]
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3"")]")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(29447, "https://github.com/dotnet/roslyn/pull/29447")>
+        Public Async Function CodeCompletionReplacesExisitingAssemblyNameWithDots_OpenEnded() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Dotted1.Dotted2.Assembly.Dotted3"/>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="TestAssembly">
+                        <Document FilePath="C.cs">
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Dotted1.Dotted2.Assem$$bly.Dotted4
+                        </Document>
+                    </Project>
+                </Workspace>)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem("Dotted1.Dotted2.Assembly.Dotted3")
+                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
+                state.AssertMatchesTextStartingAtLine(1, "[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""Dotted1.Dotted2.Assembly.Dotted3")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Completion
         private const string NonBreakingSpaceString = "\x00A0";
 
         public static TextSpan GetWordSpan(SourceText text, int position,
-            Func<char, bool> isWordStartCharacter, Func<char, bool> isWordCharacter)
+            Func<char, bool> isWordStartCharacter, Func<char, bool> isWordCharacter, bool alwaysExtendEndSpan = false)
         {
             int start = position;
             while (start > 0 && isWordStartCharacter(text[start - 1]))
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Completion
             // "overwrite" the text. Useful for correcting misspellings or just replacing unwanted
             // code with new code.
             int end = position;
-            if (start != position)
+            if (start != position || alwaysExtendEndSpan)
             {
                 while (end < text.Length && isWordCharacter(text[end]))
                 {

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -247,9 +247,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             if (syntaxFacts.IsStringLiteral(token) || syntaxFacts.IsVerbatimStringLiteral(token))
             {
                 var text = root.GetText();
-                
+
                 // Expand selection in both directions until a double quote or any line break character is reached
-                bool IsWordCharacter(char ch) => !(ch == '"' || ch== '\u0003' ||  ch == '\u000A' || ch == '\u000C' || ch == '\u000D' || ch == '\u2028' || ch == '\u2029');
+                bool IsWordCharacter(char ch) => !(ch == '"' || ch == '\u0003' || ch == '\n' || ch == '\r' || ch == '\u0085' || ch == '\u2028' || ch == '\u2029');
 
                 result = CommonCompletionUtilities.GetWordSpan(
                     text, startSpan.Start, IsWordCharacter, IsWordCharacter, alwaysExtendEndSpan: true);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 var text = root.GetText();
 
                 // Expand selection in both directions until a double quote or any line break character is reached
-                bool IsWordCharacter(char ch) => !(ch == '"' || ch == '\u0003' || ch == '\n' || ch == '\r' || ch == '\u0085' || ch == '\u2028' || ch == '\u2029');
+                bool IsWordCharacter(char ch) => !(ch == '"' || TextUtilities.IsAnyLineBreakCharacter(ch));
 
                 result = CommonCompletionUtilities.GetWordSpan(
                     text, startSpan.Start, IsWordCharacter, IsWordCharacter, alwaysExtendEndSpan: true);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -276,18 +276,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             async Task<int> GetEndOfOpenEndedStringLiteral(int startPosition)
             {
                 var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                var end = startPosition;
-                while (end < text.Length)
-                {
-                    var ch = text[end];
-                    if (char.IsWhiteSpace(ch)) // this includes new line characters
-                    {
-                        break;
-                    }
-                    end++;
-                }
+                var span = CommonCompletionUtilities.GetWordSpan(text, startPosition, ch => false, ch => !char.IsWhiteSpace(ch), alwaysExtendEndSpan: true);
 
-                return end;
+                return span.End;
             }
         }
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 var text = root.GetText();
                 
                 // Expand selection in both directions until a double quote or any line break character is reached
-                bool IsWordCharacter(char ch) => !(ch == '"' || (char.IsControl(ch) || char.IsSeparator(ch) && !char.IsWhiteSpace(ch)));
+                bool IsWordCharacter(char ch) => !(ch == '"' || ch == '\u000A' || ch == '\u000C' || ch == '\u000D' || ch == '\u2028' || ch == '\u2029');
 
                 result = CommonCompletionUtilities.GetWordSpan(
                     text, startSpan.Start, IsWordCharacter, IsWordCharacter, alwaysExtendEndSpan: true);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -85,11 +85,16 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var node = token.Parent;
             if (node != null && syntaxFactsService.IsStringLiteralExpression(node))
             {
-                // Edge case: ElementAccessExpressionSyntax is present if the following statement is another attribute:
+                // Edge cases: 
+                // ElementAccessExpressionSyntax is present if the following statement is another attribute:
                 //   [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("|
                 //   [assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
                 //   [assembly: System.Reflection.AssemblyCompany("Test")]
-                while (syntaxFactsService.IsElementAccessExpression(node.Parent))
+                // BinaryExpression is present if the string literal is concatenated:
+                //   From: https://msdn.microsoft.com/de-de/library/system.runtime.compilerservices.internalsvisibletoattribute(v=vs.110).aspx
+                //   [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Friend1, PublicKey=002400000480000094" + 
+                //                                                                 "0000000602000000240000525341310004000" + ..
+                while (syntaxFactsService.IsElementAccessExpression(node.Parent) || syntaxFactsService.IsBinaryExpression(node.Parent))
                 {
                     node = node.Parent;
                 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 var text = root.GetText();
                 
                 // Expand selection in both directions until a double quote or any line break character is reached
-                bool IsWordCharacter(char ch) => !(ch == '"' || ch == '\u000A' || ch == '\u000C' || ch == '\u000D' || ch == '\u2028' || ch == '\u2029');
+                bool IsWordCharacter(char ch) => !(ch == '"' || ch== '\u0003' ||  ch == '\u000A' || ch == '\u000C' || ch == '\u000D' || ch == '\u2028' || ch == '\u2029');
 
                 result = CommonCompletionUtilities.GetWordSpan(
                     text, startSpan.Start, IsWordCharacter, IsWordCharacter, alwaysExtendEndSpan: true);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     ? contentStartsAt + 1
                     : contentStartsAt;
                 var contentEndsAt = token.Span.Length == 0
-                    ? 0
+                    ? token.Span.End
                     : token.Text[token.Span.Length - 1] == '"'
                         ? token.Span.End - 1
                         : startSpan.End; // The string is open ended. We keep the right end as is.

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -90,6 +90,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.Completion.Tests" Key="$(CompletionTestsKey)" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\Compilers\Core\Portable\Text\TextUtilities.cs" Link="Shared\Utilities\TextUtilities.cs" />
     <Compile Include="..\..\..\Compilers\Shared\DesktopShim.cs">
       <Link>Shared\Utilities\DesktopShim.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes #29446.