### PR TITLE
[backport to 15.9] Object Initializer operations are interpreted as method calls

### DIFF
--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -198,6 +198,30 @@ class Derived : Base
 CodeStyleOptions.QualifyFieldAccess);
         }
 
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyFieldAccess_InObjectInitializer()
+        {
+            await TestAsyncWithOption(
+@"class C
+{
+    int i = 1;
+    void M()
+    {
+        var test = new System.Collections.Generic.List<int> { [|i|] };
+    }
+}",
+@"class C
+{
+    int i = 1;
+    void M()
+    {
+        var test = new System.Collections.Generic.List<int> { this.i };
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
         [WorkItem(7065, "https://github.com/dotnet/roslyn/issues/7065")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
         public async Task QualifyFieldAccess_NotSuggestedOnInstance()
@@ -228,6 +252,22 @@ CodeStyleOptions.QualifyFieldAccess);
     void M()
     {
         [|i|] = 1;
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyFieldAccess_NotSuggestedOnLocalVarInObjectInitializer()
+        {
+            await TestMissingAsyncWithOption(
+@"class C
+{
+    void M()
+    {
+         var foo = 1;
+         var test = new System.Collections.Generic.List<int> { [|foo|] };
     }
 }",
 CodeStyleOptions.QualifyFieldAccess);
@@ -636,6 +676,54 @@ CodeStyleOptions.QualifyMethodAccess);
     void M()
     {
         [|Method|]();
+    }
+}",
+CodeStyleOptions.QualifyMethodAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyMethodAccess_NotSuggestedOnObjectInitializer()
+        {
+            await TestMissingAsyncWithOption(
+@"class C
+{
+    void M()
+    {
+         var foo = 1;
+         var test = new System.Collections.Generic.List<int> { [|foo|] };
+    }
+}",
+CodeStyleOptions.QualifyMethodAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyLocalMethodAccess_NotSuggestedOnObjectInitializer()
+        {
+            await TestMissingAsyncWithOption(
+@"class C
+{
+    void M()
+    {
+        int Local() => 1;
+        var test = new System.Collections.Generic.List<int> { [|Local()|] };
+    }
+}",
+CodeStyleOptions.QualifyMethodAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyLocalMethodAccess_NotSuggestedInMethodCall()
+        {
+            await TestMissingAsyncWithOption(
+@"class C
+{
+    void M()
+    {
+        int Local() => 1;
+        [|Local|]();
     }
 }",
 CodeStyleOptions.QualifyMethodAccess);
@@ -1247,6 +1335,30 @@ CodeStyleOptions.QualifyPropertyAccess);
 {
     public string Foo { get; set; }
     public string Bar { get { return Foo; } => this.Foo; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_InObjectInitializer()
+        {
+            await TestAsyncWithOption(
+@"class C
+{
+    public int Foo { get; set }
+    void M()
+    {
+        var test = new System.Collections.Generic.List<int> { [|Foo|] };
+    }
+}",
+@"class C
+{
+    public int Foo { get; set }
+    void M()
+    {
+        var test = new System.Collections.Generic.List<int> { this.Foo };
+    }
 }",
 CodeStyleOptions.QualifyPropertyAccess);
         }

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -200,7 +200,7 @@ CodeStyleOptions.QualifyFieldAccess);
 
         [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyFieldAccess_InObjectInitializer()
+        public async Task QualifyFieldAccess_InCollectionInitializer()
         {
             await TestAsyncWithOption(
 @"class C
@@ -259,7 +259,7 @@ CodeStyleOptions.QualifyFieldAccess);
 
         [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyFieldAccess_NotSuggestedOnLocalVarInObjectInitializer()
+        public async Task QualifyFieldAccess_NotSuggestedOnLocalVarInCollectionInitializer()
         {
             await TestMissingAsyncWithOption(
 @"class C
@@ -683,7 +683,7 @@ CodeStyleOptions.QualifyMethodAccess);
 
         [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyMethodAccess_NotSuggestedOnObjectInitializer()
+        public async Task QualifyMethodAccess_NotSuggestedOnCollectionInitializer()
         {
             await TestMissingAsyncWithOption(
 @"class C
@@ -699,7 +699,7 @@ CodeStyleOptions.QualifyMethodAccess);
 
         [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyLocalMethodAccess_NotSuggestedOnObjectInitializer()
+        public async Task QualifyLocalMethodAccess_NotSuggestedOnCollectionInitializer()
         {
             await TestMissingAsyncWithOption(
 @"class C
@@ -1341,7 +1341,7 @@ CodeStyleOptions.QualifyPropertyAccess);
 
         [WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyPropertyAccess_InObjectInitializer()
+        public async Task QualifyPropertyAccess_InCollectionInitializer()
         {
             await TestAsyncWithOption(
 @"class C

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -273,6 +273,24 @@ CodeStyleOptions.QualifyFieldAccess);
 CodeStyleOptions.QualifyFieldAccess);
         }
 
+
+        [WorkItem(28091, "https://github.com/dotnet/roslyn/issues/28091")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyFieldAccess_NotSuggestedOnLocalVarInDictionaryInitializer()
+        {
+            await TestMissingAsyncWithOption(
+@"class C
+{
+    void M()
+    {
+         var foo = 1;
+         var test = new System.Collections.Generic.Dictionary<int, int> { { 2, [|foo|] } };
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+
         [WorkItem(7065, "https://github.com/dotnet/roslyn/issues/7065")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
         public async Task QualifyPropertyAccess_LHS()

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -115,6 +115,28 @@ End Class
 CodeStyleOptions.QualifyFieldAccess)
         End Function
 
+        <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function QualifyFieldAccess_InObjectInitializer() As Task
+            Await TestAsyncWithOption("
+Class C
+    Protected i As Integer = 1
+    Sub M()
+        Dim test = New System.Collections.Generic.List(Of Integer) With { [|i|] }
+    End Sub
+End Class
+",
+"
+Class C
+    Protected i As Integer = 1
+    Sub M()
+        Dim test = New System.Collections.Generic.List(Of Integer) With { Me.i }
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
+
         <WorkItem(7065, "https://github.com/dotnet/roslyn/issues/7065")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
         Public Async Function QualifyFieldAccess_NotSuggestedOnInstance() As Task
@@ -144,6 +166,19 @@ CodeStyleOptions.QualifyFieldAccess)
         Public Async Function QualifyFieldAccess_NotSuggestedInModule() As Task
             Await TestMissingAsyncWithOption(
 "Module C : Dim i As Integer : Sub M() : [|i|] = 1 : End Sub : End Module",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
+
+        <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function QualifyFieldAccess_NotSuggestedOnLocalVarInObjectInitializer() As Task
+            Await TestMissingAsyncWithOption(
+"Class C
+    Sub M()
+        Dim i = 1
+        Dim test = New System.Collections.Generic.List(Of Integer) With { [|i|] }
+    End Sub
+End Module",
 CodeStyleOptions.QualifyFieldAccess)
         End Function
 
@@ -214,6 +249,28 @@ Class Derived
     Inherits Base
     Sub M()
         Me.i = 1
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
+
+        <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function QualifyPropertyAccess_InObjectInitializer() As Task
+            Await TestAsyncWithOption("
+Class C
+    Protected Property i As Integer
+    Sub M()
+        Dim test = New System.Collections.Generic.List(Of Integer) With { [|i|] }
+    End Sub
+End Class
+",
+"
+Class C
+    Protected Property i As Integer
+    Sub M()
+        Dim test = New System.Collections.Generic.List(Of Integer) With { Me.i }
     End Sub
 End Class
 ",
@@ -350,6 +407,19 @@ CodeStyleOptions.QualifyMethodAccess)
         Public Async Function QualifyMethodAccess_NotSuggestedOnShared() As Task
             Await TestMissingAsyncWithOption(
 "Class C : Shared Sub Method() : End Sub : Sub M() : [|Method|]() : End Sub : End Class",
+CodeStyleOptions.QualifyMethodAccess)
+        End Function
+
+        <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function QualifyMethodAccess_NotSuggestedOnLocalVarInObjectInitializer() As Task
+            Await TestMissingAsyncWithOption(
+"Class C
+    Sub M()
+        Dim i = 1
+        Dim test = New System.Collections.Generic.List(Of Integer) With { [|i|] }
+    End Sub
+End Module",
 CodeStyleOptions.QualifyMethodAccess)
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -117,7 +117,7 @@ CodeStyleOptions.QualifyFieldAccess)
 
         <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
-        Public Async Function QualifyFieldAccess_InObjectInitializer() As Task
+        Public Async Function QualifyFieldAccess_InCollectionInitializer() As Task
             Await TestAsyncWithOption("
 Class C
     Protected i As Integer = 1
@@ -171,7 +171,7 @@ CodeStyleOptions.QualifyFieldAccess)
 
         <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
-        Public Async Function QualifyFieldAccess_NotSuggestedOnLocalVarInObjectInitializer() As Task
+        Public Async Function QualifyFieldAccess_NotSuggestedOnLocalVarInCollectionInitializer() As Task
             Await TestMissingAsyncWithOption(
 "Class C
     Sub M()
@@ -257,7 +257,7 @@ CodeStyleOptions.QualifyPropertyAccess)
 
         <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
-        Public Async Function QualifyPropertyAccess_InObjectInitializer() As Task
+        Public Async Function QualifyPropertyAccess_InCollectionInitializer() As Task
             Await TestAsyncWithOption("
 Class C
     Protected Property i As Integer
@@ -412,7 +412,7 @@ CodeStyleOptions.QualifyMethodAccess)
 
         <WorkItem(28509, "https://github.com/dotnet/roslyn/issues/28509")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
-        Public Async Function QualifyMethodAccess_NotSuggestedOnLocalVarInObjectInitializer() As Task
+        Public Async Function QualifyMethodAccess_NotSuggestedOnLocalVarInCollectionInitializer() As Task
             Await TestMissingAsyncWithOption(
 "Class C
     Sub M()

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -90,6 +90,14 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                 return;
             }
 
+            // Initializer lists are IInvocationOperation which if passed to GetApplicableOptionFromSymbolKind
+            // will incorrectly fetch the options for method call.
+            // We still want to handle InstanceReferenceKind.ContainingTypeInstance
+            if ((instanceOperation as IInstanceReferenceOperation)?.ReferenceKind == InstanceReferenceKind.ImplicitReceiver)
+            {
+                return;
+            }
+
             // If we can't be qualified (e.g., because we're already qualified with `base.`), we're done.
             if (!CanMemberAccessBeQualified(context.ContainingSymbol, instanceOperation.Syntax))
             {


### PR DESCRIPTION
This change is already in [master](https://github.com/dotnet/roslyn/pull/28929), we want to backport it to 15.9 as it is a very noticeable and annoying regression 

**Customer scenario**
IDE0009 misfires when using dictionary initializer syntax within LINQ expression

**Bugs this fixes**
https://github.com/dotnet/roslyn/issues/28091
https://github.com/dotnet/roslyn/issues/29413  and
https://github.com/dotnet/roslyn/issues/21846#issuecomment-414688446

**Workarounds, if any**
No

**Risk**
Low. 

**Performance impact**
Low. Just add one additional check for operation.ReferenceKind 

**Is this a regression from a previous update?**
Yes

**Root cause analysis**
Issue is introduced when enabling "prefer 'this.' qualifier" on methods.
https://github.com/dotnet/roslyn/commit/d528040f5dfe5c7280ad7e29bed1dd5f82098708

**How was the bug found?**
Customers reported

