### PR TITLE
Fix C# symbols + emit tests

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -534,7 +534,7 @@ static class Program
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnOrderedObjectParamsArgument()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 using System.Reflection;
 
@@ -569,7 +569,7 @@ static class Program
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnObjectParamsArgument()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 using System.Reflection;
 
@@ -604,7 +604,7 @@ static class Program
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnObjectParamsArgument2()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 using System.Reflection;
 
@@ -641,7 +641,7 @@ static class Program
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnObjectParamsArgument3()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 using System.Reflection;
 
@@ -675,9 +675,9 @@ static class Program
 
         [Fact]
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
-        public void TestNamedArgumentOnObjectParamsArgument4()
+        public void CreateCompilation()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 using System.Reflection;
 
@@ -748,7 +748,7 @@ static class Program
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnNonParamsArgument()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 using System.Reflection;
 
@@ -806,7 +806,7 @@ public unsafe partial class A : C, I
 }
 ";
 
-            var source = CreateCompilationWithMscorlib40AndSystemCore(code);
+            var source = CreateCompilation(code);
 
             // the following should not crash
             source.GetDiagnosticsForSyntaxTree(CompilationStage.Compile, source.SyntaxTrees[0], filterSpanWithinTree: null, includeEarlierStages: true);
@@ -1737,7 +1737,7 @@ public class Test
     public int P { get; set; }
 }
 ";
-            var comp = CreateCompilationWithMscorlib40(source);
+            var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (11,13): error CS8138: Cannot reference 'System.Runtime.CompilerServices.TupleElementNamesAttribute' explicitly. Use the tuple syntax to define tuple names.
                 //     [field: System.Runtime.CompilerServices.TupleElementNamesAttribute(new[] { "hello" })]
@@ -3480,7 +3480,7 @@ namespace AttributeTest
         [Fact]
         public void TestAttributeStringForEnumTypedConstant()
         {
-            var source = CreateCompilationWithMscorlib40(@"
+            var source = CreateCompilation(@"
 using System;
 namespace AttributeTest
 {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -25,7 +25,7 @@ class Test {
     static void LogCallerMemberName([CallerMemberName] string memberName = """") { }
 }";
 
-            CreateCompilationWithMscorlib45(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]
@@ -42,7 +42,7 @@ class Test {
     static void LogCallerMemberName([CallerMemberName] string memberName) { }
 }";
 
-            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 // (5,38): error CS4020: The CallerLineNumberAttribute may only be applied to parameters with default values
                 //     static void LogCallerLineNumber([CallerLineNumber] int lineNumber) { }
                 Diagnostic(ErrorCode.ERR_BadCallerLineNumberParamWithoutDefaultValue, @"CallerLineNumber").WithLocation(5, 38),
@@ -173,7 +173,7 @@ line: 77
 line: 78
 line: 79
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, new MetadataReference[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -207,7 +207,7 @@ line: -1
 line: -1
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new MetadataReference[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -251,7 +251,7 @@ line: 25
 line: 26
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -281,7 +281,7 @@ class Test {
     static void LogCallerMemberName5([CallerMemberName] int? memberName = 0) { }
 }";
 
-            CreateCompilationWithMscorlib45(source, references: new MetadataReference[] { SystemRef }).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 Diagnostic(ErrorCode.ERR_NoConversionForCallerLineNumberParam, "CallerLineNumber").WithLocation(5, 39).WithArguments("int", "string"),
                 Diagnostic(ErrorCode.ERR_NoConversionForCallerLineNumberParam, "CallerLineNumber").WithLocation(6, 39).WithArguments("int", "char"),
                 Diagnostic(ErrorCode.ERR_NoConversionForCallerLineNumberParam, "CallerLineNumber").WithLocation(7, 39).WithArguments("int", "bool"),
@@ -342,7 +342,7 @@ message: something happened
 line: 21
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -377,7 +377,7 @@ class Test
 line: -1
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -408,7 +408,7 @@ class Test
 line: 17
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -497,7 +497,7 @@ line: 47
 line: 55
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -528,11 +528,11 @@ class Test
 line: 17
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void TestBadCallerLineNumberMetadata()
         {
             var iLSource = @"
@@ -621,7 +621,7 @@ line:
 ";
 
             MetadataReference libReference = CompileIL(iLSource);
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { libReference }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilationWithMscorlib46(source, new[] { libReference }, TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -647,7 +647,7 @@ partial class D
     }
 }";
 
-            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 Diagnostic(ErrorCode.ERR_DuplicateAttribute, "CallerLineNumber").WithArguments("CallerLineNumber"),
                 Diagnostic(ErrorCode.WRN_CallerLineNumberParamForUnconsumedLocation, "CallerLineNumber").WithArguments("x").WithLocation(11, 23));
         }
@@ -675,7 +675,7 @@ partial class D
     }
 }";
 
-            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 // (12,10): warning CS4024: The CallerLineNumberAttribute applied to parameter 'line' will have no effect because it applies to a member that is used in contexts that do not allow optional arguments
                 //         [CallerLineNumber] int line,
                 Diagnostic(ErrorCode.WRN_CallerLineNumberParamForUnconsumedLocation, "CallerLineNumber").WithArguments("line"),
@@ -716,7 +716,7 @@ line: 16
 line: 18
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -761,7 +761,7 @@ class Test
     public static void Log23([CallerMemberName, CallerLineNumber] int x = 1) { Console.WriteLine(""line: "" + x); }
     public static void Log24([CallerLineNumber, CallerMemberName] int x = 1) { Console.WriteLine(""line: "" + x); }
 }";
-            CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDll.WithWarningLevel(0)).VerifyDiagnostics(
+            CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(0)).VerifyDiagnostics(
                 Diagnostic(ErrorCode.ERR_NoConversionForCallerFilePathParam, "CallerFilePath").WithLocation(7, 48).WithArguments("string", "int"),
                 Diagnostic(ErrorCode.ERR_NoConversionForCallerMemberNameParam, "CallerMemberName").WithLocation(7, 64).WithArguments("string", "int"),
                 Diagnostic(ErrorCode.ERR_NoConversionForCallerMemberNameParam, "CallerMemberName").WithLocation(8, 48).WithArguments("string", "int"),
@@ -824,10 +824,9 @@ C:\file.cs
 C:\file.cs
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[] { Parse(source, @"C:\file.cs") },
-                new[] { SystemRef },
-                TestOptions.ReleaseExe);
+                options: TestOptions.ReleaseExe);
 
             CompileAndVerify(compilation, expectedOutput: expected);
         }
@@ -866,7 +865,7 @@ class Test
 line: 15
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, references: new MetadataReference[] { SystemRef }, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -892,7 +891,7 @@ partial class D
     }
 }";
 
-            var compilation = CreateCompilationWithMscorlib45(source, references: new MetadataReference[] { SystemRef });
+            var compilation = CreateCompilation(source);
             compilation.VerifyDiagnostics(
                 Diagnostic(ErrorCode.WRN_CallerLineNumberParamForUnconsumedLocation, "CallerLineNumber").WithArguments("x").WithLocation(11, 23));
         }
@@ -923,7 +922,7 @@ partial class D
     }
 }";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
 
             compilation.VerifyEmitDiagnostics(
                 // (12,23): warning CS4026: The CallerMemberNameAttribute applied to parameter 'x' will have no effect because it applies to a member that is used in contexts that do not allow optional arguments
@@ -959,7 +958,7 @@ partial class D
     }
 }";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             compilation.VerifyEmitDiagnostics();
             CompileAndVerify(compilation, expectedOutput: "Main");
         }
@@ -1001,7 +1000,7 @@ class Test
 name: LambdaCaller
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, references: new MetadataReference[] { SystemRef }, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1044,7 +1043,7 @@ class Test
 name: LocalFunctionCaller
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, references: new MetadataReference[] { SystemRef }, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1083,7 +1082,7 @@ class Test
 name: op_Increment
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1131,7 +1130,7 @@ name: IsTrue
 name: IsTrue
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1169,7 +1168,7 @@ class Test
 name: MyMethod
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1206,10 +1205,9 @@ class A
 name: Compare
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 source,
-                new[] { SystemRef },
-                TestOptions.ReleaseExe);
+                options: TestOptions.ReleaseExe);
 
             CompileAndVerify(compilation, expectedOutput: expected);
         }
@@ -1267,7 +1265,7 @@ name: Add
 name: HasThing
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1309,7 +1307,7 @@ name: ThingHappened
 name: ThingHappened
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1361,7 +1359,7 @@ name: .ctor
 name: Finalize
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1435,7 +1433,7 @@ name: Item
 name: Item
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, references: new MetadataReference[] { SystemRef }, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1467,7 +1465,7 @@ partial class A
             string source3 = @"partial class A { static void Main3() { Log(); } }";
             string source4 = @"partial class A { static void Main4() { Log(); } }";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[]
                 {
                     SyntaxFactory.ParseSyntaxTree(source1, path: @"C:\filename", encoding: Encoding.UTF8),
@@ -1475,8 +1473,7 @@ partial class A
                     SyntaxFactory.ParseSyntaxTree(source3, path: @"*", encoding: Encoding.UTF8),
                     SyntaxFactory.ParseSyntaxTree(source4, path: @"       ", encoding: Encoding.UTF8),
                 },
-                new[] { SystemRef },
-                TestOptions.ReleaseExe.WithSourceReferenceResolver(SourceFileResolver.Default));
+                options: TestOptions.ReleaseExe.WithSourceReferenceResolver(SourceFileResolver.Default));
 
             CompileAndVerify(compilation, expectedOutput: @"
 1: 'C:\filename'
@@ -1526,7 +1523,7 @@ partial class A { static void Main4() { Log(); } }
 partial class A { static void Main5() { Log(); } }
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[]
                 {
                     SyntaxFactory.ParseSyntaxTree(source1, path: @"C:\filename", encoding: Encoding.UTF8),
@@ -1535,8 +1532,7 @@ partial class A { static void Main5() { Log(); } }
                     SyntaxFactory.ParseSyntaxTree(source4, path: @"C:\x.cs", encoding: Encoding.UTF8),
                     SyntaxFactory.ParseSyntaxTree(source5, path: @"C:\x.cs", encoding: Encoding.UTF8),
                 },
-                new[] { SystemRef },
-                TestOptions.ReleaseExe.WithSourceReferenceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, baseDirectory: @"C:\A\B")));
+                options: TestOptions.ReleaseExe.WithSourceReferenceResolver(new SourceFileResolver(ImmutableArray<string>.Empty, baseDirectory: @"C:\A\B")));
 
             CompileAndVerify(compilation, expectedOutput: @"
 1: 'C:\filename'
@@ -1596,7 +1592,7 @@ member: MyMethod
 member: 
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1640,7 +1636,7 @@ namespace MyNamespace
 member: MyMethod
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, references: new MetadataReference[] { SystemRef }, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1665,12 +1661,12 @@ class Test
 
             var expected = @"";
 
-            var compilation = CreateCompilationWithMscorlib45(source, references: new MetadataReference[] { SystemRef }, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void TestRecursiveAttributeMetadata()
         {
             var iLSource = @"
@@ -1747,12 +1743,11 @@ class Driver
 
             var expected = @"Bar";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
-
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void TestDuplicateCallerInfoMetadata()
         {
             var iLSource = @"
@@ -1898,7 +1893,7 @@ class Driver
 
             var expected = @"13";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -1949,7 +1944,7 @@ a.LineNumber, a.MemberName ?? ""<null>"");
 CallerInfoAttributed: (, 22, Property1)
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2019,7 +2014,7 @@ Item
 MyMethod
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2052,7 +2047,7 @@ class Program
 13
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2091,7 +2086,7 @@ class Program
 }
 ";
 
-            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 // (21,2): error CS0181: Attribute constructor parameter 'lineNumber' has type 'int?', which is not a valid attribute parameter type
                 // [LineNumber2NullableInt, LineNumber2ValueType]
                 Diagnostic(ErrorCode.ERR_BadAttributeParamType, "LineNumber2NullableInt").WithArguments("lineNumber", "int?"),
@@ -2137,7 +2132,7 @@ class Test
 19
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2167,7 +2162,7 @@ class Test
 }
 ";
 
-            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 // (13,2): error CS0181: Attribute constructor parameter 'lineNumber' has type 'decimal', which is not a valid attribute parameter type
                 // [LineNumber2DecimalAttribute]
                 Diagnostic(ErrorCode.ERR_BadAttributeParamType, "LineNumber2DecimalAttribute").WithArguments("lineNumber", "decimal"));
@@ -2256,7 +2251,7 @@ class Test
 61
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2295,7 +2290,7 @@ class Test
 }
 ";
 
-            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 // (19,38): error CS4017: CallerLineNumberAttribute cannot be applied because there are no standard conversions from type 'int' to type 'Test'
                 //     public bool M1(string expected, [CallerLineNumber] Test line = null)
                 Diagnostic(ErrorCode.ERR_NoConversionForCallerLineNumberParam, "CallerLineNumber").WithArguments("int", "Test"),
@@ -2402,10 +2397,9 @@ query line : 66
 query path : C:\filename
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[] { SyntaxFactory.ParseSyntaxTree(source, path: @"C:\filename", encoding: Encoding.UTF8) },
-                new[] { SystemCoreRef },
-                TestOptions.ReleaseExe);
+                options: TestOptions.ReleaseExe);
 
             CompileAndVerify(compilation, expectedOutput: expected);
         }
@@ -2453,7 +2447,7 @@ C:\filename
 25
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[] { SyntaxFactory.ParseSyntaxTree(source, path: @"C:\filename", encoding: Encoding.UTF8) },
                 options: TestOptions.ReleaseExe);
 
@@ -2524,7 +2518,7 @@ class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(new SyntaxTree[] { SyntaxFactory.ParseSyntaxTree(source, path: @"C:\filename") }).VerifyDiagnostics(
+            var compilation = CreateCompilation(new SyntaxTree[] { SyntaxFactory.ParseSyntaxTree(source, path: @"C:\filename") }).VerifyDiagnostics(
                 // C:\filename(7,38): error CS4018: CallerFilePathAttribute cannot be applied because there are no standard conversions from type 'string' to type 'int'
                 //     static void M1([CallerLineNumber,CallerFilePath,CallerMemberName] int i = 0) { Console.WriteLine(); }
                 Diagnostic(ErrorCode.ERR_NoConversionForCallerFilePathParam, "CallerFilePath").WithArguments("string", "int"),
@@ -2613,7 +2607,7 @@ class Test
 }";
 
             string expected = @"PASS";
-            var compilation = CreateCompilationWithMscorlib45(source, new MetadataReference[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2649,7 +2643,7 @@ public class Goo
 
             string expected = @"F1
 F2";
-            var compilation = CreateCompilationWithMscorlib45(source, new MetadataReference[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2685,7 +2679,7 @@ public class Goo
 
             string expected = @"F1
 F2";
-            var compilation = CreateCompilationWithMscorlib45(source, new MetadataReference[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2724,7 +2718,7 @@ public class Goo : I1
 ";
 
             string expected = @"F2";
-            var compilation = CreateCompilationWithMscorlib45(source, new MetadataReference[] { SystemRef }, TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2783,10 +2777,9 @@ C:\filename
 Caller file path: C:\filename
 C:\filename";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[] { SyntaxFactory.ParseSyntaxTree(source, path: @"C:\filename", encoding: Encoding.UTF8) },
-                new[] { SystemCoreRef },
-                TestOptions.ReleaseExe);
+                options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
@@ -2843,15 +2836,14 @@ static class E
 Main
 21";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[] { SyntaxFactory.ParseSyntaxTree(source, path: @"C:\filename", encoding: Encoding.UTF8) },
-                new[] { SystemCoreRef },
-                TestOptions.ReleaseExe);
+                options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
         [WorkItem(1006447, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1006447")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void Bug1006447_1()
         {
             const string vbSource =
@@ -2898,7 +2890,7 @@ class C
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilationWithMscorlib46(
                 new[] { SyntaxFactory.ParseSyntaxTree(csSource, path: @"C:\filename", encoding: Encoding.UTF8) },
                 new[] { SystemCoreRef, vbReference },
                 TestOptions.ReleaseExe);
@@ -2937,15 +2929,14 @@ class C
 
             const string expected = "Main";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 source,
-                new[] { SystemCoreRef },
-                TestOptions.ReleaseExe);
+                options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: expected);
         }
 
         [WorkItem(1006447, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1006447")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void Bug1006447_3()
         {
             const string vbSource =

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -15,16 +15,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
     public class CodeGenAsyncEHTests : EmitMetadataTestBase
     {
-        private static readonly MetadataReference[] s_asyncRefs = new[] { MscorlibRef_v4_0_30316_17626, SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929 };
-
         public CodeGenAsyncEHTests()
         {
         }
 
-        private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null)
+        private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, CSharpCompilationOptions options = null)
         {
-            references = (references != null) ? references.Concat(s_asyncRefs) : s_asyncRefs;
-            return base.CompileAndVerify(source, targetFramework: TargetFramework.Empty, expectedOutput: expectedOutput, references: references, options: options);
+            return base.CompileAndVerify(source, expectedOutput: expectedOutput, options: options);
         }
 
         [Fact]
@@ -936,7 +933,7 @@ class Test
             var expected = @"
 2
 ";
-            var v = CompileAndVerify(source, s_asyncRefs, targetFramework: TargetFramework.Empty, options: TestOptions.DebugExe.WithMetadataImportOptions(MetadataImportOptions.All), expectedOutput: expected, symbolValidator: module =>
+            var v = CompileAndVerify(source, options: TestOptions.DebugExe.WithMetadataImportOptions(MetadataImportOptions.All), expectedOutput: expected, symbolValidator: module =>
             {
                 Assert.Equal(new[]
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -15,16 +15,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
     public class CodeGenAsyncLocalsTests : EmitMetadataTestBase
     {
-        private static readonly MetadataReference[] s_asyncRefs = new[] { MscorlibRef_v4_0_30316_17626, SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929 };
-
         public CodeGenAsyncLocalsTests()
         {
         }
 
-        private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null, Verification verify = Verification.Passes)
+        private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, CSharpCompilationOptions options = null, Verification verify = Verification.Passes)
         {
-            references = (references != null) ? references.Concat(s_asyncRefs) : s_asyncRefs;
-            return base.CompileAndVerify(source, targetFramework: TargetFramework.Empty, expectedOutput: expectedOutput, references: references, options: options, verify: verify);
+            return base.CompileAndVerify(source, expectedOutput: expectedOutput, options: options, verify: verify);
         }
 
         private string GetFieldLoadsAndStores(CompilationVerifier c, string qualifiedMethodName)
@@ -1239,7 +1236,7 @@ public class C
         var b8 = await Task.FromResult(default(Tuple<long, long, long>));
     }
 }";
-            CompileAndVerify(source, targetFramework: TargetFramework.Empty, references: s_asyncRefs, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All), symbolValidator: module =>
+            CompileAndVerify(source, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All), symbolValidator: module =>
             {
                 AssertEx.Equal(new[]
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Xunit;
 using System.Threading;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
@@ -357,7 +358,7 @@ namespace System {
 namespace System.Threading.Tasks {
     public class Task<T>{}
 }";
-            var taskCompilation = CreateCompilationWithMscorlib45(taskAssembly, options: TestOptions.DebugDll);
+            var taskCompilation = CreateCompilation(taskAssembly, options: TestOptions.DebugDll);
             taskCompilation.VerifyDiagnostics();
 
             var source = @"
@@ -397,7 +398,7 @@ namespace System {
 namespace System.Threading.Tasks {
     public class Task{}
 }";
-            var taskCompilation = CreateCompilationWithMscorlib45(taskAssembly, options: TestOptions.DebugDll);
+            var taskCompilation = CreateCompilation(taskAssembly, options: TestOptions.DebugDll);
             taskCompilation.VerifyDiagnostics();
 
             var source = @"
@@ -437,7 +438,7 @@ class Program {
         Console.Write(""async main"");
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             var verifier = CompileAndVerify(c, expectedOutput: "hello async main", expectedReturnCode: 0);
         }
 
@@ -455,7 +456,7 @@ class Program {
         Console.WriteLine(""async main"");
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             c.VerifyEmitDiagnostics(
                 // (6,28): error CS0161: 'Program.Main()': not all code paths return a value
                 //     static async Task<int> Main() {
@@ -478,7 +479,7 @@ class Program {
         return 10;
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             var verifier = CompileAndVerify(c, expectedOutput: "hello async main", expectedReturnCode: 10);
         }
 
@@ -497,7 +498,7 @@ class Program {
         return 10;
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             var verifier = CompileAndVerify(c, expectedOutput: "hello async main", expectedReturnCode: 10);
         }
 
@@ -515,7 +516,7 @@ class Program {
         Console.Write(""async main"");
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             var verifier = CompileAndVerify(c, expectedOutput: "hello async main", expectedReturnCode: 0);
         }
 
@@ -533,7 +534,7 @@ class Program {
         Console.WriteLine(""async main"");
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             c.VerifyEmitDiagnostics(
                 // (6,28): error CS0161: 'Program.Main()': not all code paths return a value
                 //     static async Task<int> Main() {
@@ -555,7 +556,7 @@ class Program {
         return 10;
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             var verifier = CompileAndVerify(c, expectedOutput: "hello async main", expectedReturnCode: 10, args: new string[] { "async main" });
         }
 
@@ -573,7 +574,7 @@ class Program {
         Console.Write(args[0]);
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             var verifier = CompileAndVerify(c, expectedOutput: "hello async main", expectedReturnCode: 0, args: new string[] { "async main" });
         }
 
@@ -590,7 +591,7 @@ class A
         await Task.Factory.StartNew(() => { });
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics();
             var entry = compilation.GetEntryPoint(CancellationToken.None);
             Assert.NotNull(entry);
@@ -612,7 +613,7 @@ class A
         return Task.Factory.StartNew(() => { });
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics();
             var entry = compilation.GetEntryPoint(CancellationToken.None);
             Assert.NotNull(entry);
@@ -635,7 +636,7 @@ class A
         throw new System.Exception();
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics(
                 // (6,21): warning CS0028: 'A.Main(string[])' has the wrong signature to be an entry point
                 //     static ref Task Main(string[] args)
@@ -657,7 +658,7 @@ class A
         await Task.Factory.StartNew(() => { });
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
             compilation.VerifyDiagnostics(
                 // (6,18): error CS8107: Feature 'async main' is not available in C# 7.0. Please use language version 7.1 or greater.
                 //     async static Task Main(string[] args)
@@ -680,7 +681,7 @@ class A
         return Task.Factory.StartNew(() => { });
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
             compilation.VerifyDiagnostics(
                 // (6,18): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                 //     async static Task Main(string[] args)
@@ -702,7 +703,7 @@ class A
         await Task.Factory.StartNew(() => { });
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics();
             var entry = compilation.GetEntryPoint(CancellationToken.None);
             Assert.NotNull(entry);
@@ -721,7 +722,7 @@ class A
         return Task.Factory.StartNew(() => { });
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics();
             var entry = compilation.GetEntryPoint(CancellationToken.None);
             Assert.NotNull(entry);
@@ -741,7 +742,7 @@ class A
         await Task.Factory.StartNew(() => { });
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
             compilation.VerifyDiagnostics(
                 // (6,23): error CS9003: Async Main methods must return Task or Task<int>
                 //     async static void Main()
@@ -763,7 +764,7 @@ class A
         return await Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics(
                 // (6,22): error CS1983: The return type of an async method must be void, Task or Task<T>
                 //     async static int Main()
@@ -790,7 +791,7 @@ class A
         return await Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
             compilation.VerifyDiagnostics(
                 // (6,22): error CS1983: The return type of an async method must be void, Task or Task<T>
                 //     async static int Main()
@@ -815,7 +816,7 @@ class A
         return await Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics();
             var entry = compilation.GetEntryPoint(CancellationToken.None);
             Assert.NotNull(entry);
@@ -835,7 +836,7 @@ class A
         return Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics();
             var entry = compilation.GetEntryPoint(CancellationToken.None);
             Assert.NotNull(entry);
@@ -855,7 +856,7 @@ class A
         return await Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
             compilation.VerifyDiagnostics(
                 // (6,18): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                 //     async static Task<int> Main(string[] args)
@@ -877,7 +878,7 @@ class A
         return Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
             compilation.VerifyDiagnostics(
                 // (6,18): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                 //     async static Task<int> Main(string[] args)
@@ -899,7 +900,7 @@ class A
         return await Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics();
             var entry = compilation.GetEntryPoint(CancellationToken.None);
             Assert.NotNull(entry);
@@ -919,7 +920,7 @@ class A
         return Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics();
             var entry = compilation.GetEntryPoint(CancellationToken.None);
             Assert.NotNull(entry);
@@ -939,7 +940,7 @@ class A
         return await Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
             compilation.VerifyDiagnostics(
                 // (6,18): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                 //     async static Task<int> Main()
@@ -961,7 +962,7 @@ class A
         return Task.Factory.StartNew(() => 5);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
             compilation.VerifyDiagnostics(
                 // (6,18): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                 //     async static Task<int> Main()
@@ -984,7 +985,7 @@ class A
         return 0;
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
             compilation.VerifyDiagnostics(
                 // (6,30): warning CS0028: 'A.Main()' has the wrong signature to be an entry point
                 //     async static Task<float> Main()
@@ -1006,7 +1007,7 @@ class A
         await Task.Factory.StartNew(() => { });
     }
 }";
-            CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
+            CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
                 // (6,23): warning CS0402: 'A.Main<T>()': an entry point cannot be generic or in a generic type
                 //     async static void Main<T>()
                 Diagnostic(ErrorCode.WRN_MainCantBeGeneric, "Main").WithArguments("A.Main<T>()").WithLocation(6, 23),
@@ -1027,7 +1028,7 @@ class A
         await Task.Factory.StartNew(() => { });
     }
 }";
-            CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+            CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
                 // (6,23): warning CS0028: 'A.Main(bool)' has the wrong signature to be an entry point
                 //     async static void Main(bool truth)
                 Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("A.Main(bool)").WithLocation(6, 23),
@@ -1048,7 +1049,7 @@ class A
         await Task.Factory.StartNew(() => { });
     }
 }";
-            CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+            CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
                 // (6,23): warning CS0028: 'A.Main<T>(bool)' has the wrong signature to be an entry point
                 //     async static void Main<T>(bool truth)
                 Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("A.Main<T>(bool)").WithLocation(6, 23),
@@ -1074,7 +1075,7 @@ class A
         System.Console.WriteLine(""Task Main"");
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7)).VerifyDiagnostics();
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7)).VerifyDiagnostics();
             CompileAndVerify(compilation, expectedOutput: "Non Task Main", expectedReturnCode: 0);
         }
 
@@ -1096,7 +1097,7 @@ class A
         System.Console.WriteLine(""Task Main"");
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics();
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics();
             CompileAndVerify(compilation, expectedOutput: "Non Task Main", expectedReturnCode: 0);
         }
 
@@ -1120,7 +1121,7 @@ class A
         return 1;
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
                 // (11,22): error CS1983: The return type of an async method must be void, Task or Task<T>
                 //     async static int Main()
                 Diagnostic(ErrorCode.ERR_BadAsyncReturn, "Main").WithLocation(11, 22),
@@ -1148,7 +1149,7 @@ class A
         System.Console.WriteLine(""Async Void Main"");
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
                 // (6,23): error CS4009: A void or int returning entry point cannot be async
                 //     static async void Main(string[] args)
                 Diagnostic(ErrorCode.ERR_NonTaskMainCantBeAsync, "Main").WithArguments("A.Main(string[])").WithLocation(6, 23),
@@ -1174,7 +1175,7 @@ class A
         System.Console.WriteLine(""Task Main"");
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithMainTypeName("A")).VerifyDiagnostics();
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe.WithMainTypeName("A")).VerifyDiagnostics();
             CompileAndVerify(compilation, expectedOutput: "Non Task Main", expectedReturnCode: 0);
         }
 
@@ -1198,7 +1199,7 @@ class A
         return 0.0F;
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7)).VerifyDiagnostics(
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7)).VerifyDiagnostics(
                 // (6,28): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     async static Task<int> Main()
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "Main").WithLocation(6, 28),
@@ -1235,7 +1236,7 @@ class A
         return Task.FromResult(0.0F);
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7)).VerifyDiagnostics(
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7)).VerifyDiagnostics(
                 // (6,12): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                 //     static Task<int> Main()
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "Task<int>").WithArguments("async main", "7.1").WithLocation(6, 12),
@@ -1266,7 +1267,7 @@ class A
         return 0.0f;
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
                 // (10,30): warning CS0028: 'A.Main(string[])' has the wrong signature to be an entry point
                 //     async static Task<float> Main(string[] args)
                 Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("A.Main(string[])").WithLocation(11, 30));
@@ -1293,11 +1294,11 @@ class A
         return 0.0f;
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithMainTypeName("A")).VerifyDiagnostics();
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe.WithMainTypeName("A")).VerifyDiagnostics();
             CompileAndVerify(compilation, expectedOutput: "Non Task Main", expectedReturnCode: 0);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void ImplementGetAwaiterGetResultViaExtensionMethods()
         {
             var source = @"
@@ -1350,7 +1351,7 @@ static class Program {
             CompileAndVerify(sourceCompilation, expectedOutput: "GetAwaiter called | GetResult called");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void ImplementGetAwaiterGetResultViaExtensionMethods_Obsolete()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     [CompilerTrait(CompilerFeature.Tuples)]
     public class CodeGenDeconstructTests : CSharpTestBase
     {
-        private static readonly MetadataReference[] s_valueTupleRefs = new[] { SystemRuntimeFacadeRef, ValueTupleRef };
-
         const string commonSource =
 @"public class Pair<T1, T2>
 {
@@ -101,7 +99,7 @@ class C
                 Assert.Equal(ConversionKind.Identity, model.GetConversion(right).Kind);
             };
 
-            var comp = CompileAndVerifyWithMscorlib40(source, expectedOutput: "1 hello", references: s_valueTupleRefs, sourceSymbolValidator: validator);
+            var comp = CompileAndVerify(source, expectedOutput: "1 hello", sourceSymbolValidator: validator);
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
@@ -1268,7 +1266,7 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         [WorkItem(18629, "https://github.com/dotnet/roslyn/issues/18629")]
         public void ValueTupleNotRequiredIfReturnIsNotUsed()
         {
@@ -2019,7 +2017,7 @@ class Program
 this.set(2)
 ";
 
-            var comp = CreateCompilationWithILAndMscorlib40(source, ilSource, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithIL(source, ilSource, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
         }
 
@@ -4772,7 +4770,7 @@ System.Console.Write($""{x} {y}"");
                 Assert.Equal("alias=System.Int32", model.GetAliasInfo(yType).ToTestDisplayString());
             };
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42", sourceSymbolValidator: validator);
@@ -4843,7 +4841,7 @@ System.Console.Write($""{x} {y}"");
 @"
 (string x, int y) = (""hello"", 42);
 ";
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Regular, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics(
                 // (2,19): error CS1022: Type or namespace definition, or end-of-file expected
@@ -4871,7 +4869,7 @@ System.Console.Write($""{x} {y}"");
 (string x, (int y, int z)) = (""hello"", (42, 43));
 System.Console.Write($""{x} {y} {z}"");
 ";
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42 43");
@@ -4885,7 +4883,7 @@ System.Console.Write($""{x} {y} {z}"");
 (var x, var y) = (""hello"", 42);
 System.Console.Write($""{x} {y}"");
 ";
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42");
@@ -4931,7 +4929,7 @@ System.Console.Write($""{x1} {x2} {x3}"");
                 Assert.Null(model.GetSymbolInfo(x23Var.Type).Symbol); // The var in `var (x2, x3)` has no symbol
             };
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42 43", sourceSymbolValidator: validator);
@@ -4946,7 +4944,7 @@ System.Console.Write($""{x1} {x2} {x3}"");
 var (x2, x3) = M(out var x1);
 System.Console.Write($""{x1} {x2} {x3}"");
 ";
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "1 2 3");
@@ -5055,7 +5053,7 @@ foreach ((string x1, var (x2, x3)) in new[] { (""hello"", (42, ""world"")) })
                 Assert.Equal(SymbolKind.Local, x2Symbol.Kind);
             };
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42 world", sourceSymbolValidator: validator);
@@ -5091,7 +5089,7 @@ for ((string x1, var (x2, x3)) = (""hello"", (42, ""world"")); ; )
                 Assert.Equal(SymbolKind.Local, x2Symbol.Kind);
             };
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42 world", sourceSymbolValidator: validator);
@@ -5105,7 +5103,7 @@ for ((string x1, var (x2, x3)) = (""hello"", (42, ""world"")); ; )
 var (x, y) = (1, 2);
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp6), options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp6), options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics(
                 // (2,5): error CS8059: Feature 'tuples' is not available in C# 6. Please use language version 7.0 or greater.
@@ -5125,7 +5123,7 @@ var (x, y) = (1, 2);
 int (x, y) = (1, 2);
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (2,5): error CS8136: Deconstruction 'var (...)' form disallows a specific type for 'var'.
                 // int (x, y) = (1, 2);
@@ -5159,7 +5157,7 @@ int (x, y) = (1, 2);
 (int (x, y), int z) = ((1, 2), 3);
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (2,6): error CS8136: Deconstruction 'var (...)' form disallows a specific type for 'var'.
                 // (int (x, y), int z) = ((1, 2), 3);
@@ -5195,7 +5193,7 @@ var (x1, x2) = (1, 2);
 System.Console.Write(x1);
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (3,6): error CS0102: The type 'Script' already contains a definition for 'x1'
                 // var (x1, x2) = (1, 2);
@@ -5230,7 +5228,7 @@ var (x, y) = (1, 2);
 var (z, y) = (1, 2);
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (3,9): error CS0102: The type 'Script' already contains a definition for 'y'
                 // var (z, y) = (1, 2);
@@ -5261,7 +5259,7 @@ var (z, y) = (1, 2);
 var (x, (y, x)) = (1, (2, ""hello""));
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (2,13): error CS0102: The type 'Script' already contains a definition for 'x'
                 // var (x, (y, x)) = (1, (2, "hello"));
@@ -5293,7 +5291,7 @@ System.Console.Write(x);
 var (x, y) = (1, 2);
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "0");
 
@@ -5318,7 +5316,7 @@ var (x, y) = (1, 2);
 var (x, y) = (1, null);
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.GetDeclarationDiagnostics().Verify(
                 // (2,6): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x'.
                 // var (x, y) = (1, null);
@@ -5366,7 +5364,7 @@ var (x, y) = (1, null);
 var (x1, x2) = (x2, x1);
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.GetDeclarationDiagnostics().Verify(
                 // (2,10): error CS7019: Type of 'x2' cannot be inferred since its initializer directly or indirectly refers to the definition.
                 // var (x1, x2) = (x2, x1);
@@ -5407,7 +5405,7 @@ var (x1, x2) = (y1, y2);
 var (y1, y2) = (x1, x2);
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.GetDeclarationDiagnostics().Verify(
                 // (3,6): error CS7019: Type of 'y1' cannot be inferred since its initializer directly or indirectly refers to the definition.
                 // var (y1, y2) = (x1, x2);
@@ -5452,7 +5450,7 @@ var (x1, (x2, x3)) = (1, (2, 3));
 System.Console.Write($""{x1} {x2} {x3}"");
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (3,5): error CS8136: Deconstruction 'var (...)' form disallows a specific type for 'var'.
                 // var (x1, (x2, x3)) = (1, (2, 3));
@@ -5494,7 +5492,7 @@ var (x1, (x2, x3)) = (1, (2, 3));
 System.Console.Write($""{x1} {x2} {x3}"");
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (6,5): error CS8136: Deconstruction 'var (...)' form disallows a specific type for 'var'.
                 // var (x1, (x2, x3)) = (1, (2, 3));
@@ -5533,7 +5531,7 @@ using var = System.Byte;
 System.Console.Write($""{x1} {x2} {x3}"");
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "1 2 3");
 
@@ -5583,7 +5581,7 @@ class var
 System.Console.Write($""{x1} {x2} {x3}"");
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "var var var");
 
@@ -6399,7 +6397,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
                 // (6,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
                 //         System.Threading.Tasks.Task.Delay(new System.TimeSpan(0));
@@ -6588,7 +6586,7 @@ using alias = System.Int32;
                 Assert.Equal("(System.String, System.Int32)", model.GetTypeInfo(tuple).Type.ToTestDisplayString());
             };
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, sourceSymbolValidator: validator);
@@ -6608,7 +6606,7 @@ public class C
 ";
 
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "ctor");
@@ -6623,7 +6621,7 @@ int M() { System.Console.Write(""M""); return 1; }
 _ = M();
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "M");
         }
@@ -6658,7 +6656,7 @@ System.Console.Write($""{x3}"");
                 Assert.Null(model.GetSymbolInfo(tuple).Symbol);
             };
 
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "43", sourceSymbolValidator: validator);
@@ -7369,7 +7367,7 @@ Handler");
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         [WorkItem(16962, "https://github.com/dotnet/roslyn/issues/16962")]
         public void Events_03()
         {
@@ -7416,7 +7414,7 @@ Handler", references: WinRtRefs.Concat(new[] { ValueTupleRef, comp1.ToMetadataRe
             Assert.True(comp2.Compilation.GetMember<EventSymbol>("C.E").IsWindowsRuntimeEvent);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         [WorkItem(16962, "https://github.com/dotnet/roslyn/issues/16962")]
         public void Events_04()
         {
@@ -7712,7 +7710,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugExe);
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "3");
         }
@@ -7733,7 +7731,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
                 // (8,11): warning CS1717: Assignment made to same variable; did you mean to assign something else?
                 //         ((x, x), this.x, C.y) = ((x, (1, 2)), x, y);
@@ -7764,7 +7762,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
                 // (9,10): warning CS1717: Assignment made to same variable; did you mean to assign something else?
                 //         (x, (y, z)) = (x, (y, z));
@@ -7799,7 +7797,7 @@ class D
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
                 // (8,10): warning CS1717: Assignment made to same variable; did you mean to assign something else?
                 //         (x, y) = (x, (C)(D)y);
@@ -7829,7 +7827,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
                 // (14,14): warning CS1717: Assignment made to same variable; did you mean to assign something else?
                 //         (_, (x, y)) = (1, (x, b));
@@ -7858,7 +7856,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
                 );
 
@@ -7914,7 +7912,7 @@ static class Extensions
     }
 }";
 
-            var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
                 // (9,10): warning CS1717: Assignment made to same variable; did you mean to assign something else?
                 //         (x, (y, z)) = (x, y);
@@ -7937,7 +7935,7 @@ class C
     }
 }";
 
-            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll); // no ValueTuple reference
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll); // no ValueTuple reference
             comp.VerifyDiagnostics(
                 // (4,5): error CS0246: The type or namespace name 'Error' could not be found (are you missing a using directive or an assembly reference?)
                 //     Error M()
@@ -7949,10 +7947,10 @@ class C
         public void TestDeconstructOnErrorTypeFromImageReference()
         {
             var missing_cs = "public class Missing { }";
-            var missing  = CreateCompilationWithMscorlib45(missing_cs, options: TestOptions.DebugDll, assemblyName: "missing");
+            var missing  = CreateCompilation(missing_cs, options: TestOptions.DebugDll, assemblyName: "missing");
 
             var lib_cs = "public class C { public Missing M() { throw null; } }";
-            var lib = CreateCompilationWithMscorlib45(lib_cs, references: new[] { missing.EmitToImageReference() }, options: TestOptions.DebugDll);
+            var lib = CreateCompilation(lib_cs, references: new[] { missing.EmitToImageReference() }, options: TestOptions.DebugDll);
 
             var source =
 @"
@@ -7966,7 +7964,7 @@ class D
     }
 }";
 
-            var comp = CreateCompilationWithMscorlib45(source, references: new[] { lib.EmitToImageReference() }, options: TestOptions.DebugDll); // no ValueTuple reference
+            var comp = CreateCompilation(source, references: new[] { lib.EmitToImageReference() }, options: TestOptions.DebugDll); // no ValueTuple reference
             comp.VerifyDiagnostics(
                 // (7,18): error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         (x, y) = new C().M();
@@ -7978,10 +7976,10 @@ class D
         public void TestDeconstructOnErrorTypeFromCompilationReference()
         {
             var missing_cs = "public class Missing { }";
-            var missing = CreateCompilationWithMscorlib45(missing_cs, options: TestOptions.DebugDll, assemblyName: "missing");
+            var missing = CreateCompilation(missing_cs, options: TestOptions.DebugDll, assemblyName: "missing");
 
             var lib_cs = "public class C { public Missing M() { throw null; } }";
-            var lib = CreateCompilationWithMscorlib45(lib_cs, references: new[] { missing.ToMetadataReference() }, options: TestOptions.DebugDll);
+            var lib = CreateCompilation(lib_cs, references: new[] { missing.ToMetadataReference() }, options: TestOptions.DebugDll);
 
             var source =
 @"
@@ -7995,7 +7993,7 @@ class D
     }
 }";
 
-            var comp = CreateCompilationWithMscorlib45(source, references: new[] { lib.ToMetadataReference() }, options: TestOptions.DebugDll); // no ValueTuple reference
+            var comp = CreateCompilation(source, references: new[] { lib.ToMetadataReference() }, options: TestOptions.DebugDll); // no ValueTuple reference
             comp.VerifyDiagnostics(
                 // (7,18): error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         (x, y) = new C().M();

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -13991,7 +13991,7 @@ class C
     }
 }
 ";
-            var comp = CompileAndVerifyWithMscorlib40(source, expectedOutput: "hello!", references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: "hello!");
             comp.VerifyDiagnostics();
             // No runtime failure (System.ArrayTypeMismatchException: Attempted to access an element as a type incompatible with the array.)
             // because of the special handling for dynamic in LocalRewriter.TransformCompoundAssignmentLHS
@@ -15419,7 +15419,7 @@ class C
         public int Length = 123;
     }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "321 123", references: new[] { CSharpRef });
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: "321 123");
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -2341,7 +2341,7 @@ unsafe public class Test
         }
 
         [WorkItem(544246, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544246")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void MethodCallWithParams()
         {
             var text =
@@ -3416,7 +3416,7 @@ class C
         }
 
         [WorkItem(544429, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544429")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void ExtraConversionInDelegateCreation()
         {
             string source = @"using System;
@@ -3443,7 +3443,7 @@ class Program
 }";
             string expectedOutput = @"Convert(Call(null.[System.Delegate CreateDelegate(System.Type, System.Object, System.Reflection.MethodInfo)](Constant(Del Type:System.Type), Parameter(tc1 Type:TestClass1), Constant(Int32 Func1(System.String) Type:System.Reflection.MethodInfo)) Type:System.Delegate) Type:Del)";
 
-            var comp = CreateEmptyCompilation(
+            var comp = CreateCompilation(
                 new[] { source, ExpressionTestLibrary },
                 new[] { MscorlibRef, SystemCoreRef },
                 TestOptions.ReleaseExe);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFieldInitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFieldInitTests.cs
@@ -644,7 +644,7 @@ a.a = 1
                 expectedOutput.AppendLine(i.ToString());
             }
 
-            var compilation = CreateCompilationWithMscorlib45(trees, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(trees, options: TestOptions.ReleaseExe);
 
             CompileAndVerify(compilation, expectedOutput: expectedOutput.ToString());
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenImplicitlyTypeArraysTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenImplicitlyTypeArraysTests.cs
@@ -252,7 +252,7 @@ namespace Test
                 expectedOutput: "True");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void Test_007B()
         {
             // Implicit reference conversions -- From a one-dimensional array-type S[] to System.Collections.Generic.IReadOnlyList<S>.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -802,7 +802,7 @@ class Program
 
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Passes, expectedOutput: @"6");
         }
 
@@ -844,7 +844,7 @@ class Program
 
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             comp.VerifyEmitDiagnostics(
                 // (14,44): error CS8178: 'await' cannot be used in an expression containing a call to 'Program.RefReturning(ref int)' because it returns by reference
                 //             M1(in RefReturning(ref local), await GetT(2), 3);
@@ -896,7 +896,7 @@ class Program
 
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.UnsafeReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.UnsafeReleaseExe);
             var result = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"47");
 
             var expectedIL = @"
@@ -982,7 +982,7 @@ class Program
 
             result.VerifyIL("Program.<Test>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", expectedIL);
 
-            comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CreateCompilation(text, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
             result = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"47");
 
             result.VerifyIL("Program.<Test>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", expectedIL);
@@ -1021,7 +1021,7 @@ class Program
 
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Passes, expectedOutput: @"6");
         }
 
@@ -1081,7 +1081,7 @@ public struct S1
 
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 3
 42
@@ -1149,7 +1149,7 @@ public struct S1
 
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 3
 42
@@ -1212,7 +1212,7 @@ public struct S1
 
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 2
 42
@@ -1269,7 +1269,7 @@ public class S1
 
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 2
 42
@@ -1329,7 +1329,7 @@ public struct S1
 
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 2
 42
@@ -1408,7 +1408,7 @@ public readonly struct S1
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 3
 42
@@ -1423,7 +1423,7 @@ public readonly struct S1
 3
 3");
 
-            comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CreateCompilation(text, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
             CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 3
 42
@@ -1489,7 +1489,7 @@ public readonly struct S1
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
             var v = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 1
 2
@@ -1576,7 +1576,7 @@ public readonly struct S1
 }
 ");
 
-            comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CreateCompilation(text, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
             v = CompileAndVerify(comp, verify: Verification.Passes, expectedOutput: @"
 1
 2
@@ -2883,7 +2883,7 @@ class Program
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib40AndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(compilation, expectedOutput: "XX");
 
             verifier.VerifyIL("X.M()", @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -120,7 +120,7 @@ class C
             var compilation = CompileAndVerify(source, expectedOutput: "0123456789");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void TestSimpleIterator03()
         {
             var source =
@@ -163,7 +163,7 @@ class Program
         foreach (var i in new C(4).IE(5, 6)) Console.Write(i);
     }
 }";
-            var compilation = CompileAndVerifyWithMscorlib40(source, expectedOutput: "12324565");
+            var compilation = CompileAndVerify(source, expectedOutput: "12324565");
 
             compilation.VerifyIL("C.<IE>d__2<T>.System.Collections.Generic.IEnumerable<T>.GetEnumerator()", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -277,7 +277,7 @@ class Program
         [WorkItem(472056, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=472056")]
         public void Repro472056()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -318,7 +318,7 @@ namespace ConsoleApp2
         [Fact]
         public void AsyncStructClosure()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 using System.Threading.Tasks;
 
@@ -342,7 +342,7 @@ class C
                 "System.Runtime.CompilerServices.AsyncTaskMethodBuilder <>t__builder",
                 "System.Runtime.CompilerServices.TaskAwaiter<bool> <>u__1");
 
-            comp = CreateCompilationWithMscorlib46(@"
+            comp = CreateCompilation(@"
 using System;
 using System.Threading.Tasks;
 
@@ -374,7 +374,7 @@ class C
                 "int x",
                 "int y");
 
-            comp = CreateCompilationWithMscorlib46(@"
+            comp = CreateCompilation(@"
 using System;
 using System.Threading.Tasks;
 
@@ -994,7 +994,7 @@ class C
         [WorkItem(17890, "https://github.com/dotnet/roslyn/issues/17890")]
         public void Repro17890()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1034,7 +1034,7 @@ public class Class
          }
       }
    }
-}", references: new[] { LinqAssemblyRef });
+}");
             CompileAndVerify(comp);
         }
 
@@ -1386,8 +1386,7 @@ class C
         Console.WriteLine(x);
     }
 }";
-            CompileAndVerifyWithMscorlib46(src,
-                expectedOutput: @"1
+            CompileAndVerify(src, expectedOutput: @"1
 0");
         }
 
@@ -5114,13 +5113,13 @@ class Program
 
         internal CompilationVerifier VerifyOutput(string source, string output, CSharpCompilationOptions options, Verification verify = Verification.Passes)
         {
-            var comp = CreateCompilationWithMscorlib45AndCSharp(source, options: options);
+            var comp = CreateCompilationWithCSharp(source, options: options);
             return CompileAndVerify(comp, expectedOutput: output, verify: verify).VerifyDiagnostics(); // no diagnostics
         }
 
         internal CompilationVerifier VerifyOutput(string source, string output)
         {
-            var comp = CreateCompilationWithMscorlib45AndCSharp(source, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             return CompileAndVerify(comp, expectedOutput: output).VerifyDiagnostics(); // no diagnostics
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -4019,7 +4019,7 @@ public class Test
             var comp = CompileAndVerify(source2, references: new[] { new CSharpCompilationReference(compref) }, expectedOutput: "M");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/29431")]
         public void CrossLanguageCase1()
         {
             var vb1Compilation = CreateVisualBasicCompilation("VB1",
@@ -4087,7 +4087,7 @@ public class Program
             cs2Verifier.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/29431")]
         public void CrossLanguageCase2()
         {
             var vb1Compilation = CreateVisualBasicCompilation("VB1",

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
     public class CodeGenReadOnlySpanConstructionTest : CSharpTestBase
     {
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void EmptyOrNullStringConv()
         {
@@ -68,7 +68,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void EmptyOrNullArrayConv()
         {
@@ -130,7 +130,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void EmptyArrayCtor()
         {
@@ -185,7 +185,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void NotConstArrayCtor()
         {
@@ -242,7 +242,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void NotConstArrayCtorByte()
         {
@@ -299,7 +299,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void NotBlittableArrayConv()
         {
@@ -357,7 +357,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void EnumArrayCtor()
         {
@@ -414,7 +414,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void EnumArrayCtorPEverify()
         {
@@ -487,7 +487,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void ConvInMethodCall()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -1058,7 +1058,7 @@ class Program
             Assert.False(type.IsReadOnly);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void CorrectOverloadOfStackAllocSpanChosen()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -1080,7 +1080,7 @@ class Test
             CompileAndVerify(comp, expectedOutput: "24", verify: Verification.Fails);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void StackAllocExpressionIL()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -1112,7 +1112,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void StackAllocSpanLengthNotEvaluatedTwice()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -1170,7 +1170,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void StackAllocSpanLengthConstantFolding()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -1256,7 +1256,7 @@ class Test
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void ImplicitCastOperatorOnStackAllocIsLoweredCorrectly()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -1286,7 +1286,7 @@ unsafe class Test
             CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: Verification.Fails);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void ExplicitCastOperatorOnStackAllocIsLoweredCorrectly()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
@@ -1056,7 +1056,7 @@ class C
     }
 ";
 
-            var comp = CompileAndVerifyWithMscorlib40(source, references: new[] { SystemRuntimeFacadeRef, ValueTupleRef, SystemCoreRef }, expectedOutput: "00", verify: Verification.Fails);
+            var comp = CompileAndVerify(source, expectedOutput: "00", verify: Verification.Fails);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("Program.Main", @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefOutTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefOutTests.cs
@@ -345,7 +345,7 @@ public struct S1
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib40AndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(compilation, expectedOutput: "042");
 
             verifier.VerifyIL("C.Main", @"
@@ -407,7 +407,7 @@ public class C
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib40AndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(compilation, expectedOutput: "Q");
 
             verifier.VerifyIL("C..ctor(int)", @"
@@ -469,7 +469,7 @@ public class C
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib40AndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(compilation, expectedOutput: "Q");
 
             verifier.VerifyIL("C..ctor(int)", @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -2965,7 +2965,7 @@ public class C
 
 ";
 
-            var comp = CreateCompilationWithMscorlib45AndCSharp(source, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
 
             var v = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: "2");
 
@@ -3078,7 +3078,7 @@ public class C
     }
 ";
 
-            var comp = CreateCompilationWithMscorlib45AndCSharp(source, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
 
             var v = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: "2");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
@@ -20,10 +20,9 @@ Console.WriteLine(o.ToString());
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
             CompileAndVerify(
-                CreateCompilationWithMscorlib45(
+                CreateCompilation(
                     new[] { tree },
-                    options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                    references: new[] { SystemCoreRef }),
+                    options: TestOptions.ReleaseExe.WithScriptClassName("Script")),
                 expectedOutput: "{ a = 1 }"
             );
         }
@@ -39,10 +38,9 @@ Console.WriteLine(o.ToString());
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
             CompileAndVerify(
-                CreateCompilationWithMscorlib45(
+                CreateCompilation(
                     new[] { tree },
-                    options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                    references: new[] { SystemCoreRef }),
+                    options: TestOptions.ReleaseExe.WithScriptClassName("Script")),
                 expectedOutput: "{ a = 1 }"
             );
         }
@@ -57,10 +55,9 @@ Console.WriteLine(new { a = 1 }.ToString());
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
             CompileAndVerify(
-                CreateCompilationWithMscorlib45(
+                CreateCompilation(
                     new[] { tree },
-                    options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                    references: new[] { SystemCoreRef }),
+                    options: TestOptions.ReleaseExe.WithScriptClassName("Script")),
                 expectedOutput: "{ a = 1 }"
             );
         }
@@ -83,10 +80,9 @@ new CLS().M();
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
             CompileAndVerify(
-                CreateCompilationWithMscorlib45(
+                CreateCompilation(
                     new[] { tree },
-                    options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                    references: new[] { SystemCoreRef }),
+                    options: TestOptions.ReleaseExe.WithScriptClassName("Script")),
                 expectedOutput: "{ a = 1 }"
             );
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -1050,7 +1050,7 @@ public static class C
     }
 }";
 
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: "NULL#System.Int32[]");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: "NULL#System.Int32[]");
             comp.VerifyIL("C.Test", @"
 {
   // Code size      355 (0x163)
@@ -1196,7 +1196,7 @@ public static class C
     }
 }";
 
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: "NULL#y");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: "NULL#y");
         }
 
         [Fact]
@@ -1219,7 +1219,7 @@ public static class C
     }
 }";
 
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: "NULL#-1");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: "NULL#-1");
         }
 
         [Fact]
@@ -1243,7 +1243,7 @@ public static class C
     }
 }";
 
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: "NULL#y");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: "NULL#y");
         }
 
         [Fact]
@@ -1267,7 +1267,7 @@ public static class C
     }
 }";
 
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: "NULL#3");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: "NULL#3");
         }
 
         [Fact]
@@ -1291,7 +1291,7 @@ public static class C
     }
 }";
 
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: "NULL#3");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: "NULL#3");
         }
 
         [Fact]
@@ -1509,7 +1509,7 @@ public class C
     }
 ";
 
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: "");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: "");
             comp.VerifyIL("C.Main", @"
 {
   // Code size       82 (0x52)
@@ -1627,7 +1627,7 @@ public static class C1
     }
 }";
 
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: @"3
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: @"3
 1");
             comp.VerifyIL("C.Main", @"
 {
@@ -2633,7 +2633,7 @@ class Program
     }
 }
 ";
-            var comp = CompileAndVerify(source, references: new MetadataReference[] { CSharpRef }, expectedOutput: @"False
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: @"False
 True
 False
 False");
@@ -2692,7 +2692,7 @@ class Program
     }
 }
 ";
-            var comp = CompileAndVerify(source, references: new MetadataReference[] { CSharpRef }, expectedOutput: @"False
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: @"False
 True
 False
 False");
@@ -2757,7 +2757,7 @@ class Program
         return 1;
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilation(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"False
 True
 False
@@ -2826,7 +2826,7 @@ class Program
     }
 }
 ";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilation(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"False
 True
 False
@@ -2907,7 +2907,7 @@ public class Program
     }
 }
 ";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"False
 True
 False
@@ -2977,7 +2977,7 @@ class Program
         return 1;
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"False
 True
 False
@@ -3060,7 +3060,7 @@ class Program
         return 1;
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"False
 True
 False
@@ -3143,7 +3143,7 @@ class Program
         return 1;
     }
 }";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"False
 True
 False
@@ -3194,7 +3194,7 @@ static class Ext
 }
 
 ";
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: @"System.Nullable`1[System.Int64]");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: @"System.Nullable`1[System.Int64]");
             comp.VerifyIL("Test.Test0<T>(T)", @"
 {
   // Code size       21 (0x15)
@@ -3240,7 +3240,7 @@ static class Ext
 }
 
 ";
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: @"System.Nullable`1[System.Int64]");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: @"System.Nullable`1[System.Int64]");
             comp.VerifyIL("Test.Test0<T>(ref T)", @"
 {
   // Code size       46 (0x2e)
@@ -3294,7 +3294,7 @@ class Test
 }
 
 ";
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: @"");
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: @"");
             comp.VerifyIL("Test.Test0<T>(T)", @"
 {
   // Code size       27 (0x1b)
@@ -3365,7 +3365,7 @@ interface I1
 
 
 ";
-            var comp = CreateCompilationWithMscorlib45(source, references: new[] { CSharpRef });
+            var comp = CreateCompilationWithCSharp(source);
             base.CompileAndVerify(comp);
         }
 
@@ -3414,7 +3414,7 @@ interface I1
     int CallAsync(int x);
 }
 ";
-            var comp = CreateCompilationWithMscorlib45(source, references: new[] { CSharpRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             base.CompileAndVerify(comp, expectedOutput: "420");
         }
 
@@ -4093,7 +4093,7 @@ class Program
     }
 }
 ";
-            var comp = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: @"   >
+            var comp = CompileAndVerifyWithCSharp(source, expectedOutput: @"   >
 False
 False
 <
@@ -4748,7 +4748,7 @@ class Program
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: "").
                 VerifyIL("Program.Test0(ref System.WeakReference<string>)", @"
 {
@@ -5832,8 +5832,8 @@ class Program
         new Goo<int>().M4();
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(
-                source, references: new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, options: TestOptions.DebugExe);
+            var compilation = CreateCompilationWithCSharp(
+                source, options: TestOptions.DebugExe);
             CompileAndVerify(compilation, expectedOutput: "12456");
         }
 
@@ -6161,7 +6161,7 @@ class C
 
 
 ";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"FalseTrueTrue");
         }
 
@@ -6198,7 +6198,7 @@ class C
 
 
 ";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"FalseTrueTrue");
         }
 
@@ -6241,7 +6241,7 @@ class C
 
 
 ";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"FalseTrueTrue");
         }
 
@@ -6278,7 +6278,7 @@ class C
         }
     }
 ";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"#
 False#
 FalseqBarBar#
@@ -6321,7 +6321,7 @@ True");
         }
     }
 ";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"False
 True");
         }
@@ -6356,7 +6356,7 @@ True");
             return arg;
         }
     }";
-            var c = CreateCompilationWithMscorlib45(source, new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef }, TestOptions.ReleaseExe);
+            var c = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             var comp = CompileAndVerify(c, expectedOutput: @"False
 True");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -503,7 +503,7 @@ class C
     }
 }
 ";
-            var compilation = CreateCompilationWithILAndMscorlib40(source, il, TargetFramework.Mscorlib45, options: TestOptions.ReleaseDll);
+            var compilation = CreateCompilationWithIL(source, il, options: TestOptions.ReleaseDll);
             var result = CompileAndVerify(compilation);
 
             result.VerifyIL("C.A", @"
@@ -577,7 +577,7 @@ class C
     }
 }
 ";
-            var compilation = CreateCompilationWithILAndMscorlib40(source, il, TargetFramework.Mscorlib45, options: TestOptions.DebugDll);
+            var compilation = CreateCompilationWithIL(source, il, options: TestOptions.DebugDll);
             var result = CompileAndVerify(compilation);
 
             result.VerifyIL("C.A",
@@ -822,7 +822,7 @@ class Clazz
     }
 }
 ";
-            var compilation = CreateCompilationWithILAndMscorlib40(source, il, TargetFramework.Mscorlib45, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilationWithIL(source, il, options: TestOptions.ReleaseExe);
             var result = CompileAndVerify(compilation, expectedOutput: "Struct1 Struct2 ");
 
             result.VerifyIL("Clazz.Main", @"
@@ -6640,7 +6640,7 @@ public class D
         System.Console.WriteLine(d[4]);
     }
 }";
-            var compilation = CompileAndVerifyWithMscorlib40(source, options: TestOptions.ReleaseExe.WithModuleName("MODULE"), expectedOutput: @"
+            var compilation = CompileAndVerify(source, options: TestOptions.ReleaseExe.WithModuleName("MODULE"), expectedOutput: @"
 3
 -5
 True
@@ -6891,7 +6891,7 @@ public class D
     }
 }
 ";
-            var compilation = CompileAndVerifyWithMscorlib40(source, expectedOutput: @"
+            var compilation = CompileAndVerify(source, expectedOutput: @"
 Byte
 Char
 DBNull
@@ -6973,7 +6973,7 @@ Char
 DBNull
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(source: source, options: TestOptions.ReleaseExe.WithModuleName("MODULE"));
+            var compilation = CreateCompilation(source: source, options: TestOptions.ReleaseExe.WithModuleName("MODULE"));
             var verifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
 
             //NOTE: 
@@ -9419,7 +9419,7 @@ VerifyIL("Test.Main", @"
         [Fact(), WorkItem(543691, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543691")]
         public void NullableAsArgsForTypeParameter()
         {
-            CreateCompilationWithMscorlib40AndSystemCore(@"
+            CreateCompilation(@"
 using System;
 class C
 {
@@ -10453,9 +10453,8 @@ public class Test
         }
     }
 }";
-            CompileAndVerifyWithMscorlib40(
+            CompileAndVerify(
                 source,
-                references: new[] { SystemCoreRef },
                 expectedOutput: @"Success");
         }
 
@@ -10499,7 +10498,7 @@ class C
     }
 }
 ";
-            CreateCompilationWithMscorlib40AndSystemCore(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [WorkItem(542267, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542267")]
@@ -10733,7 +10732,7 @@ class C
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: @"
 00000000000000000000000000000000
 00000000000000000000000000010000
@@ -10853,7 +10852,7 @@ class Goo
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: @"
 00000001000000000000000000000000
 0000000a000000000000000000010000
@@ -10933,7 +10932,7 @@ class Goo
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: @"
 00000001000000000000000080000000
 0000000a000000000000000080010000
@@ -11007,7 +11006,7 @@ class Goo
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: @"
 ffffffffffffffffffffffff00000000
 ffffffffffffffffffffffff00000000
@@ -12623,7 +12622,7 @@ class C
 }
 ";
             // NOTE: this is a breaking change - dev10 builds and prints 11.
-            CreateCompilationWithMscorlib40AndSystemCore(source).VerifyDiagnostics(
+            CreateCompilation(source).VerifyDiagnostics(
                 // (8,63): error CS1939: Cannot pass the range variable 'x' as an out or ref parameter
                 //         foreach (var e in from x in new int[2] select Goo(ref x))
                 Diagnostic(ErrorCode.ERR_QueryOutRefRangeVariable, "x").WithArguments("x"));
@@ -12996,7 +12995,7 @@ enum " + "\u0915\u094d\u200d\u0937" + @"
   .field public static literal valuetype E '" + "\u0915\u094d\u200d\u0937" + @"' = int32(0x00000000)
 } // end of class E
 ";
-            var comp = CreateCompilationWithILAndMscorlib40("", il);
+            var comp = CreateCompilationWithIL("", il);
             var @enum = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("E");
             var field = @enum.GetMembers().OfType<FieldSymbol>().Single();
             Assert.False(field.CanBeReferencedByName);
@@ -13327,7 +13326,7 @@ public static class P
 }
 ";
 
-            var compilation = CompileAndVerifyWithMscorlib40(code, expectedOutput: "4");
+            var compilation = CompileAndVerify(code, expectedOutput: "4");
         }
 
         [WorkItem(26113, "https://github.com/dotnet/roslyn/issues/26113")]
@@ -14126,7 +14125,7 @@ public class Test
 }
 ";
 
-            CompileAndVerifyWithMscorlib40(source, references: new[] { SystemCoreRef, CSharpRef }, expectedOutput: @"0");
+            CompileAndVerifyWithCSharp(source, expectedOutput: @"0");
         }
 
 
@@ -14733,7 +14732,7 @@ public static class AExtensions
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib40AndSystemCore(source);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics();
         }
 
@@ -14759,7 +14758,7 @@ static class CExtensions
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib40AndSystemCore(source);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics();
         }
 
@@ -15450,7 +15449,7 @@ class M
 }
 ";
 
-            var compilation = CompileAndVerifyWithMscorlib40(source, new[] { SystemCoreRef, CSharpRef }, expectedOutput: "2");
+            var compilation = CompileAndVerifyWithCSharp(source, expectedOutput: "2");
 
             // the main point of this test is to have it PEVerify/run correctly, although checking IL too can't hurt.
             compilation.VerifyIL("M..ctor",
@@ -15519,7 +15518,7 @@ class M
 }
 ";
 
-            var compilation = CompileAndVerifyWithMscorlib40(source, new[] { SystemCoreRef, CSharpRef }, expectedOutput: "2");
+            var compilation = CompileAndVerifyWithCSharp(source, expectedOutput: "2");
 
             compilation.VerifyIL("M..ctor",
 @"{
@@ -15587,7 +15586,7 @@ class M
 ";
 
             // BREAKING CHANGE: The native compiler allowed this (and generated code that will always throw at runtime)
-            CreateCompilationWithMscorlib45AndCSharp(source).VerifyDiagnostics(
+            CreateCompilationWithCSharp(source).VerifyDiagnostics(
                 // (6,16): error CS0236: A field initializer cannot reference the non-static field, method, or property 'M.Test(object)'
                 //     object a = Test((dynamic)2);
                 Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Test").WithArguments("M.Test(object)").WithLocation(6, 16)
@@ -15632,7 +15631,7 @@ class M
 }
 ";
 
-            var compilation = CompileAndVerifyWithMscorlib40(source, new[] { SystemCoreRef, CSharpRef }, expectedOutput: "long.ex caught");
+            var compilation = CompileAndVerifyWithCSharp(source, expectedOutput: "long.ex caught");
         }
 
         [WorkItem(10463, "https://github.com/dotnet/roslyn/issues/10463")]
@@ -15678,7 +15677,7 @@ class M : B
 ";
 
             // BREAKING CHANGE: The native compiler allowed this (and generated code that will always throw at runtime)
-            CreateCompilationWithMscorlib45AndCSharp(source).VerifyDiagnostics(
+            CreateCompilationWithCSharp(source).VerifyDiagnostics(
                 // (16,31): error CS0120: An object reference is required for the non-static field, method, or property 'M.Test(object)'
                 //     public M() : base((object)Test((dynamic)2))
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "Test").WithArguments("M.Test(object)").WithLocation(16, 31)
@@ -15711,7 +15710,7 @@ class M
 ";
 
             // BREAKING CHANGE: The native compiler allowed this (and generated code that will always throw at runtime)
-            CreateCompilationWithMscorlib45AndCSharp(source).VerifyDiagnostics(
+            CreateCompilationWithCSharp(source).VerifyDiagnostics(
                 // (8,31): error CS0120: An object reference is required for the non-static field, method, or property 'M.Test(object)'
                 //         Console.Write((object)Test((dynamic)2));
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "Test").WithArguments("M.Test(object)").WithLocation(8, 31)
@@ -15739,7 +15738,7 @@ class M
 ";
 
             // BREAKING CHANGE: The native compiler allowed this (and generated code that will always throw at runtime)
-            CreateCompilationWithMscorlib45AndCSharp(source).VerifyDiagnostics(
+            CreateCompilationWithCSharp(source).VerifyDiagnostics(
                 // (4,31): error CS0236: A field initializer cannot reference the non-static field, method, or property 'M.Test(object)'
                 //     static object o = (object)Test((dynamic)2);
                 Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Test").WithArguments("M.Test(object)").WithLocation(4, 31)
@@ -15798,7 +15797,7 @@ class M
 ";
 
             // BREAKING CHANGE: The native compiler allowed this (and generated code that will always throw at runtime)
-            CreateCompilationWithMscorlib45AndCSharp(source).VerifyDiagnostics(
+            CreateCompilationWithCSharp(source).VerifyDiagnostics(
                 // (16,29): error CS0236: A field initializer cannot reference the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     static int field = (int)InstanceMethod((dynamic)2);
                 Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(16, 29),
@@ -15877,7 +15876,7 @@ class M
 ";
 
             // BREAKING CHANGE: The native compiler allowed this (and generated code that will always throw at runtime)
-            CreateCompilationWithMscorlib45AndCSharp(source).VerifyDiagnostics(
+            CreateCompilationWithCSharp(source).VerifyDiagnostics(
                 // (16,29): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     static int field = (int)C.InstanceMethod((dynamic)2);
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(16, 29),
@@ -16078,8 +16077,7 @@ class Program
     }
 }
 ";
-            CompileAndVerifyWithMscorlib40(source, references: new[] { SystemRef, SystemCoreRef },
-                expectedOutput: "0");
+            CompileAndVerify(source, expectedOutput: "0");
         }
 
         [Fact, WorkItem(9703, "https://github.com/dotnet/roslyn/issues/9703")]
@@ -16135,7 +16133,7 @@ class Test
             CompileAndVerify(comp, expectedOutput: "24", verify: Verification.Fails);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void StackAllocExpressionIL()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -16174,7 +16172,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void StackAllocSpanLengthNotEvaluatedTwice()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -16232,7 +16230,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void ImplicitCastOperatorOnStackAllocIsLoweredCorrectly()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -16262,7 +16260,7 @@ unsafe class Test
             CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: Verification.Fails);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void ExplicitCastOperatorOnStackAllocIsLoweredCorrectly()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -1936,7 +1936,7 @@ public class C
                 );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         public void TestTupleEqualityPreferredOverCustomOperator()
         {
             var source = @"
@@ -1981,7 +1981,7 @@ public class C
             CompileAndVerify(comp, expectedOutput: "FalseTrue");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         public void TestCustomOperatorPlusAllowed()
         {
             var source = @"
@@ -2020,8 +2020,8 @@ public class C
             CompileAndVerify(comp, expectedOutput: "(0, 0)");
         }
 
-        [Fact]
-        void TestTupleEqualityPreferredOverCustomOperator_Nested()
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
+        public void TestTupleEqualityPreferredOverCustomOperator_Nested()
         {
             string source = @"
 public class C
@@ -4864,7 +4864,7 @@ public class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         void TestValueTupleWithObsoleteEqualityOperator()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -1550,22 +1550,18 @@ class D
 }
 ";
 
-            var comp1 = CreateCompilationWithMscorlib40(source2 + source1, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
-                                                     options: TestOptions.ReleaseExe);
+            var comp1 = CreateCompilation(source2 + source1, options: TestOptions.ReleaseExe);
             comp1.VerifyDiagnostics();
             CompileAndVerify(comp1, expectedOutput: "1 hello hello 3");
 
-            var compLib = CreateCompilationWithMscorlib40(source1, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
-                                                     options: TestOptions.ReleaseDll);
+            var compLib = CreateCompilation(source1, options: TestOptions.ReleaseDll);
             compLib.VerifyDiagnostics();
             var compLibCompilationRef = compLib.ToMetadataReference();
-            var comp2 = CreateCompilationWithMscorlib40(source2, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, compLibCompilationRef },
-                                                     options: TestOptions.ReleaseExe);
+            var comp2 = CreateCompilation(source2, references: new[] { compLibCompilationRef }, options: TestOptions.ReleaseExe);
             comp2.VerifyDiagnostics();
             CompileAndVerify(comp2, expectedOutput: "1 hello hello 3");
 
-            var comp3 = CreateCompilationWithMscorlib40(source2, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, compLib.EmitToImageReference() },
-                                                     options: TestOptions.ReleaseExe);
+            var comp3 = CreateCompilation(source2, references: new[] { compLib.EmitToImageReference() }, options: TestOptions.ReleaseExe);
             comp3.VerifyDiagnostics();
             CompileAndVerify(comp3, expectedOutput: "1 hello hello 3");
         }
@@ -1726,7 +1722,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         public void TupleLambdaCapture03()
         {
             var source = @"
@@ -1776,7 +1772,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, targetFramework: TargetFramework.Mscorlib46Extended, expectedOutput: @"42");
+            var comp = CompileAndVerify(source, targetFramework: TargetFramework.Mscorlib46, expectedOutput: @"42");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.<>c__DisplayClass1_0<T>.<Test>b__0()", @"
 {
@@ -2286,7 +2282,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void TupleAsyncCapture03()
         {
             var source = @"
@@ -2756,7 +2752,7 @@ null
 --");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         public void LongTupleWithSubstitution()
         {
             var source = @"
@@ -3328,7 +3324,7 @@ class C
                      model.GetTypeInfo(node).Type.ToTestDisplayString());
             };
 
-            var verifier = CompileAndVerifyWithMscorlib40(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3", references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator);
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3", sourceSymbolValidator: validator);
             verifier.VerifyDiagnostics();
         }
 
@@ -3406,9 +3402,7 @@ static class C
 }
 ";
 
-            CompileAndVerifyWithMscorlib40(source,
-                references: new[] { SystemCoreRef, ValueTupleRef, SystemRuntimeFacadeRef },
-                expectedOutput: @"42 Alice");
+            CompileAndVerify(source, expectedOutput: @"42 Alice");
         }
 
         [Fact]
@@ -3885,7 +3879,6 @@ class C
 ";
 
             var verifier = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1),
-                targetFramework: TargetFramework.Mscorlib46Extended,
                 expectedOutput:"1");
             verifier.VerifyDiagnostics();
         }
@@ -4215,7 +4208,7 @@ class C3
                 );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         public void LocalTupleTypeWinsWhenTupleTypesInCompilation()
         {
             var source1 = @"
@@ -5253,7 +5246,7 @@ namespace TuplesCrash2
             // didn't crash
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         [WorkItem(11302, "https://github.com/dotnet/roslyn/issues/11302")]
         public void MultipleDefinitionsOfValueTuple()
         {
@@ -12540,7 +12533,7 @@ namespace System
             AssertEx.Equal(symbols.Select(s => s.ToTestDisplayString()), baseLine);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void UnifyUnderlyingWithTuple_01()
         {
             var source1 = @"
@@ -12705,7 +12698,7 @@ class C
                 );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void UnifyUnderlyingWithTuple_04()
         {
             var source1 = @"
@@ -13176,7 +13169,7 @@ class C
                 );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void UnifyUnderlyingWithTuple_08()
         {
             var source = @"
@@ -13438,7 +13431,7 @@ False
             CompileAndVerify(consumer2, expectedOutput: expectedOutput).VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void UnifyUnderlyingWithTuple_09()
         {
             var source = @"
@@ -13825,7 +13818,7 @@ namespace System
 4");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void UnifyUnderlyingWithTuple_12()
         {
             var source = @"
@@ -14086,7 +14079,7 @@ False
             CompileAndVerify(consumer2, expectedOutput: expectedOutput).VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void UnifyUnderlyingWithTuple_13()
         {
             var source = @"
@@ -15453,7 +15446,7 @@ class D
             comp2.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         [WorkItem(11322, "https://github.com/dotnet/roslyn/issues/11322")]
         public void LiteralsAndAmbiguousVT_01()
         {
@@ -15501,7 +15494,7 @@ class C3
             CompileAndVerify(comp, expectedOutput: "comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         [WorkItem(11322, "https://github.com/dotnet/roslyn/issues/11322")]
         public void LiteralsAndAmbiguousVT_02()
         {
@@ -15573,7 +15566,7 @@ class C3
             CompileAndVerify(comp, expectedOutput: "C2.M1");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         [WorkItem(11322, "https://github.com/dotnet/roslyn/issues/11322")]
         public void LongLiteralsAndAmbiguousVT_02()
         {
@@ -15678,13 +15671,9 @@ namespace NS2
 }
 ";
 
-            var comp1 = CreateCompilationWithMscorlib40AndSystemCore(source1,
-                references: s_valueTupleRefs,
-                assemblyName: "comp1");
+            var comp1 = CreateCompilation(source1, assemblyName: "comp1");
             comp1.VerifyDiagnostics();
-            var comp2 = CreateCompilationWithMscorlib40AndSystemCore(source2,
-                references: s_valueTupleRefs,
-                assemblyName: "comp2");
+            var comp2 = CreateCompilation(source2, assemblyName: "comp2");
             comp2.VerifyDiagnostics();
 
             var source3 = @"
@@ -15701,8 +15690,9 @@ class C3
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib40(source3,
-                references: s_valueTupleRefs.Concat(new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) }),
+            var comp = CreateCompilation(
+                source3,
+                references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) },
                 parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
@@ -15724,8 +15714,9 @@ class C3
 }
 ";
 
-            comp = CreateCompilationWithMscorlib40(source4,
-                references: s_valueTupleRefs.Concat(new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) }),
+            comp = CreateCompilation(
+                source4,
+                references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) },
                 parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
@@ -15746,12 +15737,11 @@ class C3
 }
 ";
 
-            comp = CreateCompilationWithMscorlib40(source5,
+            comp = CreateCompilation(
+                source5,
                 references: new[] {
                     comp1.ToMetadataReference(),
                     comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")),
-                    ValueTupleRef,
-                    SystemRuntimeFacadeRef
                 },
                 parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
@@ -15761,7 +15751,7 @@ class C3
             CompileAndVerify(comp, expectedOutput: "C2.M1");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         public void MultipleVT_01()
         {
             var source1 = @"
@@ -16086,7 +16076,7 @@ class C
             Assert.True(x1Symbol.Type.TupleElementNames.IsDefault);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         public void CompileTupleLib()
         {
             string additionalSource = @"
@@ -20257,7 +20247,7 @@ class C
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NeedsTupleUndefined)]
         public void DefiniteAssignment015()
         {
             var source = @"
@@ -21581,7 +21571,7 @@ namespace ClassLibrary1
     }
 }
 ";
-            var libComp = CreateCompilationWithMscorlib45AndCSharp(lib, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var libComp = CreateCompilationWithCSharp(lib, options: TestOptions.DebugDll);
             libComp.VerifyDiagnostics();
 
             var source = @"
@@ -21610,16 +21600,14 @@ namespace ConsoleApplication5
 
             var libCompRef = AssemblyMetadata.CreateFromImage(libComp.EmitToArray()).GetReference();
 
-            var comp = CompileAndVerifyWithMscorlib40(source, expectedOutput: "42qq", references: s_valueTupleRefs.Concat(new[] { libCompRef }).ToArray(), options: TestOptions.DebugExe, verify: Verification.Fails);
+            var comp = CompileAndVerify(source, expectedOutput: "42qq", references: new[] { libCompRef }, options: TestOptions.DebugExe, verify: Verification.Fails);
 
             var m = (MethodSymbol)(comp.Compilation.GetTypeByMetadataName("ConsoleApplication5.C2").GetMembers("Goo").First());
             Assert.Equal("ref (System.Int32, System.Object) ConsoleApplication5.C2.Goo(System.Int32 arg)", m.ToTestDisplayString());
 
             var b = m.OverriddenMethod;
             Assert.Equal("ref (System.Int32, dynamic) ClassLibrary1.C1.Goo(System.Int32 arg)", b.ToTestDisplayString());
-
         }
-
 
         [Fact]
         [WorkItem(269808, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=269808")]
@@ -21859,7 +21847,7 @@ implicit operator AA
 
         [WorkItem(14708, "https://github.com/dotnet/roslyn/issues/14708")]
         [WorkItem(14709, "https://github.com/dotnet/roslyn/issues/14709")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void RefTupleDynamicDecode003()
         {
             string lib = @"
@@ -21955,7 +21943,7 @@ namespace ConsoleApplication5
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45AndCSharp(source, references: (new[] { libCompRef }).Concat(s_valueTupleRefs).ToArray(), options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithCSharp(source, references: new[] { libCompRef }, options: TestOptions.DebugExe);
 
             CompileAndVerify(comp, expectedOutput: "42qq", verify: Verification.Fails);
 
@@ -23402,7 +23390,7 @@ class P
         Console.Write($""{x1} {x2} {x3}"");
     }
 }";
-            var comp = CreateCompilationWithMscorlib40(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugExe);
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "(1, 1) (1, 1) (1, System.Object)");
         }
@@ -23532,9 +23520,8 @@ class C
         }
     }
 }";
-            var comp = CreateCompilationWithMscorlib40(
+            var comp = CreateCompilation(
                 source,
-                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(comp, expectedOutput: @"(-1, 255)(-1, 255)overflow");
             verifier.VerifyIL("C.Default",

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/ForeachTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/ForeachTest.cs
@@ -304,7 +304,7 @@ public class Test
             CompileAndVerify(text).VerifyIL("Test.Main", expectedIL);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestSpan()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -357,7 +357,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestSpanSideeffectingLoopBody()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -421,7 +421,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestReadOnlySpan()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -473,7 +473,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestReadOnlySpanString()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -522,7 +522,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestReadOnlySpan2()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -571,7 +571,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestSpanNoIndexer()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -620,7 +620,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestSpanValIndexer()
         {
             var comp = CreateEmptyCompilation(@"
@@ -716,7 +716,7 @@ namespace System
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestSpanConvert()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -770,7 +770,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestSpanDeconstruct()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -842,7 +842,7 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/projects/16#card-12319302")]
         public void TestSpanConvertDebug()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
@@ -1391,7 +1391,7 @@ public class Test
 b
 c
 ";
-            var comp = CreateCompilationWithMscorlib40AndSystemCore(text, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(text, options: TestOptions.ReleaseExe);
 
             CompileAndVerify(comp, expectedOutput: expectedOutput);
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
@@ -816,7 +816,7 @@ L0: ;
             string expectedOutput =
 @"True
 False";
-            var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
+            var compilation = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Passes);
         }
 
@@ -867,7 +867,7 @@ if (Q < 4) goto L;";
 @"2: P
 3: F
 4: Q";
-            var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
+            var compilation = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Fails);
         }
 
@@ -950,7 +950,7 @@ default:
 }";
             string expectedOutput =
 @"3";
-            var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
+            var compilation = CreateCompilation(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Passes);
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/ObjectAndCollectionInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/ObjectAndCollectionInitializerTests.cs
@@ -1209,7 +1209,7 @@ class A
 -
 5";
 
-            var comp = CreateCompilationWithMscorlib45AndCSharp(source, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: expectedOutput);
         }
 
@@ -1307,7 +1307,7 @@ class A
 -
 5";
 
-            var comp = CreateCompilationWithMscorlib45AndCSharp(source, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithCSharp(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: expectedOutput);
         }
 
@@ -1347,7 +1347,7 @@ struct A
 2
 3";
 
-            var compVerifier = CompileAndVerify(source, references: new[] { CSharpRef }, expectedOutput: expectedOutput);
+            var compVerifier = CompileAndVerifyWithCSharp(source, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("A.Main()", @"
 {
   // Code size      194 (0xc2)
@@ -1645,7 +1645,7 @@ get
 get
 3";
 
-            var comp = CreateCompilationWithMscorlib45AndCSharp(source, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: expectedOutput);
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -11161,7 +11161,7 @@ public unsafe class C
         }
     }
 ";
-            var cscomp = CreateCompilationWithILAndMscorlib40(csharpSource, ilSource);
+            var cscomp = CreateCompilationWithIL(csharpSource, ilSource);
 
             var expected = new[] {
                 // (7,35): error CS0570: 'AddressHelper.AddressOf<T>(?)' is not supported by the language
@@ -11172,7 +11172,7 @@ public unsafe class C
             cscomp.VerifyDiagnostics(expected);
         }
 
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        [Fact]
         public void SystemIntPtrInSignature_BreakingChange_001()
         {
             var ilSource =
@@ -11197,7 +11197,7 @@ public unsafe class C
         }
     }
 ";
-            var compilation = CreateCompilationWithILAndMscorlib40(csharpSource, ilSource, targetFramework: TargetFramework.Mscorlib40, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilationWithIL(csharpSource, ilSource, options: TestOptions.ReleaseExe);
 
             compilation.VerifyDiagnostics();
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/BinaryCompatibility.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/BinaryCompatibility.cs
@@ -27,7 +27,7 @@ public class Derived : Base
     public override void M() { System.Console.WriteLine(""Derived0""); }
 }
 ";
-            var lib0Image = CreateCompilationWithMscorlib46(lib0, options: TestOptions.ReleaseDll, assemblyName: "lib").EmitToImageReference();
+            var lib0Image = CreateCompilation(lib0, options: TestOptions.ReleaseDll, assemblyName: "lib").EmitToImageReference();
 
             var lib1 = @"
 public class Base
@@ -39,7 +39,7 @@ public class Derived : Base
     public new virtual void M() { System.Console.WriteLine(""Derived1""); }
 }
 ";
-            var lib1Image = CreateCompilationWithMscorlib46(lib1, options: TestOptions.ReleaseDll, assemblyName: "lib").EmitToImageReference();
+            var lib1Image = CreateCompilation(lib1, options: TestOptions.ReleaseDll, assemblyName: "lib").EmitToImageReference();
 
             var client = @"
 public class Client
@@ -51,7 +51,7 @@ public class Client
     }
 }
 ";
-            var clientImage = CreateCompilationWithMscorlib46(client, references: new[] { lib0Image }, options: TestOptions.ReleaseDll).EmitToImageReference();
+            var clientImage = CreateCompilation(client, references: new[] { lib0Image }, options: TestOptions.ReleaseDll).EmitToImageReference();
 
             var program = @"
 public class Program
@@ -62,7 +62,7 @@ public class Program
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib46(program, references: new[] { lib1Image, clientImage }, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(program, references: new[] { lib1Image, clientImage }, options: TestOptions.ReleaseExe);
             CompileAndVerify(compilation, expectedOutput: @"Base1");
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitCustomModifiers.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitCustomModifiers.cs
@@ -592,7 +592,7 @@ class Test
     }
 }
 ";
-            var comp = CreateCompilationWithILAndMscorlib40(source, il, TargetFramework.Mscorlib40, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithIL(source, il, options: TestOptions.ReleaseExe);
 
             var type = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
             var method = type.GetMember<MethodSymbol>("Incr");
@@ -648,7 +648,7 @@ class Test
     }
 }
 ";
-            var comp = CreateCompilationWithILAndMscorlib40(source, il, TargetFramework.Mscorlib40, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithIL(source, il, options: TestOptions.ReleaseExe);
 
             var baseType = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
             var baseMethod = baseType.GetMember<MethodSymbol>("M");

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
@@ -858,7 +858,7 @@ class C : I
         [Fact]
         public void SetGetOnlyAutopropsInConstructors()
         {
-            var comp = CreateCompilationWithMscorlib45(@"using System;
+            var comp = CreateCompilation(@"using System;
 class C
 {
     public int P1 { get; }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -210,7 +210,7 @@ public static int Main = 1;
 System.Console.WriteLine(Main);
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[]
                 {
                     SyntaxFactory.ParseSyntaxTree(csx, options: TestOptions.Script),
@@ -231,7 +231,7 @@ int Main(string[] x) { return 2; }
 System.Console.WriteLine(Main());
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[]
                 {
                     SyntaxFactory.ParseSyntaxTree(csx, options: TestOptions.Script),
@@ -564,7 +564,7 @@ public class G
 System.Console.WriteLine(1);
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[] { SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Script) },
                 options: TestOptions.ReleaseExe);
 
@@ -585,7 +585,7 @@ public class C
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[]
                 {
                     SyntaxFactory.ParseSyntaxTree(csx, options: TestOptions.Script),
@@ -619,7 +619,7 @@ public class D
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib45(
+            var compilation = CreateCompilation(
                 new[]
                 {
                     SyntaxFactory.ParseSyntaxTree(csx, options: TestOptions.Script),

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -3298,7 +3298,7 @@ class Program
     }
 }
 ";
-            var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugExe);
+            var c = CreateCompilation(source, options: TestOptions.DebugExe);
             c.VerifyDiagnostics();
             var verifier = CompileAndVerify(c, expectedOutput: "1M2");
 
@@ -3344,7 +3344,7 @@ expectedIL: @"{
 }");
 
             // Check the release code generation too.
-            c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.ReleaseExe);
+            c = CreateCompilation(source, options: TestOptions.ReleaseExe);
             c.VerifyDiagnostics();
             verifier = CompileAndVerify(c, expectedOutput: "1M2");
 
@@ -3411,7 +3411,7 @@ class Program
     }
 }
 ";
-            var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular7_1);
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular7_1);
             c.VerifyDiagnostics();
             var verifier = CompileAndVerify(c, expectedOutput: "1234");
 
@@ -3519,7 +3519,7 @@ expectedIL: @"{
 }");
 
             // Check the release code generation too.
-            c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular7_1);
+            c = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular7_1);
             c.VerifyDiagnostics();
             verifier = CompileAndVerify(c, expectedOutput: "1234");
 
@@ -3610,7 +3610,7 @@ class Program
     }
 }
 ";
-            var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular7_1);
+            var c = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular7_1);
             c.VerifyDiagnostics();
             var verifier = CompileAndVerify(c, expectedOutput: "66");
 
@@ -3638,7 +3638,7 @@ expectedIL: @"{
 }");
 
             // Check the release code generation too.
-            c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular7_1);
+            c = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular7_1);
             c.VerifyDiagnostics();
             verifier = CompileAndVerify(c, expectedOutput: "66");
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -721,7 +721,7 @@ public class Test
         }
 
         [WorkItem(546525, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546525")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void AssemblyReferencesWithAliases()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
@@ -6140,7 +6140,7 @@ class Module1
 
         #endregion Dev10 bugs
 
-        [ClrOnlyFact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         [WorkItem(1115058, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1115058")]
         public void UnterminatedElement()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -2027,9 +2027,8 @@ class C
         (1, (2, 3)).F();
     }
 }";
-            var comp = CreateCompilationWithMscorlib40AndSystemCore(
+            var comp = CreateCompilation(
                 source,
-                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(comp, expectedOutput:
 @"1

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -2105,7 +2105,7 @@ class Derived2 : Base2, Interface
         }
 
         [WorkItem(718115, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/718115")]
-        [ClrOnlyFact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void ExplicitlyImplementedAccessorsWithoutEvent()
         {
             var il = @"
@@ -2304,7 +2304,7 @@ public class Derived : Base, I
         }
 
         [WorkItem(943542, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/943542"), WorkItem(137, "CodePlex")]
-        [ClrOnlyFact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void Bug943542()
         {
             var il = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingFields.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingFields.cs
@@ -105,8 +105,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Equal(SymbolKind.Method, csFields.GetMembers("FfF").Single().Kind);
         }
 
-        [Fact]
         [WorkItem(193333, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=193333")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void EnumWithPrivateValueField()
         {
             var il = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedMethodTests.cs
@@ -302,7 +302,7 @@ class C : I, J, K
         [ClrOnlyFact]
         public void Emit01()
         {
-            var comp = CreateCompilationWithMscorlib45(@"
+            var comp = CreateCompilation(@"
 abstract class A
 {
     protected abstract string Z();
@@ -345,7 +345,7 @@ goo8");
         [ClrOnlyFact]
         public void Emit02()
         {
-            var comp = CreateCompilationWithMscorlib45(@"
+            var comp = CreateCompilation(@"
 class C
 {
     public void M() { System.Console.WriteLine(""Hello""); }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
@@ -404,7 +404,7 @@ class C : I, J, K
         [ClrOnlyFact]
         public void Emit01()
         {
-            var comp = CreateCompilationWithMscorlib45(@"
+            var comp = CreateCompilation(@"
 abstract class A
 {
     protected abstract string Z { get; }

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -21,6 +21,7 @@ namespace Roslyn.Test.Utilities
         public const string NetModulesNeedDesktop = "Net Modules are only supported on desktop";
         public const string RestrictedTypesNeedDesktop = "Restricted types are only supported on desktop";
         public const string TestExecutionNeedsDesktopTypes = "Test execution depends on desktop types";
+        public const string NeedsTupleUndefined = "Test needs tuple to be undefined";
         public const string NativePdbRequiresDesktop = "Native PDB tests can only execute on windows desktop";
     }
 

--- a/src/Test/Utilities/Portable/Metadata/ModuleData.cs
+++ b/src/Test/Utilities/Portable/Metadata/ModuleData.cs
@@ -92,9 +92,7 @@ namespace Roslyn.Test.Utilities
             }
         }
 
-        private string GetDebuggerDisplay()
-        {
-            return FullName + " {" + Mvid + "}";
-        }
+        private string GetDebuggerDisplay() => FullName + " {" + Mvid + "}";
+        public override string ToString() => GetDebuggerDisplay();
     }
 }

--- a/src/Test/Utilities/Portable/Platform/Desktop/RuntimeModuleData.cs
+++ b/src/Test/Utilities/Portable/Platform/Desktop/RuntimeModuleData.cs
@@ -45,7 +45,7 @@ namespace Roslyn.Test.Utilities.Desktop
         }
     }
 
-    [Serializable, DebuggerDisplay("{GetDebuggerDisplay()}")]
+    [Serializable]
     public sealed class RuntimeModuleData : ISerializable
     {
         public ModuleData Data { get; }
@@ -73,6 +73,8 @@ namespace Roslyn.Test.Utilities.Desktop
             info.AddByteArray(nameof(ModuleData.Pdb), Data.Pdb);
             info.AddValue(nameof(ModuleData.InMemoryModule), Data.InMemoryModule);
         }
+
+        public override string ToString() => Data.ToString();
     }
 }
 


### PR DESCRIPTION
This changes the C# symbols and emit tests to use the correct `CreateCompilation` helper methods for portable code execution. 

Part of #29427