### PR TITLE
Bypass auto-pretty-listing of large VB code

### DIFF
--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -114,25 +114,26 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                         Return
                     End If
 
-                    If Not isExplicitFormat Then
-                        ' Avoid automatically formatting extremely large dirty spans without an explicit request from
-                        ' the user. The "large span threshold" is 7000 lines. The 7000 line threshold is an estimated
-                        ' value accounting for a lower-bound of the algorithmic complexity of text differencing in
-                        ' designer cases along with measurements of a pathological example demonstrated at 14000 lines.
-                        ' We expect Windows Forms designer formatting operations to run in under ~15 seconds on average
-                        ' current hardware when nearing the threshold.
+                    Dim useSemantics = info.UseSemantics
+                    If useSemantics AndAlso Not isExplicitFormat Then
+                        ' Avoid using semantics for formatting extremely large dirty spans without an explicit request
+                        ' from the user. The "large span threshold" is 7000 lines. The 7000 line threshold is an
+                        ' estimated value accounting for a lower-bound of the algorithmic complexity of text
+                        ' differencing in designer cases along with measurements of a pathological example demonstrated
+                        ' at 14000 lines. We expect Windows Forms designer formatting operations to run in under ~15
+                        ' seconds on average current hardware when nearing the threshold.
                         Dim startLineNumber = 0
                         Dim startColumnIndex = 0
                         Dim endLineNumber = 0
                         Dim endColumnIndex = 0
                         info.SpanToFormat.GetLinesAndColumns(startLineNumber, startColumnIndex, endLineNumber, endColumnIndex)
                         If endLineNumber - startLineNumber > 7000 Then
-                            Return
+                            useSemantics = false
                         End If
                     End If
 
                     Dim tree = _dirtyState.BaseDocument.GetSyntaxTreeSynchronously(cancellationToken)
-                    _commitFormatter.CommitRegion(info.SpanToFormat, isExplicitFormat, info.UseSemantics, dirtyRegion, _dirtyState.BaseSnapshot, tree, cancellationToken)
+                    _commitFormatter.CommitRegion(info.SpanToFormat, isExplicitFormat, useSemantics, dirtyRegion, _dirtyState.BaseSnapshot, tree, cancellationToken)
                 End Using
             Finally
                 ' We may have tracked a dirty region while committing or it may have been aborted.

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -114,6 +114,23 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                         Return
                     End If
 
+                    If Not isExplicitFormat Then
+                        ' Avoid automatically formatting extremely large dirty spans without an explicit request from
+                        ' the user. The "large span threshold" is 7000 lines. The 7000 line threshold is an estimated
+                        ' value accounting for a lower-bound of the algorithmic complexity of text differencing in
+                        ' designer cases along with measurements of a pathological example demonstrated at 14000 lines.
+                        ' We expect Windows Forms designer formatting operations to run in under ~15 seconds on average
+                        ' current hardware when nearing the threshold.
+                        Dim startLineNumber = 0
+                        Dim startColumnIndex = 0
+                        Dim endLineNumber = 0
+                        Dim endColumnIndex = 0
+                        info.SpanToFormat.GetLinesAndColumns(startLineNumber, startColumnIndex, endLineNumber, endColumnIndex)
+                        If endLineNumber - startLineNumber > 7000 Then
+                            Return
+                        End If
+                    End If
+
                     Dim tree = _dirtyState.BaseDocument.GetSyntaxTreeSynchronously(cancellationToken)
                     _commitFormatter.CommitRegion(info.SpanToFormat, isExplicitFormat, info.UseSemantics, dirtyRegion, _dirtyState.BaseSnapshot, tree, cancellationToken)
                 End Using


### PR DESCRIPTION
The formatter produces large and complicated diffs for content generated for large VB forms, resulting in long delays when working with the designer. This change bypasses the most expensive features that require semantic information for cases where the dirty span exceeds a "large span theshold" of 7000 lines.

Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/659925

⚠️ This change reduces the time to create an event handler for a button (double click in designer) from ~60 seconds to ~10 seconds in the repro case, with moderate but not unreasonable impact on the generated code.

### Customer scenario

After opening a complicated VB form in the Windows Forms designer, changes to the view that impact generated code take a long time to complete. This includes "obvious" actions like adding a control, as well as less obvious actions like double clicking on a control to add an event handler (which in VB does not require an event hookup in the generated code itself).

### Bugs this fixes

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/659925

### Workarounds, if any

Use fewer/less complicated controls in forms.

### Risk

Overall moderate.

For the driving user scenario (large VB forms), the risk is low because the threshold created with this pull request is larger than most real-world forms. A hard-coded threshold of 10,000 lines appeared in Visual Studio 2013 and earlier. Local experimentation suggests that performance delays first become observable in the 7,000-10,000 line range, with severe problems appearing before 14,000. The conservative value used accounts for users frequently changing properties like `BackColor` that result in larger numbers of changes to the generated code.

The current implementation has other observable situations for VB users. Any of the following cases that exceed the hard-coded threshold will also bypass the pretty-printer.

* Automatic format when moving the caret
* Automatic format on save
* Automatic format on paste
* Automatic format when focus is lost

Note that formatting operations that do not involve semantics, such as indentation, spacing, and the capitalization of keywords, is not impacted by this change.

### Performance impact

For most users, this will have no noticeable performance impact. Users with very large forms (above the threshold) will *observe* performance improvements, in some cases (including the linked bug) more than a 5:1 improvement.

### Is this a regression from a previous update?

Yes, introduced with Visual Studio 2015 relative to Visual Studio 2013.

### Root cause analysis

The size of form required to observe the change *vastly* exceeds "normal" forms (many hundreds to thousands of controls). Depth testing missed this as a customer scenario. To avoid changes without performance validation, the code contains an explanation of the underlying performance issue at the point where the pretty-printing bypass is implemented.

### How was the bug found?

Customer reported.

### Test documentation updated?

No.
