### PR TITLE
Fix issue where 'remove parens' would break code with ++/-- operators.

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
@@ -2052,5 +2052,77 @@ offeredWhenRequireForClarityIsEnabled: true);
 }",
 offeredWhenRequireForClarityIsEnabled: true);
         }
+
+        [WorkItem(29454, "https://github.com/dotnet/roslyn/issues/29454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestMissingForPreIncrement()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    void M(int x)
+    {
+        var v = (byte)$$(++x);
+    }
+}", new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [WorkItem(29454, "https://github.com/dotnet/roslyn/issues/29454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestMissingForPreDecrement()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    void M(int x)
+    {
+        var v = (byte)$$(--x);
+    }
+}", new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [WorkItem(29454, "https://github.com/dotnet/roslyn/issues/29454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestForPostIncrement()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M(int x)
+    {
+        var v = (byte)$$(x++);
+    }
+}",
+
+@"class C
+{
+    void M(int x)
+    {
+        var v = (byte)x++;
+    }
+}", parameters: new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [WorkItem(29454, "https://github.com/dotnet/roslyn/issues/29454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestForPostDecrement()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M(int x)
+    {
+        var v = (byte)$$(x--);
+    }
+}",
+
+@"class C
+{
+    void M(int x)
+    {
+        var v = (byte)x--;
+    }
+}", parameters: new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
@@ -2187,5 +2187,33 @@ offeredWhenRequireForClarityIsEnabled: true);
     }
 }", parameters: new TestParameters(options: RemoveAllUnnecessaryParentheses));
         }
+
+        [WorkItem(29454, "https://github.com/dotnet/roslyn/issues/29454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestMissingForPreIncrementAfterAdd()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    void M(int x)
+    {
+        var v = x+$$(++x);
+    }
+}", new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [WorkItem(29454, "https://github.com/dotnet/roslyn/issues/29454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestMissingForUnaryPlusAfterAdd()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    void M(int x)
+    {
+        var v = x+$$(+x);
+    }
+}", new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
@@ -2124,5 +2124,68 @@ offeredWhenRequireForClarityIsEnabled: true);
     }
 }", parameters: new TestParameters(options: RemoveAllUnnecessaryParentheses));
         }
+
+        [WorkItem(29454, "https://github.com/dotnet/roslyn/issues/29454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestForPreIncrementInLocalDeclaration()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M(int x)
+    {
+        var v = $$(++x);
+    }
+}",
+@"class C
+{
+    void M(int x)
+    {
+        var v = ++x;
+    }
+}", parameters: new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [WorkItem(29454, "https://github.com/dotnet/roslyn/issues/29454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestForPreIncrementInSimpleAssignment()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M(int x, int v)
+    {
+        v = $$(++x);
+    }
+}",
+@"class C
+{
+    void M(int x, int v)
+    {
+        v = ++x;
+    }
+}", parameters: new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [WorkItem(29454, "https://github.com/dotnet/roslyn/issues/29454")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestForPreIncrementInArgument()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M(int x)
+    {
+        M($$(++x));
+    }
+}",
+@"class C
+{
+    void M(int x)
+    {
+        M(++x);
+    }
+}", parameters: new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -224,6 +224,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return true;
             }
 
+            // If we have: (++x) or (--x), we don't want to remove the parens. doing so can make the
+            // ++/-- now associate with the previous part of the expression.
+            if (expression.IsKind(SyntaxKind.PreIncrementExpression) ||
+                expression.IsKind(SyntaxKind.PreDecrementExpression))
+            {
+                return false;
+            }
+
             // Operator precedence cases:
             // - If the parent is not an expression, do not remove parentheses
             // - Otherwise, parentheses may be removed if doing so does not change operator associations.

--- a/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -224,12 +224,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return true;
             }
 
-            // If we have: (++x) or (--x), we don't want to remove the parens. doing so can make the
-            // ++/-- now associate with the previous part of the expression.
-            if (expression.IsKind(SyntaxKind.PreIncrementExpression) ||
-                expression.IsKind(SyntaxKind.PreDecrementExpression))
+            // If we have: (X)(++x) or (X)(--x), we don't want to remove the parens. doing so can
+            // make the ++/-- now associate with the previous part of the cast expression.
+            if (parentExpression.IsKind(SyntaxKind.CastExpression))
             {
-                return false;
+                if (expression.IsKind(SyntaxKind.PreIncrementExpression) ||
+                    expression.IsKind(SyntaxKind.PreDecrementExpression))
+                {
+                    return false;
+                }
             }
 
             // Operator precedence cases:


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/29454

Also fixes a related issue i found while looking into this area where we could break code of the form `x+(++y)`.  