### PR TITLE
Fix .editorconfig rule dotnet_style_explicit_tuple_names works the same way for true and false

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseExplicitTupleName/UseExplicitTupleNameTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExplicitTupleName/UseExplicitTupleNameTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -193,6 +194,36 @@ class C
         v1.i = v1.s;
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTupleName)]
+        public async Task TestFalseOptionImplicitTuple()
+        {
+            await TestDiagnosticMissingAsync(
+@"
+class C
+{
+    void M()
+    {
+        (int i, string s) v1 = default((int, string));
+        var v2 = v1.[|Item1|];
+    }
+}", new TestParameters(options: Option(CodeStyleOptions.PreferExplicitTupleNames, false, NotificationOption.Warning)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTupleName)]
+        public async Task TestFalseOptionExplicitTuple()
+        {
+            await TestDiagnosticMissingAsync(
+@"
+class C
+{
+    void M()
+    {
+        (int i, string s) v1 = default((int, string));
+        var v2 = v1.[|i|];
+    }
+}", new TestParameters(options: Option(CodeStyleOptions.PreferExplicitTupleNames, false, NotificationOption.Warning)));
         }
     }
 }

--- a/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
@@ -37,35 +37,39 @@ namespace Microsoft.CodeAnalysis.UseExplicitTupleName
                 return;
             }
 
+            // We only create a diagnostic if the option's value is set to true.
             var option = optionSet.GetOption(CodeStyleOptions.PreferExplicitTupleNames, context.Compilation.Language);
-            var severity = option.Notification.Severity;
-            if (severity == ReportDiagnostic.Suppress)
+            if (option.Value)
             {
-                return;
-            }
-
-            var fieldReferenceOperation = (IFieldReferenceOperation)context.Operation;
-
-            var field = fieldReferenceOperation.Field;
-            if (field.ContainingType.IsTupleType)
-            {
-                if (option.Value && field.CorrespondingTupleField.Equals(field))
+                var severity = option.Notification.Severity;
+                if (severity == ReportDiagnostic.Suppress)
                 {
-                    var namedField = GetNamedField(field.ContainingType, field, cancellationToken);
-                    if (namedField != null)
+                    return;
+                }
+
+                var fieldReferenceOperation = (IFieldReferenceOperation)context.Operation;
+
+                var field = fieldReferenceOperation.Field;
+                if (field.ContainingType.IsTupleType)
+                {
+                    if (field.CorrespondingTupleField.Equals(field))
                     {
-                        var memberAccessSyntax = fieldReferenceOperation.Syntax;
-                        var nameNode = memberAccessSyntax.ChildNodesAndTokens().Reverse().FirstOrDefault();
-                        if (nameNode != null)
+                        var namedField = GetNamedField(field.ContainingType, field, cancellationToken);
+                        if (namedField != null)
                         {
-                            var properties = ImmutableDictionary<string, string>.Empty.Add(
-                                nameof(ElementName), namedField.Name);
-                            context.ReportDiagnostic(DiagnosticHelper.Create(
-                                Descriptor,
-                                nameNode.GetLocation(),
-                                severity,
-                                additionalLocations: null,
-                                properties));
+                            var memberAccessSyntax = fieldReferenceOperation.Syntax;
+                            var nameNode = memberAccessSyntax.ChildNodesAndTokens().Reverse().FirstOrDefault();
+                            if (nameNode != null)
+                            {
+                                var properties = ImmutableDictionary<string, string>.Empty.Add(
+                                    nameof(ElementName), namedField.Name);
+                                context.ReportDiagnostic(DiagnosticHelper.Create(
+                                    Descriptor,
+                                    nameNode.GetLocation(),
+                                    severity,
+                                    additionalLocations: null,
+                                    properties));
+                            }
                         }
                     }
                 }

--- a/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.UseExplicitTupleName
             var field = fieldReferenceOperation.Field;
             if (field.ContainingType.IsTupleType)
             {
-                if (field.CorrespondingTupleField.Equals(field))
+                if (option.Value && field.CorrespondingTupleField.Equals(field))
                 {
                     var namedField = GetNamedField(field.ContainingType, field, cancellationToken);
                     if (namedField != null)


### PR DESCRIPTION
Fixes #27407.
--
After discussing with @sharwell, the rule "dotnet_style_explicit_tuple_names" at the moment is intended to only be enforced one way (i.e. no diagnostic should be reported if rule is configured to false).