### PR TITLE
Cleanup Mono heplers

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -19773,7 +19773,8 @@ namespace A
                 Diagnostic(ErrorCode.ERR_TypeForwardedToMultipleAssemblies, "ClassB.MethodB").WithArguments("CModule.dll", "C, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C.ClassC", "D1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "D2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
         }
 
-        [Fact, WorkItem(16484, "https://github.com/dotnet/roslyn/issues/16484")]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10332")]
+        [WorkItem(16484, "https://github.com/dotnet/roslyn/issues/16484")]
         public void MultipleTypeForwardersToTheSameAssemblyShouldNotResultInMultipleForwardError()
         {
             var codeC = @"

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -115,6 +115,7 @@ namespace Roslyn.Test.Utilities
     {
         public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
         public static bool IsDesktop => CoreClrShim.AssemblyLoadContext.Type == null;
+        public static bool IsWindowsDesktop => IsWindows && IsDesktop;
     }
 
     public class x86 : ExecutionCondition
@@ -166,7 +167,7 @@ namespace Roslyn.Test.Utilities
 
     public class WindowsDesktopOnly : ExecutionCondition
     {
-        public override bool ShouldSkip => !(ExecutionConditionUtil.IsWindows && ExecutionConditionUtil.IsDesktop);
+        public override bool ShouldSkip => !ExecutionConditionUtil.IsWindowsDesktop;
         public override string SkipReason => "Test only supported on Windows desktop";
     }
 

--- a/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
+++ b/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         private static string GetIlasmPath()
         {
-            if (CoreClrShim.AssemblyLoadContext.Type == null)
+            if (ExecutionConditionUtil.IsWindowsDesktop)
             {
                 return Path.Combine(
                     Path.GetDirectoryName(RuntimeUtilities.GetAssemblyLocation(typeof(object))),
@@ -98,22 +98,13 @@ $@".assembly '{sourceFileName}' {{}}
                     pdbPath = null;
                 }
 
-                var program = IlasmPath;
-                if (MonoHelpers.IsRunningOnMono())
-                {
-                    arguments = string.Format("{0} {1}", IlasmPath, arguments);
-                    arguments = arguments.Replace("\"", "");
-                    arguments = arguments.Replace("=", ":");
-                    program = "mono";
-                }
-
-                var result = ProcessUtilities.Run(program, arguments);
+                var result = ProcessUtilities.Run(IlasmPath, arguments);
 
                 if (result.ContainsErrors)
                 {
                     throw new ArgumentException(
                         "The provided IL cannot be compiled." + Environment.NewLine +
-                        program + " " + arguments + Environment.NewLine +
+                        IlasmPath + " " + arguments + Environment.NewLine +
                         result,
                         nameof(declarations));
                 }

--- a/src/Test/Utilities/Portable/Platform/Desktop/DesktopRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/Platform/Desktop/DesktopRuntimeEnvironment.cs
@@ -291,6 +291,12 @@ namespace Roslyn.Test.Utilities.Desktop
 
         public void Verify(Verification verification)
         {
+            // Verification is only done on windows desktop 
+            if (!ExecutionConditionUtil.IsWindowsDesktop)
+            {
+                return;
+            }
+
             if (verification == Verification.Skipped)
             {
                 return;


### PR DESCRIPTION
Change the Mono helpers:

1. Properly don't run verification on Mono. Only Windows Desktop runs
verification at this time
1. Use the CoreClr ilasm utility instead of the Mono version. It has the
functionality we need for our unit tests.

Related #28011