### PR TITLE
Fix Microbuild parameters

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -108,7 +108,7 @@ function Process-Arguments() {
         exit 1
     }
 
-    if (($cibuild -and $anyVsi)) {
+    if ((-not $official -and $anyVsi)) {
         # Avoid spending time in analyzers when requested, and also in the slowest integration test builds
         $script:skipAnalyzers = $true
     }
@@ -253,7 +253,7 @@ function Build-Artifacts() {
         Run-SignTool
     }
 
-    if ($pack -and ($cibuild -or $official)) {
+    if ($pack -and $cibuild) {
         Build-DeployToSymStore
     }
 
@@ -499,7 +499,7 @@ function Test-XUnit() {
     $dlls = $dlls | ?{ -not ($_.FullName -match ".*\\ref\\.*") }
     $dlls = $dlls | ?{ -not ($_.FullName -match ".*/ref/.*") }
 
-    if ($cibuild -or $official) {
+    if ($cibuild) {
         # Use a 75 minute timeout on CI
         $args += " -xml -timeout:75"
     }
@@ -734,7 +734,7 @@ catch {
 }
 finally {
     Pop-Location
-    if ($cibuild) {
+    if (-not $official) {
         Stop-VSProcesses
         Stop-BuildProcesses
     }

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <Target Name="Build">
-    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)microbuild.ps1 -restore -official $(ScriptArgs) " />
+    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)microbuild.ps1 -official $(ScriptArgs) " />
 
     <ItemGroup>
       <_PublishProps Include="Configuration=$(Configuration)"/>

--- a/src/Tools/MicroBuild/cibuild.cmd
+++ b/src/Tools/MicroBuild/cibuild.cmd
@@ -1,1 +1,1 @@
-powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\microbuild.ps1" -restore -cibuild -release
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\microbuild.ps1" -release

--- a/src/Tools/MicroBuild/microbuild.ps1
+++ b/src/Tools/MicroBuild/microbuild.ps1
@@ -60,9 +60,12 @@ function Copy-InsertionItems() {
     foreach ($item in $items) { 
         $itemPath = Join-Path $configDir $item
         Copy-Item $itemPath $insertionDir
-    }
+    }       
 
-    Copy-Item (Join-Path $configDir "NuGet\VS\*.nupkg") $insertionDir
+    $devDivPackagesDir = Join-Path $configDir "DevDivPackages\Roslyn"
+    Create-Directory $devDivPackagesDir
+
+    Copy-Item (Join-Path $configDir "NuGet\VS\*.nupkg") $devDivPackagesDir
 }
 
 Push-Location $PSScriptRoot

--- a/src/Tools/MicroBuild/microbuild.ps1
+++ b/src/Tools/MicroBuild/microbuild.ps1
@@ -1,9 +1,7 @@
 [CmdletBinding(PositionalBinding=$false)]
 param (
-    [switch]$restore = $false,
     [switch]$release = $false,
     [switch]$official = $false,
-    [switch]$cibuild = $false,
     [string]$branchName = "master",
     [switch]$testDesktop = $false,
     [string]$publishType = "",
@@ -26,9 +24,7 @@ $ErrorActionPreference = "Stop"
 function Print-Usage() {
     Write-Host "Usage: build.ps1"
     Write-Host "  -release                  Perform release build (default is debug)"
-    Write-Host "  -restore                  Restore packages"
     Write-Host "  -official                 Perform an official build"
-    Write-Host "  -cibuild                  Run CI specific operations"
     Write-Host "  -testDesktop              Run unit tests"
     Write-Host "  -publishType              Publish to run: vsts, blob or none (default is none)"
     Write-Host "  -branchName               Branch being built"
@@ -86,7 +82,7 @@ try {
     # On Jenkins runs we deliberately run microbuild with a clean NuGet cache. This means at least 
     # one job runs with a clean cache and assures all packages we depend on are restored during 
     # the restore phase. As opposed to getting lucky based on a NuGet being available in the cache.
-    if ($cibuild) {
+    if (-not $official) {
         Clear-PackageCache
     }
 
@@ -95,7 +91,7 @@ try {
     $configDir = Join-Path $binariesDir $config
     $setupDir = Join-Path $repoDir "src\Setup"
 
-    Exec-Block { & (Join-Path $scriptDir "build.ps1") -restore:$restore -build -cibuild:$cibuild -official:$official -release:$release -sign -signType $signType -pack -testDesktop:$testDesktop -binaryLog -procdump }
+    Exec-Block { & (Join-Path $scriptDir "build.ps1") -restore:$true -build -cibuild:$true -official:$official -release:$release -sign -signType $signType -pack -testDesktop:$testDesktop -binaryLog -procdump }
     Copy-InsertionItems
 
     # Insertion scripts currently look for a sentinel file on the drop share to determine that the build was green
@@ -134,7 +130,7 @@ catch {
 }
 finally {
     Pop-Location
-    if ($cibuild) {
+    if (-not $official) {
         Get-Process msbuild -ErrorAction SilentlyContinue | Stop-Process
         Get-Process vbcscompiler -ErrorAction SilentlyContinue | Stop-Process
     }


### PR DESCRIPTION
Setting `-cibuild` in scripts now translates to `/p:ContinuousIntegrationBuild=true` in targets files,
`-official` translates to `/p:OfficialBuildId=$(BUILD_BUILDNUMBER)`. Previously, `-cibuild` meant Jenkins, not an official CI build.

Also copy Roslyn CoreXT packages to `DevDivPackages\Roslyn` directory instead of `Insertion` directory. The former is uploaded to CoreXT store, the latter is uploaded to VSTS store, where we upload Willow VSIXes. Prior PR https://github.com/dotnet/roslyn/pull/29408 we copied them to both places.
