### PR TITLE
Fix temp creation with `in` parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -183,8 +183,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
         }
 
-        internal static bool IsStackLocal(LocalSymbol local, HashSet<LocalSymbol> _stackLocalsOpt)
-            => _stackLocalsOpt?.Contains(local) ?? false;
+        internal static bool IsStackLocal(LocalSymbol local, HashSet<LocalSymbol> stackLocalsOpt)
+            => stackLocalsOpt?.Contains(local) ?? false;
 
         private bool IsStackLocal(LocalSymbol local) => IsStackLocal(local, _stackLocals);
 

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -139,10 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return _module.Compilation.Options.DebugPlusMode;
         }
 
-        private bool EnablePEVerifyCompat()
-        {
-            return _module.Compilation.LanguageVersion < LanguageVersion.CSharp7_2 || _module.Compilation.FeaturePEVerifyCompatEnabled;
-        }
+        private bool IsPeVerifyCompatEnabled() => _module.Compilation.IsPeVerifyCompatEnabled;
 
         private LocalDefinition LazyReturnTemp
         {
@@ -186,10 +183,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
         }
 
-        private bool IsStackLocal(LocalSymbol local)
-        {
-            return _stackLocals != null && _stackLocals.Contains(local);
-        }
+        internal static bool IsStackLocal(LocalSymbol local, HashSet<LocalSymbol> _stackLocalsOpt)
+            => _stackLocalsOpt?.Contains(local) ?? false;
+
+        private bool IsStackLocal(LocalSymbol local) => IsStackLocal(local, _stackLocals);
 
         public void Generate()
         {

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     break;
 
                 case BoundKind.ThisReference:
-                    Debug.Assert(expression.Type.IsValueType || IsReadOnly(addressKind), "'this' is readonly in classes");
+                    Debug.Assert(expression.Type.IsValueType || IsAnyReadOnly(addressKind), "'this' is readonly in classes");
 
                     if (expression.Type.IsValueType)
                     {
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     var methodRefKind = call.Method.RefKind;
 
                     if (methodRefKind == RefKind.Ref || 
-                        (IsReadOnly(addressKind) && methodRefKind == RefKind.RefReadOnly))
+                        (IsAnyReadOnly(addressKind) && methodRefKind == RefKind.RefReadOnly))
                     {
                         EmitCallExpression(call, UseKind.UsedAsAddress);
                         break;
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 return true;
             }
 
-            if (!IsReadOnly(addressKind))
+            if (!IsAnyReadOnly(addressKind))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -1,37 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.CSharp.Binder;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 {
     internal partial class CodeGenerator
     {
-        private enum AddressKind
-        {
-            // reference may be written to
-            Writeable,
-
-            // reference itself will not be written to, but may be used for call, callvirt.
-            // for all purposes it is the same as Writeable, except when fetching an address of an array element
-            // where it results in a ".readonly" prefix to deal with array covariance.
-            Constrained,
-
-            // reference itself will not be written to, nor it will be used to modify fields.
-            ReadOnly,
-
-            // same as ReadOnly, but we are not supposed to get a reference to a clone
-            // regardless of compat settings.
-            ReadOnlyStrict,
-        }
-
-        private static bool IsReadOnly(AddressKind addressKind) => addressKind >= AddressKind.ReadOnly;
-
         /// <summary>
         /// Emits address as in &amp; 
         /// 
@@ -372,193 +354,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return null;
         }
 
-
-        /// <summary>
-        /// Checks if expression directly or indirectly represents a value with its own home. In
-        /// such cases it is possible to get a reference without loading into a temporary.
-        /// </summary>
-        private bool HasHome(BoundExpression expression, AddressKind addressKind)
-        {
-            switch (expression.Kind)
-            {
-                case BoundKind.ArrayAccess:
-                    if (addressKind == AddressKind.ReadOnly && 
-                        !expression.Type.IsValueType &&
-                        EnablePEVerifyCompat())
-                    {
-                        // due to array covariance getting a reference may throw ArrayTypeMismatch when element is not a struct, 
-                        // passing "readonly." prefix would prevent that, but it is unverifiable, so will make a copy in compat case
-                        return false;
-                    }
-
-                    return true;
-
-                case BoundKind.PointerIndirectionOperator:
-                case BoundKind.RefValueOperator:
-                    return true;
-
-                case BoundKind.ThisReference:
-                    var type = expression.Type;
-                    if (type.IsReferenceType)
-                    {
-                        Debug.Assert(IsReadOnly(addressKind), "`this` is readonly in classes");
-                        return true;
-                    }
-
-                    if (!IsReadOnly(addressKind) && type.IsReadOnly)
-                    {
-                        return _method.MethodKind == MethodKind.Constructor;
-                    }
-
-                    return true;
-
-                case BoundKind.ThrowExpression:
-                    // vacuously this is true, we can take address of throw without temps
-                    return true;
-
-                case BoundKind.Parameter:
-                    return IsReadOnly(addressKind) || 
-                        ((BoundParameter)expression).ParameterSymbol.RefKind != RefKind.In;
-
-                case BoundKind.Local:
-                    // locals have home unless they are byval stack locals or ref-readonly
-                    // locals in a mutating call
-                    var local = ((BoundLocal)expression).LocalSymbol;
-                    return !((IsStackLocal(local) && local.RefKind == RefKind.None) || 
-                        (!IsReadOnly(addressKind) && local.RefKind == RefKind.RefReadOnly));
-
-                case BoundKind.Call:
-                    var methodRefKind = ((BoundCall)expression).Method.RefKind;
-                    return methodRefKind == RefKind.Ref ||
-                           (IsReadOnly(addressKind) && methodRefKind == RefKind.RefReadOnly);
-
-                case BoundKind.Dup:
-                    //NB: Dup represents locals that do not need IL slot
-                    var dupRefKind = ((BoundDup)expression).RefKind;
-                    return dupRefKind == RefKind.Ref ||
-                        (IsReadOnly(addressKind) && dupRefKind == RefKind.RefReadOnly);
-
-                case BoundKind.FieldAccess:
-                    return HasHome((BoundFieldAccess)expression, addressKind);
-
-                case BoundKind.Sequence:
-                    return HasHome(((BoundSequence)expression).Value, addressKind);
-
-                case BoundKind.AssignmentOperator:
-                    var assignment = (BoundAssignmentOperator)expression;
-                    if (!assignment.IsRef)
-                    {
-                        return false;
-                    }
-                    var lhsRefKind = assignment.Left.GetRefKind();
-                    return lhsRefKind == RefKind.Ref ||
-                        (IsReadOnly(addressKind) && lhsRefKind == RefKind.RefReadOnly);
-
-                case BoundKind.ComplexConditionalReceiver:
-                    Debug.Assert(HasHome(((BoundComplexConditionalReceiver)expression).ValueTypeReceiver, addressKind));
-                    Debug.Assert(HasHome(((BoundComplexConditionalReceiver)expression).ReferenceTypeReceiver, addressKind));
-                    goto case BoundKind.ConditionalReceiver;
-
-                case BoundKind.ConditionalReceiver:
-                    //ConditionalReceiver is a noop from Emit point of view. - it represents something that has already been pushed. 
-                    //We should never need a temp for it. 
-                    return true;
-
-                case BoundKind.ConditionalOperator:
-                    var ternary = (BoundConditionalOperator)expression;
-                    
-                    // only ref ternary may be referenced as a variable
-                    if (!ternary.IsRef)
-                    {
-                        return false;
-                    }
- 
-                    // branch that has no home will need a temporary
-                    // if both have no home, just say whole expression has no home 
-                    // so we could just use one temp for the whole thing
-                    return HasHome(ternary.Consequence, addressKind) && HasHome(ternary.Alternative, addressKind);
-
-                default:
-                    return false;
-            }
-        }
-
-        /// <summary>
-        /// Special HasHome for fields. 
-        /// Fields have readable homes when they are not constants.
-        /// Fields have writeable homes unless they are readonly and used outside of the constructor.
-        /// </summary>
-        private bool HasHome(BoundFieldAccess fieldAccess, AddressKind addressKind)
-        {
-            FieldSymbol field = fieldAccess.FieldSymbol;
-
-            // const fields are literal values with no homes. (ex: decimal.Zero)
-            if (field.IsConst)
-            {
-                return false;
-            }
-
-            // in readonly situations where ref to a copy is not allowed, consider fields as addressable
-            if (addressKind == AddressKind.ReadOnlyStrict)
-            {
-                return true;
-            }
-
-            // ReadOnly references can always be taken unless we are in peverify compat mode
-            if (addressKind == AddressKind.ReadOnly && !EnablePEVerifyCompat())
-            {
-                return true;
-            }
-
-            // Some field accesses must be values; values do not have homes.
-            if (fieldAccess.IsByValue)
-            {
-                return false;
-            }
-
-            if (!field.IsReadOnly)
-            {
-                // in a case if we have a writeable struct field with a receiver that only has a readable home we would need to pass it via a temp.
-                // it would be advantageous to make a temp for the field, not for the the outer struct, since the field is smaller and we can get to is by fetching references.
-                // NOTE: this would not be profitable if we have to satisfy verifier, since for verifiability 
-                //       we would not be able to dig for the inner field using references and the outer struct will have to be copied to a temp anyways.
-                if (!EnablePEVerifyCompat())
-                {
-                    Debug.Assert(!IsReadOnly(addressKind));
-
-                    var receiver = fieldAccess.ReceiverOpt;
-                    if (receiver?.Type.IsValueType == true)
-                    {
-                        // Check receiver:
-                        // has writeable home -> return true - the whole chain has writeable home (also a more common case)
-                        // has readable home -> return false - we need to copy the field
-                        // otherwise         -> return true  - the copy will be made at higher level so the leaf field can have writeable home
-
-                        return HasHome(receiver, addressKind) ||  
-                               !HasHome(receiver, AddressKind.ReadOnly);
-                    }
-                }
-
-                return true;
-            }
-
-            // while readonly fields have home it is not valid to refer to it when not constructing.
-            if (field.ContainingType != _method.ContainingType)
-            {
-                return false;
-            }
-
-            if (field.IsStatic)
-            {
-                return _method.MethodKind == MethodKind.StaticConstructor;
-            }
-            else
-            {
-                return _method.MethodKind == MethodKind.Constructor &&
-                    fieldAccess.ReceiverOpt.Kind == BoundKind.ThisReference;
-            }
-        }
-
         private void EmitArrayIndices(ImmutableArray<BoundExpression> indices)
         {
             for (int i = 0; i < indices.Length; ++i)
@@ -637,6 +432,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             _builder.EmitOpCode(ILOpCode.Ldsflda);
             EmitSymbolToken(field, syntaxNode);
         }
+
+        /// <summary>
+        /// Checks if expression directly or indirectly represents a value with its own home. In
+        /// such cases it is possible to get a reference without loading into a temporary.
+        /// </summary>
+        private bool HasHome(BoundExpression expression, AddressKind addressKind)
+            => Binder.HasHome(expression, addressKind, _method, IsPeVerifyCompatEnabled(), _stackLocals);
 
         private LocalDefinition EmitParameterAddress(BoundParameter parameter, AddressKind addressKind)
         {

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
@@ -408,7 +408,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                if (EnablePEVerifyCompat())
+                if (IsPeVerifyCompatEnabled())
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
 
 using static System.Linq.ImmutableArrayExtensions;
+using static Microsoft.CodeAnalysis.CSharp.Binder;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 {

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.CSharp.Binder;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -164,12 +164,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool FeatureStrictEnabled => Feature("strict") != null;
 
         /// <summary>
-        /// True when "peverify-compat" is set
+        /// True when the "peverify-compat" feature flag is set or the language version is below C# 7.2.
         /// With this flag we will avoid certain patterns known not be compatible with PEVerify.
         /// The code may be less efficient and may deviate from spec in corner cases.
         /// The flag is only to be used if PEVerify pass is extremely important.
         /// </summary>
-        internal bool FeaturePEVerifyCompatEnabled => Feature("peverify-compat") != null;
+        internal bool IsPeVerifyCompatEnabled => LanguageVersion < LanguageVersion.CSharp7_2 || Feature("peverify-compat") != null; 
 
         /// <summary>
         /// The language version that was used to parse the syntax trees of this compilation.

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private AwaitExpressionSpiller(MethodSymbol method, SyntaxNode syntaxNode, TypeCompilationState compilationState, PooledDictionary<LocalSymbol, LocalSymbol> tempSubstitution, DiagnosticBag diagnostics)
         {
             _F = new SyntheticBoundNodeFactory(method, syntaxNode, compilationState, diagnostics);
+            _F.CurrentFunction = method;
             _tempSubstitution = tempSubstitution;
         }
 
@@ -972,6 +973,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return UpdateExpression(builder, node.Update(left, right, node.LeftConversion, node.Type));
+        }
+
+        public override BoundNode VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        public override BoundNode VisitLambda(BoundLambda node)
+        {
+            throw ExceptionUtilities.Unreachable;
         }
 
         public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -292,8 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ref argumentRefKindsOpt,
                 out argTemps,
                 invokedAsExtensionMethod: false,
-                enableCallerInfo: ThreeState.True,
-                argumentsBinderOpt);
+                enableCallerInfo: ThreeState.True);
 
             if (used)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -187,7 +187,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             default(ImmutableArray<int>),
                             rewrittenRight,
                             type,
-                            used);
+                            used,
+                            argumentsBinderOpt: null);
                     }
 
                 case BoundKind.IndexerAccess:
@@ -208,7 +209,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             indexerAccess.ArgsToParamsOpt,
                             rewrittenRight,
                             type,
-                            used);
+                            used,
+                            indexerAccess.BinderOpt);
                     }
 
                 case BoundKind.Local:
@@ -260,7 +262,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<int> argsToParamsOpt,
             BoundExpression rewrittenRight,
             TypeSymbol type,
-            bool used)
+            bool used,
+            Binder argumentsBinderOpt)
         {
             // Rewrite property assignment into call to setter.
             var setMethod = property.GetOwnOrInheritedSetMethod();
@@ -279,7 +282,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We have already lowered each argument, but we may need some additional rewriting for the arguments,
             // such as generating a params array, re-ordering arguments based on argsToParamsOpt map, inserting arguments for optional parameters, etc.
             ImmutableArray<LocalSymbol> argTemps;
-            rewrittenArguments = MakeArguments(syntax, rewrittenArguments, property, setMethod, expanded, argsToParamsOpt, ref argumentRefKindsOpt, out argTemps, enableCallerInfo: ThreeState.True);
+            rewrittenArguments = MakeArguments(
+                syntax,
+                rewrittenArguments,
+                property,
+                setMethod,
+                expanded,
+                argsToParamsOpt,
+                ref argumentRefKindsOpt,
+                out argTemps,
+                invokedAsExtensionMethod: false,
+                enableCallerInfo: ThreeState.True,
+                argumentsBinderOpt);
 
             if (used)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -187,8 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             default(ImmutableArray<int>),
                             rewrittenRight,
                             type,
-                            used,
-                            argumentsBinderOpt: null);
+                            used);
                     }
 
                 case BoundKind.IndexerAccess:
@@ -209,8 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             indexerAccess.ArgsToParamsOpt,
                             rewrittenRight,
                             type,
-                            used,
-                            indexerAccess.BinderOpt);
+                            used);
                     }
 
                 case BoundKind.Local:
@@ -262,8 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<int> argsToParamsOpt,
             BoundExpression rewrittenRight,
             TypeSymbol type,
-            bool used,
-            Binder argumentsBinderOpt)
+            bool used)
         {
             // Rewrite property assignment into call to setter.
             var setMethod = property.GetOwnOrInheritedSetMethod();

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -691,8 +691,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(refKinds.Count == arguments.Length);
             Debug.Assert(storesToTemps.Count == 0);
 
-            var discardedDiags = DiagnosticBag.GetInstance();
-
             for (int a = 0; a < rewrittenArguments.Length; ++a)
             {
                 BoundExpression argument = rewrittenArguments[a];
@@ -726,7 +724,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (IsBeginningOfParamArray(p, a, expanded, arguments.Length, rewrittenArguments, argsToParamsOpt, out int paramArrayArgumentCount)
                     && a + paramArrayArgumentCount == rewrittenArguments.Length)
                 {
-                    discardedDiags.Free();
                     return;
                 }
 
@@ -759,8 +756,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 refKinds[p] = argRefKind;
             }
-
-            discardedDiags.Free();
 
             return;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -287,6 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argumentRefKinds,
                 rewrittenArguments,
                 forceLambdaSpilling: true, // lambdas must produce exactly one delegate so they must be spilled into a temp
+                indexerAccess.BinderOpt,
                 actualArguments,
                 refKinds,
                 storesToTemps);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -287,7 +287,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argumentRefKinds,
                 rewrittenArguments,
                 forceLambdaSpilling: true, // lambdas must produce exactly one delegate so they must be spilled into a temp
-                indexerAccess.BinderOpt,
                 actualArguments,
                 refKinds,
                 storesToTemps);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -82,8 +82,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             // NOTE: This is done later by MakeArguments, for now we just lower each argument.
             ImmutableArray<BoundExpression> rewrittenArguments = VisitList(node.Arguments);
 
-            return MakeIndexerAccess(node.Syntax, rewrittenReceiver, indexer, rewrittenArguments, node.ArgumentNamesOpt,
-                 node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.Type, node, isLeftOfAssignment);
+            return MakeIndexerAccess(
+                node.Syntax,
+                rewrittenReceiver,
+                indexer,
+                rewrittenArguments,
+                node.ArgumentNamesOpt,
+                node.ArgumentRefKindsOpt,
+                node.Expanded,
+                node.ArgsToParamsOpt,
+                node.Type,
+                node,
+                isLeftOfAssignment);
         }
 
         private BoundExpression MakeIndexerAccess(
@@ -105,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // This node will be rewritten with MakePropertyAssignment when rewriting the enclosing BoundAssignmentOperator.
 
                 return oldNodeOpt != null ?
-                    oldNodeOpt.Update(rewrittenReceiver, indexer, rewrittenArguments, argumentNamesOpt, argumentRefKindsOpt, expanded, argsToParamsOpt, null, isLeftOfAssignment, type) :
+                    oldNodeOpt.Update(rewrittenReceiver, indexer, rewrittenArguments, argumentNamesOpt, argumentRefKindsOpt, expanded, argsToParamsOpt, oldNodeOpt.BinderOpt, isLeftOfAssignment, type) :
                     new BoundIndexerAccess(syntax, rewrittenReceiver, indexer, rewrittenArguments, argumentNamesOpt, argumentRefKindsOpt, expanded, argsToParamsOpt, null, isLeftOfAssignment, type);
             }
             else
@@ -116,7 +126,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // We have already lowered each argument, but we may need some additional rewriting for the arguments,
                 // such as generating a params array, re-ordering arguments based on argsToParamsOpt map, inserting arguments for optional parameters, etc.
                 ImmutableArray<LocalSymbol> temps;
-                rewrittenArguments = MakeArguments(syntax, rewrittenArguments, indexer, getMethod, expanded, argsToParamsOpt, ref argumentRefKindsOpt, out temps, enableCallerInfo: ThreeState.True);
+                rewrittenArguments = MakeArguments(
+                    syntax,
+                    rewrittenArguments,
+                    indexer,
+                    getMethod,
+                    expanded,
+                    argsToParamsOpt,
+                    ref argumentRefKindsOpt,
+                    out temps,
+                    enableCallerInfo: ThreeState.True,
+                    argumentsBinderOpt: oldNodeOpt?.BinderOpt);
 
                 BoundExpression call = MakePropertyGetAccess(syntax, rewrittenReceiver, indexer, rewrittenArguments, getMethod);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -135,8 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     argsToParamsOpt,
                     ref argumentRefKindsOpt,
                     out temps,
-                    enableCallerInfo: ThreeState.True,
-                    argumentsBinderOpt: oldNodeOpt?.BinderOpt);
+                    enableCallerInfo: ThreeState.True);
 
                 BoundExpression call = MakePropertyGetAccess(syntax, rewrittenReceiver, indexer, rewrittenArguments, getMethod);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // This node will be rewritten with MakePropertyAssignment when rewriting the enclosing BoundAssignmentOperator.
 
                 return oldNodeOpt != null ?
-                    oldNodeOpt.Update(rewrittenReceiver, indexer, rewrittenArguments, argumentNamesOpt, argumentRefKindsOpt, expanded, argsToParamsOpt, oldNodeOpt.BinderOpt, isLeftOfAssignment, type) :
+                    oldNodeOpt.Update(rewrittenReceiver, indexer, rewrittenArguments, argumentNamesOpt, argumentRefKindsOpt, expanded, argsToParamsOpt, null, isLeftOfAssignment, type) :
                     new BoundIndexerAccess(syntax, rewrittenReceiver, indexer, rewrittenArguments, argumentNamesOpt, argumentRefKindsOpt, expanded, argsToParamsOpt, null, isLeftOfAssignment, type);
             }
             else

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -37,7 +37,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             // such as generating a params array, re-ordering arguments based on argsToParamsOpt map, inserting arguments for optional parameters, etc.
             ImmutableArray<LocalSymbol> temps;
             ImmutableArray<RefKind> argumentRefKindsOpt = node.ArgumentRefKindsOpt;
-            rewrittenArguments = MakeArguments(node.Syntax, rewrittenArguments, node.Constructor, node.Constructor, node.Expanded, node.ArgsToParamsOpt, ref argumentRefKindsOpt, out temps);
+            rewrittenArguments = MakeArguments(
+                node.Syntax,
+                rewrittenArguments,
+                node.Constructor,
+                node.Constructor,
+                node.Expanded,
+                node.ArgsToParamsOpt,
+                ref argumentRefKindsOpt,
+                out temps,
+                argumentsBinderOpt: node.BinderOpt);
 
             BoundExpression rewrittenObjectCreation;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -45,8 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 node.Expanded,
                 node.ArgsToParamsOpt,
                 ref argumentRefKindsOpt,
-                out temps,
-                argumentsBinderOpt: node.BinderOpt);
+                out temps);
 
             BoundExpression rewrittenObjectCreation;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -404,11 +404,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     RefKind refKind = paramRefKindsOpt.RefKinds(i);
-                    if (refKind == RefKind.In
-                        && !InArgumentRequiresCopy(arg, argumentsBinderOpt, discarded))
-                    {
-                        refKind = RefKindExtensions.StrictIn;
-                    }
 
                     BoundAssignmentOperator store;
                     var temp = _factory.StoreToTemp(arg, out store, refKind);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -232,7 +232,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var args = EvaluateSideEffectingArgumentsToTemps(
                                 memberInit.Arguments,
                                 memberInit.MemberSymbol?.GetParameterRefKinds() ?? default(ImmutableArray<RefKind>),
-                                memberInit.BinderOpt,
                                 result,
                                 ref temps);
 
@@ -324,7 +323,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var indices = EvaluateSideEffectingArgumentsToTemps(
                             arrayAccess.Indices,
                             paramRefKindsOpt: default,
-                            argumentsBinderOpt: null,
                             result,
                             ref temps);
                         rewrittenAccess = arrayAccess.Update(rewrittenReceiver, indices, arrayAccess.Type);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -383,13 +383,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ImmutableArray<BoundExpression> EvaluateSideEffectingArgumentsToTemps(
                                                  ImmutableArray<BoundExpression> args,
                                                  ImmutableArray<RefKind> paramRefKindsOpt,
-                                                 Binder argumentsBinderOpt,
                                                  ArrayBuilder<BoundExpression> sideeffects,
                                                  ref ArrayBuilder<LocalSymbol> temps)
         {
             ArrayBuilder<BoundExpression> newArgs = null;
-
-            var discarded = DiagnosticBag.GetInstance();
 
             for (int i = 0; i < args.Length; i++)
             {
@@ -422,11 +419,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            discarded.Free();
-
-            return newArgs?
-                .ToImmutableAndFree() ??
-                args;
+            return newArgs?.ToImmutableAndFree() ?? args;
         }
 
         private BoundExpression MakeObjectInitializerMemberAccess(

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1280,12 +1280,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case RefKind.Out:
                     refKind = RefKind.Ref;
                     break;
+
+                // "in" arguments are spilled by-value, while "strict-in" arguments are
+                // spilled by-ref. It's the responsibility of the caller to determine
+                // whether or not their argument can be spilled by-ref.
                 case RefKind.In:
-                    if (argument.GetRefKind() == RefKind.None)
-                    {
-                        refKind = RefKind.None;
-                    }
+                    refKind = RefKind.None;
                     break;
+                case RefKindExtensions.StrictIn:
+                    refKind = RefKind.In;
+                    break;
+
                 case RefKind.None:
                 case RefKind.Ref:
                     break;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -336,8 +336,8 @@ GetField 1
   IL_0021:  ret
 }");
         }
-        [Fact]
 
+        [Fact]
         public void InIndexerReorderWithCopy()
         {
             var verifier = CompileAndVerify(@"


### PR DESCRIPTION
There's a variety of cases in the compiler where we need to store an
expression into a temporary variable, e.g. to sequence side effects
in the right order. This code was not adjusted to deal with `in`
parameters, so it exhibited various pathologies.

The first case is the simplest -- sometimes when using the "explicit in"
modifier on an argument, the temp creation routine would simply crash.

The other cases are more subtle and mostly have to do with whether or
not the temp is created as a ref local or regular local. This is
specific to the "implicit in", where the "in" keyword is not mentioned
on the argument. In this case, the semantics for the call should be that
the argument is passed by-ref without storing to a copy unless
absolutely necessary. Absolutely necessary in this case is defined as 1)
the argument is an rvalue or 2) the argument requires a conversion to
the parameter type.

A lot of this knowledge was already present in CodeGen, but not available
in lowering, so I've pulled out the HasHome helper to Binding, as I felt that
was the best place for the common code.

Fixes #29371 