### PR TITLE
Queue tasks rather than invoking them inline

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioTaskSchedulerFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioTaskSchedulerFactory.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 _joinableTaskFactory.RunAsync(async () =>
                 {
-                    await _joinableTaskFactory.SwitchToMainThreadAsync();
+                    await _joinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true);
                     TryExecuteTask(task);
                 });
             }


### PR DESCRIPTION
Prior to this change, `JoinableTaskFactoryTaskScheduler` would inline operations when called from the UI thread. This change forces the operations to be placed in the queue, which matches the behavior of the queue prior to the introduction of `IThreadingContext`.