### PR TITLE
Nullability warnings in ternary expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -341,37 +341,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var nullableSyntax = (NullableTypeSyntax)syntax;
                         TypeSyntax typeArgumentSyntax = nullableSyntax.ElementType;
                         TypeSymbolWithAnnotations typeArgument = BindType(typeArgumentSyntax, diagnostics, basesBeingResolved);
-                        TypeSymbolWithAnnotations constructedType;
-                        if (typeArgument.TypeKind != TypeKind.TypeParameter && (typeArgument.IsValueType || typeArgument.IsErrorType()))
+                        TypeSymbolWithAnnotations constructedType = typeArgument.SetIsAnnotated(Compilation);
+
+                        if (InExecutableBinder)
                         {
-                            NamedTypeSymbol nullableT = GetSpecialType(SpecialType.System_Nullable_T, diagnostics, syntax);
-                            constructedType = TypeSymbolWithAnnotations.Create(nullableT.Construct(ImmutableArray.Create(typeArgument)));
-                        }
-                        else
-                        {
-                            if (InExecutableBinder)
+                            // Inside a method body or other executable code, we can pull on NonNullTypes symbol or question IsValueType without causing cycles.
+                            // Types created outside executable context should be checked by the responsible symbol (the method symbol checks its return type, for instance).
+                            // We still need to delay that check when binding in an attribute argument
+                            if (!ShouldCheckConstraintsNullability)
                             {
-                                // Inside a method body or other executable code, we can pull on NonNullTypes symbol or question IsValueType without causing cycles.
-                                // Types created outside executable context should be checked by the responsible symbol (the method symbol checks its return type, for instance).
-                                // We still need to delay that check when binding in an attribute argument
-                                if (!ShouldCheckConstraintsNullability)
-                                {
-                                    diagnostics.Add(new LazyMissingNonNullTypesContextDiagnosticInfo(Compilation, NonNullTypesContext, typeArgument), nullableSyntax.QuestionToken.GetLocation());
-                                }
-                                else if (!typeArgument.IsValueType)
-                                {
-                                    Symbol.ReportNullableReferenceTypesIfNeeded(Compilation, NonNullTypesContext, diagnostics, nullableSyntax.QuestionToken.GetLocation());
-                                }
+                                diagnostics.Add(new LazyMissingNonNullTypesContextDiagnosticInfo(Compilation, NonNullTypesContext, typeArgument), nullableSyntax.QuestionToken.GetLocation());
                             }
-                            constructedType = typeArgument.SetIsAnnotated(Compilation);
-                            if (!ShouldCheckConstraints)
+                            else if (!typeArgument.IsValueType)
                             {
-                                diagnostics.Add(new LazyUseSiteDiagnosticsInfoForNullableType(constructedType), syntax.GetLocation());
+                                Symbol.ReportNullableReferenceTypesIfNeeded(Compilation, NonNullTypesContext, diagnostics, nullableSyntax.QuestionToken.GetLocation());
                             }
                         }
 
-                        if (ShouldCheckConstraints && constructedType.IsNullableType())
+                        if (!ShouldCheckConstraints)
                         {
+                            diagnostics.Add(new LazyUseSiteDiagnosticsInfoForNullableType(constructedType), syntax.GetLocation());
+                        }
+                        else if (constructedType.IsNullableType())
+                        {
+                            ReportUseSiteDiagnostics(constructedType.TypeSymbol.OriginalDefinition, diagnostics, syntax);
                             var type = (NamedTypeSymbol)constructedType.TypeSymbol;
                             var location = syntax.Location;
                             var conversions = this.Conversions.WithNullability(includeNullability: true);
@@ -382,6 +375,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             type.CheckConstraints(this.Compilation, conversions, location, diagnostics);
                         }
+
                         return constructedType;
                     }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -372,7 +372,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (ShouldCheckConstraints && constructedType.IsNullableType())
                         {
-                            ReportUseSiteDiagnostics(constructedType.TypeSymbol.OriginalDefinition, diagnostics, syntax);
                             var type = (NamedTypeSymbol)constructedType.TypeSymbol;
                             var location = syntax.Location;
                             var conversions = this.Conversions.WithNullability(includeNullability: true);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -835,14 +835,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case BoundKind.SuppressNullableWarningExpression:
-                    var innerExpression = ((BoundSuppressNullableWarningExpression)sourceExpression).Expression;
-                    var innerConversion = ClassifyImplicitBuiltInConversionFromExpression(innerExpression, innerExpression.Type, destination, ref useSiteDiagnostics);
-                    if (innerConversion.Exists)
                     {
-                        return innerConversion;
+                        var innerExpression = ((BoundSuppressNullableWarningExpression)sourceExpression).Expression;
+                        var innerConversion = ClassifyImplicitBuiltInConversionFromExpression(innerExpression, innerExpression.Type, destination, ref useSiteDiagnostics);
+                        if (innerConversion.Exists)
+                        {
+                            return innerConversion;
+                        }
+                        break;
                     }
-                    break;
 
+                case BoundKind.ExpressionWithNullability:
+                    {
+                        var innerExpression = ((BoundExpressionWithNullability)sourceExpression).Expression;
+                        var innerConversion = ClassifyImplicitBuiltInConversionFromExpression(innerExpression, innerExpression.Type, destination, ref useSiteDiagnostics);
+                        if (innerConversion.Exists)
+                        {
+                            return innerConversion;
+                        }
+                        break;
+                    }
                 case BoundKind.TupleLiteral:
                     var tupleConversion = ClassifyImplicitTupleLiteralConversion((BoundTupleLiteral)sourceExpression, destination, ref useSiteDiagnostics);
                     if (tupleConversion.Exists)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1776,27 +1776,31 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression consequence;
             BoundExpression alternative;
+            Conversion consequenceConversion;
+            Conversion alternativeConversion;
             TypeSymbolWithAnnotations consequenceResult;
             TypeSymbolWithAnnotations alternativeResult;
             bool? isNullableIfReferenceType;
 
-            if (IsConstantTrue(node.Condition))
+            bool isConstantTrue = IsConstantTrue(node.Condition);
+            bool isConstantFalse = IsConstantFalse(node.Condition);
+            if (isConstantTrue)
             {
-                (alternative, alternativeResult) = visitConditionalOperand(alternativeState, node.Alternative);
-                (consequence, consequenceResult) = visitConditionalOperand(consequenceState, node.Consequence);
+                (alternative, alternativeConversion, alternativeResult) = visitConditionalOperand(alternativeState, node.Alternative);
+                (consequence, consequenceConversion, consequenceResult) = visitConditionalOperand(consequenceState, node.Consequence);
                 isNullableIfReferenceType = getIsNullableIfReferenceType(consequence, consequenceResult);
             }
-            else if (IsConstantFalse(node.Condition))
+            else if (isConstantFalse)
             {
-                (consequence, consequenceResult) = visitConditionalOperand(consequenceState, node.Consequence);
-                (alternative, alternativeResult) = visitConditionalOperand(alternativeState, node.Alternative);
+                (consequence, consequenceConversion, consequenceResult) = visitConditionalOperand(consequenceState, node.Consequence);
+                (alternative, alternativeConversion, alternativeResult) = visitConditionalOperand(alternativeState, node.Alternative);
                 isNullableIfReferenceType = getIsNullableIfReferenceType(alternative, alternativeResult);
             }
             else
             {
-                (consequence, consequenceResult) = visitConditionalOperand(consequenceState, node.Consequence);
+                (consequence, consequenceConversion, consequenceResult) = visitConditionalOperand(consequenceState, node.Consequence);
                 Unsplit();
-                (alternative, alternativeResult) = visitConditionalOperand(alternativeState, node.Alternative);
+                (alternative, alternativeConversion, alternativeResult) = visitConditionalOperand(alternativeState, node.Alternative);
                 Unsplit();
                 IntersectWith(ref this.State, ref consequenceState);
                 isNullableIfReferenceType = (getIsNullableIfReferenceType(consequence, consequenceResult) | getIsNullableIfReferenceType(alternative, alternativeResult));
@@ -1834,7 +1838,40 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            _resultType = TypeSymbolWithAnnotations.Create(resultType ?? node.Type.SetUnknownNullabilityForReferenceTypes(), isNullableIfReferenceType);
+            var resultTypeWithAnnotations = TypeSymbolWithAnnotations.Create(resultType ?? node.Type.SetUnknownNullabilityForReferenceTypes(), isNullableIfReferenceType);
+
+            if ((object)resultType != null)
+            {
+                if (!isConstantFalse)
+                {
+                    ApplyConversion(
+                    node.Consequence,
+                    consequence,
+                    consequenceConversion,
+                    resultTypeWithAnnotations,
+                    consequenceResult,
+                    checkConversion: true,
+                    fromExplicitCast: false,
+                    useLegacyWarnings: false,
+                    AssignmentKind.Assignment);
+                }
+
+                if (!isConstantTrue)
+                {
+                    ApplyConversion(
+                        node.Alternative,
+                        alternative,
+                        alternativeConversion,
+                        resultTypeWithAnnotations,
+                        alternativeResult,
+                        checkConversion: true,
+                        fromExplicitCast: false,
+                        useLegacyWarnings: false,
+                        AssignmentKind.Assignment);
+                }
+            }
+            _resultType = resultTypeWithAnnotations;
+
             return null;
 
             bool? getIsNullableIfReferenceType(BoundExpression expr, TypeSymbolWithAnnotations type)
@@ -1857,19 +1894,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     new BoundExpressionWithNullability(expr.Syntax, expr, type.IsNullable, type.TypeSymbol);
             }
 
-            (BoundExpression, TypeSymbolWithAnnotations) visitConditionalOperand(LocalState state, BoundExpression operand)
+            (BoundExpression, Conversion, TypeSymbolWithAnnotations) visitConditionalOperand(LocalState state, BoundExpression operand)
             {
+                Conversion conversion;
                 SetState(state);
                 if (isByRef)
                 {
                     VisitLvalue(operand);
+                    conversion = Conversion.Identity;
                 }
                 else
                 {
-                    (operand, _) = RemoveConversion(operand, includeExplicitConversions: false);
+                    (operand, conversion) = RemoveConversion(operand, includeExplicitConversions: false);
                     Visit(operand);
                 }
-                return (operand, _resultType);
+                return (operand, conversion, _resultType);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1845,15 +1845,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (!isConstantFalse)
                 {
                     ApplyConversion(
-                    node.Consequence,
-                    consequence,
-                    consequenceConversion,
-                    resultTypeWithAnnotations,
-                    consequenceResult,
-                    checkConversion: true,
-                    fromExplicitCast: false,
-                    useLegacyWarnings: false,
-                    AssignmentKind.Assignment);
+                        node.Consequence,
+                        consequence,
+                        consequenceConversion,
+                        resultTypeWithAnnotations,
+                        consequenceResult,
+                        checkConversion: true,
+                        fromExplicitCast: false,
+                        useLegacyWarnings: false,
+                        AssignmentKind.Assignment);
                 }
 
                 if (!isConstantTrue)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // In this case we delay asking this question as long as possible.
             if (typeSymbol.TypeKind != TypeKind.TypeParameter)
             {
-                if (!typeSymbol.IsValueType)
+                if (!typeSymbol.IsValueType && !typeSymbol.IsErrorType())
                 {
                     return CreateNonLazyType(typeSymbol, NonNullTypesContext, isAnnotated: true, treatUnconstrainedTypeParameterAsNullable: false, this.CustomModifiers);
                 }
@@ -549,7 +549,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var type = TypeSymbolExtensions.VisitType(
                 typeWithAnnotationsOpt,
                 typeOpt,
-                typeWithAnnotationsPredicateOpt: (t, a, b) => t.IsAnnotated && !t.TypeSymbol.IsValueType,
+                typeWithAnnotationsPredicateOpt: (t, a, b) => t.IsAnnotated && !t.TypeSymbol.IsErrorType() && !t.TypeSymbol.IsValueType,
                 typePredicateOpt: null,
                 arg: (object)null);
             return (object)type != null;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -248,7 +248,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    // PROTOTYPE(NullableReferenceTypes): what if the Nullable<T> type is missing? (are we missing diagnostics?)
                     return Create(compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(ImmutableArray.Create(typeSymbol), NonNullTypesContext));
                 }
             }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
@@ -2208,7 +2208,6 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = tru
     null
 ";
 
-            // PROTOTYPE(NullableReferenceTypes): Why are two errors reported for missing System.Nullable`1.
             var expectedDiagnostics = new DiagnosticDescription[] {
                 // (4,12): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     static P M1()
@@ -2216,9 +2215,6 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = tru
                 // (9,7): error CS0518: Predefined type 'System.Boolean' is not defined or imported
                 //     P(bool? x = true)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool").WithArguments("System.Boolean").WithLocation(9, 7),
-                // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     P(bool? x = true)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
                 // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
                 //     P(bool? x = true)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
@@ -2422,8 +2418,10 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = nul
     null
 ";
 
-            // PROTOTYPE(NullableReferenceTypes): Why are two errors reported for missing System.Nullable`1.
             var expectedDiagnostics = new DiagnosticDescription[] {
+                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // class P
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
                 // (4,12): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     static P M1()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(4, 12),
@@ -2433,17 +2431,11 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = nul
                 // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
                 //     P(bool? x = null)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
-                // (9,7): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
-                //     P(bool? x = null)
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "bool?").WithArguments("System.Nullable`1").WithLocation(9, 7),
                 // (9,5): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //     P(bool? x = null)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"P(bool? x = null)
     {
     }").WithArguments("System.Void").WithLocation(9, 5),
-                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class P
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
                 // (9,7): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
                 //     P(bool? x = null)
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "bool? x = null").WithLocation(9, 7),

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
@@ -2160,9 +2160,6 @@ IInvocationOperation (void P.M2([System.Boolean[missing]? x = true])) (Operation
                 // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // class P
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (9,20): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
-                //     static void M2(bool? x = true)
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "bool? x = true").WithLocation(9, 20),
                 // (9,30): error CS0518: Predefined type 'System.Boolean' is not defined or imported
                 //     static void M2(bool? x = true)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "true").WithArguments("System.Boolean").WithLocation(9, 30),
@@ -2226,9 +2223,6 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = tru
                 // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // class P
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (9,7): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
-                //     P(bool? x = true)
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "bool? x = true").WithLocation(9, 7),
                 // (9,17): error CS0518: Predefined type 'System.Boolean' is not defined or imported
                 //     P(bool? x = true)
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "true").WithArguments("System.Boolean").WithLocation(9, 17),
@@ -2307,9 +2301,6 @@ IPropertyReferenceOperation: System.Int32[missing] P.this[System.Int32[missing] 
                 // (3,7): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // class P
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(3, 7),
-                // (6,28): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
-                //     public int this[int x, int? y = 5]
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "int? y = 5").WithLocation(6, 28),
                 // (6,37): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     public int this[int x, int? y = 5]
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "5").WithArguments("System.Int32").WithLocation(6, 37),
@@ -2375,9 +2366,6 @@ IInvocationOperation (void P.M2([System.Boolean[missing]? x = null])) (Operation
                 // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // class P
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (9,20): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
-                //     static void M2(bool? x = null)
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "bool? x = null").WithLocation(9, 20),
                 // (6,19): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //         /*<bind>*/M2()/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "M2").WithArguments("System.Object").WithLocation(6, 19),
@@ -2436,9 +2424,6 @@ IObjectCreationOperation (Constructor: P..ctor([System.Boolean[missing]? x = nul
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"P(bool? x = null)
     {
     }").WithArguments("System.Void").WithLocation(9, 5),
-                // (9,7): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
-                //     P(bool? x = null)
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "bool? x = null").WithLocation(9, 7),
                 // (6,30): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //         return /*<bind>*/new P()/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(6, 30),
@@ -2515,9 +2500,6 @@ IPropertyReferenceOperation: System.Int32[missing] P.this[System.Int32[missing] 
                 // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // class P
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (5,28): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
-                //     public int this[int x, int? y = null]
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "int? y = null").WithLocation(5, 28),
                 // (4,27): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     private int _number = 0;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(4, 27),
@@ -3521,9 +3503,6 @@ IInvalidOperation (OperationKind.Invalid, Type: P, IsInvalid) (Syntax: 'new P() 
                 // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // class P
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (5,28): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
-                //     public int this[int x, int? y = 0]
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "int? y = 0").WithLocation(5, 28),
                 // (5,37): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     public int this[int x, int? y = 0]
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(5, 37),
@@ -3619,9 +3598,6 @@ IInvalidOperation (OperationKind.Invalid, Type: P, IsInvalid) (Syntax: 'new P() 
                 // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // class P
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "P").WithArguments("System.Object").WithLocation(2, 7),
-                // (5,28): warning CS8632: The annotation for nullable reference types should only be used in code within a '[NonNullTypes(true)]' context.
-                //     public int this[int x, int? y = null]
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "int? y = null").WithLocation(5, 28),
                 // (4,27): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //     private int _number = 0;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "0").WithArguments("System.Int32").WithLocation(4, 27),


### PR DESCRIPTION
In ternary expressions with literals, NullableWalker was not inferring the best type properly, because the literals are wrapped in BoundExpressionWithAnnotations. The solution is to unwrap such expressions when computing builtin conversions from expressions (where the wrapping cannot affect nullability).
Also, we need to compute conversion warnings in such ternary expressions.

Fixes https://github.com/dotnet/roslyn/issues/26746 (nullability warnings in ternary expressions)

Also fixing an issue with duplicate reporting of use-site diagnostics when `Nullable<T>` is missing.