### PR TITLE
Fix generate field doesn't recognize accessibility modifier configuration

### DIFF
--- a/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
@@ -2,8 +2,10 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.InitializeParameter;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -647,6 +649,165 @@ class C
         this.s = s;
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializePropertyWithRequiredAccessibilityOmitIfDefault()
+        {
+            await TestInRegularAndScript1Async(
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int [|test2|])
+    {
+    }
+}",
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int test2)
+    {
+        Test2 = test2;
+    }
+
+    int Test2 { get; }
+}", index: 0, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.OmitIfDefault, NotificationOption.Warning)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializePropertyWithRequiredAccessibilityNever()
+        {
+            await TestInRegularAndScript1Async(
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int [|test2|])
+    {
+    }
+}",
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int test2)
+    {
+        Test2 = test2;
+    }
+
+    int Test2 { get; }
+}", index: 0, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Never, NotificationOption.Warning)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializePropertyWithRequiredAccessibilityAlways()
+        {
+            await TestInRegularAndScript1Async(
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int [|test2|])
+    {
+    }
+}",
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int test2)
+    {
+        Test2 = test2;
+    }
+
+    public int Test2 { get; }
+}", index: 0, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Always, NotificationOption.Warning)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeFieldWithRequiredAccessibilityOmitIfDefault()
+        {
+            await TestInRegularAndScript1Async(
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int [|test2|])
+    {
+    }
+}",
+@"
+class C
+{
+    readonly int test = 5;
+    readonly int test2;
+
+    public C(int test, int [|test2|])
+    {
+        this.test2 = test2;
+    }
+}", index: 1, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.OmitIfDefault, NotificationOption.Warning)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeFieldWithRequiredAccessibilityNever()
+        {
+            await TestInRegularAndScript1Async(
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int [|test2|])
+    {
+    }
+}",
+@"
+class C
+{
+    readonly int test = 5;
+    readonly int test2;
+
+    public C(int test, int [|test2|])
+    {
+        this.test2 = test2;
+    }
+}", index: 1, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Never, NotificationOption.Warning)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeFieldWithRequiredAccessibilityAlways()
+        {
+            await TestInRegularAndScript1Async(
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int [|test2|])
+    {
+    }
+}",
+@"
+class C
+{
+    readonly int test = 5;
+    private readonly int test2;
+
+    public C(int test, int [|test2|])
+    {
+        this.test2 = test2;
+    }
+}", index: 1, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Always, NotificationOption.Warning)));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
@@ -627,7 +627,7 @@ class C
 
         [WorkItem(29190, "https://github.com/dotnet/roslyn/issues/29190")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
-        public async Task TestInitializeFieldWithParameterNameSelected2()
+        public async Task TestInitializeClassField_ParameterNameSelected2()
         {
             await TestInRegularAndScript1Async(
 @"
@@ -652,61 +652,7 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
-        public async Task TestInitializePropertyWithRequiredAccessibilityOmitIfDefault()
-        {
-            await TestInRegularAndScript1Async(
-@"
-class C
-{
-    readonly int test = 5;
-
-    public C(int test, int [|test2|])
-    {
-    }
-}",
-@"
-class C
-{
-    readonly int test = 5;
-
-    public C(int test, int test2)
-    {
-        Test2 = test2;
-    }
-
-    int Test2 { get; }
-}", index: 0, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.OmitIfDefault, NotificationOption.Warning)));
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
-        public async Task TestInitializePropertyWithRequiredAccessibilityNever()
-        {
-            await TestInRegularAndScript1Async(
-@"
-class C
-{
-    readonly int test = 5;
-
-    public C(int test, int [|test2|])
-    {
-    }
-}",
-@"
-class C
-{
-    readonly int test = 5;
-
-    public C(int test, int test2)
-    {
-        Test2 = test2;
-    }
-
-    int Test2 { get; }
-}", index: 0, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Never, NotificationOption.Warning)));
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
-        public async Task TestInitializePropertyWithRequiredAccessibilityAlways()
+        public async Task TestInitializeClassProperty_RequiredAccessibilityOmitIfDefault()
         {
             await TestInRegularAndScript1Async(
 @"
@@ -729,11 +675,65 @@ class C
     }
 
     public int Test2 { get; }
-}", index: 0, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Always, NotificationOption.Warning)));
+}", index: 0, parameters: OmitIfDefault_Warning);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
-        public async Task TestInitializeFieldWithRequiredAccessibilityOmitIfDefault()
+        public async Task TestInitializeClassProperty_RequiredAccessibilityNever()
+        {
+            await TestInRegularAndScript1Async(
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int [|test2|])
+    {
+    }
+}",
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int test2)
+    {
+        Test2 = test2;
+    }
+
+    public int Test2 { get; }
+}", index: 0, parameters: Never_Warning);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeClassProperty_RequiredAccessibilityAlways()
+        {
+            await TestInRegularAndScript1Async(
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int [|test2|])
+    {
+    }
+}",
+@"
+class C
+{
+    readonly int test = 5;
+
+    public C(int test, int test2)
+    {
+        Test2 = test2;
+    }
+
+    public int Test2 { get; }
+}", index: 0, parameters: Always_Warning);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeClassField_RequiredAccessibilityOmitIfDefault()
         {
             await TestInRegularAndScript1Async(
 @"
@@ -751,15 +751,15 @@ class C
     readonly int test = 5;
     readonly int test2;
 
-    public C(int test, int [|test2|])
+    public C(int test, int test2)
     {
         this.test2 = test2;
     }
-}", index: 1, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.OmitIfDefault, NotificationOption.Warning)));
+}", index: 1, parameters: OmitIfDefault_Warning);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
-        public async Task TestInitializeFieldWithRequiredAccessibilityNever()
+        public async Task TestInitializeClassField_RequiredAccessibilityNever()
         {
             await TestInRegularAndScript1Async(
 @"
@@ -777,15 +777,15 @@ class C
     readonly int test = 5;
     readonly int test2;
 
-    public C(int test, int [|test2|])
+    public C(int test, int test2)
     {
         this.test2 = test2;
     }
-}", index: 1, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Never, NotificationOption.Warning)));
+}", index: 1, parameters: Never_Warning);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
-        public async Task TestInitializeFieldWithRequiredAccessibilityAlways()
+        public async Task TestInitializeClassField_RequiredAccessibilityAlways()
         {
             await TestInRegularAndScript1Async(
 @"
@@ -803,11 +803,153 @@ class C
     readonly int test = 5;
     private readonly int test2;
 
-    public C(int test, int [|test2|])
+    public C(int test, int test2)
     {
         this.test2 = test2;
     }
-}", index: 1, parameters: new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Always, NotificationOption.Warning)));
+}", index: 1, parameters: Always_Warning);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeStructProperty_RequiredAccessibilityOmitIfDefault()
+        {
+            await TestInRegularAndScript1Async(
+@"
+struct S
+{
+    public Test(int [|test|])
+    {
+    }
+}",
+@"
+struct S
+{
+    public Test(int test)
+    {
+        Test = test;
+    }
+
+    public int Test { get; }
+}", index: 0, parameters: OmitIfDefault_Warning);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeStructProperty_RequiredAccessibilityNever()
+        {
+            await TestInRegularAndScript1Async(
+@"
+struct S
+{
+    public Test(int [|test|])
+    {
+    }
+}",
+@"
+struct S
+{
+    public Test(int test)
+    {
+        Test = test;
+    }
+
+    public int Test { get; }
+}", index: 0, parameters: Never_Warning);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeStructProperty_RequiredAccessibilityAlways()
+        {
+            await TestInRegularAndScript1Async(
+@"
+struct S
+{
+    public Test(int [|test|])
+    {
+    }
+}",
+@"
+struct S
+{
+    public Test(int test)
+    {
+        Test = test;
+    }
+
+    public int Test { get; }
+}", index: 0, parameters: Always_Warning);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeStructField_RequiredAccessibilityOmitIfDefault()
+        {
+            await TestInRegularAndScript1Async(
+@"
+struct S
+{
+    public Test(int [|test|])
+    {
+    }
+}",
+@"
+struct S
+{
+    readonly int test;
+
+    public Test(int test)
+    {
+        this.test = test;
+    }
+}", index: 1, parameters: OmitIfDefault_Warning);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeStructField_RequiredAccessibilityNever()
+        {
+            await TestInRegularAndScript1Async(
+@"
+struct S
+{
+    public Test(int [|test|])
+    {
+    }
+}",
+@"
+struct S
+{
+    readonly int test;
+
+    public Test(int test)
+    {
+        this.test = test;
+    }
+}", index: 1, parameters: Never_Warning);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestInitializeStructField_RequiredAccessibilityAlways()
+        {
+            await TestInRegularAndScript1Async(
+@"
+struct S
+{
+    public Test(int [|test|])
+    {
+    }
+}",
+@"
+struct S
+{
+    private readonly int test;
+
+    public Test(int test)
+    {
+        this.test = test;
+    }
+}", index: 1, parameters: Always_Warning);
+        }
+
+        private TestParameters OmitIfDefault_Warning => new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.OmitIfDefault, NotificationOption.Warning));
+        private TestParameters Never_Warning => new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Never, NotificationOption.Warning));
+        private TestParameters Always_Warning => new TestParameters(options: Option(CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Always, NotificationOption.Warning));
     }
 }

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
@@ -627,7 +627,7 @@ class C
 
         [WorkItem(29190, "https://github.com/dotnet/roslyn/issues/29190")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
-        public async Task TestInitializeClassField_ParameterNameSelected2()
+        public async Task TestInitializeField_ParameterNameSelected2()
         {
             await TestInRegularAndScript1Async(
 @"

--- a/src/EditorFeatures/VisualBasicTest/InitializeParameter/InitializeMemberFromParameterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/InitializeParameter/InitializeMemberFromParameterTests.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.CodeStyle
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
 Imports Microsoft.CodeAnalysis.VisualBasic.InitializeParameter
 
@@ -455,5 +456,260 @@ class C
     end sub
 end class")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeClassProperty_RequiredAccessibilityOmitIfDefault() As Task
+            Await TestInRegularAndScript1Async("
+Class C
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal [|test2|] As Integer)
+    End Sub
+End Class
+", "
+Class C
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal test2 As Integer)
+        Me.Test2 = test2
+    End Sub
+
+    Public ReadOnly Property Test2 As Integer
+End Class
+", index:=0, parameters:=OmitIfDefault_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeClassProperty_RequiredAccessibilityNever() As Task
+            Await TestInRegularAndScript1Async("
+Class C
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal [|test2|] As Integer)
+    End Sub
+End Class
+", "
+Class C
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal test2 As Integer)
+        Me.Test2 = test2
+    End Sub
+
+    Public ReadOnly Property Test2 As Integer
+End Class
+", index:=0, parameters:=Never_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeClassProperty_RequiredAccessibilityAlways() As Task
+            Await TestInRegularAndScript1Async("
+Class C
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal [|test2|] As Integer)
+    End Sub
+End Class
+", "
+Class C
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal test2 As Integer)
+        Me.Test2 = test2
+    End Sub
+
+    Public ReadOnly Property Test2 As Integer
+End Class
+", index:=0, parameters:=Always_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeClassField_RequiredAccessibilityOmitIfDefault() As Task
+            Await TestInRegularAndScript1Async("
+Class C
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal [|test2|] As Integer)
+    End Sub
+End Class
+", "
+Class C
+    ReadOnly test2 As Integer
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal test2 As Integer)
+        Me.test2 = test2
+    End Sub
+End Class
+", index:=1, parameters:=OmitIfDefault_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeClassField_RequiredAccessibilityNever() As Task
+            Await TestInRegularAndScript1Async("
+Class C
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal [|test2|] As Integer)
+    End Sub
+End Class
+", "
+Class C
+    ReadOnly test2 As Integer
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal test2 As Integer)
+        Me.test2 = test2
+    End Sub
+End Class
+", index:=1, parameters:=Never_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeClassField_RequiredAccessibilityAlways() As Task
+            Await TestInRegularAndScript1Async("
+Class C
+    ReadOnly test As Integer = 5
+
+    Public Sub New(ByVal test As Integer, ByVal [|test2|] As Integer)
+    End Sub
+End Class
+", "
+Class C
+    ReadOnly test As Integer = 5
+    Private ReadOnly test2 As Integer
+
+    Public Sub New(ByVal test As Integer, ByVal test2 As Integer)
+        Me.test2 = test2
+    End Sub
+End Class
+", index:=1, parameters:=Always_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeStructProperty_RequiredAccessibilityOmitIfDefault() As Task
+            Await TestInRegularAndScript1Async("
+Structure S
+    Public Sub New(ByVal [|test|] As Integer)
+    End Sub
+End Structure
+", "
+Structure S
+    Public Sub New(ByVal test As Integer)
+        Me.Test = test
+    End Sub
+
+    Public ReadOnly Property Test As Integer
+End Structure
+", index:=0, parameters:=OmitIfDefault_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeStructProperty_RequiredAccessibilityNever() As Task
+            Await TestInRegularAndScript1Async("
+Structure S
+    Public Sub New(ByVal [|test|] As Integer)
+    End Sub
+End Structure
+", "
+Structure S
+    Public Sub New(ByVal test As Integer)
+        Me.Test = test
+    End Sub
+
+    Public ReadOnly Property Test As Integer
+End Structure
+", index:=0, parameters:=Never_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeStructProperty_RequiredAccessibilityAlways() As Task
+            Await TestInRegularAndScript1Async("
+Structure S
+    Public Sub New(ByVal [|test|] As Integer)
+    End Sub
+End Structure
+", "
+Structure S
+    Public Sub New(ByVal test As Integer)
+        Me.Test = test
+    End Sub
+
+    Public ReadOnly Property Test As Integer
+End Structure
+", index:=0, parameters:=Always_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeStructField_RequiredAccessibilityOmitIfDefault() As Task
+            Await TestInRegularAndScript1Async("
+Structure S
+    Public Sub New(ByVal [|test|] As Integer)
+    End Sub
+End Structure
+", "
+Structure S
+    Private ReadOnly test As Integer
+
+    Public Sub New(ByVal test As Integer)
+        Me.test = test
+    End Sub
+End Structure
+", index:=1, parameters:=OmitIfDefault_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeStructField_RequiredAccessibilityNever() As Task
+            Await TestInRegularAndScript1Async("
+Structure S
+    Public Sub New(ByVal [|test|] As Integer)
+    End Sub
+End Structure
+", "
+Structure S
+    Private ReadOnly test As Integer
+
+    Public Sub New(ByVal test As Integer)
+        Me.test = test
+    End Sub
+End Structure
+", index:=1, parameters:=Never_Warning)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)>
+        Public Async Function TestInitializeStructField_RequiredAccessibilityAlways() As Task
+            Await TestInRegularAndScript1Async("
+Structure S
+    Public Sub New(ByVal [|test|] As Integer)
+    End Sub
+End Structure
+", "
+Structure S
+    Private ReadOnly test As Integer
+
+    Public Sub New(ByVal test As Integer)
+        Me.test = test
+    End Sub
+End Structure
+", index:=1, parameters:=Always_Warning)
+        End Function
+
+        Private ReadOnly Property OmitIfDefault_Warning As TestParameters
+            Get
+                Return New TestParameters(options:=[Option](CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.OmitIfDefault, NotificationOption.Warning))
+            End Get
+        End Property
+
+        Private ReadOnly Property Never_Warning As TestParameters
+            Get
+                Return New TestParameters(options:=[Option](CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Never, NotificationOption.Warning))
+            End Get
+        End Property
+
+        Private ReadOnly Property Always_Warning As TestParameters
+            Get
+                Return New TestParameters(options:=[Option](CodeStyleOptions.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Always, NotificationOption.Warning))
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/InitializeParameter/InitializeMemberFromParameterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/InitializeParameter/InitializeMemberFromParameterTests.vb
@@ -474,7 +474,7 @@ Class C
         Me.Test2 = test2
     End Sub
 
-    Public ReadOnly Property Test2 As Integer
+    ReadOnly Property Test2 As Integer
 End Class
 ", index:=0, parameters:=OmitIfDefault_Warning)
         End Function
@@ -496,7 +496,7 @@ Class C
         Me.Test2 = test2
     End Sub
 
-    Public ReadOnly Property Test2 As Integer
+    ReadOnly Property Test2 As Integer
 End Class
 ", index:=0, parameters:=Never_Warning)
         End Function
@@ -599,7 +599,7 @@ Structure S
         Me.Test = test
     End Sub
 
-    Public ReadOnly Property Test As Integer
+    ReadOnly Property Test As Integer
 End Structure
 ", index:=0, parameters:=OmitIfDefault_Warning)
         End Function
@@ -617,7 +617,7 @@ Structure S
         Me.Test = test
     End Sub
 
-    Public ReadOnly Property Test As Integer
+    ReadOnly Property Test As Integer
 End Structure
 ", index:=0, parameters:=Never_Warning)
         End Function

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
         protected override bool IsImplicitConversion(Compilation compilation, ITypeSymbol source, ITypeSymbol destination)
             => InitializeParameterHelpers.IsImplicitConversion(compilation, source, destination);
 
+        // We always generate a private field. Since "private" is the default accessibility for fields in C#, we do not need an accessibility modifier.
         protected override Accessibility CreateFieldHelper(Document document, SyntaxNode functionDeclaration, SemanticModel model, CancellationToken cancellationToken) => Accessibility.NotApplicable;
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
         protected override bool IsImplicitConversion(Compilation compilation, ITypeSymbol source, ITypeSymbol destination)
             => InitializeParameterHelpers.IsImplicitConversion(compilation, source, destination);
 
-        // We always generate a private field. Since "private" is the default accessibility for fields in C#, we do not need an accessibility modifier.
+        // We always generate private fields. Since "private" is the default accessibility for fields in C#, we do not need an accessibility modifier.
         protected override Accessibility CreateFieldHelper(Document document, SyntaxNode functionDeclaration, SemanticModel model, CancellationToken cancellationToken) => Accessibility.NotApplicable;
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
@@ -35,5 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
         protected override bool IsImplicitConversion(Compilation compilation, ITypeSymbol source, ITypeSymbol destination)
             => InitializeParameterHelpers.IsImplicitConversion(compilation, source, destination);
+
+        protected override Accessibility CreateFieldHelper(Document document, SyntaxNode functionDeclaration, SemanticModel model, CancellationToken cancellationToken) => Accessibility.NotApplicable;
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
@@ -36,7 +36,12 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
         protected override bool IsImplicitConversion(Compilation compilation, ITypeSymbol source, ITypeSymbol destination)
             => InitializeParameterHelpers.IsImplicitConversion(compilation, source, destination);
 
-        // We always generate private fields. Since "private" is the default accessibility for fields in C#, we do not need an accessibility modifier.
-        protected override Accessibility CreateFieldHelper(Document document, SyntaxNode functionDeclaration, SemanticModel model, CancellationToken cancellationToken) => Accessibility.NotApplicable;
+        // Fields are always private by default in C#.
+        protected override Accessibility DetermineDefaultFieldAccessibility(Document document, SyntaxNode functionDeclaration, SemanticModel model, CancellationToken cancellationToken)
+            => Accessibility.Private;
+
+        // Properties are always private by default in C#.
+        protected override Accessibility DetermineDefaultPropertyAccessibility()
+            => Accessibility.Private;
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             => InitializeParameterHelpers.IsImplicitConversion(compilation, source, destination);
 
         // Fields are always private by default in C#.
-        protected override Accessibility DetermineDefaultFieldAccessibility(Document document, SyntaxNode functionDeclaration, SemanticModel model, CancellationToken cancellationToken)
+        protected override Accessibility DetermineDefaultFieldAccessibility(Document document, SyntaxNode functionDeclaration, INamedTypeSymbol containingType, CancellationToken cancellationToken)
             => Accessibility.Private;
 
         // Properties are always private by default in C#.

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             => InitializeParameterHelpers.IsImplicitConversion(compilation, source, destination);
 
         // Fields are always private by default in C#.
-        protected override Accessibility DetermineDefaultFieldAccessibility(Document document, SyntaxNode functionDeclaration, INamedTypeSymbol containingType, CancellationToken cancellationToken)
+        protected override Accessibility DetermineDefaultFieldAccessibility(INamedTypeSymbol containingType)
             => Accessibility.Private;
 
         // Properties are always private by default in C#.

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -9,10 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -20,7 +17,6 @@ using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis.LanguageServices;
 
 namespace Microsoft.CodeAnalysis.InitializeParameter
 {

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                         {
                             accessibilityLevel = Accessibility.NotApplicable;
                         }
-                        // VB: only remove modifier if code is in C# or if it's within a class or module
+                        // VB: only remove modifier for fields if "omit if default" or "never" option is set and code is within a class or module
                         else if (functionDeclaration.Language == LanguageNames.VisualBasic)
                         {
                             var service = document.GetLanguageService<ISyntaxFactsService>();
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                                 var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                                 var containingTypeSymbol = (INamedTypeSymbol) model.GetDeclaredSymbol(containingTypeNode, cancellationToken);
                                 switch (containingTypeSymbol.TypeKind)
-                                {
+       
                                     case TypeKind.Class:
                                     case TypeKind.Module:
                                         accessibilityLevel = Accessibility.NotApplicable;

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -202,9 +202,9 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                     }
 
                     var getMethod = CodeGenerationSymbolFactory.CreateAccessorSymbol(
-                    default,
-                    Accessibility.Public,
-                    default);
+                        default,
+                        Accessibility.Public,
+                        default);
 
                     return CodeGenerationSymbolFactory.CreatePropertySymbol(
                         default,

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -155,8 +155,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                             {
                                 var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                                 var containingTypeSymbol = (INamedTypeSymbol) model.GetDeclaredSymbol(containingTypeNode, cancellationToken);
-                                switch (containingTypeSymbol.TypeKind)
-       
+                                switch (containingTypeSymbol.TypeKind) {
                                     case TypeKind.Class:
                                     case TypeKind.Module:
                                         accessibilityLevel = Accessibility.NotApplicable;

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -137,10 +137,6 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                     if (requireAccessibilityModifiers.Value == AccessibilityModifiersRequired.Never || requireAccessibilityModifiers.Value == AccessibilityModifiersRequired.OmitIfDefault)
                     {
                         var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-                        // We always generate a private field.
-                        // C#: Since "private" is the default accessibility for fields in C#, we do not need an accessibility modifier.
-                        // VB: Fields are public by default, except in the case of classes and modules. In those two cases, we can safely remove the accessibility modifier.
                         accessibilityLevel = CreateFieldHelper(document, functionDeclaration, model, cancellationToken);
                     }
 

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
 
                 // First, look for the right containing type (As a type may be partial). 
                 // We want the type-block that this constructor is contained within.
-                var typeDeclaration =
+                var typeDeclaration = 
                     parameter.ContainingType.DeclaringSyntaxReferences
                                             .Select(r => GetTypeBlock(r.GetSyntax(cancellationToken)))
                                             .Single(d => functionDeclaration.Ancestors().Contains(d));

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                 var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
                 var requireAccessibilityModifiers = options.GetOption(CodeStyleOptions.RequireAccessibilityModifiers);
 
-                var field = await CreateFieldAsync(document, requireAccessibilityModifiers, functionDeclaration, parameter, rules, parameterNameParts, cancellationToken).ConfigureAwait(false);
+                var field = CreateField(document, requireAccessibilityModifiers, functionDeclaration, parameter, rules, parameterNameParts, cancellationToken);
                 var property = CreateProperty(document, requireAccessibilityModifiers, parameter, rules, parameterNameParts, cancellationToken);
 
                 // Offer to generate either a property or a field.  Currently we place the property
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
             }
         }
 
-        private async Task<IFieldSymbol> CreateFieldAsync(
+        private IFieldSymbol CreateField(
             Document document,
             CodeStyleOption<AccessibilityModifiersRequired> requireAccessibilityModifiers,
             SyntaxNode functionDeclaration,

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
 
                     var getMethod = CodeGenerationSymbolFactory.CreateAccessorSymbol(
                         default,
-                        Accessibility.Public,
+                        accessibilityLevel,
                         default);
 
                     return CodeGenerationSymbolFactory.CreatePropertySymbol(

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
+    <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
-    <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicInitializeMemberFromParameterCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicInitializeMemberFromParameterCodeRefactoringProvider.vb
@@ -50,6 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InitializeParameter
             If containingTypeNode IsNot Nothing Then
                 Dim containingTypeSymbol = CType(model.GetDeclaredSymbol(containingTypeNode, cancellationToken), INamedTypeSymbol)
 
+                ' We always generate private fields. Fields are public by default, except in the case of classes and modules. In those two cases, we can safely remove the accessibility modifier.
                 Select Case containingTypeSymbol.TypeKind
                     Case TypeKind.[Class], TypeKind.[Module]
                         accessibilityLevel = Accessibility.NotApplicable

--- a/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicInitializeMemberFromParameterCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicInitializeMemberFromParameterCodeRefactoringProvider.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InitializeParameter
         End Sub
 
         ' Fields are public by default in VB, except in the case of classes and modules.
-        Protected Overrides Function DetermineDefaultFieldAccessibility(document As Document, functionDeclaration As SyntaxNode, containingType As INamedTypeSymbol, cancellationToken As CancellationToken) As Accessibility
+        Protected Overrides Function DetermineDefaultFieldAccessibility(containingType As INamedTypeSymbol) As Accessibility
             Return If(containingType.TypeKind = TypeKind.Class Or containingType.TypeKind = TypeKind.Module, Accessibility.Private, Accessibility.Public)
         End Function
 

--- a/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicInitializeMemberFromParameterCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicInitializeMemberFromParameterCodeRefactoringProvider.vb
@@ -42,26 +42,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InitializeParameter
             InitializeParameterHelpers.InsertStatement(editor, functionDeclaration, statementToAddAfterOpt, statement)
         End Sub
 
-        Protected Overrides Function DetermineDefaultFieldAccessibility(document As Document, functionDeclaration As SyntaxNode, model As SemanticModel, cancellationToken As CancellationToken) As Accessibility
-            Dim accessibilityLevel = Accessibility.[Public]
-            Dim service = document.GetLanguageService(Of ISyntaxFactsService)()
-            Dim containingTypeNode = service.GetContainingTypeDeclaration(functionDeclaration, functionDeclaration.SpanStart)
-
-            If containingTypeNode IsNot Nothing Then
-                Dim containingTypeSymbol = CType(model.GetDeclaredSymbol(containingTypeNode, cancellationToken), INamedTypeSymbol)
-
-                ' Fields are public by default in VB, except in the case of classes and modules.
-                Select Case containingTypeSymbol.TypeKind
-                    Case TypeKind.[Class], TypeKind.[Module]
-                        accessibilityLevel = Accessibility.[Private]
-                End Select
-            End If
-            Return accessibilityLevel
+        ' Fields are public by default in VB, except in the case of classes and modules.
+        Protected Overrides Function DetermineDefaultFieldAccessibility(document As Document, functionDeclaration As SyntaxNode, containingType As INamedTypeSymbol, cancellationToken As CancellationToken) As Accessibility
+            Return If(containingType.TypeKind = TypeKind.Class Or containingType.TypeKind = TypeKind.Module, Accessibility.Private, Accessibility.Public)
         End Function
 
         ' Properties are always public by default in VB.
         Protected Overrides Function DetermineDefaultPropertyAccessibility() As Accessibility
-            Return Accessibility.[Public]
+            Return Accessibility.Public
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicInitializeMemberFromParameterCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicInitializeMemberFromParameterCodeRefactoringProvider.vb
@@ -42,21 +42,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InitializeParameter
             InitializeParameterHelpers.InsertStatement(editor, functionDeclaration, statementToAddAfterOpt, statement)
         End Sub
 
-        Protected Overrides Function CreateFieldHelper(document As Document, functionDeclaration As SyntaxNode, model As SemanticModel, cancellationToken As CancellationToken) As Accessibility
-            Dim accessibilityLevel = Accessibility.[Private]
+        Protected Overrides Function DetermineDefaultFieldAccessibility(document As Document, functionDeclaration As SyntaxNode, model As SemanticModel, cancellationToken As CancellationToken) As Accessibility
+            Dim accessibilityLevel = Accessibility.[Public]
             Dim service = document.GetLanguageService(Of ISyntaxFactsService)()
             Dim containingTypeNode = service.GetContainingTypeDeclaration(functionDeclaration, functionDeclaration.SpanStart)
 
             If containingTypeNode IsNot Nothing Then
                 Dim containingTypeSymbol = CType(model.GetDeclaredSymbol(containingTypeNode, cancellationToken), INamedTypeSymbol)
 
-                ' We always generate private fields. Fields are public by default, except in the case of classes and modules. In those two cases, we can safely remove the accessibility modifier.
+                ' Fields are public by default in VB, except in the case of classes and modules.
                 Select Case containingTypeSymbol.TypeKind
                     Case TypeKind.[Class], TypeKind.[Module]
-                        accessibilityLevel = Accessibility.NotApplicable
+                        accessibilityLevel = Accessibility.[Private]
                 End Select
             End If
             Return accessibilityLevel
+        End Function
+
+        ' Properties are always public by default in VB.
+        Protected Overrides Function DetermineDefaultPropertyAccessibility() As Accessibility
+            Return Accessibility.[Public]
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #27716 
--
This fix operates under the assumption that the option "omit_if_default" operates the same way as "never" whenever the generate field/property option is invoked.

Also added applicable tests.