### PR TITLE
Update xunit to 2.4.1-pre.build.4059

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -34,7 +34,6 @@
     <CommandLineParserVersion>2.0.273-beta</CommandLineParserVersion>
     <EnvDTEVersion>8.0.2</EnvDTEVersion>
     <EnvDTE80Version>8.0.0</EnvDTE80Version>
-    <dotnetxunitVersion>2.4.0-beta.1.build3958</dotnetxunitVersion>
     <FakeSignVersion>0.9.2</FakeSignVersion>
     <HumanizerCoreVersion>2.2.0</HumanizerCoreVersion>
     <ICSharpCodeDecompilerVersion>4.0.0.4285-beta1</ICSharpCodeDecompilerVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -34,7 +34,7 @@
     <CommandLineParserVersion>2.0.273-beta</CommandLineParserVersion>
     <EnvDTEVersion>8.0.2</EnvDTEVersion>
     <EnvDTE80Version>8.0.0</EnvDTE80Version>
-    <dotnetxunitVersion>2.3.1</dotnetxunitVersion>
+    <dotnetxunitVersion>2.4.0-beta.1.build3958</dotnetxunitVersion>
     <FakeSignVersion>0.9.2</FakeSignVersion>
     <HumanizerCoreVersion>2.2.0</HumanizerCoreVersion>
     <ICSharpCodeDecompilerVersion>4.0.0.4285-beta1</ICSharpCodeDecompilerVersion>
@@ -251,12 +251,12 @@
     <VsWebsiteInteropVersion>8.0.50727</VsWebsiteInteropVersion>
     <vswhereVersion>2.4.1</vswhereVersion>
     <XliffTasksVersion>0.2.0-beta-63004-01</XliffTasksVersion>
-    <xunitVersion>2.3.1</xunitVersion>
-    <xunitanalyzersVersion>0.8.0</xunitanalyzersVersion>
-    <xunitassertVersion>2.3.1</xunitassertVersion>
-    <xunitrunnerconsoleVersion>2.3.1</xunitrunnerconsoleVersion>
+    <xunitVersion>2.4.1-pre.build.4059</xunitVersion>
+    <xunitanalyzersVersion>0.10.0</xunitanalyzersVersion>
+    <xunitassertVersion>2.4.1-pre.build.4059</xunitassertVersion>
+    <xunitrunnerconsoleVersion>2.4.1-pre.build.4059</xunitrunnerconsoleVersion>
     <xunitrunnerwpfVersion>1.0.51</xunitrunnerwpfVersion>
-    <xunitrunnervisualstudioVersion>2.3.1</xunitrunnervisualstudioVersion>
+    <xunitrunnervisualstudioVersion>2.4.1-pre.build.4059</xunitrunnervisualstudioVersion>
   </PropertyGroup>
 
   <!-- 

--- a/build/ToolsetPackages/RoslynToolset.csproj
+++ b/build/ToolsetPackages/RoslynToolset.csproj
@@ -36,7 +36,6 @@
     <PackageReference Include="vswhere" Version="$(vswhereVersion)" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="dotnet-xunit" Version="$(dotnetxunitVersion)" ExcludeAssets="all" />
     <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersVersion)" ExcludeAssets="all" />
   </ItemGroup>
 </Project>

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -16,7 +16,7 @@ binaries_path="${root_path}"/Binaries
 unittest_dir="${binaries_path}"/"${build_configuration}"/UnitTests
 log_dir="${binaries_path}"/"${build_configuration}"/xUnitResults
 nuget_dir="${HOME}"/.nuget/packages
-xunit_console_version="$(get_package_version dotnet-xunit)"
+xunit_console_version="$(get_package_version xunitrunnerconsole)"
 
 if [[ "${runtime}" == "dotnet" ]]; then
     target_framework=netcoreapp2.0

--- a/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
@@ -16,7 +16,7 @@ namespace Roslyn.Test.Utilities
         }
 
         protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
-            => new WpfTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            => new WpfTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
     }
 
     public class WpfTheoryDiscoverer : TheoryDiscoverer
@@ -30,13 +30,13 @@ namespace Roslyn.Test.Utilities
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
         {
-            var testCase = new WpfTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, dataRow);
+            var testCase = new WpfTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, dataRow);
             return new[] { testCase };
         }
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
-            var testCase = new WpfTheoryTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            var testCase = new WpfTheoryTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
             return new[] { testCase };
         }
     }

--- a/src/EditorFeatures/TestUtilities/Threading/WpfTestCase.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfTestCase.cs
@@ -18,13 +18,13 @@ namespace Roslyn.Test.Utilities
         public WpfTestCase()
         {
         }
- 
-        public WpfTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, object[] testMethodArguments = null)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
+
+        public WpfTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
         {
             SharedData = WpfTestSharedData.Instance;
         }
- 
+
         public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
         {
             var runner = new WpfTestCaseRunner(SharedData, this, DisplayName, SkipReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource);

--- a/src/EditorFeatures/TestUtilities/Threading/WpfTheoryTestCase.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfTheoryTestCase.cs
@@ -17,8 +17,8 @@ namespace Roslyn.Test.Utilities
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
         public WpfTheoryTestCase() { }
 
-        public WpfTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod)
+        public WpfTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
         {
             SharedData = WpfTestSharedData.Instance;
         }


### PR DESCRIPTION
Version 2.4.0 has Portable PDBs enabled on .NET Framework:

```xml
<runtime>
    <AppContextSwitchOverrides value="Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false" />
  </runtime>
```

Version 2.4.1-pre.build.4059 has some additional bug fixes.