### PR TITLE
follow up fix for https://github.com/dotnet/roslyn/pull/29066

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
                 return packages;
             }
-            catch (InvalidOperationException)
+            catch (TargetInvocationException ex) when (ex.InnerException is InvalidOperationException)
             {
                 // this can be called from any thread, and extension manager could be disposed in the middle of us using it since
                 // now all these are free-threaded and there is no central coordinator, or API or state is immutable that prevent states from


### PR DESCRIPTION
due to us not directly calling extension manager APIs but calling it through reflection the exception doesn't propagate us as plain invalidOperationException but wrapped in the TargetInvocationException

change the exception catch condition accordingly

https://github.com/dotnet/roslyn/pull/29066

...

### Customer scenario

close VS and sometimes VS crash while shutting down.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/657750?src=WorkItemMention&amp%3Bsrc-action=artifact_link

### Workarounds, if any

wait VS is idle before shutdown VS.

### Risk

Low. it removes existing crash.

### Performance impact

Low. all we do is catching a known exception on VS shutdown and ignore it.

### Is this a regression from a previous update?

Yes. these used to happen on UI thread during package load, now we moved it out from UI thread and made lazy. in some case, it looks like the code above get called while VS is already in shutdown.

### Root cause analysis

I believe this is a common issue in async, lazy world when some states are not immutable. especially disposable. since in that world, guaranteeing the mutation ordering is not as simple as the synchronous world.

### How was the bug found?

watson.