### PR TITLE
Support TargetsTriggeredBeforeCompilation in CSharp and VB

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -27,6 +27,8 @@
                    @(CustomAdditionalCompileOutputs)"
           Returns="@(CscCommandLineArgs)"
           DependsOnTargets="$(CoreCompileDependsOn);_BeforeVBCSCoreCompile">
+    <CallTarget Targets="$(TargetsTriggeredBeforeCompilation)" Condition="'$(TargetsTriggeredBeforeCompilation)' != ''" />
+    
     <!-- These two compiler warnings are raised when a reference is bound to a different version
              than specified in the assembly reference version number.  MSBuild raises the same warning in this case,
              so the compiler warning would be redundant. -->

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -27,6 +27,8 @@
                    @(CustomAdditionalCompileOutputs)"
           Returns="@(VbcCommandLineArgs)"
           DependsOnTargets="$(CoreCompileDependsOn);_BeforeVBCSCoreCompile">
+    <CallTarget Targets="$(TargetsTriggeredBeforeCompilation)" Condition="'$(TargetsTriggeredBeforeCompilation)' != ''" />
+    
     <PropertyGroup>
       <_NoWarnings Condition="'$(WarningLevel)' == '0'">true</_NoWarnings>
       <_NoWarnings Condition="'$(WarningLevel)' == '1'">false</_NoWarnings>


### PR DESCRIPTION
Discussion: https://github.com/dotnet/roslyn/issues/24053

## What capability does `TargetsTriggeredBeforeCompilation` add?

There is more than one hook available if a target author would like a target to run before `CoreCompile` is run _or skipped_. However, it turns out that none of the available hooks will run a target _only_ before `CoreCompile` is run, but not before `CoreCompile` is skipped due to its output files being up-to-date with respect to its input files.

## Why did pre-existing hooks not provide that capability?

### `<Target Name="CustomBeforeCompile" BeforeTargets="CoreCompile">`

https://docs.microsoft.com/en-us/visualstudio/msbuild/target-build-order?view=vs-2017#determine-the-target-build-order

>  5.  Before a target is executed _or skipped_, any target that lists it in a BeforeTargets attribute is run.

### `<PropertyGroup>$(CoreCompileDependsOn);CustomBeforeCompile</PropertyGroup>`

https://docs.microsoft.com/en-us/visualstudio/msbuild/target-build-order?view=vs-2017#determine-the-target-build-order

>  4.  Before a target is executed _or skipped_, if its `Condition` attribute was absent or did not evaluate to `false`, its `DependsOnTargets` targets are run.

### `<Target Name="BeforeCompile">`

This hook makes use of the fact that `BeforeCompile` is included in `$(CompileDependsOn)`. But `CoreCompile` is also included in `$(CompileDependsOn)`, so `BeforeCompile` will run even if `CoreCompile` was going to be skipped.

ref:
https://github.com/Microsoft/msbuild/blob/master/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3239-L3256

## How would it be useful?

Generating code presents an inherent catch-22 with respect to incremental build. Suppose a project's output assembly must include an assembly attribute or constant for which the value can only be determined at build time, but that a change in that value alone does not necessitate recompiling the assembly. (Real-world examples of such a value: the current time, or an incrementing version number.) When compilation output files are up-to-date with respect to compilation input files, compilation can be skipped. But if a custom target in the project always writes a value to a `.cs` or `.vb` file before compilation, compilation output will never be up-to-date with respect to compilation input files. The consequence of each unnecessary compilation this causes will be a substantial penalty to build performance, and in the example of the incrementing version number, version gaps that might violate requirements (such as SemVer compliance).