### PR TITLE
VB - fix broken code generated when converting to auto property

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseAutoProperty/UseAutoPropertyTests.vb
@@ -194,6 +194,32 @@ End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
+        <WorkItem(28989, "https://github.com/dotnet/roslyn/issues/28989")>
+        Public Async Function TestInitializer_Multiline() As Task
+            Await TestInRegularAndScriptAsync(
+"Public Class C
+    Dim [|_b|] = {
+        ""one"",
+        ""two"",
+        ""three""}
+    Public Property P()
+        Get
+            Return _b
+        End Get
+        Set
+            _b = Value
+        End Set
+    End Property
+End Class",
+"Public Class C
+    Public Property P() = {
+        ""one"",
+        ""two"",
+        ""three""}
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
         Public Async Function TestReadOnlyField() As Task
             Await TestInRegularAndScriptAsync(
 "class Class1

--- a/src/EditorFeatures/VisualBasicTest/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseAutoProperty/UseAutoPropertyTests.vb
@@ -174,6 +174,26 @@ End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
+        <WorkItem(28989, "https://github.com/dotnet/roslyn/issues/28989")>
+        Public Async Function TestInitializer_BooleanWithComments() As Task
+            Await TestInRegularAndScriptAsync(
+"Public Class C
+    Private _b As Boolean = True 'Comments1
+    Public Property [|P|]() As Boolean 'Comments2
+        Get
+            Return _b
+        End Get
+        Set(value As Boolean)
+            _b = value
+        End Set
+    End Property
+End Class",
+"Public Class C
+    Public Property P() As Boolean = True 'Comments2 'Comments1
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
         Public Async Function TestReadOnlyField() As Task
             Await TestInRegularAndScriptAsync(
 "class Class1

--- a/src/EditorFeatures/VisualBasicTest/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseAutoProperty/UseAutoPropertyTests.vb
@@ -104,8 +104,7 @@ end class")
     end property|]
 end class",
 "class Class1
-    readonly property P as integer
-= 1
+    readonly property P as integer = 1
 end class")
         End Function
 
@@ -152,6 +151,26 @@ end class")
         end get
     end property|]
 end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
+        <WorkItem(28989, "https://github.com/dotnet/roslyn/issues/28989")>
+        Public Async Function TestInitializer_Boolean() As Task
+            Await TestInRegularAndScriptAsync(
+"Public Class C
+    Private _b As Boolean = True
+    Public Property [|P|]() As Boolean
+        Get
+            Return _b
+        End Get
+        Set(value As Boolean)
+            _b = value
+        End Set
+    End Property
+End Class",
+"Public Class C
+    Public Property P() As Boolean = True
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>

--- a/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
@@ -34,6 +34,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
             var project = propertyDocument.Project;
             var sourceText = await propertyDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
+            var trailingTrivia = propertyDeclaration.GetTrailingTrivia();
+
             var updatedProperty = propertyDeclaration.WithAccessorList(UpdateAccessorList(propertyDeclaration.AccessorList))
                                                      .WithExpressionBody(null)
                                                      .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None));
@@ -61,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
                                                  .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
             }
 
-            return updatedProperty.WithAdditionalAnnotations(SpecializedFormattingAnnotation);
+            return updatedProperty.WithTrailingTrivia(trailingTrivia).WithAdditionalAnnotations(SpecializedFormattingAnnotation);
         }
 
         protected override IEnumerable<IFormattingRule> GetFormattingRules(Document document)

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -93,9 +93,6 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 propertyDocument, compilation, fieldSymbol, propertySymbol, property,
                 isWrittenToOutsideOfConstructor, cancellationToken).ConfigureAwait(false);
 
-            // Ensure the new and old property share the same trailing trivia.
-            updatedProperty = updatedProperty.WithTrailingTrivia(property.GetTrailingTrivia());
-
             // Note: rename will try to update all the references in linked files as well.  However, 
             // this can lead to some very bad behavior as we will change the references in linked files
             // but only remove the field and update the property in a single document.  So, you can

--- a/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
@@ -7,7 +7,6 @@ Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.UseAutoProperty
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
     <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(VisualBasicUseAutoPropertyCodeFixProvider)), [Shared]>

--- a/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseAutoProperty/VisualBasicUseAutoPropertyCodeFixProvider.vb
@@ -36,7 +36,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
 
             Dim initializer = Await GetFieldInitializer(fieldSymbol, cancellationToken).ConfigureAwait(False)
             If initializer.equalsValue IsNot Nothing Then
-                statement = statement.WithInitializer(initializer.equalsValue)
+                'Before adding initializer, need to remove any end of line trivia from the statement
+                statement = If(statement.GetTrailingTrivia.Any(SyntaxKind.EndOfLineTrivia), statement.WithTrailingTrivia(SyntaxFactory.Space).WithInitializer(initializer.equalsValue), statement.WithInitializer(initializer.equalsValue))
             End If
 
             If initializer.asNewClause IsNot Nothing Then


### PR DESCRIPTION
Fixes #28989

Customer scenario:
VB only - when a backing field has an initial value, converting it to an auto property will put the initializer on a new line which results in broken code

Fix:
If the statement has trailing end of line trivia, remove it before adding the initializer