### PR TITLE
Compile Server Hash Check

### DIFF
--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
     <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Core\Portable\Microsoft.CodeAnalysis.csproj" />

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -80,6 +80,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
             var requestLength = args.Count + 1 + (libDirectory == null ? 0 : 1);
             var requestArgs = new List<Argument>(requestLength);
 
+            var compilerHash = GetCommitHash();
+            Log($"Comipler hash: {compilerHash}");
+
             requestArgs.Add(new Argument(ArgumentId.CurrentDirectory, 0, workingDirectory));
             requestArgs.Add(new Argument(ArgumentId.TempDirectory, 0, tempDirectory));
 
@@ -100,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 requestArgs.Add(new Argument(ArgumentId.CommandLineArgument, i, arg));
             }
 
-            return new BuildRequest(BuildProtocolConstants.ProtocolVersion, language, GetCommitHash(), requestArgs);
+            return new BuildRequest(BuildProtocolConstants.ProtocolVersion, language, compilerHash, requestArgs);
         }
 
         public static BuildRequest CreateShutdown()
@@ -570,7 +573,13 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// <returns>The hash value of the current assembly or an empty string</returns>
         public static string GetCommitHash()
         {
-            return typeof(BuildRequest).Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;
+            var hashAttribute = typeof(BuildRequest).Assembly.GetCustomAttribute<CommitHashAttribute>();
+            if(hashAttribute is null)
+            {
+                Log("CommitHashAttribute is missing from the assembly.");
+                return string.Empty;
+            }
+            return hashAttribute.Hash;
         }
 
         /// <summary>

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
     ///  Field Name         Type                Size (bytes)
     /// ----------------------------------------------------
     ///  Length             Integer             4
+    ///  ProtocolVersion    Integer             4
     ///  Language           RequestLanguage     4
     ///  CompilerHash       String              Variable
     ///  Argument Count     UInteger            4

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -614,6 +614,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     LogErrorOutput("Roslyn compiler server reports different protocol version than build task.");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
+                case BuildResponse.ResponseType.IncorrectHash:
+                    LogErrorOutput("Roslyn compiler server reports different hash version than build task.");
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
+
                 case BuildResponse.ResponseType.Rejected:
                 case BuildResponse.ResponseType.AnalyzerInconsistency:
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -20,6 +20,7 @@
       The build task and targets used by MSBuild to run the C# and VB compilers.
       Supports using VBCSCompiler on Windows.
     </PackageDescription>
+    <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
@@ -39,6 +40,7 @@
     <Compile Include="..\..\Shared\CoreClrShim.cs">
       <Link>CoreClrShim.cs</Link>
     </Compile>
+    <Compile Include="..\Portable\CommitHashAttribute.cs" Link="CommitHashAttribute.cs" />
     <Compile Include="..\Portable\CorLightup.cs">
       <Link>CorLightup.cs</Link>
     </Compile>

--- a/src/Compilers/Server/VBCSCompiler/Connection.cs
+++ b/src/Compilers/Server/VBCSCompiler/Connection.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 {
                     return await HandleMismatchedVersionRequest(cancellationToken).ConfigureAwait(false);
                 }
-                else if(request.CompilerHash != BuildProtocolConstants.GetCommitHash())
+                else if(!string.Equals(request.CompilerHash, BuildProtocolConstants.GetCommitHash(), StringComparison.CurrentCultureIgnoreCase))
                 {
                     return await HandleIncorrectHashRequest(cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Compilers/Server/VBCSCompiler/Connection.cs
+++ b/src/Compilers/Server/VBCSCompiler/Connection.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 {
                     return await HandleMismatchedVersionRequest(cancellationToken).ConfigureAwait(false);
                 }
-                else if(!string.Equals(request.CompilerHash, BuildProtocolConstants.GetCommitHash(), StringComparison.CurrentCultureIgnoreCase))
+                else if(!string.Equals(request.CompilerHash, BuildProtocolConstants.GetCommitHash(), StringComparison.OrdinalIgnoreCase))
                 {
                     return await HandleIncorrectHashRequest(cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Compilers/Server/VBCSCompiler/Connection.cs
+++ b/src/Compilers/Server/VBCSCompiler/Connection.cs
@@ -109,6 +109,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 {
                     return await HandleMismatchedVersionRequest(cancellationToken).ConfigureAwait(false);
                 }
+                else if(request.CompilerHash != BuildProtocolConstants.GetCommitHash())
+                {
+                    return await HandleIncorrectHashRequest(cancellationToken).ConfigureAwait(false);
+                }
                 else if (IsShutdownRequest(request))
                 {
                     return await HandleShutdownRequest(cancellationToken).ConfigureAwait(false);
@@ -171,6 +175,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         private async Task<ConnectionData> HandleMismatchedVersionRequest(CancellationToken cancellationToken)
         {
             var response = new MismatchedVersionBuildResponse();
+            await response.WriteAsync(_stream, cancellationToken).ConfigureAwait(false);
+            return new ConnectionData(CompletionReason.CompilationNotStarted);
+        }
+
+        private async Task<ConnectionData> HandleIncorrectHashRequest(CancellationToken cancellationToken)
+        {
+            var response = new IncorrectHashBuildResponse();
             await response.WriteAsync(_stream, cancellationToken).ConfigureAwait(false);
             return new ConnectionData(CompletionReason.CompilationNotStarted);
         }

--- a/src/Compilers/Server/VBCSCompiler/Connection.cs
+++ b/src/Compilers/Server/VBCSCompiler/Connection.cs
@@ -104,8 +104,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     LogException(e, "Error reading build request.");
                     return new ConnectionData(CompletionReason.CompilationNotStarted);
                 }
-
-                if (IsShutdownRequest(request))
+                
+                if(request.ProtocolVersion != BuildProtocolConstants.ProtocolVersion)
+                {
+                    return await HandleMismatchedVersionRequest(cancellationToken).ConfigureAwait(false);
+                }
+                else if (IsShutdownRequest(request))
                 {
                     return await HandleShutdownRequest(cancellationToken).ConfigureAwait(false);
                 }
@@ -162,6 +166,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             // Begin the tear down of the Task which didn't complete.
             buildCts.Cancel();
             return new ConnectionData(reason, keepAlive);
+        }
+
+        private async Task<ConnectionData> HandleMismatchedVersionRequest(CancellationToken cancellationToken)
+        {
+            var response = new MismatchedVersionBuildResponse();
+            await response.WriteAsync(_stream, cancellationToken).ConfigureAwait(false);
+            return new ConnectionData(CompletionReason.CompilationNotStarted);
         }
 
         private async Task<ConnectionData> HandleRejectedRequest(CancellationToken cancellationToken)

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -13,6 +13,7 @@
     <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />

--- a/src/Compilers/Server/VBCSCompilerTests/BuildProtocolTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildProtocolTest.cs
@@ -43,6 +43,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var request = new BuildRequest(
                 BuildProtocolConstants.ProtocolVersion,
                 RequestLanguage.VisualBasicCompile,
+                "HashValue",
                 ImmutableArray.Create(
                     new BuildRequest.Argument(BuildProtocolConstants.ArgumentId.CurrentDirectory, argumentIndex: 0, value: "directory"),
                     new BuildRequest.Argument(BuildProtocolConstants.ArgumentId.CommandLineArgument, argumentIndex: 1, value: "file")));
@@ -53,6 +54,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var read = await BuildRequest.ReadAsync(memoryStream, default(CancellationToken));
             Assert.Equal(BuildProtocolConstants.ProtocolVersion, read.ProtocolVersion);
             Assert.Equal(RequestLanguage.VisualBasicCompile, read.Language);
+            Assert.Equal("HashValue", read.CompilerHash);
             Assert.Equal(2, read.Arguments.Count);
             Assert.Equal(BuildProtocolConstants.ArgumentId.CurrentDirectory, read.Arguments[0].ArgumentId);
             Assert.Equal(0, read.Arguments[0].ArgumentIndex);

--- a/src/Compilers/Server/VBCSCompilerTests/ClientConnectionTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ClientConnectionTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         }
 
         private static readonly BuildRequest s_emptyCSharpBuildRequest = new BuildRequest(
-            1,
+            BuildProtocolConstants.ProtocolVersion,
             RequestLanguage.CSharpCompile,
             ImmutableArray<BuildRequest.Argument>.Empty);
 

--- a/src/Compilers/Server/VBCSCompilerTests/ClientConnectionTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ClientConnectionTests.cs
@@ -108,6 +108,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         private static readonly BuildRequest s_emptyCSharpBuildRequest = new BuildRequest(
             BuildProtocolConstants.ProtocolVersion,
             RequestLanguage.CSharpCompile,
+            BuildProtocolConstants.GetCommitHash(),
             ImmutableArray<BuildRequest.Argument>.Empty);
 
         private static readonly BuildResponse s_emptyBuildResponse = new CompletedBuildResponse(

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         private static readonly BuildRequest s_emptyCSharpBuildRequest = new BuildRequest(
             BuildProtocolConstants.ProtocolVersion,
             RequestLanguage.CSharpCompile,
+            BuildProtocolConstants.GetCommitHash(),
             ImmutableArray<BuildRequest.Argument>.Empty);
 
         private static readonly BuildResponse s_emptyBuildResponse = new CompletedBuildResponse(
@@ -94,6 +95,7 @@ class Hello
             return new BuildRequest(
                 BuildProtocolConstants.ProtocolVersion,
                 RequestLanguage.CSharpCompile,
+                BuildProtocolConstants.GetCommitHash(),
                 builder.ToImmutable());
         }
 
@@ -526,8 +528,18 @@ class Hello
         {
             using (var serverData = ServerUtil.CreateServer())
             {
-                var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(1, RequestLanguage.CSharpCompile, new List<BuildRequest.Argument> { }));
+                var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(1, RequestLanguage.CSharpCompile, string.Empty, new List<BuildRequest.Argument> { }));
                 Assert.Equal(BuildResponse.ResponseType.MismatchedVersion, buildResponse.Type);
+            }
+        }
+
+        [Fact]
+        public async Task IncorrectServerHashReturnsIncorrectHashResponse()
+        {
+            using (var serverData = ServerUtil.CreateServer())
+            {
+                var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(BuildProtocolConstants.ProtocolVersion, RequestLanguage.CSharpCompile, string.Empty, new List<BuildRequest.Argument> { }));
+                Assert.Equal(BuildResponse.ResponseType.IncorrectHash, buildResponse.Type);
             }
         }
     }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -528,7 +528,7 @@ class Hello
         {
             using (var serverData = ServerUtil.CreateServer())
             {
-                var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(1, RequestLanguage.CSharpCompile, string.Empty, new List<BuildRequest.Argument> { }));
+                var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(1, RequestLanguage.CSharpCompile, "abc", new List<BuildRequest.Argument> { }));
                 Assert.Equal(BuildResponse.ResponseType.MismatchedVersion, buildResponse.Type);
             }
         }
@@ -538,7 +538,7 @@ class Hello
         {
             using (var serverData = ServerUtil.CreateServer())
             {
-                var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(BuildProtocolConstants.ProtocolVersion, RequestLanguage.CSharpCompile, string.Empty, new List<BuildRequest.Argument> { }));
+                var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(BuildProtocolConstants.ProtocolVersion, RequestLanguage.CSharpCompile, "abc", new List<BuildRequest.Argument> { }));
                 Assert.Equal(BuildResponse.ResponseType.IncorrectHash, buildResponse.Type);
             }
         }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
     public class CompilerServerApiTest : TestBase
     {
         private static readonly BuildRequest s_emptyCSharpBuildRequest = new BuildRequest(
-            1,
+            BuildProtocolConstants.ProtocolVersion,
             RequestLanguage.CSharpCompile,
             ImmutableArray<BuildRequest.Argument>.Empty);
 
@@ -518,6 +518,16 @@ class Hello
 
                     Assert.True(threw);
                 }
+            }
+        }
+
+        [Fact]
+        public async Task IncorrectProtocolReturnsMismatchedVersionResponse()
+        {
+            using (var serverData = ServerUtil.CreateServer())
+            {
+                var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(1, RequestLanguage.CSharpCompile, new List<BuildRequest.Argument> { }));
+                Assert.Equal(BuildResponse.ResponseType.MismatchedVersion, buildResponse.Type);
             }
         }
     }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -1416,7 +1416,7 @@ class Program
             });
             using (var serverData = ServerUtil.CreateServer(compilerServerHost: host))
             {
-                var request = new BuildRequest(1, RequestLanguage.CSharpCompile, new BuildRequest.Argument[0]);
+                var request = new BuildRequest(1, RequestLanguage.CSharpCompile, string.Empty, new BuildRequest.Argument[0]);
                 var compileTask = ServerUtil.Send(serverData.PipeName, request);
                 var response = await compileTask;
                 Assert.Equal(BuildResponse.ResponseType.Completed, response.Type);

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -202,6 +202,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     }
 
                 case BuildResponse.ResponseType.MismatchedVersion:
+                case BuildResponse.ResponseType.IncorrectHash:
                 case BuildResponse.ResponseType.Rejected:
                 case BuildResponse.ResponseType.AnalyzerInconsistency:
                     // Build could not be completed on the server.

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -194,6 +194,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     var request = BuildRequest.Create(language,
                                                       buildPaths.WorkingDirectory,
                                                       buildPaths.TempDirectory,
+                                                      BuildProtocolConstants.GetCommitHash(),
                                                       arguments,
                                                       keepAlive,
                                                       libEnvVariable);

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -118,6 +118,12 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 return new RejectedBuildResponse();
             }
 
+            // early check for the build hash. If we can't find it something is wrong; no point even trying to go to the server
+            if (string.IsNullOrWhiteSpace(BuildProtocolConstants.GetCommitHash()))
+            {
+                return new IncorrectHashBuildResponse();
+            }
+
             var clientDir = buildPaths.ClientDirectory;
             var timeoutNewProcess = timeoutOverride ?? TimeOutMsNewProcess;
             var timeoutExistingProcess = timeoutOverride ?? TimeOutMsExistingProcess;

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
     <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Core\Portable\Microsoft.CodeAnalysis.csproj" />


### PR DESCRIPTION
Adds the compiler sha to the build server protocol, and fails the request if the client and server sha's don't match.

Also fixes the server not checking the build protocol version, and now fails the request appropriately if they don't match.

Fixes #28974